### PR TITLE
spaces: default name to ID in list if missing

### DIFF
--- a/packages/spaces/commands/vpn/index.js
+++ b/packages/spaces/commands/vpn/index.js
@@ -12,7 +12,7 @@ function displayVPNConnections (space, connections) {
   cli.styledHeader(`${space} VPN Connections`)
   cli.table(connections, {
     columns: [
-      {label: 'Name', key: 'name'},
+      {label: 'Name', format: (_, v) => v.name || v.id},
       {label: 'Status', key: 'status', format: format.VPNStatus},
       {label: 'Tunnels', key: 'tunnels', format: t => tunnelFormat(t)}
     ]

--- a/packages/spaces/test/commands/vpn/index.js
+++ b/packages/spaces/test/commands/vpn/index.js
@@ -55,6 +55,23 @@ office  active  UP/UP
       ))
       .then(() => api.done())
   })
+  it('displays VPN Connection ID when name is unavailable', function () {
+    let conn = {...space, name: ''}
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/vpn-connections')
+      .reply(200, [ conn ])
+    return cmd.run({flags: {
+      space: 'my-space'
+    }})
+      .then(() => expect(cli.stdout).to.equal(
+        `=== my-space VPN Connections
+Name          Status  Tunnels
+────────────  ──────  ───────
+123456789012  active  UP/UP
+`
+      ))
+      .then(() => api.done())
+  })
   it('displays VPN Connections in json', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/vpn-connections')


### PR DESCRIPTION
Some internal testing and customer private beta VPN connections don't have names. With the latest CLI commands, however, it's only possible to get the ID of an existing VPN connection by using the JSON output.

This updates the `spaces:vpn:connections` command to show the ID in the name field when it's blank, so that legacy VPN connections can still be interacted with.

Closes https://github.com/heroku/dogwood/issues/1936.