### PR TITLE
Always truncate analytics after upload

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -111,12 +111,14 @@ func SubmitAnalytics() {
 	req := sling.New().Client(apiHTTPClient).Base(host)
 	req.Set("User-Agent", version())
 	resp, err := req.Post("/record").BodyJSON(file).ReceiveSuccess(nil)
+
+	writeAnalyticsFile(analyticsBody{Schema: 1})
+
 	if err != nil {
 		LogIfError(err)
 		return
 	}
 	LogIfError(getHTTPError(resp))
-	writeAnalyticsFile(analyticsBody{Schema: 1})
 }
 
 func skipAnalytics() bool {


### PR DESCRIPTION
@dickeyxxx could you review?  Still trying to fix H12 errors in heroku-cli-analytics and this seems like the final thing we can fix under our control.  After this I will just chock up the H12s to slow / funky clients.