### PR TITLE
Changes 'force' to 'forced'

### DIFF
--- a/packages/pg-v5/commands/credentials/rotate.js
+++ b/packages/pg-v5/commands/credentials/rotate.js
@@ -42,8 +42,7 @@ function * run (context, heroku) {
   yield cli.confirmApp(app, flags.confirm, `WARNING: Destructive Action
 ${warnings.join('\n')}`)
 
-  let body = flags.force ? {host: host(db), force: true} : {host: host(db)}
-
+  let body = flags.force ? {host: host(db), forced: true} : {host: host(db)}
   if (all) {
     yield cli.action(`Rotating all credentials on ${cli.color.addon(db.name)}`, co(function * () {
       yield heroku.post(`/postgres/v0/databases/${db.name}/credentials_rotation`,


### PR DESCRIPTION
The shogun API for force rotate credential accepts the parameter 'forced'. Currently, the cli passes 'force' which is ignored.

The tests still pass since the payloads were never verified in the test suites. We tried to fix it but we could not get it to work. We're not sure how the `heroku.post` sends the body payload and the `nock` error messages did not explain what was wrong.