### PR TITLE
feat(apps-v5): allow viewing heroku:logs in local timezone

### DIFF
--- a/packages/run-v5/commands/logs.js
+++ b/packages/run-v5/commands/logs.js
@@ -10,6 +10,7 @@ async function run (context, heroku) {
     app: context.app,
     dyno: context.flags.dyno || context.flags.ps,
     lines: context.flags.num || 100,
+    localTimezone: context.flags['local-timezone'],
     tail: context.flags.tail,
     source: context.flags.source
   })
@@ -30,6 +31,7 @@ disable colors with --no-color, HEROKU_LOGS_COLOR=0, or HEROKU_COLOR=0`,
     { name: 'dyno', char: 'd', description: 'only show output from this dyno type (such as "web" or "worker")', hasValue: true, completion: DynoCompletion },
     { name: 'source', char: 's', description: 'only show output from this source (such as "app" or "heroku")', hasValue: true, completion: ProcessTypeCompletion },
     { name: 'tail', char: 't', description: 'continually stream logs' },
+    { name: 'local-timezone', description: 'show timestamps in local timezone' },
     { name: 'force-colors', description: 'force use of colors (even on non-tty output)' }
   ],
   run: cli.command(run)

--- a/packages/run-v5/lib/colorize.js
+++ b/packages/run-v5/lib/colorize.js
@@ -1,3 +1,5 @@
+let dateFormat = require('dateformat')
+
 const {default: ux} = require('cli-ux')
 const {default: c} = require('@heroku-cli/color')
 
@@ -28,7 +30,7 @@ getColorForIdentifier('web')
 getColorForIdentifier('postgres')
 getColorForIdentifier('heroku-postgres')
 
-let lineRegex = /^(.*?\[([\w-]+)([\d.]+)?]:)(.*)?$/
+let lineRegex = /^(.*?)( .*?)(\[([\w-]+)([\d.]+)?]:)(.*)?$/
 
 const red = c.red
 const dim = i => c.dim(i)
@@ -256,14 +258,19 @@ function colorizePG (body) {
   return body
 }
 
-module.exports = function colorize (line) {
+module.exports = function colorize (line, localTimezone) {
   if (process.env.HEROKU_LOGS_COLOR === '0') return line
 
   let parsed = line.match(lineRegex)
   if (!parsed) return line
-  let header = parsed[1]
-  let identifier = parsed[2]
-  let body = (parsed[4] || '').trim()
+
+  let time = parsed[1]
+  if (localTimezone) {
+    time = dateFormat(Date.parse(time), "yyyy-mm-dd'T'HH:MM:ss.lo")
+  }
+  let header = time + parsed[2] + parsed[3]
+  let identifier = parsed[4]
+  let body = (parsed[6] || '').trim()
   switch (identifier) {
     case 'api':
       body = colorizeAPI(body)

--- a/packages/run-v5/lib/log_displayer.js
+++ b/packages/run-v5/lib/log_displayer.js
@@ -7,12 +7,12 @@ let liner = require('../lib/line_transform')
 const colorize = require('./colorize')
 const HTTP = require('http-call')
 
-function readLogs (logplexURL) {
+function readLogs (logplexURL, localTimezone) {
   let u = url.parse(logplexURL)
   if (u.query && u.query.includes('srv')) {
     return readLogsV1(logplexURL)
   } else {
-    return readLogsV2(logplexURL)
+    return readLogsV2(logplexURL, localTimezone)
   }
 }
 
@@ -28,7 +28,7 @@ async function readLogsV1 (logplexURL) {
   })
 }
 
-function readLogsV2 (logplexURL) {
+function readLogsV2 (logplexURL, localTimezone) {
   return new Promise(function (resolve, reject) {
     const u = url.parse(logplexURL, true)
     const isTail = u.query.tail && u.query.tail === 'true'
@@ -60,7 +60,7 @@ function readLogsV2 (logplexURL) {
 
     es.onmessage = function (e) {
       e.data.trim().split(/\n+/).forEach((line) => {
-        cli.log(colorize(line))
+        cli.log(colorize(line, localTimezone))
       })
     }
   })
@@ -85,7 +85,7 @@ async function logDisplayer (heroku, options) {
       lines: options.lines
     }
   })
-  return readLogs(response.logplex_url)
+  return readLogs(response.logplex_url, options.localTimezone)
 }
 
 module.exports = logDisplayer

--- a/packages/run-v5/test/commands/logs.js
+++ b/packages/run-v5/test/commands/logs.js
@@ -11,4 +11,9 @@ describe('logs', () => {
     return cmd.run({ app: 'heroku-run-test-app', flags: {}, auth: { password: global.apikey } })
       .then(() => expect(cli.stdout, 'to begin with', '20')) // starts with the year
   })
+
+  it('shows the logs in timezone', () => {
+    return cmd.run({ app: 'heroku-run-test-app', flags: { 'local-timezone': 'true' }, auth: { password: global.apikey } })
+      .then(() => expect(cli.stdout, 'to begin with', '20')) // starts with the year
+  })
 })


### PR DESCRIPTION
Fixes https://github.com/heroku/cli/issues/1059


<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](http://conventionalcommits.org).
-->