### PR TITLE
change source_blob url to GET from kolkrabbi

### DIFF
--- a/packages/pipelines-v5/commands/pipelines/setup.js
+++ b/packages/pipelines-v5/commands/pipelines/setup.js
@@ -93,7 +93,7 @@ View your new pipeline by running \`heroku pipelines:open e5a55ffa-de3f-11e6-a24
       kolkrabbi.createPipelineRepository(pipeline.id, repo.id)
     )
 
-    const archiveURL = yield github.getArchiveURL(repoName, repo.default_branch)
+    const archiveURL = yield kolkrabbi.getArchiveURL(repoName, repo.default_branch)
     const appSetups = yield createApps(heroku, archiveURL, pipeline, pipelineName, stagingAppName, organization)
 
     yield cli.action(

--- a/packages/pipelines-v5/lib/github-api.js
+++ b/packages/pipelines-v5/lib/github-api.js
@@ -19,10 +19,4 @@ module.exports = class GitHubAPI {
   getRepo (name) {
     return this.request(`/repos/${name}`).then((res) => res.body)
   }
-
-  getArchiveURL (repo, ref) {
-    return this.request(`/repos/${repo}/tarball/${ref}`, {
-      followRedirect: false
-    }).then((res) => res.headers.location)
-  }
 }

--- a/packages/pipelines-v5/lib/kolkrabbi-api.js
+++ b/packages/pipelines-v5/lib/kolkrabbi-api.js
@@ -62,4 +62,10 @@ module.exports = class KolkrabbiAPI {
       method: 'GET'
     })
   }
+
+  getArchiveURL (repo, ref) {
+    return this.request(`/github/repos/${repo}/tarball/${ref}`, {
+      followRedirect: false
+    }).then((res) => res.body.archive_link);
+  }
 }

--- a/packages/pipelines-v5/test/commands/pipelines/setup.js
+++ b/packages/pipelines-v5/test/commands/pipelines/setup.js
@@ -91,8 +91,9 @@ describe('pipelines:setup', function () {
     context('and pipeline name is valid', function () {
       beforeEach(function () {
         github.get(`/repos/${repo.name}`).reply(200, repo)
-        github.get(`/repos/${repo.name}/tarball/${repo.default_branch}`).reply(301, '', {
-          location: archiveURL
+
+        kolkrabbi.get(`/github/repos/${repo.name}/tarball/${repo.default_branch}`).reply(200, {
+          archive_link: archiveURL
         })
 
         api = nock('https://api.heroku.com')


### PR DESCRIPTION
When running `heroku pipelines:setup`, there's an error (`No source_blob URL provided.`) because GitHub does not return the expected response headers which should point to a tarball. Instead of using GitHub API, we can use Heroku's internal service to retrieve a url for the same tarball for a repository's branch.