### PR TITLE
Add a snapcraft build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Heroku CLI
 
 [![Circle CI](https://circleci.com/gh/heroku/cli/tree/master.svg?style=svg)](https://circleci.com/gh/heroku/cli/tree/master)
 [![Build status](https://ci.appveyor.com/api/projects/status/ouee3b9d7jwkjcr1/branch/master?svg=true)](https://ci.appveyor.com/project/Heroku/cli/branch/master)
+[![Snap Status](https://build.snapcraft.io/badge/heroku/cli.svg)](https://build.snapcraft.io/user/heroku/cli)
 [![ISC License](https://img.shields.io/github/license/heroku/cli.svg)](https://github.com/heroku/cli/blob/master/LICENSE)
 
 The Heroku CLI is used to manage Heroku apps from the command line.


### PR DESCRIPTION
Adds a badge for snapcraft builds, which links off to a list of the latest.