### PR TITLE
fix(pipelines-v5): Only consider succeeded releases in pipelines:diff

### DIFF
--- a/packages/pipelines-v5/commands/pipelines/diff.js
+++ b/packages/pipelines-v5/commands/pipelines/diff.js
@@ -52,7 +52,7 @@ function * getAppInfo (heroku, appName, appId) {
       headers: { 'Accept': V3_HEADER, 'Range': 'version ..; order=desc' },
       partial: true
     })
-    const release = releases.filter((r) => r.status === 'succeeded')[0]
+    const release = releases.find((r) => r.status === 'succeeded')
     if (release === null || release.slug === null) {
       throw new Error(`no release found for ${appName}`)
     }

--- a/packages/pipelines-v5/commands/pipelines/diff.js
+++ b/packages/pipelines-v5/commands/pipelines/diff.js
@@ -53,7 +53,7 @@ function * getAppInfo (heroku, appName, appId) {
       partial: true
     })
     const release = releases.filter((r) => r.status === 'succeeded')[0]
-    if (release.slug === null) {
+    if (release === null || release.slug === null) {
       throw new Error(`no release found for ${appName}`)
     }
     slug = yield heroku.request({

--- a/packages/pipelines-v5/commands/pipelines/diff.js
+++ b/packages/pipelines-v5/commands/pipelines/diff.js
@@ -46,18 +46,19 @@ function * getAppInfo (heroku, appName, appId) {
   // Find the commit hash of the latest release for this app
   let slug
   try {
-    const release = yield heroku.request({
+    const releases = yield heroku.request({
       method: 'GET',
       path: `/apps/${appId}/releases`,
-      headers: { 'Accept': V3_HEADER, 'Range': 'version ..; order=desc,max=1' },
+      headers: { 'Accept': V3_HEADER, 'Range': 'version ..; order=desc' },
       partial: true
     })
-    if (release[0].slug === null) {
+    const release = releases.filter((r) => r.status === 'succeeded')[0]
+    if (release.slug === null) {
       throw new Error(`no release found for ${appName}`)
     }
     slug = yield heroku.request({
       method: 'GET',
-      path: `/apps/${appId}/slugs/${release[0].slug.id}`,
+      path: `/apps/${appId}/slugs/${release.slug.id}`,
       headers: { 'Accept': V3_HEADER }
     })
   } catch (err) {

--- a/packages/pipelines-v5/commands/pipelines/diff.js
+++ b/packages/pipelines-v5/commands/pipelines/diff.js
@@ -53,7 +53,7 @@ function * getAppInfo (heroku, appName, appId) {
       partial: true
     })
     const release = releases.find((r) => r.status === 'succeeded')
-    if (release === null || release.slug === null) {
+    if (!release || !release.slug) {
       throw new Error(`no release found for ${appName}`)
     }
     slug = yield heroku.request({

--- a/packages/pipelines-v5/test/commands/pipelines/diff.js
+++ b/packages/pipelines-v5/test/commands/pipelines/diff.js
@@ -183,9 +183,12 @@ describe('pipelines:diff', function () {
       // Mock latest release/slug endpoints for two apps:
       nock(api)
         .get(`/apps/${targetApp.id}/releases`)
-        .reply(200, [{ slug: { id: targetSlugId } }])
+        .reply(200, [{ slug: { id: targetSlugId }, status: 'succeeded' }])
         .get(`/apps/${downstreamApp1.id}/releases`)
-        .reply(200, [{ slug: { id: downstreamSlugId } }])
+        .reply(200, [
+          { status: 'failed' },
+          { slug: { id: downstreamSlugId }, status: 'succeeded' }
+        ])
     })
 
     it('should not compare apps if update to date NOR if repo differs', function () {

--- a/packages/pipelines-v5/test/commands/pipelines/diff.js
+++ b/packages/pipelines-v5/test/commands/pipelines/diff.js
@@ -145,13 +145,28 @@ describe('pipelines:diff', function () {
         })
     })
 
-    it('should return an error if the target app has no release', function () {
+    it('should return an error if the target app has a release with no slug', function () {
       nock(kolkrabbiApi)
         .get(`/apps/${targetApp.id}/github`)
         .reply(200, targetGithubApp)
       const req = nock(api)
         .get(`/apps/${targetApp.id}/releases`)
         .reply(200, [{ slug: null }])
+
+      return cmd.run({ app: targetApp.name })
+        .then(function () {
+          req.done()
+          expect(cli.stderr).to.contain('No release was found')
+        })
+    })
+
+    it('should return an error if the target app has no release', function () {
+      nock(kolkrabbiApi)
+        .get(`/apps/${targetApp.id}/github`)
+        .reply(200, targetGithubApp)
+      const req = nock(api)
+        .get(`/apps/${targetApp.id}/releases`)
+        .reply(200, [])
 
       return cmd.run({ app: targetApp.name })
         .then(function () {


### PR DESCRIPTION
`pipelines:diff` fetches the releases and compares them. We shouldn't consider a pending or failed release as currently running on the app. Only succeeded ones.
