### PR TITLE
Update vpn wait / info / config

### DIFF
--- a/packages/spaces/commands/vpn/config.js
+++ b/packages/spaces/commands/vpn/config.js
@@ -24,7 +24,7 @@ function displayVPNConfigInfo (space, name, config) {
 }
 
 function check (val, message) {
-  if (!val) throw new Error(`${message}.\nUSAGE: heroku spaces:vpn:info --space example-space --name vpn-connection-name`)
+  if (!val) throw new Error(`${message}.\nUSAGE: heroku spaces:vpn:config --space my-space vpn-connection-name`)
 }
 
 function * run (context, heroku) {
@@ -50,7 +50,7 @@ module.exports = {
   description: 'display the configuration information for VPN',
   help: `Example:
 
-    $ heroku spaces:vpn:config example-space --name vpn-connection-name
+    $ heroku spaces:vpn:config --space my-space vpn-connection-name
     === vpn-connection-name VPN Tunnels
     VPN Tunnel  Customer Gateway  VPN Gateway     Pre-shared Key  Routable Subnets  IKE Version
     ──────────  ────────────────  ──────────────  ──────────────  ────────────────  ───────────

--- a/packages/spaces/commands/vpn/config.js
+++ b/packages/spaces/commands/vpn/config.js
@@ -67,7 +67,7 @@ You will use the information provided by this command to establish a Private Spa
   hidden: true,
   needsApp: false,
   needsAuth: true,
-  args: [{name: 'space', optional: true, hidden: true}],
+  args: [{name: 'name', optional: true, hidden: true}],
   flags: [
     {name: 'space', char: 's', hasValue: true, description: 'space the VPN connection belongs to'},
     {name: 'name', char: 'n', hasValue: true, description: 'name or id of the VPN connection to retrieve config from'},

--- a/packages/spaces/commands/vpn/config.js
+++ b/packages/spaces/commands/vpn/config.js
@@ -4,7 +4,7 @@ const cli = require('heroku-cli-util')
 const co = require('co')
 
 function displayVPNConfigInfo (space, name, config) {
-  cli.styledHeader(`${name} VPNs`)
+  cli.styledHeader(`${name} VPN Tunnels`)
   config.tunnels.forEach((val, i) => {
     val.tunnel_id = 'Tunnel ' + (i + 1)
     val.routable_cidr = config.space_cidr_block
@@ -23,10 +23,16 @@ function displayVPNConfigInfo (space, name, config) {
   })
 }
 
+function check (val, message) {
+  if (!val) throw new Error(`${message}.\nUSAGE: heroku spaces:vpn:info --space example-space --name vpn-connection-name`)
+}
+
 function * run (context, heroku) {
   let space = context.flags.space || context.args.space
+  check(space, 'Space name required')
+
   let name = context.flags.name || context.args.name
-  if (!space) throw new Error('Space name required.\nUSAGE: heroku spaces:vpn:config --space my-space')
+  check(name, 'VPN connection name required')
 
   let lib = require('../../lib/vpn-connections')(heroku)
   let config = yield lib.getVPNConnection(space, name)
@@ -45,7 +51,7 @@ module.exports = {
   help: `Example:
 
     $ heroku spaces:vpn:config example-space --name vpn-connection-name
-    === vpn-connection-name VPNs
+    === vpn-connection-name VPN Tunnels
     VPN Tunnel  Customer Gateway  VPN Gateway     Pre-shared Key  Routable Subnets  IKE Version
     ──────────  ────────────────  ──────────────  ──────────────  ────────────────  ───────────
     Tunnel 1    104.196.121.200   35.171.237.136  abcdef12345     10.0.0.0/16       1

--- a/packages/spaces/commands/vpn/config.js
+++ b/packages/spaces/commands/vpn/config.js
@@ -44,8 +44,8 @@ module.exports = {
   description: 'display the configuration information for VPN',
   help: `Example:
 
-    $ heroku spaces:vpn:config example-space
-    === example-space VPNs
+    $ heroku spaces:vpn:config example-space --name vpn-connection-name
+    === vpn-connection-name VPNs
     VPN Tunnel  Customer Gateway  VPN Gateway     Pre-shared Key  Routable Subnets  IKE Version
     ──────────  ────────────────  ──────────────  ──────────────  ────────────────  ───────────
     Tunnel 1    104.196.121.200   35.171.237.136  abcdef12345     10.0.0.0/16       1

--- a/packages/spaces/commands/vpn/config.js
+++ b/packages/spaces/commands/vpn/config.js
@@ -63,8 +63,8 @@ You will use the information provided by this command to establish a Private Spa
   needsAuth: true,
   args: [{name: 'space', optional: true, hidden: true}],
   flags: [
-    {name: 'space', char: 's', hasValue: true, description: 'space to get VPN config from'},
-    {name: 'name', char: 'n', hasValue: true, description: 'name of the VPN connection to retrieve config from'},
+    {name: 'space', char: 's', hasValue: true, description: 'space the VPN connection belongs to'},
+    {name: 'name', char: 'n', hasValue: true, description: 'name or id of the VPN connection to retrieve config from'},
     {name: 'json', description: 'output in json format'}
   ],
   run: cli.command(co.wrap(run))

--- a/packages/spaces/commands/vpn/info.js
+++ b/packages/spaces/commands/vpn/info.js
@@ -94,7 +94,7 @@ module.exports = {
   hidden: true,
   needsApp: false,
   needsAuth: true,
-  args: [{name: 'space', optional: false, hidden: true}],
+  args: [{name: 'name', optional: true, hidden: true}],
   flags: [
     {name: 'space', char: 's', hasValue: true, description: 'space the vpn connection belongs to'},
     {name: 'json', description: 'output in json format'},

--- a/packages/spaces/commands/vpn/info.js
+++ b/packages/spaces/commands/vpn/info.js
@@ -37,7 +37,7 @@ function render (space, name, info, flags) {
 }
 
 function check (val, message) {
-  if (!val) throw new Error(`${message}.\nUSAGE: heroku spaces:vpn:info --space example-space --name vpn-connection-name`)
+  if (!val) throw new Error(`${message}.\nUSAGE: heroku spaces:vpn:info --space my-space vpn-connection-name`)
 }
 
 function * run (context, heroku) {
@@ -58,7 +58,7 @@ module.exports = {
   description: 'display the information for VPN',
   help: `Example:
 
-    $ heroku spaces:vpn:info my-space --name vpn-connection-name
+    $ heroku spaces:vpn:info --space my-space vpn-connection-name
     === vpn-connection-name VPN Tunnel Info
     Name:           vpn-connection-name
     ID:             123456789012

--- a/packages/spaces/commands/vpn/info.js
+++ b/packages/spaces/commands/vpn/info.js
@@ -93,7 +93,7 @@ module.exports = {
   flags: [
     {name: 'space', char: 's', hasValue: true, description: 'space the vpn connection belongs to'},
     {name: 'json', description: 'output in json format'},
-    {name: 'name', char: 'n', hasValue: true, description: 'name or UUID of the VPN connection to get info from'}
+    {name: 'name', char: 'n', hasValue: true, description: 'name or id of the VPN connection to get info from'}
   ],
   run: cli.command(co.wrap(run)),
   render: render

--- a/packages/spaces/commands/vpn/info.js
+++ b/packages/spaces/commands/vpn/info.js
@@ -4,7 +4,7 @@ const cli = require('heroku-cli-util')
 const co = require('co')
 const format = require('../../lib/format')()
 
-function displayVPNInfo (space, info) {
+function displayVPNInfo (space, name, info) {
   let sF = function (s) {
     let colored = s
     switch (s) {
@@ -25,23 +25,22 @@ function displayVPNInfo (space, info) {
     return colored
   }
 
-  cli.styledHeader(`${space} VPN Info`)
+  cli.styledHeader(`${name} VPN Info`)
   cli.styledObject({
     ID: info.id,
     'Public IP': info.public_ip,
     'Routable CIDRs': format.CIDR(info.routable_cidrs),
-    State: `${sF(info.state)}`,
-    'Provisioning Status': info.status,
+    'Status': info.status,
     'Status Message': info.status_message
-  }, ['ID', 'Public IP', 'Routable CIDRs', 'State', 'Provisioning Status', 'Status Message'])
+  }, ['ID', 'Public IP', 'Routable CIDRs', 'State', 'Status', 'Status Message'])
 
   // make up tunnel IDs
   info.tunnels.forEach((val, i) => { val.tunnel_id = 'Tunnel ' + (i + 1) })
-  cli.styledHeader(`${space} Tunnel Info`)
+  cli.styledHeader(`${name} Tunnel Info`)
   cli.table(info.tunnels, {
     columns: [
       {key: 'tunnel_id', label: 'VPN Tunnel'},
-      {key: 'outside_ip_address', label: 'IP Address'},
+      {key: 'ip', label: 'IP Address'},
       {key: 'status', label: 'Status', format: status => sF(status)},
       {key: 'last_status_change', label: 'Status Last Changed'},
       {key: 'status_message', label: 'Details'}
@@ -49,21 +48,23 @@ function displayVPNInfo (space, info) {
   })
 }
 
-function render (space, info, flags) {
+function render (space, name, info, flags) {
   if (flags.json) {
     cli.styledJSON(info)
   } else {
-    displayVPNInfo(space, info)
+    displayVPNInfo(space, name, info)
   }
 }
 
 function * run (context, heroku) {
   let space = context.flags.space || context.args.space
+  let name = context.flags.name || context.args.name
   if (!space) throw new Error('Space name required.\nUSAGE: heroku spaces:vpn:info --space my-space')
+  if (!name) throw new Error('VPN connection name required.\nUSAGE: heroku spaces:vpn:info --space my-space --name vpn-connection-name')
 
-  let lib = require('../../lib/vpn')(heroku)
-  let info = yield lib.getVPNInfo(space)
-  render(space, info, context.flags)
+  let lib = require('../../lib/vpn-connections')(heroku)
+  let info = yield lib.getVPNConnection(space, name)
+  render(space, name, info, context.flags)
 }
 
 module.exports = {
@@ -72,12 +73,12 @@ module.exports = {
   description: 'display the information for VPN',
   help: `Example:
 
-    $ heroku spaces:vpn:info my-space
-    === my-space VPN Info
+    $ heroku spaces:vpn:info my-space vpn-connection-name
+    === vpn-connection-name VPN Info
+    Name:           vpn-connection-name
     ID:             123456789012
     Public IP:      35.161.69.30
     Routable CIDRs: 172.16.0.0/16
-    State:          available
     Status:         failed
     Status Message: supplied CIDR block already in use
     === my-space Tunnel Info
@@ -88,10 +89,11 @@ module.exports = {
   hidden: true,
   needsApp: false,
   needsAuth: true,
-  args: [{name: 'space', optional: true, hidden: true}],
+  args: [{name: 'space', optional: false, hidden: true}, {name: 'name', optional: false, hidden: false}],
   flags: [
-    {name: 'space', char: 's', hasValue: true, description: 'space to get VPN info from'},
-    {name: 'json', description: 'output in json format'}
+    {name: 'space', char: 's', hasValue: true, description: 'space the vpn connection belongs to'},
+    {name: 'json', description: 'output in json format'},
+    {name: 'name', char: 'n', hasValue: true, description: 'name or UUID of the VPN connection to get info from'}
   ],
   run: cli.command(co.wrap(run)),
   render: render

--- a/packages/spaces/commands/vpn/info.js
+++ b/packages/spaces/commands/vpn/info.js
@@ -36,7 +36,7 @@ function displayVPNInfo (space, name, info) {
 
   // make up tunnel IDs
   info.tunnels.forEach((val, i) => { val.tunnel_id = 'Tunnel ' + (i + 1) })
-  cli.styledHeader(`${name} Tunnel Info`)
+  cli.styledHeader(`${name} VPN Tunnel Info`)
   cli.table(info.tunnels, {
     columns: [
       {key: 'tunnel_id', label: 'VPN Tunnel'},
@@ -56,11 +56,16 @@ function render (space, name, info, flags) {
   }
 }
 
+function check (val, message) {
+  if (!val) throw new Error(`${message}.\nUSAGE: heroku spaces:vpn:info --space example-space --name vpn-connection-name`)
+}
+
 function * run (context, heroku) {
   let space = context.flags.space || context.args.space
+  check(space, 'Space name required')
+
   let name = context.flags.name || context.args.name
-  if (!space) throw new Error('Space name required.\nUSAGE: heroku spaces:vpn:info --space my-space')
-  if (!name) throw new Error('VPN connection name required.\nUSAGE: heroku spaces:vpn:info --space my-space --name vpn-connection-name')
+  check(name, 'VPN connection name required')
 
   let lib = require('../../lib/vpn-connections')(heroku)
   let info = yield lib.getVPNConnection(space, name)
@@ -74,7 +79,7 @@ module.exports = {
   help: `Example:
 
     $ heroku spaces:vpn:info my-space --name vpn-connection-name
-    === vpn-connection-name VPN Info
+    === vpn-connection-name VPN Tunnel Info
     Name:           vpn-connection-name
     ID:             123456789012
     Public IP:      35.161.69.30

--- a/packages/spaces/commands/vpn/info.js
+++ b/packages/spaces/commands/vpn/info.js
@@ -4,13 +4,13 @@ const cli = require('heroku-cli-util')
 const co = require('co')
 const format = require('../../lib/format')()
 
-function displayVPNInfo (space, info) {
+function displayVPNInfo (space, name, info) {
   cli.styledHeader(`${name} VPN Info`)
   cli.styledObject({
     ID: info.id,
     'Public IP': info.public_ip,
     'Routable CIDRs': format.CIDR(info.routable_cidrs),
-    'Status': `${format.VPNStatus(info.state)}`,
+    'Status': `${format.VPNStatus(info.status)}`,
     'Status Message': info.status_message
   }, ['ID', 'Public IP', 'Routable CIDRs', 'State', 'Status', 'Status Message'])
 
@@ -21,7 +21,7 @@ function displayVPNInfo (space, info) {
     columns: [
       {key: 'tunnel_id', label: 'VPN Tunnel'},
       {key: 'ip', label: 'IP Address'},
-      {key: 'status', label: 'Status', format: status => sF(status)},
+      {key: 'status', label: 'Status', format: status => format.VPNStatus(status)},
       {key: 'last_status_change', label: 'Status Last Changed'},
       {key: 'status_message', label: 'Details'}
     ]

--- a/packages/spaces/commands/vpn/info.js
+++ b/packages/spaces/commands/vpn/info.js
@@ -73,7 +73,7 @@ module.exports = {
   description: 'display the information for VPN',
   help: `Example:
 
-    $ heroku spaces:vpn:info my-space vpn-connection-name
+    $ heroku spaces:vpn:info my-space --name vpn-connection-name
     === vpn-connection-name VPN Info
     Name:           vpn-connection-name
     ID:             123456789012
@@ -89,7 +89,7 @@ module.exports = {
   hidden: true,
   needsApp: false,
   needsAuth: true,
-  args: [{name: 'space', optional: false, hidden: true}, {name: 'name', optional: false, hidden: false}],
+  args: [{name: 'space', optional: false, hidden: true}],
   flags: [
     {name: 'space', char: 's', hasValue: true, description: 'space the vpn connection belongs to'},
     {name: 'json', description: 'output in json format'},

--- a/packages/spaces/commands/vpn/wait.js
+++ b/packages/spaces/commands/vpn/wait.js
@@ -52,7 +52,7 @@ module.exports = {
   hidden: true,
   needsApp: false,
   needsAuth: true,
-  args: [{name: 'space', optional: true, hidden: true}, {name: 'name', optional: true, hidden: true}],
+  args: [{name: 'space', optional: true, hidden: true}],
   flags: [
     {name: 'space', char: 's', hasValue: true, description: 'space the vpn connection belongs to'},
     {name: 'name', char: 'n', hasValue: true, description: 'name of the vpn connection to wait for'},

--- a/packages/spaces/commands/vpn/wait.js
+++ b/packages/spaces/commands/vpn/wait.js
@@ -55,7 +55,7 @@ module.exports = {
   args: [{name: 'space', optional: true, hidden: true}],
   flags: [
     {name: 'space', char: 's', hasValue: true, description: 'space the vpn connection belongs to'},
-    {name: 'name', char: 'n', hasValue: true, description: 'name of the vpn connection to wait for'},
+    {name: 'name', char: 'n', hasValue: true, description: 'name or id of the vpn connection to wait for'},
     {name: 'json', description: 'output in json format'},
     {name: 'interval', char: 'i', hasValue: true, description: 'seconds to wait between poll intervals'},
     {name: 'timeout', char: 't', hasValue: true, description: 'maximum number of seconds to wait'}

--- a/packages/spaces/commands/vpn/wait.js
+++ b/packages/spaces/commands/vpn/wait.js
@@ -5,11 +5,15 @@ const co = require('co')
 const infoCmd = require('./info')
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
+function check (val, message) {
+  if (!val) throw new Error(`${message}.\nUSAGE: heroku spaces:vpn:wait my-space --name vpn-connection-name`)
+}
+
 function * run (context, heroku) {
   const space = context.flags.space || context.args.space
+  check(space, 'Space name required')
   const name = context.flags.name || context.args.name
-  if (!space) throw new Error('Space name required.\nUSAGE: heroku spaces:vpn:wait my-space')
-  if (!space) throw new Error('VPN connection name required.\nUSAGE: heroku spaces:vpn:wait my-space --name vpn-connection-name')
+  check(name, 'VPN connection name required')
 
   const interval = (typeof context.flags.interval !== 'undefined' ? context.flags.interval : 10) * 1000
   const timeout = (typeof context.flags.timeout !== 'undefined' ? context.flags.timeout : 20 * 60) * 1000

--- a/packages/spaces/commands/vpn/wait.js
+++ b/packages/spaces/commands/vpn/wait.js
@@ -52,7 +52,7 @@ module.exports = {
   hidden: true,
   needsApp: false,
   needsAuth: true,
-  args: [{name: 'space', optional: true, hidden: true}],
+  args: [{name: 'name', optional: true, hidden: true}],
   flags: [
     {name: 'space', char: 's', hasValue: true, description: 'space the vpn connection belongs to'},
     {name: 'name', char: 'n', hasValue: true, description: 'name or id of the vpn connection to wait for'},

--- a/packages/spaces/commands/vpn/wait.js
+++ b/packages/spaces/commands/vpn/wait.js
@@ -7,12 +7,14 @@ const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
 function * run (context, heroku) {
   const space = context.flags.space || context.args.space
+  const name = context.flags.name || context.args.name
   if (!space) throw new Error('Space name required.\nUSAGE: heroku spaces:vpn:wait my-space')
+  if (!space) throw new Error('VPN connection name required.\nUSAGE: heroku spaces:vpn:wait my-space --name vpn-connection-name')
 
   const interval = (typeof context.flags.interval !== 'undefined' ? context.flags.interval : 10) * 1000
   const timeout = (typeof context.flags.timeout !== 'undefined' ? context.flags.timeout : 20 * 60) * 1000
   const deadline = new Date(new Date().getTime() + timeout)
-  const spinner = new cli.Spinner({text: `Waiting for VPN in space ${cli.color.green(space)} to allocate...`})
+  const spinner = new cli.Spinner({text: `Waiting for VPN Connection ${cli.color.green(name)} to allocate...`})
 
   spinner.start()
 
@@ -20,7 +22,7 @@ function * run (context, heroku) {
   let info = {}
   do {
     try {
-      info = yield lib.getVPNInfo(space)
+      info = yield lib.getVPNInfo(space, name)
     } catch (e) {
       // if 404 is received while in this loop, the VPN was deleted because provisioning failed
       if (e.statusCode !== 422) { // ignore 422 since that means VPN is not ready
@@ -37,22 +39,23 @@ function * run (context, heroku) {
     }
 
     yield wait(interval)
-  } while (info.state !== 'available')
+  } while (info.status !== 'available')
 
   spinner.stop('done\n')
-  infoCmd.render(space, info, context.flags)
+  infoCmd.render(space, name, info, context.flags)
 }
 
 module.exports = {
   topic: 'spaces',
   command: 'vpn:wait',
-  description: 'wait for VPN to be created',
+  description: 'wait for VPN Connection to be created',
   hidden: true,
   needsApp: false,
   needsAuth: true,
-  args: [{name: 'space', optional: true, hidden: true}],
+  args: [{name: 'space', optional: true, hidden: true}, {name: 'name', optional: true, hidden: true}],
   flags: [
-    {name: 'space', char: 's', hasValue: true, description: 'space to wait for VPN from'},
+    {name: 'space', char: 's', hasValue: true, description: 'space the vpn connection belongs to'},
+    {name: 'name', char: 'n', hasValue: true, description: 'name of the vpn connection to wait for'},
     {name: 'json', description: 'output in json format'},
     {name: 'interval', char: 'i', hasValue: true, description: 'seconds to wait between poll intervals'},
     {name: 'timeout', char: 't', hasValue: true, description: 'maximum number of seconds to wait'}

--- a/packages/spaces/commands/vpn/wait.js
+++ b/packages/spaces/commands/vpn/wait.js
@@ -6,7 +6,7 @@ const infoCmd = require('./info')
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
 function check (val, message) {
-  if (!val) throw new Error(`${message}.\nUSAGE: heroku spaces:vpn:wait my-space --name vpn-connection-name`)
+  if (!val) throw new Error(`${message}.\nUSAGE: heroku spaces:vpn:wait --space my-space vpn-connection-name`)
 }
 
 function * run (context, heroku) {

--- a/packages/spaces/lib/vpn-connections.js
+++ b/packages/spaces/lib/vpn-connections.js
@@ -19,6 +19,10 @@ module.exports = function (heroku) {
     return request('DELETE', `/spaces/${space}/vpn-connections/${name}`)
   }
 
+  function getVPNConnection (space, name) {
+    return request('GET', `/spaces/${space}/vpn-connections/${name}`)
+  }
+
   function request (method, path, body) {
     return heroku.request({
       method: method,
@@ -29,6 +33,7 @@ module.exports = function (heroku) {
 
   return {
     postVPNConnections,
-    deleteVPNConnection
+    deleteVPNConnection,
+    getVPNConnection
   }
 }

--- a/packages/spaces/test/commands/vpn/config.js
+++ b/packages/spaces/test/commands/vpn/config.js
@@ -47,7 +47,7 @@ describe('spaces:vpn:config', function () {
       name: 'vpn-connection-name-config'
     }})
       .then(() => expect(cli.stdout).to.equal(
-        `=== vpn-connection-name-config VPNs
+        `=== vpn-connection-name-config VPN Tunnels
 VPN Tunnel  Customer Gateway  VPN Gateway    Pre-shared Key  Routable Subnets  IKE Version
 ──────────  ────────────────  ─────────────  ──────────────  ────────────────  ───────────
 Tunnel 1    52.44.146.197     52.44.146.196  apresharedkey1  10.0.0.0/16       1

--- a/packages/spaces/test/commands/vpn/config.js
+++ b/packages/spaces/test/commands/vpn/config.js
@@ -6,33 +6,33 @@ const cmd = require('../../../commands/vpn/config')
 const expect = require('chai').expect
 const cli = require('heroku-cli-util')
 
-let response = {
-  ipsec_tunnels: [
+let vpnResponse = {
+  id: '123456789012',
+  name: 'vpn-connection-name-config',
+  public_ip: '35.161.69.30',
+  routable_cidrs: [ '172.16.0.0/16' ],
+  ike_version: 1,
+  space_cidr_block: '10.0.0.0/16',
+  status: 'failed',
+  status_message: 'supplied CIDR block already in use',
+  tunnels: [
     {
-      customer_gateway: {
-        outside_address: { ip_address: '52.44.146.197' },
-        inside_address: { ip_address: '52.44.146.198' }
-      },
-      vpn_gateway: {
-        outside_address: { ip_address: '52.44.146.197' },
-        inside_address: { ip_address: '52.44.146.198' }
-      },
-      ike: { pre_shared_key: 'apresharedkey1' }
+      last_status_change: '2016-10-25T22:09:05Z',
+      ip: '52.44.146.196', // The one needed right now
+      customer_ip: '52.44.146.197',
+      pre_shared_key: 'apresharedkey1',
+      status: 'UP',
+      status_message: 'status message'
     },
     {
-      customer_gateway: {
-        outside_address: { ip_address: '52.44.146.196' },
-        inside_address: { ip_address: '52.44.146.198' }
-      },
-      vpn_gateway: {
-        outside_address: { ip_address: '52.44.146.196' },
-        inside_address: { ip_address: '52.44.146.198' }
-      },
-      ike: { pre_shared_key: 'apresharedkey2' }
+      last_status_change: '2016-10-25T22:09:05Z',
+      ip: '52.44.146.198',
+      customer_ip: '52.44.146.199',
+      pre_shared_key: 'apresharedkey2',
+      status: 'UP',
+      status_message: 'status message'
     }
-  ],
-  full_space_cidr_block: '10.0.0.0/16',
-  ike_version: 1
+  ]
 }
 
 describe('spaces:vpn:config', function () {
@@ -40,76 +40,60 @@ describe('spaces:vpn:config', function () {
 
   it('gets VPN config', function () {
     let api = nock('https://api.heroku.com:443')
-      .get('/spaces/my-space/vpn/config')
-      .reply(200, response)
+      .get('/spaces/my-space/vpn-connections/vpn-connection-name-config')
+      .reply(200, vpnResponse)
     return cmd.run({flags: {
-      space: 'my-space'
+      space: 'my-space',
+      name: 'vpn-connection-name-config'
     }})
       .then(() => expect(cli.stdout).to.equal(
-        `=== my-space VPNs
+        `=== vpn-connection-name-config VPNs
 VPN Tunnel  Customer Gateway  VPN Gateway    Pre-shared Key  Routable Subnets  IKE Version
 ──────────  ────────────────  ─────────────  ──────────────  ────────────────  ───────────
-Tunnel 1    52.44.146.197     52.44.146.197  apresharedkey1  10.0.0.0/16       1
-Tunnel 2    52.44.146.196     52.44.146.196  apresharedkey2  10.0.0.0/16       1\n`))
+Tunnel 1    52.44.146.197     52.44.146.196  apresharedkey1  10.0.0.0/16       1
+Tunnel 2    52.44.146.199     52.44.146.198  apresharedkey2  10.0.0.0/16       1\n`))
       .then(() => api.done())
   })
 
   it('gets VPN config in JSON', function () {
     let api = nock('https://api.heroku.com:443')
-      .get('/spaces/my-space/vpn/config')
-      .reply(200, response)
+      .get('/spaces/my-space/vpn-connections/vpn-connection-name-config')
+      .reply(200, vpnResponse)
     return cmd.run({flags: {
       space: 'my-space',
+      name: 'vpn-connection-name-config',
       json: true
     }})
       .then(() => expect(cli.stdout).to.equal(
         `{
-  "ipsec_tunnels": [
+  "id": "123456789012",
+  "name": "vpn-connection-name-config",
+  "public_ip": "35.161.69.30",
+  "routable_cidrs": [
+    "172.16.0.0/16"
+  ],
+  "ike_version": 1,
+  "space_cidr_block": "10.0.0.0/16",
+  "status": "failed",
+  "status_message": "supplied CIDR block already in use",
+  "tunnels": [
     {
-      "customer_gateway": {
-        "outside_address": {
-          "ip_address": "52.44.146.197"
-        },
-        "inside_address": {
-          "ip_address": "52.44.146.198"
-        }
-      },
-      "vpn_gateway": {
-        "outside_address": {
-          "ip_address": "52.44.146.197"
-        },
-        "inside_address": {
-          "ip_address": "52.44.146.198"
-        }
-      },
-      "ike": {
-        "pre_shared_key": "apresharedkey1"
-      }
+      "last_status_change": "2016-10-25T22:09:05Z",
+      "ip": "52.44.146.196",
+      "customer_ip": "52.44.146.197",
+      "pre_shared_key": "apresharedkey1",
+      "status": "UP",
+      "status_message": "status message"
     },
     {
-      "customer_gateway": {
-        "outside_address": {
-          "ip_address": "52.44.146.196"
-        },
-        "inside_address": {
-          "ip_address": "52.44.146.198"
-        }
-      },
-      "vpn_gateway": {
-        "outside_address": {
-          "ip_address": "52.44.146.196"
-        },
-        "inside_address": {
-          "ip_address": "52.44.146.198"
-        }
-      },
-      "ike": {
-        "pre_shared_key": "apresharedkey2"
-      }
+      "last_status_change": "2016-10-25T22:09:05Z",
+      "ip": "52.44.146.198",
+      "customer_ip": "52.44.146.199",
+      "pre_shared_key": "apresharedkey2",
+      "status": "UP",
+      "status_message": "status message"
     }
-  ],
-  "full_space_cidr_block": "10.0.0.0/16",
-  "ike_version": 1
+  ]
 }\n`))
       .then(() => api.done())
   })

--- a/packages/spaces/test/commands/vpn/info.js
+++ b/packages/spaces/test/commands/vpn/info.js
@@ -48,7 +48,7 @@ Public IP:      35.161.69.30
 Routable CIDRs: 172.16.0.0/16
 Status:         failed
 Status Message: supplied CIDR block already in use
-=== vpn-connection-name Tunnel Info
+=== vpn-connection-name VPN Tunnel Info
 VPN Tunnel  IP Address     Status  Status Last Changed   Details
 ──────────  ─────────────  ──────  ────────────────────  ──────────────
 Tunnel 1    52.44.146.197  UP      2016-10-25T22:09:05Z  status message

--- a/packages/spaces/test/commands/vpn/info.js
+++ b/packages/spaces/test/commands/vpn/info.js
@@ -11,41 +11,44 @@ describe('spaces:vpn:info', function () {
 
   it('gets VPN info', function () {
     let api = nock('https://api.heroku.com:443')
-      .get('/spaces/my-space/vpn')
+      .get('/spaces/my-space/vpn-connections/vpn-connection-name')
       .reply(200, {
         id: '123456789012',
+        name: 'vpn-connection-name',
         public_ip: '35.161.69.30',
         routable_cidrs: [ '172.16.0.0/16' ],
-        state: 'deleted',
+        ike_version: 1,
         status: 'failed',
         status_message: 'supplied CIDR block already in use',
         tunnels: [
           {
             last_status_change: '2016-10-25T22:09:05Z',
-            outside_ip_address: '52.44.146.197',
+            ip: '52.44.146.197', // The one needed right now
+            customer_ip: '52.44.146.198',
             status: 'UP',
             status_message: 'status message'
           },
           {
             last_status_change: '2016-10-25T22:09:05Z',
-            outside_ip_address: '52.44.146.197',
+            ip: '52.44.146.197',
+            customer_ip: '52.44.146.198',
             status: 'UP',
             status_message: 'status message'
           }
         ]
       })
     return cmd.run({flags: {
-      space: 'my-space'
+      space: 'my-space',
+      name: 'vpn-connection-name'
     }})
       .then(() => expect(cli.stdout).to.equal(
-        `=== my-space VPN Info
-ID:                  123456789012
-Public IP:           35.161.69.30
-Routable CIDRs:      172.16.0.0/16
-State:               deleted
-Provisioning Status: failed
-Status Message:      supplied CIDR block already in use
-=== my-space Tunnel Info
+        `=== vpn-connection-name VPN Info
+ID:             123456789012
+Public IP:      35.161.69.30
+Routable CIDRs: 172.16.0.0/16
+Status:         failed
+Status Message: supplied CIDR block already in use
+=== vpn-connection-name Tunnel Info
 VPN Tunnel  IP Address     Status  Status Last Changed   Details
 ──────────  ─────────────  ──────  ────────────────────  ──────────────
 Tunnel 1    52.44.146.197  UP      2016-10-25T22:09:05Z  status message
@@ -56,7 +59,7 @@ Tunnel 2    52.44.146.197  UP      2016-10-25T22:09:05Z  status message\n`
 
   it('gets VPN info in JSON', function () {
     let api = nock('https://api.heroku.com:443')
-      .get('/spaces/my-space/vpn')
+      .get('/spaces/my-space/vpn-connections/vpn-connection-name')
       .reply(200, {
         id: '123456789012',
         public_ip: '35.161.69.30',
@@ -67,13 +70,15 @@ Tunnel 2    52.44.146.197  UP      2016-10-25T22:09:05Z  status message\n`
         tunnels: [
           {
             last_status_change: '2016-10-25T22:09:05Z',
-            outside_ip_address: '52.44.146.197',
+            ip: '52.44.146.197',
+            customer_ip: '52.44.146.197',
             status: 'UP',
             status_message: 'status message'
           },
           {
             last_status_change: '2016-10-25T22:09:05Z',
-            outside_ip_address: '52.44.146.197',
+            ip: '52.44.146.197',
+            customer_ip: '52.44.146.197',
             status: 'UP',
             status_message: 'status message'
           }
@@ -81,6 +86,7 @@ Tunnel 2    52.44.146.197  UP      2016-10-25T22:09:05Z  status message\n`
       })
     return cmd.run({flags: {
       space: 'my-space',
+      name: 'vpn-connection-name',
       json: true
     }})
       .then(() => expect(cli.stdout).to.equal(
@@ -96,13 +102,15 @@ Tunnel 2    52.44.146.197  UP      2016-10-25T22:09:05Z  status message\n`
   "tunnels": [
     {
       "last_status_change": "2016-10-25T22:09:05Z",
-      "outside_ip_address": "52.44.146.197",
+      "ip": "52.44.146.197",
+      "customer_ip": "52.44.146.197",
       "status": "UP",
       "status_message": "status message"
     },
     {
       "last_status_change": "2016-10-25T22:09:05Z",
-      "outside_ip_address": "52.44.146.197",
+      "ip": "52.44.146.197",
+      "customer_ip": "52.44.146.197",
       "status": "UP",
       "status_message": "status message"
     }

--- a/packages/spaces/test/commands/vpn/wait.js
+++ b/packages/spaces/test/commands/vpn/wait.js
@@ -74,7 +74,7 @@ Public IP:      35.161.69.30
 Routable CIDRs: 172.16.0.0/16
 Status:         available
 Status Message: 
-=== vpn-connection-name Tunnel Info
+=== vpn-connection-name VPN Tunnel Info
 VPN Tunnel  IP Address     Status  Status Last Changed   Details
 ──────────  ─────────────  ──────  ────────────────────  ──────────────
 Tunnel 1    52.44.146.197  UP      2016-10-25T22:09:05Z  status message

--- a/packages/spaces/test/commands/vpn/wait.js
+++ b/packages/spaces/test/commands/vpn/wait.js
@@ -16,9 +16,13 @@ describe('spaces:vpn:wait', function () {
       .get('/spaces/my-space/vpn')
       .reply(200, {
         id: '123456789012',
+        name: 'vpn-connection-name',
         public_ip: '35.161.69.30',
         routable_cidrs: [ '172.16.0.0/16' ],
-        state: 'pending',
+        ike_version: 1,
+        space_cidr_block: '10.0.0.0/16',
+        status: 'pending',
+        status_message: '',
         tunnels: [
           {
             last_status_change: '2016-10-25T22:09:05Z',
@@ -37,35 +41,40 @@ describe('spaces:vpn:wait', function () {
       .get('/spaces/my-space/vpn')
       .reply(200, {
         id: '123456789012',
+        name: 'vpn-connection-name',
         public_ip: '35.161.69.30',
         routable_cidrs: [ '172.16.0.0/16' ],
-        state: 'available',
+        ike_version: 1,
+        space_cidr_block: '10.0.0.0/16',
+        status: 'available',
+        status_message: '',
         tunnels: [
           {
             last_status_change: '2016-10-25T22:09:05Z',
-            outside_ip_address: '52.44.146.197',
+            ip: '52.44.146.197',
             status: 'UP',
             status_message: 'status message'
           },
           {
             last_status_change: '2016-10-25T22:09:05Z',
-            outside_ip_address: '52.44.146.197',
+            ip: '52.44.146.197',
             status: 'UP',
             status_message: 'status message'
           }
         ]
       })
 
-    return cmd.run({flags: {space: 'my-space', interval: 0}})
+    return cmd.run({flags: {space: 'my-space', name: 'vpn-connection-name', interval: 0}})
       .then(() => expect(cli.stderr).to.equal(
-        `Waiting for VPN in space my-space to allocate... done\n\n`))
+        `Waiting for VPN Connection vpn-connection-name to allocate... done\n\n`))
       .then(() => expect(cli.stdout).to.equal(
-        `=== my-space VPN Info
-ID:                  123456789012
-Public IP:           35.161.69.30
-Routable CIDRs:      172.16.0.0/16
-State:               available
-=== my-space Tunnel Info
+        `=== vpn-connection-name VPN Info
+ID:             123456789012
+Public IP:      35.161.69.30
+Routable CIDRs: 172.16.0.0/16
+Status:         available
+Status Message: 
+=== vpn-connection-name Tunnel Info
 VPN Tunnel  IP Address     Status  Status Last Changed   Details
 ──────────  ─────────────  ──────  ────────────────────  ──────────────
 Tunnel 1    52.44.146.197  UP      2016-10-25T22:09:05Z  status message
@@ -81,6 +90,7 @@ Tunnel 2    52.44.146.197  UP      2016-10-25T22:09:05Z  status message\n`
       .get('/spaces/my-space/vpn')
       .reply(200, {
         id: '123456789012',
+        name: 'vpn-connection-name',
         public_ip: '35.161.69.30',
         routable_cidrs: [ '172.16.0.0/16' ],
         state: 'pending',
@@ -102,6 +112,7 @@ Tunnel 2    52.44.146.197  UP      2016-10-25T22:09:05Z  status message\n`
       .get('/spaces/my-space/vpn')
       .reply(200, {
         id: '123456789012',
+        name: 'vpn-connection-name',
         public_ip: '35.161.69.30',
         routable_cidrs: [ '172.16.0.0/16' ],
         state: 'deleted',
@@ -123,7 +134,7 @@ Tunnel 2    52.44.146.197  UP      2016-10-25T22:09:05Z  status message\n`
         ]
       })
 
-    return cmd.run({flags: {space: 'my-space', interval: 0}})
+    return cmd.run({flags: {space: 'my-space', name: 'vpn-connection-name', interval: 0}})
       .catch(reason => {
         expect(reason.message).to.equal('supplied CIDR block already in use')
       })


### PR DESCRIPTION
This adds support for multiple VPN connections to the `spaces:vpn` `:wait`, `:info`, and `:config` commands. Previously the vpn connections were not named, but with the introduction of `GET /vpn-connections/:name-or-id`, the commands need to be updated to support name input.

https://github.com/heroku/dogwood/issues/1903