### PR TITLE
spaces: wait should check that the status is active, not available

### DIFF
--- a/packages/spaces/commands/vpn/wait.js
+++ b/packages/spaces/commands/vpn/wait.js
@@ -43,7 +43,7 @@ function * run (context, heroku) {
     }
 
     yield wait(interval)
-  } while (info.status !== 'available')
+  } while (info.status !== 'active')
 
   spinner.stop('done\n')
   infoCmd.render(space, name, info, context.flags)

--- a/packages/spaces/test/commands/vpn/wait.js
+++ b/packages/spaces/test/commands/vpn/wait.js
@@ -46,7 +46,7 @@ describe('spaces:vpn:wait', function () {
         routable_cidrs: [ '172.16.0.0/16' ],
         ike_version: 1,
         space_cidr_block: '10.0.0.0/16',
-        status: 'available',
+        status: 'active',
         status_message: '',
         tunnels: [
           {
@@ -72,7 +72,7 @@ describe('spaces:vpn:wait', function () {
 ID:             123456789012
 Public IP:      35.161.69.30
 Routable CIDRs: 172.16.0.0/16
-Status:         available
+Status:         active
 Status Message: 
 === vpn-connection-name VPN Tunnel Info
 VPN Tunnel  IP Address     Status  Status Last Changed   Details


### PR DESCRIPTION
While working on the Direwolf test, @watsonian discovered that `:wait` was hanging although the VPN was available. This is because it was waiting on `available`, not `active` like it should be since we have removed the state and rely on the `status`

closes https://github.com/orgs/heroku/projects/52#card-11188425