### PR TITLE
Ensure paths are escaped to account for names used as IDs

### DIFF
--- a/packages/spaces/lib/vpn-connections.js
+++ b/packages/spaces/lib/vpn-connections.js
@@ -18,12 +18,6 @@ module.exports = function (heroku) {
   }
 
   function deleteVPNConnection (space, name) {
-    let lib = require('../lib/vpn')(heroku)
-
-    if (!name) {
-      return lib.deleteVPN(space)
-    }
-
     return request('DELETE', `/spaces/${space}/vpn-connections/${name}`)
   }
 

--- a/packages/spaces/lib/vpn-connections.js
+++ b/packages/spaces/lib/vpn-connections.js
@@ -30,7 +30,7 @@ module.exports = function (heroku) {
   function request (method, path, body) {
     return heroku.request({
       method: method,
-      path: path,
+      path: encodeURI(path),
       body: body
     })
   }


### PR DESCRIPTION
Ensures paths are properly encoded in the event they contain spaces or special characters

Also noticed that some `deleteVPN` code was still present while i was editing that file so I went ahead and removed that.

https://github.com/orgs/heroku/projects/52#card-11649683