### PR TITLE
Bump heroku-ci to v1.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "cli-engine": "3.5.57",
     "heroku-apps": "2.4.9",
     "heroku-certs": "1.1.41",
-    "heroku-ci": "1.9.4",
+    "heroku-ci": "1.9.5",
     "heroku-cli-addons": "1.2.25",
     "heroku-cli-oauth": "2.0.14",
     "heroku-cli-status": "4.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -847,9 +847,9 @@ flexbuffer@0.0.6:
   version "0.0.6"
   resolved "http://cli-npm.heroku.com/flexbuffer/-/flexbuffer-0.0.6/039fdf23f8823e440c38f3277e6fef1174215b30.tgz#039fdf23f8823e440c38f3277e6fef1174215b30"
 
-"foreman@https://github.com/heroku/node-foreman.git":
+"foreman@git+https://github.com/heroku/node-foreman.git":
   version "2.0.0"
-  resolved "https://github.com/heroku/node-foreman.git#799ba64191dd652e797b4e7711f17a520d5d69c8"
+  resolved "git+https://github.com/heroku/node-foreman.git#799ba64191dd652e797b4e7711f17a520d5d69c8"
   dependencies:
     commander "~2.9.0"
     http-proxy "~1.11.1"
@@ -1102,9 +1102,9 @@ heroku-certs@1.1.41:
     moment "^2.18.1"
     psl "^1.1.19"
 
-heroku-ci@1.9.4:
-  version "1.9.4"
-  resolved "http://cli-npm.heroku.com/heroku-ci/-/heroku-ci-1.9.4/482c8d2dddc08a5b8b17e1d0318349e2e88db915.tgz#482c8d2dddc08a5b8b17e1d0318349e2e88db915"
+heroku-ci@1.9.5:
+  version "1.9.5"
+  resolved "http://cli-npm.heroku.com/heroku-ci/-/heroku-ci-1.9.5/87d3c6589857c1a25517943405e2af58c318d697.tgz#87d3c6589857c1a25517943405e2af58c318d697"
   dependencies:
     ansi-escapes "1.4.0"
     bluebird "^3.4.6"


### PR DESCRIPTION
Bumps heroku-ci to v1.9.5, which has minor changes, see https://github.com/heroku/heroku-ci/pull/57.