### PR TITLE
Bump heroku-pg to 2.0.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "heroku-git": "2.5.16",
     "heroku-local": "5.1.13",
     "heroku-orgs": "1.5.12",
-    "heroku-pg": "2.0.25",
+    "heroku-pg": "2.0.26",
     "heroku-pipelines": "1.4.4",
     "heroku-redis": "1.2.13",
     "heroku-run": "3.4.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -441,9 +441,9 @@ heroku-orgs@1.5.12:
     lodash "4.17.4"
     lodash.flatten "4.4.0"
 
-heroku-pg@2.0.25:
-  version "2.0.25"
-  resolved "https://registry.yarnpkg.com/heroku-pg/-/heroku-pg-2.0.25.tgz#50fb37c25aca93103c9bc01d8d7ade452dff6ff9"
+heroku-pg@2.0.26:
+  version "2.0.26"
+  resolved "https://registry.yarnpkg.com/heroku-pg/-/heroku-pg-2.0.26.tgz#fe4a1444969f6aa81788315291b42bc42be032bc"
   dependencies:
     bytes "2.5.0"
     co "4.6.0"


### PR DESCRIPTION
Fixes issues with long-running queries.

Not urgent, can go out in next release.