### PR TITLE
Fix inconsistencies in vpn:connect and vpn:wait 

### DIFF
--- a/packages/spaces/commands/vpn/connect.js
+++ b/packages/spaces/commands/vpn/connect.js
@@ -11,10 +11,10 @@ function check (val, message) {
 function * run (context, heroku) {
   let lib = require('../../lib/vpn-connections')(heroku)
 
-  let space = context.flags.space || context.args.space
+  let space = context.flags.space
   check(space, 'Space name required')
 
-  let name = context.flags.name
+  let name = context.flags.name || context.args.name
   check(name, 'VPN name required')
 
   let ip = context.flags.ip
@@ -42,7 +42,7 @@ module.exports = {
   needsApp: false,
   needsAuth: true,
   args: [
-    {name: 'space', optional: true, hidden: true}
+    {name: 'name', optional: true, hidden: true}
   ],
   flags: [
     {name: 'name', char: 'n', hasValue: true, description: 'VPN name'},

--- a/packages/spaces/commands/vpn/wait.js
+++ b/packages/spaces/commands/vpn/wait.js
@@ -10,7 +10,7 @@ function check (val, message) {
 }
 
 function * run (context, heroku) {
-  const space = context.flags.space || context.args.space
+  const space = context.flags.space
   check(space, 'Space name required')
   const name = context.flags.name || context.args.name
   check(name, 'VPN connection name required')


### PR DESCRIPTION
For consistency with the other commands, `connect` should accept name as an argument as well as a flag. 

This PR also removes a reference to a `space` argument in the `wait` command, which is not defined as an argument and should not be.

closes https://github.com/orgs/heroku/projects/52#card-11546913