### PR TITLE
Fix Go => Node arch differences for 32bit

### DIFF
--- a/install.go
+++ b/install.go
@@ -27,6 +27,9 @@ func Install(channel string) {
 	if arch == "amd64" {
 		arch = "x64"
 	}
+	if arch == "386" {
+		arch = "x86"
+	}
 	manifest := GetUpdateManifest(channel, os, arch)
 	DownloadCLI(channel, filepath.Join(DataHome, "client"), os, arch, manifest)
 }


### PR DESCRIPTION
@dickeyxxx could you review?
```
IEUser@IE11Win7 MINGW32 ~
$ heroku
 !    HTTP Error: http://cli-assets.heroku.com/heroku-cli/channels/beta/win32-386 404 Not Found

IEUser@IE11Win7 MINGW32 ~
```