### PR TITLE
get archive_link from payload instead of body

### DIFF
--- a/packages/pipelines-v5/lib/kolkrabbi-api.js
+++ b/packages/pipelines-v5/lib/kolkrabbi-api.js
@@ -66,6 +66,6 @@ module.exports = class KolkrabbiAPI {
   getArchiveURL (repo, ref) {
     return this.request(`/github/repos/${repo}/tarball/${ref}`, {
       followRedirect: false
-    }).then((res) => res.body.archive_link);
+    }).then((res) => res.archive_link)
   }
 }


### PR DESCRIPTION
Follow up to https://github.com/heroku/cli/pull/944 since the return payload doesn't have `body`.

Proof that I tested after my last push 😒 
<img width="793" alt="screen shot 2018-07-18 at 11 00 23 am" src="https://user-images.githubusercontent.com/6271256/42890039-d79f19ea-8a79-11e8-969f-faf4d3e48042.png">