### PR TITLE
Add --data-cidr flag for space creation

### DIFF
--- a/packages/spaces/commands/create.js
+++ b/packages/spaces/commands/create.js
@@ -28,7 +28,8 @@ function * run (context, heroku) {
       shield: context.flags['shield'],
       owner_pool: context.flags['owner-pool'],
       cidr: context.flags['cidr'],
-      kpi_url: context.flags['kpi-url']
+      kpi_url: context.flags['kpi-url'],
+      data_cidr: context.flags['data-cidr']
     }
   })
 
@@ -76,6 +77,7 @@ module.exports = {
     {name: 'shield', hasValue: false, hidden: true, description: 'create a Shield space'},
     {name: 'cidr', hasValue: true, hidden: true, description: 'the RFC-1918 CIDR the space will use'},
     {name: 'kpi-url', hasValue: true, hidden: true, description: 'self-managed KPI endpoint to use'},
+    {name: 'data-cidr', hasValue: true, hidden: true, description: "the RFC-1918 CIDR that the space will use when peering with DoD's spaces"},
     flags.team({name: 'team', hasValue: true})
   ],
   run: cli.command(co.wrap(run))

--- a/packages/spaces/test/commands/create.js
+++ b/packages/spaces/test/commands/create.js
@@ -96,19 +96,20 @@ Created at: ${now.toISOString()}
       .then(() => api.done())
   })
 
-  it('creates a space with custom cidr', function () {
+  it('creates a space with custom cidr and data cidr', function () {
     let api = nock('https://api.heroku.com:443')
       .post('/spaces', {
         name: 'my-space',
         team: 'my-team',
         region: 'my-region',
         cidr: '10.0.0.0/16',
+        data_cidr: '10.2.0.0/16',
         features: features
       })
       .reply(201,
         {shield: false, name: 'my-space', team: {name: 'my-team'}, region: {name: 'my-region'}, features: [ 'one', 'two' ], state: 'enabled', created_at: now}
       )
-    return cmd.run({team: 'my-team', flags: {space: 'my-space', region: 'my-region', features: 'one, two', cidr: '10.0.0.0/16'}, shield: true, log_drain_url: 'https://logs.cheetah.com'})
+    return cmd.run({team: 'my-team', flags: {space: 'my-space', region: 'my-region', features: 'one, two', cidr: '10.0.0.0/16', 'data-cidr': '10.2.0.0/16'}, shield: true, log_drain_url: 'https://logs.cheetah.com'})
       .then(() => expect(cli.stdout).to.equal(
         `=== my-space
 Team:       my-team


### PR DESCRIPTION
This adds a `--data-cidr` flag that specifies the RFC-1918 CIDR that the space will use when peering with DOD's spaces. This is a part of the new choose your own cidr feature.

Closes https://github.com/orgs/heroku/projects/52#card-12137969

Dependent on: https://github.com/heroku/api/pull/9789