### PR TITLE
Fix classic confinement of snap package

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,3 @@
-
 name: heroku
 version: '6.12.17'
 summary: Heroku CLI
@@ -8,11 +7,17 @@ confinement: classic
 
 apps:
     heroku:
-        command: bin/heroku
+        command: bin/node $SNAP/lib/node_modules/heroku-cli/bin/run.js
 
 parts:
-  hello-node-snap:
+  heroku:
+    source: .
     plugin: nodejs
-    node-engine: 7.10.0
-    node-packages:
-      - heroku-cli
+    node-engine: 8.2.1
+    # In Node 8 local projects get symlinked instead of copied. This results in
+    # a dangling symlink back to the build directory in snapcraft. So until
+    # http://pad.lv/1702661 is fixed, copy heroku-cli in place.
+    install: |
+        heroku_cli=$SNAPCRAFT_PART_INSTALL/lib/node_modules/heroku-cli
+        rm $heroku_cli
+        cp -r . $heroku_cli/


### PR DESCRIPTION
The `confinement: classic` move broke the snap because PATH is not set up the same way in `confinement: strict` and `confinement: classic` [1]. There was also an issue preventing the use of Node 8.x with the snap (http://pad.lv/1702661). This pull request fixes both (thanks to @sergiusens).

You can test this by running `snapcraft` on an Ubuntu 16.04 or later VM in a checkout of this branch. That will produce a `*.snap` you can install with `sudo snap install --dangerous --classic *.snap`. The `heroku` command should then work without issue, including `heroku local`.

Thanks

1: When using classic confinement, selecting the right binaries is not a clear cut decision. If heroku calls applications that use node, should those applications use node from the snap or from the system? Here we use the snap copy of node for the heroku command and the system node for everything else.