### PR TITLE
Bumping heroku-spaces to 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "heroku-pipelines": "1.2.2",
     "heroku-redis": "1.2.8",
     "heroku-run": "3.3.4",
-    "heroku-spaces": "2.5.0",
+    "heroku-spaces": "2.6.0",
     "heroku-status": "3.0.2"
   }
 }


### PR DESCRIPTION
Just released this version. Making it standard. 