### PR TITLE
go1.7.4

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,8 +7,8 @@ machine:
     JOBZ: 6
   post:
     - sudo rm -rf /usr/local/go
-    - if [ ! -e ~/deps/go1.7.3.linux-amd64.tar.gz ]; then mkdir -p ~/deps && wget -O ~/deps/go1.7.3.linux-amd64.tar.gz https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz; fi
-    - sudo tar -C /usr/local -xzf ~/deps/go1.7.3.linux-amd64.tar.gz
+    - if [ ! -e ~/deps/go1.7.4.linux-amd64.tar.gz ]; then mkdir -p ~/deps && wget -O ~/deps/go1.7.4.linux-amd64.tar.gz https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz; fi
+    - sudo tar -C /usr/local -xzf ~/deps/go1.7.4.linux-amd64.tar.gz
 checkout:
   post:
     - |


### PR DESCRIPTION
This is to fix this security issue with golang

https://github.com/golang/go/issues/18141

For comparison purposes, here was our upgrade to 1.7.3

https://github.com/heroku/cli/pull/347