### PR TITLE
Swallow SIGINT when exec'ing updated heroku exe

### DIFF
--- a/update.go
+++ b/update.go
@@ -217,6 +217,7 @@ func loadNewCLI() {
 	if !os.SameFile(current, expected) {
 		bin := expectedBinPath()
 		Debugf("Executing %s\n", bin)
+		swallowSigint = true
 		cmd := exec.Command(bin, Args[1:]...)
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout


### PR DESCRIPTION
@dickeyxxx could you review / deploy?  This fixes a bug in `pg:psql` where when the heroku in `/usr/local/lib/heroku/bin/heroku` executes the updated `~/.local/share/heroku/cli/bin/heroku` it does not allow SIGINT to pass through.  This fixes the problem where ctrl-c causes psql to exit rather than canceling the current line.