### PR TITLE
Use the expectedBinPath rather than stat.Name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,8 +186,9 @@ $(DIST_DIR)/$(VERSION)/heroku-windows-%.exe: tmp/windows-% $(CACHE_DIR)/git/Git-
 		-i https://toolbelt.heroku.com/ \
 		-in tmp/windows-$*-installer/heroku/installer.exe -out $@
 
-$(DIST_DIR)/$(VERSION)/heroku-osx.pkg: tmp/darwin-amd64/heroku/VERSION
-	@echo "TODO OSX"
+$(DIST_DIR)/$(VERSION)/heroku-osx.pkg: tmp/darwin-amd64
+	@mkdir -p $(@D)
+	./resources/osx/build $@
 
 .PHONY: build
 build: $(WORKSPACE)/bin/heroku $(WORKSPACE)/lib/npm $(WORKSPACE)/lib/node $(WORKSPACE)/lib/plugins.json $(WORKSPACE)/lib/cacert.pem

--- a/resources/osx/Distribution
+++ b/resources/osx/Distribution
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<installer-script minSpecVersion="1.000000" authoringTool="com.apple.PackageMaker" authoringToolVersion="3.0.3">
+  <title>Heroku CLI VERSION</title>
+  <options customize="never"/>
+  <choices-outline>
+    <line choice="heroku-cli"/>
+  </choices-outline>
+  <choice id="heroku-cli" title="base">
+    <pkg-ref id="com.heroku.cli.base.pkg"/>
+  </choice>
+  <pkg-ref id="com.heroku.cli.base.pkg" installKBytes="KBYTES" version="VERSION" auth="Root">#base.pkg</pkg-ref>
+</installer-script>

--- a/resources/osx/PackageInfo
+++ b/resources/osx/PackageInfo
@@ -1,0 +1,6 @@
+<pkg-info format-version="2" identifier="com.heroku.cli" version="VERSION" install-location="/" auth="root">
+  <payload installKBytes="KBYTES" numberOfFiles="NUM_FILES"/>
+  <scripts>
+    <postinstall file="./postinstall"/>
+  </scripts>
+</pkg-info>

--- a/resources/osx/build
+++ b/resources/osx/build
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -ex
+
+VERSION=`./bin/version`
+mkdir -p tmp/osx/build
+rm -rf tmp/osx/build/*
+cd tmp/osx/build
+mkdir -p flat/base.pkg flat/Resources/en.lproj
+mkdir -p root/usr/local/lib; cp -r ../../darwin-amd64/heroku root/usr/local/lib/heroku
+mv root/usr/local/lib/heroku/bin root/usr/local
+(cd root && find . | cpio -o --format odc --owner 0:80 | gzip -c) > flat/base.pkg/Payload
+sed "s/VERSION/$VERSION/" ../../../resources/osx/PackageInfo |
+sed "s/KBYTES/`du -ks root | awk '{print $1}'`/" |
+sed "s/NUM_FILES/`find root | wc -l | awk '{print $1}'`/" > flat/base.pkg/PackageInfo
+sed "s/VERSION/$VERSION/" ../../../resources/osx/Distribution |
+sed "s/KBYTES/`du -ks root | awk '{print $1}'`/" > flat/Distribution
+(cd ../../../resources/osx/scripts && find . | cpio -o --format odc --owner 0:80 | gzip -c) > flat/base.pkg/Scripts
+#mkbom -u -g 80 root flat/base.pkg/Bom
+mkbom root flat/base.pkg/Bom
+(cd flat && xar --compression none -cf ../../../../$1 *)

--- a/resources/osx/scripts/postinstall
+++ b/resources/osx/scripts/postinstall
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+#osascript -e 'tell app "Finder" to display dialog "heroku installed."'

--- a/update.go
+++ b/update.go
@@ -215,6 +215,8 @@ func loadNewCLI() {
 	current, err := os.Stat(BinPath)
 	must(err)
 	if !os.SameFile(current, expected) {
+		Errln(expectedBinPath())
+		Errln(BinPath)
 		execBin(expected.Name(), Args...)
 	}
 }

--- a/update.go
+++ b/update.go
@@ -201,7 +201,8 @@ func loadNewCLI() {
 	if Autoupdate == "no" {
 		return
 	}
-	expected, err := os.Stat(expectedBinPath())
+	expectedBinPath := expectedBinPath()
+	expected, err := os.Stat(expectedBinPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			if !npmExists() {
@@ -215,9 +216,7 @@ func loadNewCLI() {
 	current, err := os.Stat(BinPath)
 	must(err)
 	if !os.SameFile(current, expected) {
-		Errln(expectedBinPath())
-		Errln(BinPath)
-		execBin(expected.Name(), Args...)
+		execBin(expectedBinPath, Args...)
 	}
 }
 


### PR DESCRIPTION
@dickeyxxx `expected.Name() === heroku` so it kept finding `/usr/local/bin/heroku` in my path over and over and re-exec-ing it.  If possible I would have used `expected.Path()` but no such thing exists so this seems like the best thing to do.