### PR TITLE
Upgrade heroku-run to v3.4.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "heroku-pipelines": "2.1.3",
     "heroku-ps-exec": "1.0.6",
     "heroku-redis": "1.2.15",
-    "heroku-run": "3.4.15",
+    "heroku-run": "3.4.16",
     "heroku-spaces": "2.9.5",
     "semver": "5.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,9 +971,9 @@ heroku-redis@1.2.15:
     ioredis "1.9.0"
     ssh2 "^0.4.11"
 
-heroku-run@3.4.15:
-  version "3.4.15"
-  resolved "http://cli-npm.heroku.com/heroku-run/-/heroku-run-3.4.15/7315a70812bb798b39bc1fdf60627ce434ea79f5.tgz#7315a70812bb798b39bc1fdf60627ce434ea79f5"
+heroku-run@3.4.16:
+  version "3.4.16"
+  resolved "http://cli-npm.heroku.com/heroku-run/-/heroku-run-3.4.16/dddf442905c83d2bc20845d4e77559f48b500b62.tgz#dddf442905c83d2bc20845d4e77559f48b500b62"
   dependencies:
     co "4.6.0"
     heroku-cli-util "^6.2.2"


### PR DESCRIPTION
Brings https://github.com/heroku/heroku-run/pull/34.

This would allow us to use `heroku-run` uptstream in heroku-ci: https://github.com/heroku/heroku-ci/blob/master/package.json#L42.

cc @heroku/devex 