### PR TITLE
Add --scripts-prepend-node-path=true to npm args

### DIFF
--- a/npm.go
+++ b/npm.go
@@ -113,6 +113,7 @@ func (p *Plugins) npmCmd(args ...string) (*exec.Cmd, error) {
 		}
 		args = append(args, "--loglevel="+level)
 	}
+	args = append(args, "--scripts-prepend-node-path=true")
 	cmd := exec.Command(nodeBinPath(), args...)
 	cmd.Dir = p.Path
 	cmd.Env = p.environ()


### PR DESCRIPTION
@dickeyxxx could you review? there is a change in npm 3 to 4 where it no longer uses the node that npm was exec'ed with as part of the scripts.  So if users have node 6 in their PATH it will pick that up and use that instead causing issues with `heroku-kafka`.  This basically adds to the PATH in the subcommand so that the right node is found.
```
~/.local/share/heroku/plugins ᐅ ~/.local/share/heroku/cli/lib/node ~/.local/share/heroku/cli/lib/npm/cli.js rebuild
npm WARN lifecycle npm is using /Users/jdowning/.local/share/heroku/cli/lib/node but there is no node binary in the current PATH. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.
```