### PR TITLE
space: update vpn:destroy for multiple vpn connections

### DIFF
--- a/packages/spaces/commands/vpn/destroy.js
+++ b/packages/spaces/commands/vpn/destroy.js
@@ -12,13 +12,14 @@ function * run (context, heroku) {
   check(space, 'Space name required')
 
   let name = context.args.name
-  check(name, 'VPN name required')
+  // For when we've fully migrated to the multiple VPN UX
+  // check(name, 'VPN name required')
 
   let lib = require('../../lib/vpn')(heroku)
 
   yield cli.confirmApp(space, context.flags.confirm, `Destructive Action
 This command will attempt to destroy the specified VPN Connection in space ${cli.color.green(space)}`)
-  yield cli.action(`Tearing down VPN Connection in space ${cli.color.cyan(space)}`, lib.deleteVPN(space))
+  yield cli.action(`Tearing down VPN Connection in space ${cli.color.cyan(space)}`, lib.deleteVPNConnection(space, name))
 }
 
 module.exports = {
@@ -34,7 +35,7 @@ module.exports = {
   needsApp: false,
   needsAuth: true,
   args: [
-    {name: 'name', optional: false, hidden: false}
+    {name: 'name', optional: true, hidden: false}
   ],
   flags: [
     {name: 'space', char: 's', hasValue: true, description: 'space to get peering info from'},

--- a/packages/spaces/commands/vpn/destroy.js
+++ b/packages/spaces/commands/vpn/destroy.js
@@ -11,7 +11,7 @@ function * run (context, heroku) {
   let space = context.flags.space || context.args.space
   check(space, 'Space name required')
 
-  let name = context.args.name
+  let name = context.args && context.args.name
   // For when we've fully migrated to the multiple VPN UX
   // check(name, 'VPN name required')
 

--- a/packages/spaces/commands/vpn/destroy.js
+++ b/packages/spaces/commands/vpn/destroy.js
@@ -4,7 +4,7 @@ const cli = require('heroku-cli-util')
 const co = require('co')
 
 function check (val, message) {
-  if (!val) throw new Error(`${message}.\nUSAGE: heroku spaces:vpn:destroy --space example-space vpn-connection-name-or-uuid`)
+  if (!val) throw new Error(`${message}.\nUSAGE: heroku spaces:vpn:destroy --space example-space vpn-connection-name`)
 }
 
 function * run (context, heroku) {
@@ -28,7 +28,7 @@ module.exports = {
   description: 'destroys VPN in a private space',
   help: `Example:
 
-    $ heroku spaces:vpn:destroy --confirm --space example-space vpn-connection-name-or-uuid
+    $ heroku spaces:vpn:destroy --confirm --space example-space vpn-connection-name
     Tearing down VPN Connection in space example-space
   `,
   hidden: true,

--- a/packages/spaces/commands/vpn/destroy.js
+++ b/packages/spaces/commands/vpn/destroy.js
@@ -3,15 +3,22 @@
 const cli = require('heroku-cli-util')
 const co = require('co')
 
+function check (val, message) {
+  if (!val) throw new Error(`${message}.\nUSAGE: heroku spaces:vpn:destroy --space example-space vpn-connection-name-or-uuid`)
+}
+
 function * run (context, heroku) {
   let space = context.flags.space || context.args.space
-  if (!space) throw new Error('Space name required.\nUSAGE: heroku spaces:vpn:destroy --space my-space')
+  check(space, 'Space name required')
+
+  let name = context.args.name
+  check(name, 'VPN name required')
 
   let lib = require('../../lib/vpn')(heroku)
 
   yield cli.confirmApp(space, context.flags.confirm, `Destructive Action
-This command will attempt to destroy VPN in space ${cli.color.green(space)}`)
-  yield cli.action(`Tearing down VPN in space ${cli.color.cyan(space)}`, lib.deleteVPN(space))
+This command will attempt to destroy the specified VPN Connection in space ${cli.color.green(space)}`)
+  yield cli.action(`Tearing down VPN Connection in space ${cli.color.cyan(space)}`, lib.deleteVPN(space))
 }
 
 module.exports = {
@@ -20,13 +27,15 @@ module.exports = {
   description: 'destroys VPN in a private space',
   help: `Example:
 
-    $ heroku spaces:vpn:destroy --confirm --space my-space
-    Tearing down VPN in space my-space
+    $ heroku spaces:vpn:destroy --confirm --space example-space vpn-connection-name-or-uuid
+    Tearing down VPN Connection in space example-space
   `,
   hidden: true,
   needsApp: false,
   needsAuth: true,
-  args: [{name: 'space', optional: true, hidden: true}],
+  args: [
+    {name: 'name', optional: false, hidden: false}
+  ],
   flags: [
     {name: 'space', char: 's', hasValue: true, description: 'space to get peering info from'},
     {name: 'confirm', hasValue: true, description: 'set to space name bypass confirm prompt'}

--- a/packages/spaces/commands/vpn/destroy.js
+++ b/packages/spaces/commands/vpn/destroy.js
@@ -15,7 +15,7 @@ function * run (context, heroku) {
   // For when we've fully migrated to the multiple VPN UX
   // check(name, 'VPN name required')
 
-  let lib = require('../../lib/vpn')(heroku)
+  let lib = require('../../lib/vpn-connections')(heroku)
 
   yield cli.confirmApp(space, context.flags.confirm, `Destructive Action
 This command will attempt to destroy the specified VPN Connection in space ${cli.color.green(space)}`)

--- a/packages/spaces/lib/vpn-connections.js
+++ b/packages/spaces/lib/vpn-connections.js
@@ -10,6 +10,8 @@ module.exports = function (heroku) {
   }
 
   function deleteVPNConnection (space, name) {
+    let lib = require('../lib/vpn')(heroku)
+
     if (!name) {
       return lib.deleteVPN(space)
     }

--- a/packages/spaces/lib/vpn-connections.js
+++ b/packages/spaces/lib/vpn-connections.js
@@ -10,6 +10,10 @@ module.exports = function (heroku) {
   }
 
   function deleteVPNConnection (space, name) {
+    if (!name) {
+      return lib.deleteVPN(space)
+    }
+
     return request('DELETE', `/spaces/${space}/vpn-connections/${name}`)
   }
 

--- a/packages/spaces/lib/vpn-connections.js
+++ b/packages/spaces/lib/vpn-connections.js
@@ -9,6 +9,10 @@ module.exports = function (heroku) {
     })
   }
 
+  function deleteVPNConnection (space, name) {
+    return request('DELETE', `/spaces/${space}/vpn-connections/${name}`)
+  }
+
   function request (method, path, body) {
     return heroku.request({
       method: method,
@@ -18,6 +22,7 @@ module.exports = function (heroku) {
   }
 
   return {
-    postVPNConnections
+    postVPNConnections,
+    deleteVPNConnection
   }
 }

--- a/packages/spaces/test/commands/vpn/destroy.js
+++ b/packages/spaces/test/commands/vpn/destroy.js
@@ -21,11 +21,11 @@ describe('spaces:vpn:destroy', function () {
 
   it('destroys VPN when no name is specified', function () {
     let api = nock('https://api.heroku.com:443')
-    .delete('/spaces/my-space/vpn')
-    .reply(202)
+      .delete('/spaces/my-space/vpn')
+      .reply(202)
   return cmd.run({flags: {space: 'my-space', confirm: 'my-space'}})
-    .then(() => expect(cli.stderr).to.equal(
-      `Tearing down VPN Connection in space my-space... done\n`))
-    .then(() => api.done())
+      .then(() => expect(cli.stderr).to.equal(
+        `Tearing down VPN Connection in space my-space... done\n`))
+      .then(() => api.done())
   })
 })

--- a/packages/spaces/test/commands/vpn/destroy.js
+++ b/packages/spaces/test/commands/vpn/destroy.js
@@ -9,13 +9,13 @@ const cli = require('heroku-cli-util')
 describe('spaces:vpn:destroy', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('destroys VPN', function () {
+  it('destroys VPN Connection', function () {
     let api = nock('https://api.heroku.com:443')
-      .delete('/spaces/my-space/vpn')
+      .delete('/spaces/my-space/vpn-connections/my-vpn-connection')
       .reply(202)
-    return cmd.run({flags: {space: 'my-space', confirm: 'my-space'}})
+    return cmd.run({args: {name: 'my-vpn-connection'}, flags: {space: 'my-space', confirm: 'my-space'}})
       .then(() => expect(cli.stderr).to.equal(
-        `Tearing down VPN in space my-space... done\n`))
+        `Tearing down VPN Connection in space my-space... done\n`))
       .then(() => api.done())
   })
 })

--- a/packages/spaces/test/commands/vpn/destroy.js
+++ b/packages/spaces/test/commands/vpn/destroy.js
@@ -23,7 +23,7 @@ describe('spaces:vpn:destroy', function () {
     let api = nock('https://api.heroku.com:443')
       .delete('/spaces/my-space/vpn')
       .reply(202)
-  return cmd.run({flags: {space: 'my-space', confirm: 'my-space'}})
+    return cmd.run({flags: {space: 'my-space', confirm: 'my-space'}})
       .then(() => expect(cli.stderr).to.equal(
         `Tearing down VPN Connection in space my-space... done\n`))
       .then(() => api.done())

--- a/packages/spaces/test/commands/vpn/destroy.js
+++ b/packages/spaces/test/commands/vpn/destroy.js
@@ -9,7 +9,7 @@ const cli = require('heroku-cli-util')
 describe('spaces:vpn:destroy', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('destroys VPN Connection', function () {
+  it('destroys VPN Connection when name is specified', function () {
     let api = nock('https://api.heroku.com:443')
       .delete('/spaces/my-space/vpn-connections/my-vpn-connection')
       .reply(202)
@@ -17,5 +17,15 @@ describe('spaces:vpn:destroy', function () {
       .then(() => expect(cli.stderr).to.equal(
         `Tearing down VPN Connection in space my-space... done\n`))
       .then(() => api.done())
+  })
+
+  it('destroys VPN when no name is specified', function () {
+    let api = nock('https://api.heroku.com:443')
+    .delete('/spaces/my-space/vpn')
+    .reply(202)
+  return cmd.run({flags: {space: 'my-space', confirm: 'my-space'}})
+    .then(() => expect(cli.stderr).to.equal(
+      `Tearing down VPN Connection in space my-space... done\n`))
+    .then(() => api.done())
   })
 })


### PR DESCRIPTION
This re-works the `vpn:destroy` command to function properly with the new UX design that allows multiple VPN connections.