### PR TITLE
Display 'no VPN connections' message if none exist yet

### DIFF
--- a/packages/spaces/commands/vpn/index.js
+++ b/packages/spaces/commands/vpn/index.js
@@ -5,6 +5,11 @@ const co = require('co')
 const format = require('../../lib/format')()
 
 function displayVPNConnections (space, connections) {
+  if (connections.length === 0) {
+    cli.log('No VPN Connections have been created yet')
+    return
+  }
+
   let tunnelFormat = function (t) {
     return t.map((tunnel) => format.VPNStatus(tunnel.status)).join('/')
   }

--- a/packages/spaces/test/commands/vpn/index.js
+++ b/packages/spaces/test/commands/vpn/index.js
@@ -39,6 +39,16 @@ describe('spaces:vpn:connections', function () {
       }
     ]
   }
+  it('displays no connection message if none exist', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/vpn-connections')
+      .reply(200, [])
+    return cmd.run({flags: {
+      space: 'my-space'
+    }})
+      .then(() => expect(cli.stdout).to.equal('No VPN Connections have been created yet\n'))
+      .then(() => api.done())
+  })
   it('displays VPN Connections', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/vpn-connections')


### PR DESCRIPTION
This adds a new message that's printed if no VPN connections exist yet rather than just printing an empty table.