### PR TITLE
fix: pass env vars down to pg_pull/pg_drop

### DIFF
--- a/packages/pg-v5/commands/pull.js
+++ b/packages/pg-v5/commands/pull.js
@@ -143,7 +143,7 @@ const run = co.wrap(function * (sourceIn, targetIn, exclusions) {
 
   const restoreFlags = ['--verbose', '-F', 'c', '--no-acl', '--no-owner', ...connArgs(target)]
   const restoreOptions = {
-    env: {...env},
+    env: { ...env },
     stdio: ['pipe', 'pipe', 2],
     encoding: 'utf8',
     shell: true

--- a/packages/pg-v5/commands/pull.js
+++ b/packages/pg-v5/commands/pull.js
@@ -132,7 +132,8 @@ const run = co.wrap(function * (sourceIn, targetIn, exclusions) {
 
   const dumpOptions = {
     env: {
-      PGSSLMODE: 'prefer'
+      PGSSLMODE: 'prefer',
+      ...env
     },
     stdio: ['pipe', 'pipe', 2],
     encoding: 'utf8',
@@ -142,11 +143,12 @@ const run = co.wrap(function * (sourceIn, targetIn, exclusions) {
 
   const restoreFlags = ['--verbose', '-F', 'c', '--no-acl', '--no-owner', ...connArgs(target)]
   const restoreOptions = {
+    env: {...env},
     stdio: ['pipe', 'pipe', 2],
     encoding: 'utf8',
     shell: true
   }
-  if (target.password) restoreOptions.env = { PGPASSWORD: target.password }
+  if (target.password) restoreOptions.env.PGPASSWORD = target.password
 
   const pgDump = cp.spawn('pg_dump', dumpFlags, dumpOptions)
   const pgRestore = cp.spawn('pg_restore', restoreFlags, restoreOptions)

--- a/packages/pg-v5/lib/bastion.js
+++ b/packages/pg-v5/lib/bastion.js
@@ -6,7 +6,7 @@ const cli = require('heroku-cli-util')
 const host = require('./host')
 
 const getBastion = function (config, baseName) {
-  const {sample} = require('lodash')
+  const { sample } = require('lodash')
   // If there are bastions, extract a host and a key
   // otherwise, return an empty Object
 
@@ -20,7 +20,7 @@ const getBastion = function (config, baseName) {
   const bastionHost = sample((config[`${baseName}_BASTIONS`] || '').split(','))
   return (!(bastionKey && bastionHost))
     ? {}
-    : {bastionHost, bastionKey}
+    : { bastionHost, bastionKey }
 }
 
 exports.getBastion = getBastion
@@ -114,7 +114,7 @@ function * fetchConfig (heroku, db) {
   return yield heroku.get(
     `/client/v11/databases/${encodeURIComponent(db.id)}/bastion`,
     {
-      host: host(db),
+      host: host(db)
     }
   )
 }

--- a/packages/pg-v5/lib/download.js
+++ b/packages/pg-v5/lib/download.js
@@ -17,7 +17,7 @@ function download (url, path, opts) {
     let total = 0
     rsp.on('data', function (chunk) {
       total += chunk.length
-      bar.tick(chunk.length, {data: bytes(total, {decimalPlaces: 2, fixedDecimals: 2})})
+      bar.tick(chunk.length, { data: bytes(total, { decimalPlaces: 2, fixedDecimals: 2 }) })
     })
   }
 

--- a/packages/pg-v5/lib/fetcher.js
+++ b/packages/pg-v5/lib/fetcher.js
@@ -12,26 +12,26 @@ module.exports = heroku => {
     let db = passedDb || 'DATABASE_URL'
 
     function matchesHelper (app, db) {
-      const {resolve} = require('@heroku-cli/plugin-addons')
+      const { resolve } = require('@heroku-cli/plugin-addons')
 
       debug(`fetching ${db} on ${app}`)
 
-      return resolve.appAttachment(heroku, app, db, {addon_service: 'heroku-postgresql', namespace: namespace})
-        .then(attached => ({matches: [attached]}))
+      return resolve.appAttachment(heroku, app, db, { addon_service: 'heroku-postgresql', namespace: namespace })
+        .then(attached => ({ matches: [attached] }))
         .catch(function (err) {
           if (err.statusCode === 422 && err.body && err.body.id === 'multiple_matches' && err.matches) {
-            return {matches: err.matches, err: err}
+            return { matches: err.matches, err: err }
           }
 
           if (err.statusCode === 404 && err.body && err.body.id === 'not_found') {
-            return {matches: null, err: err}
+            return { matches: null, err: err }
           }
 
           throw err
         })
     }
 
-    let {matches, err} = yield matchesHelper(app, db)
+    let { matches, err } = yield matchesHelper(app, db)
 
     // happy path where the resolver matches just one
     if (matches && matches.length === 1) {
@@ -100,7 +100,7 @@ module.exports = heroku => {
       let bastionHost = bastionConfig.host
       let bastionKey = bastionConfig.private_key
 
-      Object.assign(database, {bastionHost, bastionKey})
+      Object.assign(database, { bastionHost, bastionKey })
     }
 
     return database
@@ -108,7 +108,7 @@ module.exports = heroku => {
 
   function * allAttachments (app) {
     let attachments = yield heroku.get(`/apps/${app}/addon-attachments`, {
-      headers: {'Accept-Inclusion': 'addon:plan,config_vars'}
+      headers: { 'Accept-Inclusion': 'addon:plan,config_vars' }
     })
     return attachments.filter(a => a.addon.plan.name.startsWith('heroku-postgresql'))
   }
@@ -121,7 +121,7 @@ module.exports = heroku => {
   }
 
   function * all (app) {
-    const {uniqBy} = require('lodash')
+    const { uniqBy } = require('lodash')
 
     debug(`fetching all DBs on ${app}`)
 

--- a/packages/pg-v5/lib/pgbackups.js
+++ b/packages/pg-v5/lib/pgbackups.js
@@ -35,7 +35,7 @@ module.exports = (context, heroku) => ({
       m = name.match(/^o[ab]\d+$/)
       if (m) {
         const host = require('./host')()
-        let transfers = yield heroku.get(`/client/v11/apps/${context.app}/transfers`, {host})
+        let transfers = yield heroku.get(`/client/v11/apps/${context.app}/transfers`, { host })
         let transfer = transfers.find(t => module.exports(context, heroku).transfer.name(t) === name)
         if (transfer) return transfer.num
       }
@@ -91,7 +91,7 @@ module.exports = (context, heroku) => ({
 
       while (true) {
         try {
-          backup = yield heroku.get(url, {host})
+          backup = yield heroku.get(url, { host })
         } catch (err) {
           if (failures++ > 20) throw err
         }
@@ -110,7 +110,7 @@ module.exports = (context, heroku) => ({
           if (backup.succeeded) return
           else {
             // logs is undefined unless verbose=true is passed
-            backup = yield heroku.get(verboseUrl, {host})
+            backup = yield heroku.get(verboseUrl, { host })
 
             throw new Error(`An error occurred and the backup did not finish.
 

--- a/packages/pg-v5/lib/psql.js
+++ b/packages/pg-v5/lib/psql.js
@@ -15,11 +15,11 @@ function handlePsqlError (reject, psql) {
 }
 
 function execPsql (query, dbEnv) {
-  const {spawn} = require('child_process')
+  const { spawn } = require('child_process')
   return new Promise((resolve, reject) => {
     let result = ''
     debug('Running query: %s', query.trim())
-    let psql = spawn('psql', ['-c', query], {env: dbEnv, encoding: 'utf8', stdio: [ 'ignore', 'pipe', 'inherit' ]})
+    let psql = spawn('psql', ['-c', query], { env: dbEnv, encoding: 'utf8', stdio: [ 'ignore', 'pipe', 'inherit' ] })
     psql.stdout.on('data', function (data) {
       result += data.toString()
     })
@@ -31,11 +31,11 @@ function execPsql (query, dbEnv) {
 }
 
 function execPsqlWithFile (file, dbEnv) {
-  const {spawn} = require('child_process')
+  const { spawn } = require('child_process')
   return new Promise((resolve, reject) => {
     let result = ''
     debug('Running sql file: %s', file.trim())
-    let psql = spawn('psql', ['-f', file], {env: dbEnv, encoding: 'utf8', stdio: [ 'ignore', 'pipe', 'inherit' ]})
+    let psql = spawn('psql', ['-f', file], { env: dbEnv, encoding: 'utf8', stdio: [ 'ignore', 'pipe', 'inherit' ] })
     psql.stdout.on('data', function (data) {
       result += data.toString()
     })
@@ -47,29 +47,27 @@ function execPsqlWithFile (file, dbEnv) {
 }
 
 function psqlInteractive (dbEnv, prompt) {
-  const {spawn} = require('child_process')
+  const { spawn } = require('child_process')
   return new Promise((resolve, reject) => {
-    let psqlArgs = ['--set', `PROMPT1=${prompt}`, '--set', `PROMPT2=${prompt}`, ]
+    let psqlArgs = ['--set', `PROMPT1=${prompt}`, '--set', `PROMPT2=${prompt}`]
     let psqlHistoryPath = process.env.HEROKU_PSQL_HISTORY
-    if(psqlHistoryPath) {
+    if (psqlHistoryPath) {
       const fs = require('fs')
       const path = require('path')
-      if(fs.existsSync(psqlHistoryPath) && fs.statSync(psqlHistoryPath).isDirectory()) {
+      if (fs.existsSync(psqlHistoryPath) && fs.statSync(psqlHistoryPath).isDirectory()) {
         let appLogFile = `${psqlHistoryPath}/${prompt.split(':')[0]}`
         debug('Logging psql history to %s', appLogFile)
         psqlArgs = psqlArgs.concat(['--set', `HISTFILE=${appLogFile}`])
-      }
-      else if (fs.existsSync(path.dirname(psqlHistoryPath))) {
+      } else if (fs.existsSync(path.dirname(psqlHistoryPath))) {
         debug('Logging psql history to %s', psqlHistoryPath)
         psqlArgs = psqlArgs.concat(['--set', `HISTFILE=${psqlHistoryPath}`])
-      }
-      else {
+      } else {
         const cli = require('heroku-cli-util')
         cli.warn(`HEROKU_PSQL_HISTORY is set but is not a valid path (${psqlHistoryPath})`)
       }
     }
 
-    let psql = spawn('psql', psqlArgs, {env: dbEnv, stdio: 'inherit'})
+    let psql = spawn('psql', psqlArgs, { env: dbEnv, stdio: 'inherit' })
     handlePsqlError(reject, psql)
     psql.on('close', (data) => {
       resolve()

--- a/packages/pg-v5/lib/setter.js
+++ b/packages/pg-v5/lib/setter.js
@@ -31,8 +31,8 @@ exports.generate = (name, convert, explain) => {
     const host = require('./host')
     const util = require('./util')
     const fetcher = require('./fetcher')(heroku)
-    const {app, args} = context
-    const {value, database} = args
+    const { app, args } = context
+    const { value, database } = args
 
     const db = yield fetcher.addon(app, database)
 
@@ -40,7 +40,7 @@ exports.generate = (name, convert, explain) => {
     if (util.legacyPlan(db)) throw new Error('This operation is not supported by Legacy tier databases.')
 
     if (!value) {
-      let settings = yield heroku.get(`/postgres/v0/databases/${db.id}/config`, {host: host(db)})
+      let settings = yield heroku.get(`/postgres/v0/databases/${db.id}/config`, { host: host(db) })
       let setting = settings[name]
       cli.log(`${name.replace(/_/g, '-')} is set to ${setting.value} for ${db.name}.`)
       cli.log(explain(setting))

--- a/packages/pg-v5/lib/util.js
+++ b/packages/pg-v5/lib/util.js
@@ -3,7 +3,7 @@
 const cli = require('heroku-cli-util')
 const debug = require('./debug')
 const getBastion = require('./bastion').getBastion
-const {sortBy} = require('lodash')
+const { sortBy } = require('lodash')
 const printf = require('printf')
 const URL = require('url').URL
 
@@ -62,9 +62,9 @@ function presentCredentialAttachments (app, credAttachments, credentials, cred) 
         printHeader: false,
         printLine: function (line) { rotationLines.push(line) },
         columns: [
-          {key: 'user', format: (v, r) => `${prefix}${v}`},
-          {key: 'state', format: (v, r) => (v === 'revoking') ? 'waiting for no connections to be revoked' : v},
-          {key: 'connections', format: (v, r) => `${v} connections`}
+          { key: 'user', format: (v, r) => `${prefix}${v}` },
+          { key: 'state', format: (v, r) => (v === 'revoking') ? 'waiting for no connections to be revoked' : v },
+          { key: 'connections', format: (v, r) => `${v} connections` }
         ]
       })
     }

--- a/packages/pg-v5/package.json
+++ b/packages/pg-v5/package.json
@@ -37,6 +37,7 @@
     "nyc": "^13.0.1",
     "proxyquire": "^2.1.0",
     "sinon": "<2",
+    "standard": "^12.0.1",
     "unexpected": "^10.39.1"
   },
   "files": [

--- a/packages/pg-v5/test/commands/pull.js
+++ b/packages/pg-v5/test/commands/pull.js
@@ -72,7 +72,8 @@ describe('pg', () => {
   describe('push', () => {
     const dumpOpts = {
       env: {
-        PGSSLMODE: 'prefer'
+        PGSSLMODE: 'prefer',
+        ...env
       },
       stdio: ['pipe', 'pipe', 2],
       encoding: 'utf8',
@@ -80,7 +81,8 @@ describe('pg', () => {
     }
     const restoreOpts = {
       env: {
-        PGPASSWORD: 'pass'
+        PGPASSWORD: 'pass',
+        ...env
       },
       stdio: ['pipe', 'pipe', 2],
       encoding: 'utf8',
@@ -101,6 +103,8 @@ describe('pg', () => {
       psql.exec.restore()
       spawnStub.restore()
       delete env.PGPORT
+      delete restoreOpts.env.PGPORT
+      delete dumpOpts.env.PGPORT
     })
 
     it('pushes out a db', () => {
@@ -150,7 +154,8 @@ describe('pg', () => {
     })
 
     it('pushes out a db using PGPORT', () => {
-      env.PGPORT = 5433
+      env.PGPORT = dumpOpts.env.PGPORT = '5433'
+      restoreOpts.env.PGPORT = '5433'
 
       const dumpFlags = ['--verbose', '-F', 'c', '-Z', '0', '-p', '5433', 'localdb']
       const restoreFlags = ['--verbose', '-F', 'c', '--no-acl', '--no-owner', '-U', 'jeff', '-h', 'herokai.com', '-p', '5432', '-d', 'mydb']
@@ -244,7 +249,8 @@ describe('pg', () => {
     const dumpOpts = {
       env: {
         PGPASSWORD: 'pass',
-        PGSSLMODE: 'prefer'
+        PGSSLMODE: 'prefer',
+        ...env
       },
       stdio: ['pipe', 'pipe', 2],
       encoding: 'utf8',
@@ -252,6 +258,7 @@ describe('pg', () => {
     }
     const restoreFlags = ['--verbose', '-F', 'c', '--no-acl', '--no-owner', '-d', 'localdb']
     const restoreOpts = {
+      env: {...env},
       stdio: ['pipe', 'pipe', 2],
       encoding: 'utf8',
       shell: true

--- a/packages/pg-v5/test/commands/pull.js
+++ b/packages/pg-v5/test/commands/pull.js
@@ -258,7 +258,7 @@ describe('pg', () => {
     }
     const restoreFlags = ['--verbose', '-F', 'c', '--no-acl', '--no-owner', '-d', 'localdb']
     const restoreOpts = {
-      env: {...env},
+      env: { ...env },
       stdio: ['pipe', 'pipe', 2],
       encoding: 'utf8',
       shell: true

--- a/packages/pg-v5/test/lib/psql.js
+++ b/packages/pg-v5/test/lib/psql.js
@@ -203,7 +203,12 @@ describe('psql', () => {
     }
 
     context('when HEROKU_PSQL_HISTORY is set', () => {
-      process.env.HEROKU_PSQL_HISTORY = `${path.join('/', 'path', 'to', 'history')}`
+      beforeEach(() => {
+        process.env.HEROKU_PSQL_HISTORY = `${path.join('/', 'path', 'to', 'history')}`
+      })
+      afterEach(() => {
+        delete process.env.HEROKU_PSQL_HISTORY
+      })
 
       context('when HEROKU_PSQL_HISTORY is a valid directory path', () => {
         it('is the directory path to per-app history files', sinon.test(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7409,7 +7409,7 @@ standard-engine@~9.0.0:
     minimist "^1.1.0"
     pkg-conf "^2.0.0"
 
-standard@12.0.1:
+standard@12.0.1, standard@^12.0.1:
   version "12.0.1"
   resolved "https://registry.yarnpkg.com/standard/-/standard-12.0.1.tgz#0fc5a8aa6c34c546c5562aae644242b24dae2e61"
   integrity sha512-UqdHjh87OG2gUrNCSM4QRLF5n9h3TFPwrCNyVlkqu31Hej0L/rc8hzKqVvkb2W3x0WMq7PzZdkLfEcBhVOR6lg==


### PR DESCRIPTION
Fixes: https://github.com/heroku/cli/issues/1073

I don't know if this really will fix the issue, but I do know that before the environment variables were not being passed down so I am pretty sure this is the issue. The user in the ticket had a non-standard pg path using Postgres.app.