### PR TITLE
Switch the snap to yarn

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,3 +14,4 @@ parts:
     source: .
     plugin: nodejs
     node-engine: 8.7.0
+    node-package-manager: yarn


### PR DESCRIPTION
This switches the snap to yarn, which fixes running heroku. Previous commits would error out:

```
$ heroku login
 ▸    'MODULE_NOT_FOUND': Cannot find module '/snap/heroku/x3/lib/node_modules/heroku-cli/lib/legacy'
```