### PR TITLE
Increase vpn:wait timeout

### DIFF
--- a/packages/spaces/commands/vpn/wait.js
+++ b/packages/spaces/commands/vpn/wait.js
@@ -10,7 +10,7 @@ function * run (context, heroku) {
   if (!space) throw new Error('Space name required.\nUSAGE: heroku spaces:vpn:wait my-space')
 
   const interval = (typeof context.flags.interval !== 'undefined' ? context.flags.interval : 10) * 1000
-  const timeout = (typeof context.flags.timeout !== 'undefined' ? context.flags.timeout : 10 * 60) * 1000
+  const timeout = (typeof context.flags.timeout !== 'undefined' ? context.flags.timeout : 20 * 60) * 1000
   const deadline = new Date(new Date().getTime() + timeout)
   const spinner = new cli.Spinner({text: `Waiting for VPN in space ${cli.color.green(space)} to allocate...`})
 


### PR DESCRIPTION
VPN provisioning can sometimes take longer than 10 minutes. This increases the wait timeout to 20 minutes to take into account longer VPN provisioning times.

Issue: 
https://github.com/heroku/dogwood/issues/1825