### PR TITLE
Display the name in vpn:info

### DIFF
--- a/packages/spaces/commands/vpn/info.js
+++ b/packages/spaces/commands/vpn/info.js
@@ -50,6 +50,10 @@ function * run (context, heroku) {
 
   let lib = require('../../lib/vpn-connections')(heroku)
   let info = yield lib.getVPNConnection(space, name)
+
+  if (info.name != null) {
+    name = info.name
+  }
   render(space, name, info, context.flags)
 }
 

--- a/packages/spaces/commands/vpn/info.js
+++ b/packages/spaces/commands/vpn/info.js
@@ -7,12 +7,13 @@ const format = require('../../lib/format')()
 function displayVPNInfo (space, name, info) {
   cli.styledHeader(`${name} VPN Info`)
   cli.styledObject({
+    Name: name,
     ID: info.id,
     'Public IP': info.public_ip,
     'Routable CIDRs': format.CIDR(info.routable_cidrs),
     'Status': `${format.VPNStatus(info.status)}`,
     'Status Message': info.status_message
-  }, ['ID', 'Public IP', 'Routable CIDRs', 'State', 'Status', 'Status Message'])
+  }, ['Name', 'ID', 'Public IP', 'Routable CIDRs', 'State', 'Status', 'Status Message'])
 
   // make up tunnel IDs
   info.tunnels.forEach((val, i) => { val.tunnel_id = 'Tunnel ' + (i + 1) })

--- a/packages/spaces/commands/vpn/info.js
+++ b/packages/spaces/commands/vpn/info.js
@@ -51,7 +51,7 @@ function * run (context, heroku) {
   let lib = require('../../lib/vpn-connections')(heroku)
   let info = yield lib.getVPNConnection(space, name)
 
-  if (info.name != null) {
+  if (info.name) {
     name = info.name
   }
   render(space, name, info, context.flags)

--- a/packages/spaces/test/commands/vpn/info.js
+++ b/packages/spaces/test/commands/vpn/info.js
@@ -119,7 +119,7 @@ Tunnel 2    52.44.146.197  UP      2016-10-25T22:09:05Z  status message\n`
 }\n`))
       .then(() => api.done())
   })
-  it('gets VPN info and uses id as the name', function () {
+  it('gets VPN info with id', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/vpn-connections/123456789012')
       .reply(200, {
@@ -152,14 +152,14 @@ Tunnel 2    52.44.146.197  UP      2016-10-25T22:09:05Z  status message\n`
       name: '123456789012'
     }})
       .then(() => expect(cli.stdout).to.equal(
-        `=== 123456789012 VPN Info
-Name:           123456789012
+        `=== vpn-connection-name VPN Info
+Name:           vpn-connection-name
 ID:             123456789012
 Public IP:      35.161.69.30
 Routable CIDRs: 172.16.0.0/16
 Status:         failed
 Status Message: supplied CIDR block already in use
-=== 123456789012 VPN Tunnel Info
+=== vpn-connection-name VPN Tunnel Info
 VPN Tunnel  IP Address     Status  Status Last Changed   Details
 ──────────  ─────────────  ──────  ────────────────────  ──────────────
 Tunnel 1    52.44.146.197  UP      2016-10-25T22:09:05Z  status message

--- a/packages/spaces/test/commands/vpn/info.js
+++ b/packages/spaces/test/commands/vpn/info.js
@@ -43,6 +43,7 @@ describe('spaces:vpn:info', function () {
     }})
       .then(() => expect(cli.stdout).to.equal(
         `=== vpn-connection-name VPN Info
+Name:           vpn-connection-name
 ID:             123456789012
 Public IP:      35.161.69.30
 Routable CIDRs: 172.16.0.0/16
@@ -116,6 +117,54 @@ Tunnel 2    52.44.146.197  UP      2016-10-25T22:09:05Z  status message\n`
     }
   ]
 }\n`))
+      .then(() => api.done())
+  })
+  it('gets VPN info and uses id as the name', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/vpn-connections/123456789012')
+      .reply(200, {
+        id: '123456789012',
+        name: 'vpn-connection-name',
+        public_ip: '35.161.69.30',
+        routable_cidrs: [ '172.16.0.0/16' ],
+        ike_version: 1,
+        status: 'failed',
+        status_message: 'supplied CIDR block already in use',
+        tunnels: [
+          {
+            last_status_change: '2016-10-25T22:09:05Z',
+            ip: '52.44.146.197', // The one needed right now
+            customer_ip: '52.44.146.198',
+            status: 'UP',
+            status_message: 'status message'
+          },
+          {
+            last_status_change: '2016-10-25T22:09:05Z',
+            ip: '52.44.146.197',
+            customer_ip: '52.44.146.198',
+            status: 'UP',
+            status_message: 'status message'
+          }
+        ]
+      })
+    return cmd.run({flags: {
+      space: 'my-space',
+      name: '123456789012'
+    }})
+      .then(() => expect(cli.stdout).to.equal(
+        `=== 123456789012 VPN Info
+Name:           123456789012
+ID:             123456789012
+Public IP:      35.161.69.30
+Routable CIDRs: 172.16.0.0/16
+Status:         failed
+Status Message: supplied CIDR block already in use
+=== 123456789012 VPN Tunnel Info
+VPN Tunnel  IP Address     Status  Status Last Changed   Details
+──────────  ─────────────  ──────  ────────────────────  ──────────────
+Tunnel 1    52.44.146.197  UP      2016-10-25T22:09:05Z  status message
+Tunnel 2    52.44.146.197  UP      2016-10-25T22:09:05Z  status message\n`
+      ))
       .then(() => api.done())
   })
 })

--- a/packages/spaces/test/commands/vpn/wait.js
+++ b/packages/spaces/test/commands/vpn/wait.js
@@ -69,6 +69,7 @@ describe('spaces:vpn:wait', function () {
         `Waiting for VPN Connection vpn-connection-name to allocate... done\n\n`))
       .then(() => expect(cli.stdout).to.equal(
         `=== vpn-connection-name VPN Info
+Name:           vpn-connection-name
 ID:             123456789012
 Public IP:      35.161.69.30
 Routable CIDRs: 172.16.0.0/16


### PR DESCRIPTION
This fixes:
* The name was not being displayed in `display:info` despite it being shown in the example
* If an ID is used to retrieve a VPN connection, the name will be used in the headers if one is present 

Resolves https://github.com/heroku/dogwood/issues/1937