### PR TITLE
spaces: add top-level help for spaces:vpn

### DIFF
--- a/packages/spaces/commands/vpn/connect.js
+++ b/packages/spaces/commands/vpn/connect.js
@@ -32,13 +32,15 @@ module.exports = {
   topic: 'spaces',
   command: 'vpn:connect',
   description: 'create VPN',
-  help: `Example:
+  help: `Private Spaces can be connected to another private network via an IPSec VPN connection allowing dynos to connect to hosts on your private networks and vice versa.
+The connection is established over the public Internet but all traffic is encrypted using IPSec.
+  
+  Example:
 
     $ heroku spaces:vpn:connect --name office --ip 35.161.69.30 --cidrs 172.16.0.0/16,10.0.0.0/24 --space my-space
     Creating VPN Connection in space my-space... done
     ▸    Use spaces:vpn:wait to track allocation.
   `,
-  hidden: true,
   needsApp: false,
   needsAuth: true,
   args: [

--- a/packages/spaces/commands/vpn/connect.js
+++ b/packages/spaces/commands/vpn/connect.js
@@ -32,15 +32,12 @@ module.exports = {
   topic: 'spaces',
   command: 'vpn:connect',
   description: 'create VPN',
-  help: `Private Spaces can be connected to another private network via an IPSec VPN connection allowing dynos to connect to hosts on your private networks and vice versa.
-The connection is established over the public Internet but all traffic is encrypted using IPSec.
-  
-  Example:
-
-    $ heroku spaces:vpn:connect --name office --ip 35.161.69.30 --cidrs 172.16.0.0/16,10.0.0.0/24 --space my-space
+  example: `$ heroku spaces:vpn:connect --name office --ip 35.161.69.30 --cidrs 172.16.0.0/16,10.0.0.0/24 --space my-space
     Creating VPN Connection in space my-space... done
     ▸    Use spaces:vpn:wait to track allocation.
   `,
+  help: `Private Spaces can be connected to another private network via an IPSec VPN connection allowing dynos to connect to hosts on your private networks and vice versa.
+The connection is established over the public Internet but all traffic is encrypted using IPSec.`,
   needsApp: false,
   needsAuth: true,
   args: [

--- a/packages/spaces/commands/vpn/destroy.js
+++ b/packages/spaces/commands/vpn/destroy.js
@@ -31,7 +31,6 @@ module.exports = {
     $ heroku spaces:vpn:destroy --confirm --space example-space vpn-connection-name
     Tearing down VPN Connection in space example-space
   `,
-  hidden: true,
   needsApp: false,
   needsAuth: true,
   args: [

--- a/packages/spaces/commands/vpn/index.js
+++ b/packages/spaces/commands/vpn/index.js
@@ -48,7 +48,6 @@ module.exports = {
   ──────  ──────  ───────
   office  active  UP/UP
   `,
-  hidden: true,
   needsApp: false,
   needsAuth: true,
   args: [{name: 'space', optional: true, hidden: true}],

--- a/packages/spaces/commands/vpn/info.js
+++ b/packages/spaces/commands/vpn/info.js
@@ -76,7 +76,6 @@ module.exports = {
     ──────────  ─────────────  ──────  ────────────────────  ──────────────
     Tunnel 1    52.44.146.197  UP      2016-10-25T22:09:05Z  status message
     Tunnel 2    52.44.146.197  UP      2016-10-25T22:09:05Z  status message`,
-  hidden: true,
   needsApp: false,
   needsAuth: true,
   args: [{name: 'name', optional: true, hidden: true}],

--- a/packages/spaces/commands/vpn/wait.js
+++ b/packages/spaces/commands/vpn/wait.js
@@ -55,7 +55,6 @@ module.exports = {
   topic: 'spaces',
   command: 'vpn:wait',
   description: 'wait for VPN Connection to be created',
-  hidden: true,
   needsApp: false,
   needsAuth: true,
   args: [{name: 'name', optional: true, hidden: true}],


### PR DESCRIPTION
This removes the `hidden` attributes for vpn commands so that there is top-level help, as well as adds some additional information for the `vpn:connect` - I saw some other commands with useful information so I thought I would add some into it. 

Example:
```
$ heroku help spaces:vpn
create VPN

USAGE
  $ heroku spaces:vpn:COMMAND

DESCRIPTION
  Private Spaces can be connected to another private network via an IPSec VPN connection allowing dynos to connect to hosts on your private networks and vice versa.
  The connection is established over the public Internet but all traffic is encrypted using IPSec.
  
     Example:

       $ heroku spaces:vpn:connect --name office --ip 35.161.69.30 --cidrs 172.16.0.0/16,10.0.0.0/24 --space my-space
       Creating VPN Connection in space my-space... done
       ▸    Use spaces:vpn:wait to track allocation.
  

COMMANDS
  spaces:vpn:connect      create VPN
  spaces:vpn:connections  list the VPN Connections for a space
  spaces:vpn:destroy      destroys VPN in a private space
  spaces:vpn:info         display the information for VPN
  spaces:vpn:wait         wait for VPN Connection to be created

```

closes https://github.com/heroku/dogwood/issues/1950