### PR TITLE
Fix error when testNodes is empty

### DIFF
--- a/packages/ci/src/utils/test-run.ts
+++ b/packages/ci/src/utils/test-run.ts
@@ -174,6 +174,10 @@ export async function renderList(command: Command, testRuns: Heroku.TestRun[], p
 }
 
 async function renderNodeOutput(command: Command, testRun: Heroku.TestRun, testNode: Heroku.TestNode) {
+  if (!testNode) {
+    command.error(`Test run ${testRun.number} was ${testRun.status}. No Heroku CI runs found for this pipeline.`)
+  }
+
   await stream(testNode.setup_stream_url!)
   await stream(testNode.output_stream_url!)
 


### PR DESCRIPTION
Found in ticket https://support.heroku.com/tickets/623553.

When a test run is cancelled, the API request for `/test-nodes` returns an empty array. This patches shows a proper error message in that case.

**Before:**

```bash
› heroku sudo ci:info ID --pipeline my-pipeline
TypeError: Cannot read property 'setup_stream_url' of undefined
    at renderNodeOutput (~/.local/share/heroku/client/7.12.3/node_modules/@heroku-cli/plugin-ci/lib/utils/test-run.js:143:27)
    at Object.displayTestRunInfo (~/.local/share/heroku/client/7.12.3/node_modules/@heroku-cli/plugin-ci/lib/utils/test-run.js:215:19)
    at CiInfo.run (~/.local/share/heroku/client/7.12.3/node_modules/@heroku-cli/plugin-ci/lib/commands/ci/info.js:12:26)
```

**Now:**

```bash
› heroku sudo ci:info ID --pipeline my-pipeline
 ›   Error: Test run ID was cancelled. No Heroku CI runs found for this pipeline.
```