### PR TITLE
spaces: add vpn:connect command

### DIFF
--- a/packages/spaces/commands/vpn/connect.js
+++ b/packages/spaces/commands/vpn/connect.js
@@ -35,7 +35,7 @@ module.exports = {
   help: `Example:
 
     $ heroku spaces:vpn:connect --name office --ip 35.161.69.30 --cidrs 172.16.0.0/16,10.0.0.0/24 --space my-space
-    Creating VPN in space my-space... done
+    Creating VPN Connection in space my-space... done
     ▸    Use spaces:vpn:wait to track allocation.
   `,
   hidden: true,

--- a/packages/spaces/commands/vpn/connect.js
+++ b/packages/spaces/commands/vpn/connect.js
@@ -24,7 +24,7 @@ function * run (context, heroku) {
   check(cidrs, 'CIDRs required')
   cidrs = parsers.splitCsv(cidrs)
 
-  yield cli.action(`Creating VPN in space ${cli.color.green(space)}`, lib.postVPNConnections(space, name, ip, cidrs))
+  yield cli.action(`Creating VPN Connection in space ${cli.color.green(space)}`, lib.postVPNConnections(space, name, ip, cidrs))
   cli.warn('Use spaces:vpn:wait to track allocation.')
 }
 

--- a/packages/spaces/commands/vpn/connect.js
+++ b/packages/spaces/commands/vpn/connect.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const cli = require('heroku-cli-util')
+const co = require('co')
+const parsers = require('../../lib/parsers')()
+
+function check (val, message) {
+  if (!val) throw new Error(`${message}.\nUSAGE: heroku spaces:vpn:connect --name office --ip 35.161.69.30 --cidrs 172.16.0.0/16,10.0.0.0/24 --space example-space`)
+}
+
+function * run (context, heroku) {
+  let lib = require('../../lib/vpn-connections')(heroku)
+
+  let space = context.flags.space || context.args.space
+  check(space, 'Space name required')
+
+  let name = context.flags.name
+  check(name, 'VPN name required')
+
+  let ip = context.flags.ip
+  check(ip, 'IP required')
+
+  let cidrs = context.flags.cidrs
+  check(cidrs, 'CIDRs required')
+  cidrs = parsers.splitCsv(cidrs)
+
+  yield cli.action(`Creating VPN in space ${cli.color.green(space)}`, lib.postVPNConnections(space, name, ip, cidrs))
+  cli.warn('Use spaces:vpn:wait to track allocation.')
+}
+
+module.exports = {
+  topic: 'spaces',
+  command: 'vpn:connect',
+  description: 'create VPN',
+  help: `Example:
+
+    $ heroku spaces:vpn:connect --name office --ip 35.161.69.30 --cidrs 172.16.0.0/16,10.0.0.0/24 --space my-space
+    Creating VPN in space my-space... done
+    ▸    Use spaces:vpn:wait to track allocation.
+  `,
+  hidden: true,
+  needsApp: false,
+  needsAuth: true,
+  args: [
+    {name: 'space', optional: true, hidden: true}
+  ],
+  flags: [
+    {name: 'name', char: 'n', hasValue: true, description: 'VPN name'},
+    {name: 'ip', char: 'i', hasValue: true, description: 'public IP of customer gateway'},
+    {name: 'cidrs', char: 'c', hasValue: true, description: 'a list of routable CIDRs separated by commas'},
+    {name: 'space', char: 's', hasValue: true, description: 'space name'}
+  ],
+  run: cli.command(co.wrap(run))
+}

--- a/packages/spaces/index.js
+++ b/packages/spaces/index.js
@@ -16,6 +16,7 @@ exports.commands = [
   require('./commands/peering/index'),
   require('./commands/peering/accept'),
   require('./commands/peering/destroy'),
+  require('./commands/vpn/connect'),
   require('./commands/vpn/create'),
   require('./commands/vpn/info'),
   require('./commands/vpn/config'),

--- a/packages/spaces/lib/vpn-connections.js
+++ b/packages/spaces/lib/vpn-connections.js
@@ -1,0 +1,24 @@
+'use strict'
+
+module.exports = function (heroku) {
+  function postVPNConnections (space, name, ip, cidrs) {
+    return request('POST', `/spaces/${space}/vpn-connections`, {
+      name: name,
+      public_ip: ip,
+      routable_cidrs: cidrs
+    })
+  }
+
+  function request (method, path, body) {
+    return heroku.request({
+      method: method,
+      path: path,
+      body: body,
+      headers: { Accept: 'application/vnd.heroku+json; version=3.dogwood' }
+    })
+  }
+
+  return {
+    postVPNConnections
+  }
+}

--- a/packages/spaces/lib/vpn-connections.js
+++ b/packages/spaces/lib/vpn-connections.js
@@ -13,8 +13,7 @@ module.exports = function (heroku) {
     return heroku.request({
       method: method,
       path: path,
-      body: body,
-      headers: { Accept: 'application/vnd.heroku+json; version=3.dogwood' }
+      body: body
     })
   }
 

--- a/packages/spaces/test/commands/vpn/connect.js
+++ b/packages/spaces/test/commands/vpn/connect.js
@@ -1,0 +1,30 @@
+'use strict'
+/* globals describe beforeEach it */
+
+const nock = require('nock')
+const cmd = require('../../../commands/vpn/connect')
+const expect = require('chai').expect
+const cli = require('heroku-cli-util')
+
+describe('spaces:vpn:connect', function () {
+  beforeEach(() => cli.mockConsole())
+
+  it('creates VPN', function () {
+    let api = nock('https://api.heroku.com:443')
+      .post('/spaces/my-space/vpn-connections', {
+        name: 'office',
+        public_ip: '192.168.0.1',
+        routable_cidrs: [ '192.168.0.1/16', '192.168.0.2/16' ]
+      })
+      .reply(201)
+    return cmd.run({flags: {
+      name: 'office',
+      space: 'my-space',
+      ip: '192.168.0.1',
+      cidrs: '192.168.0.1/16,192.168.0.2/16'
+    }})
+      .then(() => expect(cli.stderr).to.equal(
+        `Creating VPN in space my-space... done\n ▸    Use spaces:vpn:wait to track allocation.\n`))
+      .then(() => api.done())
+  })
+})

--- a/packages/spaces/test/commands/vpn/connect.js
+++ b/packages/spaces/test/commands/vpn/connect.js
@@ -24,7 +24,7 @@ describe('spaces:vpn:connect', function () {
       cidrs: '192.168.0.1/16,192.168.0.2/16'
     }})
       .then(() => expect(cli.stderr).to.equal(
-        `Creating VPN in space my-space... done\n ▸    Use spaces:vpn:wait to track allocation.\n`))
+        `Creating VPN Connection in space my-space... done\n ▸    Use spaces:vpn:wait to track allocation.\n`))
       .then(() => api.done())
   })
 })


### PR DESCRIPTION
Existing `spaces:vpn` commands assume there can only ever be a single VPN connection for a space. This begins re-working them for the new UX designed to enable future support for multiple connections, starting with a `vpn:connect` command to set up a VPN connection.

The connect command accepts a name argument and passes it to the new `/vpn-connections` endpoint in API.