### PR TITLE
Upgrade heroku-ps-exec to 2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "heroku-orgs": "1.7.1",
     "heroku-pg": "2.4.1",
     "heroku-pipelines": "2.5.0",
-    "heroku-ps-exec": "2.2.1",
+    "heroku-ps-exec": "2.2.2",
     "heroku-redis": "1.3.0",
     "heroku-run": "3.5.4",
     "heroku-spaces": "2.10.0",


### PR DESCRIPTION
This will pin heroku-cli-util to version 6.2.11 to fix an issue with the `body:` argument to `cli.got` .