### PR TITLE
Bump Heroku CI plugin version to 1.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "cli-engine": "3.5.35",
     "heroku-apps": "2.4.1",
     "heroku-certs": "1.1.38",
-    "heroku-ci": "1.8.1",
+    "heroku-ci": "1.8.3",
     "heroku-cli-addons": "1.2.21",
     "heroku-cli-oauth": "2.0.13",
     "heroku-cli-status": "4.0.0",


### PR DESCRIPTION
Minor change to make `heroku ci:debug` behave have the same `CI=true` environment variable as normal test runs. See: https://github.com/heroku/heroku-ci/pull/47.