### PR TITLE
Warn that force-rotating creds may impact access to followers

### DIFF
--- a/packages/pg-v5/commands/credentials/rotate.js
+++ b/packages/pg-v5/commands/credentials/rotate.js
@@ -35,6 +35,9 @@ function * run (context, heroku) {
   } else {
     warnings.push(`Connections older than 30 minutes will be reset, and a temporary rotation username will be used during the process.`)
   }
+  if (flags.force) {
+      warnings.push(`Any followers lagging in replication (see ${cli.color.cmd('heroku pg:info')}) will be inaccessible until caught up.`)
+  }
   if (attachments.length > 0) {
     warnings.push(`This command will affect the app${(attachments.length > 1) ? 's' : ''} ${[...new Set(attachments.map(c => cli.color.app(c.app.name)))].sort().join(', ')}.`)
   }

--- a/packages/pg-v5/test/commands/credentials/rotate.js
+++ b/packages/pg-v5/test/commands/credentials/rotate.js
@@ -190,6 +190,7 @@ This command will affect the apps appname_1, appname_2, appname_3.`
     const message = `WARNING: Destructive Action
 This forces rotation on all credentials including the default credential.
 Connections will be reset and applications will be restarted.
+Any followers lagging in replication (see heroku pg:info) will be inaccessible until caught up.
 This command will affect the apps appname_1, appname_2, appname_3.`
 
     return cmd.run({app: 'myapp',
@@ -226,6 +227,7 @@ This command will affect the apps appname_1, appname_2.`
     const message = `WARNING: Destructive Action
 The password for the my_role credential will rotate.
 Connections will be reset and applications will be restarted.
+Any followers lagging in replication (see heroku pg:info) will be inaccessible until caught up.
 This command will affect the apps appname_1, appname_2.`
 
     return cmd.run({app: 'myapp',


### PR DESCRIPTION
I opted for a fairly generic warning and terser warning rather than going into the details of how exactly your followers will break and when they'll unbreak.

See also discussion in https://github.com/heroku/shogun/pull/10156#discussion_r210582595