### PR TITLE
fix(ci): unknown local commit path

### DIFF
--- a/packages/ci/src/utils/source.ts
+++ b/packages/ci/src/utils/source.ts
@@ -4,6 +4,7 @@ const git = require('./git')
 import {Command} from '@heroku-cli/command'
 
 import * as fs from 'async-file'
+import {ux} from 'cli-ux'
 
 async function uploadArchive(url: string, filePath: string) {
   const request = got.stream.put(url, {
@@ -40,7 +41,10 @@ export async function createSourceBlob(ref: any, command: Command) {
     if (await urlExists(archiveLink.archive_link)) {
       return archiveLink.archive_link
     }
-  } catch { }
+  } catch (ex) {
+    // the commit isn't in the repo, we will package the local git commit instead
+    ux.debug(`Commit not found in pipeline repository: ${ex}`)
+  }
 
   const sourceBlob = await prepareSource(ref, command)
   return sourceBlob.source_blob.get_url

--- a/packages/ci/src/utils/source.ts
+++ b/packages/ci/src/utils/source.ts
@@ -21,10 +21,8 @@ async function uploadArchive(url: string, filePath: string) {
 }
 
 async function prepareSource(ref: any, command: Command) {
-  const [filePath, source] = await [
-    git.createArchive(ref),
-    command.heroku.post('/sources', {body: command})
-  ]
+  const filePath = await git.createArchive(ref)
+  const {body: source} = await command.heroku.post<any>('/sources')
   await uploadArchive(source.source_blob.put_url, filePath)
   return Promise.resolve(source)
 }
@@ -42,7 +40,7 @@ export async function createSourceBlob(ref: any, command: Command) {
     if (await urlExists(archiveLink.archive_link)) {
       return archiveLink.archive_link
     }
-  } catch (ex) { command.error(ex) }
+  } catch { }
 
   const sourceBlob = await prepareSource(ref, command)
   return sourceBlob.source_blob.get_url

--- a/packages/ci/test/commands/ci/run.test.ts
+++ b/packages/ci/test/commands/ci/run.test.ts
@@ -1,5 +1,7 @@
 import Nock from '@fancy-test/nock'
 import * as Test from '@oclif/test'
+import * as fs from 'async-file'
+const got = require('got')
 
 import * as git from '../../../src/utils/git'
 
@@ -37,7 +39,7 @@ describe('ci:run', () => {
       getRef: () => Promise.resolve(ghRepository.ref),
       getCommitTitle: () => Promise.resolve(`pushed to ${ghRepository.branch}`),
       githubRepository: () => Promise.resolve({user: ghRepository.user, repo: ghRepository.repo}),
-      createArchive: () => Promise.resolve('https://someurl'),
+      createArchive: () => Promise.resolve('new-archive.tgz'),
       spawn: () => Promise.resolve(),
       urlExists: () => Promise.resolve(),
       exec: (args: any) => {
@@ -48,6 +50,21 @@ describe('ci:run', () => {
             return Promise.resolve()
         }
       }
+    }
+
+    const fsFake = {
+      stat: () => Promise.resolve({size: 500}),
+      createReadStream: () => ({pipe: () => {}})
+    }
+
+    const gotFake = {
+      stream: { put: () => {
+        return {
+          on: (eventName: string, callback: () => void) => {
+            if (eventName === 'response') callback()
+          }
+        }
+      }}
     }
 
     test
@@ -119,6 +136,81 @@ describe('ci:run', () => {
     .command(['ci:run', `--pipeline=${pipeline.name}`])
     .it('it runs the test and displays the test output for the first node', ({stdout}) => {
       expect(stdout).to.equal('New Test setup outputNew Test output\n✓ #11 my-test-branch:668a5ce succeeded\n')
+    })
+
+    describe('when the commit is not in the remote repository', function () {
+      test
+      .stdout()
+      .nock('https://api.heroku.com', api => {
+        api.get(`/pipelines?eq[name]=${pipeline.name}`)
+        .reply(200, [
+          {id: pipeline.id}
+        ])
+
+        api.post('/test-runs')
+        .reply(200, newTestRun)
+
+        api.get(`/pipelines/${pipeline.id}/test-runs/${newTestRun.number}`)
+        .reply(200, newTestRun)
+
+        api.get(`/test-runs/${newTestRun.id}/test-nodes`)
+        .times(2)
+        .reply(200, [
+          {
+            commit_branch: newTestRun.commit_branch,
+            commit_message: newTestRun.commit_message,
+            commit_sha: newTestRun.commit_sha,
+            id: newTestRun.id,
+            number: newTestRun.number,
+            pipeline: {id: pipeline.id},
+            exit_code: 0,
+            status: newTestRun.status,
+            setup_stream_url: `https://test-setup-output.heroku.com/streams/${newTestRun.id.substring(0, 3)}/test-runs/${newTestRun.id}`,
+            output_stream_url: `https://test-output.heroku.com/streams/${newTestRun.id.substring(0, 3)}/test-runs/${newTestRun.id}`
+          }
+        ])
+
+        api.post('/sources')
+        .reply(200, {source_blob: {put_url: 'https://aws-puturl', get_url: 'https://aws-geturl'}})
+      })
+      .nock('https://test-setup-output.heroku.com/streams', testOutputAPI => {
+        testOutputAPI.get(`/${newTestRun.id.substring(0, 3)}/test-runs/${newTestRun.id}`)
+        .reply(200, 'New Test setup output')
+      })
+      .nock('https://test-output.heroku.com/streams', testOutputAPI => {
+        testOutputAPI.get(`/${newTestRun.id.substring(0, 3)}/test-runs/${newTestRun.id}`)
+        .reply(200, 'New Test output')
+      })
+      .nock('https://kolkrabbi.heroku.com', kolkrabbiAPI => {
+        kolkrabbiAPI.get(`/github/repos/${ghRepository.user}/${ghRepository.repo}/tarball/${ghRepository.ref}`)
+        .reply(404)
+        kolkrabbiAPI.get(`/pipelines/${pipeline.id}/repository`)
+        .reply(200, {
+          ci: true,
+          organization: {id: 'e037ed63-5781-48ee-b2b7-8c55c571b63e'},
+          owner: {
+            id: '463147bf-d572-41cf-bbf4-11ebc1c0bc3b',
+            heroku: {
+              user_id: '463147bf-d572-41cf-bbf4-11ebc1c0bc3b' },
+              github: {user_id: 306015}
+            },
+            repository: {
+              id: 138865824,
+              name: 'raulb/atleti',
+              type: 'github'
+            }
+        })
+      })
+      .stub(git, 'readCommit', gitFake.readCommit)
+      .stub(git, 'githubRepository', gitFake.githubRepository)
+      .stub(git, 'createArchive', gitFake.createArchive)
+      .stub(fs, 'stat', fsFake.stat)
+      .stub(fs, 'createReadStream', fsFake.createReadStream)
+      .stub(got, 'stream', gotFake.stream)
+      .command(['ci:run', `--pipeline=${pipeline.name}`])
+      .it('it runs the test and displays the test output for the first node', ({stdout}) => {
+        expect(stdout).to.equal('New Test setup outputNew Test output\n✓ #11 my-test-branch:668a5ce succeeded\n')
+      })
     })
   })
 })


### PR DESCRIPTION
The new `ci:run` had an untested path for new commits that have not yet been pushed to a repo. It's supposed to create a source and upload the archive (like `ci:debug`).

This fixes the bugs and adds a test to help prevent regressions.