### PR TITLE
Throw friendly error when .netrc is a directory instead of a file

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,4 +1,5 @@
 import {vars} from '@heroku-cli/command'
+import {CLIError} from '@oclif/errors'
 import * as Config from '@oclif/config'
 import ux from 'cli-ux'
 import netrc from 'netrc-parser'
@@ -161,8 +162,20 @@ export default class AnalyticsCommand {
     return score
   }
 
+  async loadNetRc(): Promise<void> {
+    try {
+      await netrc.load()
+    } catch (err) {
+      if (err.code === 'EISDIR') {
+        throw new CLIError('Problem reading ~/.netrc config, directory found')
+      } else {
+        throw err
+      }
+    }
+  }
+
   private async init() {
-    await netrc.load()
+    await this.loadNetRc()
     this.userConfig = new deps.UserConfig(this.config)
     await this.userConfig.init()
   }


### PR DESCRIPTION
I ran into a really annoying issue today when on-boarding a new employee. We mount our `.netrc` file into our Docker containers on our local environment to be able to automate some things like syncing a copy of our database to our local environment for debugging, etc.

Docker mounts missing files as directories by default and in doing so, had created `.netrc` folder when spinning up the Docker instance. Heroku CLI was throwing an error that made no sense when trying to use the `heroku login` command.

```
(node:40255) [EISDIR] Error Plugin: heroku: EISDIR: illegal operation on a directory, read
module: @oclif/config@1.6.17
task: runHook prerun
plugin: heroku
root: /Users/eric/.local/share/heroku/client/7.0.36
Error: EISDIR: illegal operation on a directory, read
```

This may not be the best way to handle this but I would love to commit some version of this into the `cli` to prevent others from dealing with this issue in the future. We wasted a solid hour trying to figure out what was going.