### PR TITLE
spaces: add vpn:connections command

### DIFF
--- a/packages/spaces/commands/vpn/index.js
+++ b/packages/spaces/commands/vpn/index.js
@@ -5,14 +5,20 @@ const co = require('co')
 const format = require('../../lib/format')()
 
 function displayVPNConnections (space, connections) {
+  let tunnelFormat = function (t) {
+    return t.map((tunnel) => format.VPNStatus(tunnel.status)).join('/')
+  }
+
   cli.styledHeader(`${space} VPN Connections`)
   cli.table(connections, {
     columns: [
-      {key: 'name', label: 'Name'},
-      {key: 'status', label: 'Status', format: format.VPNStatus}
+      {label: 'Name', key: 'name'},
+      {label: 'Status', key: 'status', format: format.VPNStatus},
+      {label: 'Tunnels', key: 'tunnels', format: t => tunnelFormat(t)}
     ]
   })
 }
+
 function render (space, connections, flags) {
   if (flags.json) {
     cli.styledJSON(connections)

--- a/packages/spaces/commands/vpn/index.js
+++ b/packages/spaces/commands/vpn/index.js
@@ -2,17 +2,32 @@
 
 const cli = require('heroku-cli-util')
 const co = require('co')
+const format = require('../../lib/format')()
 
+function displayVPNConnections (space, connections) {
+  cli.styledHeader(`${space} VPN Connections`)
+  cli.table(connections, {
+    columns: [
+      {key: 'name', label: 'Name'},
+      {key: 'status', label: 'Status', format: format.VPNStatus}
+    ]
+  })
+}
 function render (space, connections, flags) {
   if (flags.json) {
     cli.styledJSON(connections)
   } else {
-
+    displayVPNConnections(space, connections)
   }
 }
 
 function * run (context, heroku) {
+  let space = context.flags.space || context.args.space
+  if (!space) throw new Error('Space name required.\nUSAGE: heroku spaces:vpn:connections --space my-space')
 
+  let lib = require('../../lib/vpn-connections')(heroku)
+  let connections = yield lib.getVPNConnections(space)
+  render(space, connections, context.flags)
 }
 
 module.exports = {
@@ -26,7 +41,8 @@ module.exports = {
   needsAuth: true,
   args: [{name: 'space', optional: true, hidden: true}],
   flags: [
-
+    {name: 'space', char: 's', hasValue: true, description: 'space to get VPN connections from'},
+    {name: 'json', description: 'output in json format'}
   ],
   run: cli.command(co.wrap(run)),
   render: render

--- a/packages/spaces/commands/vpn/index.js
+++ b/packages/spaces/commands/vpn/index.js
@@ -38,9 +38,15 @@ function * run (context, heroku) {
 
 module.exports = {
   topic: 'spaces',
-  command: 'vpn:info',
+  command: 'vpn:connections',
   description: 'list the VPN Connections for a space',
-  help: `$TODO
+  help: `Example:
+
+  $ heroku spaces:vpn:connections --space my-space
+  === my-space VPN Connections
+  Name    Status  Tunnels
+  ──────  ──────  ───────
+  office  active  UP/UP
   `,
   hidden: true,
   needsApp: false,

--- a/packages/spaces/commands/vpn/index.js
+++ b/packages/spaces/commands/vpn/index.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const cli = require('heroku-cli-util')
+const co = require('co')
+
+function render (space, connections, flags) {
+  if (flags.json) {
+    cli.styledJSON(connections)
+  } else {
+
+  }
+}
+
+function * run (context, heroku) {
+
+}
+
+module.exports = {
+  topic: 'spaces',
+  command: 'vpn:info',
+  description: 'list the VPN Connections for a space',
+  help: `$TODO
+  `,
+  hidden: true,
+  needsApp: false,
+  needsAuth: true,
+  args: [{name: 'space', optional: true, hidden: true}],
+  flags: [
+
+  ],
+  run: cli.command(co.wrap(run)),
+  render: render
+}

--- a/packages/spaces/commands/vpn/info.js
+++ b/packages/spaces/commands/vpn/info.js
@@ -5,32 +5,12 @@ const co = require('co')
 const format = require('../../lib/format')()
 
 function displayVPNInfo (space, info) {
-  let sF = function (s) {
-    let colored = s
-    switch (s) {
-      case 'UP':
-      case 'available':
-        colored = `${cli.color.green(colored)}`
-        break
-      case 'pending':
-        colored = `${cli.color.yellow(colored)}`
-        break
-      case 'DOWN':
-      case 'deleting':
-      case 'deleted':
-        colored = `${cli.color.red(colored)}`
-        break
-    }
-
-    return colored
-  }
-
   cli.styledHeader(`${space} VPN Info`)
   cli.styledObject({
     ID: info.id,
     'Public IP': info.public_ip,
     'Routable CIDRs': format.CIDR(info.routable_cidrs),
-    State: `${sF(info.state)}`,
+    State: `${format.VPNStatus(info.state)}`,
     'Provisioning Status': info.status,
     'Status Message': info.status_message
   }, ['ID', 'Public IP', 'Routable CIDRs', 'State', 'Provisioning Status', 'Status Message'])
@@ -42,7 +22,7 @@ function displayVPNInfo (space, info) {
     columns: [
       {key: 'tunnel_id', label: 'VPN Tunnel'},
       {key: 'outside_ip_address', label: 'IP Address'},
-      {key: 'status', label: 'Status', format: status => sF(status)},
+      {key: 'status', label: 'Status', format: format.VPNStatus},
       {key: 'last_status_change', label: 'Status Last Changed'},
       {key: 'status_message', label: 'Details'}
     ]

--- a/packages/spaces/index.js
+++ b/packages/spaces/index.js
@@ -18,6 +18,7 @@ exports.commands = [
   require('./commands/peering/destroy'),
   require('./commands/vpn/connect'),
   require('./commands/vpn/create'),
+  require('./commands/vpn/index'),
   require('./commands/vpn/info'),
   require('./commands/vpn/config'),
   require('./commands/vpn/wait'),

--- a/packages/spaces/lib/format.js
+++ b/packages/spaces/lib/format.js
@@ -21,6 +21,8 @@ module.exports = function () {
         colored = `${cli.color.green(colored)}`
         break
       case 'pending':
+      case 'provisioning':
+      case 'deprovisioning':
         colored = `${cli.color.yellow(colored)}`
         break
       case 'DOWN':

--- a/packages/spaces/lib/format.js
+++ b/packages/spaces/lib/format.js
@@ -13,7 +13,27 @@ module.exports = function () {
     return CIDR(cidrBlocks)
   }
 
-  function Status (s) {
+  function VPNStatus (s) {
+    let colored = s
+    switch (s) {
+      case 'UP':
+      case 'available':
+        colored = `${cli.color.green(colored)}`
+        break
+      case 'pending':
+        colored = `${cli.color.yellow(colored)}`
+        break
+      case 'DOWN':
+      case 'deleting':
+      case 'deleted':
+        colored = `${cli.color.red(colored)}`
+        break
+    }
+
+    return colored
+  }
+
+  function PeeringStatus (s) {
     var colored = s
     switch (s) {
       case 'active':
@@ -37,6 +57,7 @@ module.exports = function () {
   return {
     CIDR,
     CIDRBlocksOrCIDRBlock,
-    Status
+    PeeringStatus,
+    VPNStatus
   }
 }

--- a/packages/spaces/lib/peering.js
+++ b/packages/spaces/lib/peering.js
@@ -39,7 +39,7 @@ module.exports = function (heroku) {
         {key: 'pcx_id', label: 'PCX ID'},
         {key: 'type', label: 'Type'},
         {key: 'cidr_blocks', label: 'CIDR Blocks', format: format.CIDRBlocksOrCIDRBlock},
-        {key: 'status', label: 'Status', format: format.Status},
+        {key: 'status', label: 'Status', format: format.PeeringStatus},
         {key: 'aws_vpc_id', label: 'VPC ID'},
         {key: 'aws_account_id', label: 'AWS Account ID'},
         {key: 'expires', label: 'Expires'}

--- a/packages/spaces/lib/vpn-connections.js
+++ b/packages/spaces/lib/vpn-connections.js
@@ -9,6 +9,10 @@ module.exports = function (heroku) {
     })
   }
 
+  function getVPNConnections (space) {
+    return request('GET', `/spaces/${space}/vpn-connections`)
+  }
+
   function request (method, path, body) {
     return heroku.request({
       method: method,
@@ -18,6 +22,7 @@ module.exports = function (heroku) {
   }
 
   return {
-    postVPNConnections
+    postVPNConnections,
+    getVPNConnections
   }
 }

--- a/packages/spaces/test/commands/vpn/index.js
+++ b/packages/spaces/test/commands/vpn/index.js
@@ -9,41 +9,40 @@ const expect = require('chai').expect
 describe('spaces:vpn:connections', function () {
   beforeEach(() => cli.mockConsole())
 
+  let space = {
+    id: '123456789012',
+    name: 'office',
+    public_ip: '35.161.69.30',
+    routable_cidrs: [
+      '172.16.0.0/16'
+    ],
+    ike_version: 1,
+    space_cidr_block: '10.0.0.0/16',
+    status: 'active',
+    status_message: 'Active',
+    tunnels: [
+      {
+        last_status_change: '2016-10-25T22:10:05Z',
+        ip: '52.44.146.197',
+        customer_ip: '52.44.146.197',
+        pre_shared_key: 'secret',
+        status: 'UP',
+        status_message: 'status message'
+      },
+      {
+        last_status_change: '2016-10-25T22:09:05Z',
+        ip: '52.44.146.196',
+        customer_ip: '52.44.146.196',
+        pre_shared_key: 'secret',
+        status: 'UP',
+        status_message: 'status message'
+      }
+    ]
+  }
   it('displays VPN Connections', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/vpn-connections')
-      .reply(200, [
-        {
-          id: '123456789012',
-          name: 'office',
-          public_ip: '35.161.69.30',
-          routable_cidrs: [
-            '172.16.0.0/16'
-          ],
-          ike_version: 1,
-          space_cidr_block: '10.0.0.0/16',
-          status: 'active',
-          status_message: 'Active',
-          tunnels: [
-            {
-              last_status_change: '2016-10-25T22:10:05Z',
-              ip: '52.44.146.197',
-              customer_ip: '52.44.146.197',
-              pre_shared_key: 'secret',
-              status: 'UP',
-              status_message: 'status message'
-            },
-            {
-              last_status_change: '2016-10-25T22:09:05Z',
-              ip: '52.44.146.196',
-              customer_ip: '52.44.146.196',
-              pre_shared_key: 'secret',
-              status: 'UP',
-              status_message: 'status message'
-            }
-          ]
-        }
-      ])
+      .reply(200, [ space ])
     return cmd.run({flags: {
       space: 'my-space'
     }})
@@ -59,38 +58,7 @@ office  active  UP/UP
   it('displays VPN Connections in json', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/vpn-connections')
-      .reply(200, [
-        {
-          id: '123456789012',
-          name: 'office',
-          public_ip: '35.161.69.30',
-          routable_cidrs: [
-            '172.16.0.0/16'
-          ],
-          ike_version: 1,
-          space_cidr_block: '10.0.0.0/16',
-          status: 'active',
-          status_message: 'Active',
-          tunnels: [
-            {
-              last_status_change: '2016-10-25T22:10:05Z',
-              ip: '52.44.146.197',
-              customer_ip: '52.44.146.197',
-              pre_shared_key: 'secret',
-              status: 'UP',
-              status_message: 'status message'
-            },
-            {
-              last_status_change: '2016-10-25T22:09:05Z',
-              ip: '52.44.146.196',
-              customer_ip: '52.44.146.196',
-              pre_shared_key: 'secret',
-              status: 'UP',
-              status_message: 'status message'
-            }
-          ]
-        }
-      ])
+      .reply(200, [ space ])
     return cmd.run({flags: {
       space: 'my-space',
       json: true

--- a/packages/spaces/test/commands/vpn/index.js
+++ b/packages/spaces/test/commands/vpn/index.js
@@ -2,16 +2,58 @@
 /* globals describe beforeEach it */
 
 const cli = require('heroku-cli-util')
-// const nock = require('nock')
+const nock = require('nock')
 const cmd = require('../../../commands/vpn/index')
-// const expect = require('chai').expect
+const expect = require('chai').expect
 
 describe('spaces:vpn:connections', function () {
   beforeEach(() => cli.mockConsole())
 
   it('displays VPN Connections', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/vpn-connections')
+      .reply(200, [
+        {
+          id: '123456789012',
+          name: 'office',
+          public_ip: '35.161.69.30',
+          routable_cidrs: [
+            '172.16.0.0/16'
+          ],
+          ike_version: 1,
+          space_cidr_block: '10.0.0.0/16',
+          status: 'active',
+          status_message: 'Active',
+          tunnels: [
+            {
+              last_status_change: '2016-10-25T22:10:05Z',
+              ip: '52.44.146.197',
+              customer_ip: '52.44.146.197',
+              pre_shared_key: 'secret',
+              status: 'UP',
+              status_message: 'status message'
+            },
+            {
+              last_status_change: '2016-10-25T22:09:05Z',
+              ip: '52.44.146.196',
+              customer_ip: '52.44.146.196',
+              pre_shared_key: 'secret',
+              status: 'UP',
+              status_message: 'status message'
+            }
+          ]
+        }
+      ])
     return cmd.run({flags: {
       space: 'my-space'
     }})
+      .then(() => expect(cli.stdout).to.equal(
+        `=== my-space VPN Connections
+Name    Status
+──────  ──────
+office  active
+`
+      ))
+      .then(() => api.done())
   })
 })

--- a/packages/spaces/test/commands/vpn/index.js
+++ b/packages/spaces/test/commands/vpn/index.js
@@ -49,9 +49,85 @@ describe('spaces:vpn:connections', function () {
     }})
       .then(() => expect(cli.stdout).to.equal(
         `=== my-space VPN Connections
-Name    Status
-──────  ──────
-office  active
+Name    Status  Tunnels
+──────  ──────  ───────
+office  active  UP/UP
+`
+      ))
+      .then(() => api.done())
+  })
+  it('displays VPN Connections in json', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/vpn-connections')
+      .reply(200, [
+        {
+          id: '123456789012',
+          name: 'office',
+          public_ip: '35.161.69.30',
+          routable_cidrs: [
+            '172.16.0.0/16'
+          ],
+          ike_version: 1,
+          space_cidr_block: '10.0.0.0/16',
+          status: 'active',
+          status_message: 'Active',
+          tunnels: [
+            {
+              last_status_change: '2016-10-25T22:10:05Z',
+              ip: '52.44.146.197',
+              customer_ip: '52.44.146.197',
+              pre_shared_key: 'secret',
+              status: 'UP',
+              status_message: 'status message'
+            },
+            {
+              last_status_change: '2016-10-25T22:09:05Z',
+              ip: '52.44.146.196',
+              customer_ip: '52.44.146.196',
+              pre_shared_key: 'secret',
+              status: 'UP',
+              status_message: 'status message'
+            }
+          ]
+        }
+      ])
+    return cmd.run({flags: {
+      space: 'my-space',
+      json: true
+    }})
+      .then(() => expect(cli.stdout).to.equal(
+        `[
+  {
+    "id": "123456789012",
+    "name": "office",
+    "public_ip": "35.161.69.30",
+    "routable_cidrs": [
+      "172.16.0.0/16"
+    ],
+    "ike_version": 1,
+    "space_cidr_block": "10.0.0.0/16",
+    "status": "active",
+    "status_message": "Active",
+    "tunnels": [
+      {
+        "last_status_change": "2016-10-25T22:10:05Z",
+        "ip": "52.44.146.197",
+        "customer_ip": "52.44.146.197",
+        "pre_shared_key": "secret",
+        "status": "UP",
+        "status_message": "status message"
+      },
+      {
+        "last_status_change": "2016-10-25T22:09:05Z",
+        "ip": "52.44.146.196",
+        "customer_ip": "52.44.146.196",
+        "pre_shared_key": "secret",
+        "status": "UP",
+        "status_message": "status message"
+      }
+    ]
+  }
+]
 `
       ))
       .then(() => api.done())

--- a/packages/spaces/test/commands/vpn/index.js
+++ b/packages/spaces/test/commands/vpn/index.js
@@ -1,0 +1,17 @@
+'use strict'
+/* globals describe beforeEach it */
+
+const cli = require('heroku-cli-util')
+// const nock = require('nock')
+const cmd = require('../../../commands/vpn/index')
+// const expect = require('chai').expect
+
+describe('spaces:vpn:connections', function () {
+  beforeEach(() => cli.mockConsole())
+
+  it('displays VPN Connections', function () {
+    return cmd.run({flags: {
+      space: 'my-space'
+    }})
+  })
+})


### PR DESCRIPTION
Continuing from #931, Existing spaces:vpn commands assume there can only ever be a single VPN connection for a space.

This modification adds a new `heroku spaces:vpn:connections` command to list all the connections for a given space.