### PR TITLE
Bump heroku-pg to 2.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "heroku-git": "2.5.19",
     "heroku-local": "5.1.18",
     "heroku-orgs": "1.6.4",
-    "heroku-pg": "2.2.5",
+    "heroku-pg": "2.2.6",
     "heroku-pipelines": "2.1.3",
     "heroku-ps-exec": "1.0.6",
     "heroku-redis": "1.2.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -918,9 +918,9 @@ heroku-orgs@1.6.4:
     lodash "4.17.4"
     lodash.flatten "4.4.0"
 
-heroku-pg@2.2.5:
-  version "2.2.5"
-  resolved "http://cli-npm.heroku.com/heroku-pg/-/heroku-pg-2.2.5/e182cd7f4e7ff0faa2d78f8c94a88373b925919a.tgz#e182cd7f4e7ff0faa2d78f8c94a88373b925919a"
+heroku-pg@2.2.6:
+  version "2.2.6"
+  resolved "http://cli-npm.heroku.com/heroku-pg/-/heroku-pg-2.2.6/30241a2bff59e45027334013a26a8be5c88f858e.tgz#30241a2bff59e45027334013a26a8be5c88f858e"
   dependencies:
     bytes "^2.5.0"
     co "^4.6.0"


### PR DESCRIPTION
Bump heroku-pg to 2.2.6, for new commands.