### PR TITLE
Add heroku-certs 1.1.15 to core

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "heroku-apps": "2.1.16",
+    "heroku-certs": "1.1.15",
     "heroku-cli-addons": "1.1.3",
     "heroku-fork": "4.1.11",
     "heroku-git": "2.5.8",


### PR DESCRIPTION
@dickeyxxx could you review?  This adds the `heroku-certs` plugin to core, now all the `certs` commands are implemented in node and `http-sni` functionality is available to everyone.  See https://devcenter.heroku.com/articles/ssl-beta for more info about changes related to `http-sni`