### PR TITLE
remove 422 check from vpn:wait

### DIFF
--- a/packages/spaces/commands/vpn/wait.js
+++ b/packages/spaces/commands/vpn/wait.js
@@ -25,14 +25,7 @@ function * run (context, heroku) {
   let lib = require('../../lib/vpn-connections')(heroku)
   let info = {}
   do {
-    try {
-      info = yield lib.getVPNConnection(space, name)
-    } catch (e) {
-      // if 404 is received while in this loop, the VPN was deleted because provisioning failed
-      if (e.statusCode !== 422) { // ignore 422 since that means VPN is not ready
-        throw e
-      }
-    }
+    info = yield lib.getVPNConnection(space, name)
 
     if ((new Date()).getTime() >= deadline) {
       throw new Error('Timeout waiting for VPN to become allocated.')


### PR DESCRIPTION
a `VPN` is now returned as soon as it's created, no longer making the `422` check in `vpn:wait` necessary

closes https://github.com/heroku/dogwood/issues/1819