### PR TITLE
Update heroku-pipelines to use cli.color.pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "heroku-local": "5.1.8",
     "heroku-orgs": "1.5.5",
     "heroku-pg": "2.0.16",
-    "heroku-pipelines": "1.2.4",
+    "heroku-pipelines": "1.3.0",
     "heroku-redis": "1.2.8",
     "heroku-run": "3.4.3",
     "heroku-spaces": "2.6.0",


### PR DESCRIPTION
@dickeyxxx I saw that you had already bumped up the `heroku-pipelines` version to use the latest `heroku-cli-util` (thanks for doing that!), but this update is to bring the usage of what was added there:

https://github.com/heroku/heroku-pipelines/pull/51
