### PR TITLE
Exit non-zero on plugin existing already

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -118,7 +118,7 @@ func pluginsInstall(ctx *Context) {
 		toinstall = append(toinstall, plugin)
 	}
 	if len(toinstall) == 0 {
-		Exit(1)
+		Exit(0)
 	}
 	action("Installing "+plural("plugin", len(toinstall))+" "+strings.Join(toinstall, " "), "done", func() {
 		err := UserPlugins.InstallPlugins(toinstall...)


### PR DESCRIPTION
@dickeyxxx please review?  this is new behavior and was breaking someones script because it was working before heroku-pipelines was in core and it kept working until v5 went out.