### PR TITLE
Allow the `ci` package to include `*.js` files.

### DIFF
--- a/packages/ci/package.json
+++ b/packages/ci/package.json
@@ -68,7 +68,7 @@
   "repository": "heroku/cli",
   "scripts": {
     "postpack": "rm -f oclif.manifest.json npm-shrinkwrap.json",
-    "posttest": "tsc -p test --noEmit && tslint -p test -t stylish",
+    "posttest": "tsc -p test --noEmit && tslint -p test -t stylish -e \"**/*.js\"",
     "prepack": "rm -rf lib && tsc && oclif-dev manifest && oclif-dev readme && npm shrinkwrap",
     "prepare": "rm -rf lib && tsc",
     "test": "nyc mocha --forbid-only \"test/**/*.test.ts\"",

--- a/packages/ci/tsconfig.json
+++ b/packages/ci/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "declaration": true,
+    "declaration": false,
+    "allowJs": true,
     "forceConsistentCasingInFileNames": true,
     "importHelpers": true,
     "module": "commonjs",


### PR DESCRIPTION
We use a `git.js` file that was not being packaged up. We had to turn off declarations in order to set the `allowJs` option. We can probably enable this in the future (https://github.com/Microsoft/TypeScript/issues/7546) or convert it to typescript.