### PR TITLE
Bump heroku-pg version

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "heroku-git": "2.5.23",
     "heroku-local": "5.1.21",
     "heroku-orgs": "1.6.6",
-    "heroku-pg": "2.3.0",
+    "heroku-pg": "2.4.0",
     "heroku-pipelines": "2.4.0",
     "heroku-ps-exec": "2.2.1",
     "heroku-redis": "1.3.0",


### PR DESCRIPTION
Bump heroku-pg version, to make pg:outliers available to everyone.