### PR TITLE
fix(cli): container:push shouldn't fail for cases where dockerfiles have multiple periods

### DIFF
--- a/packages/container-registry-v5/lib/sanbashi.js
+++ b/packages/container-registry-v5/lib/sanbashi.js
@@ -18,7 +18,7 @@ Sanbashi.getDockerfiles = function (rootdir, recursive) {
     nodir: true
   })
   if (recursive) {
-    dockerfiles = dockerfiles.filter(df => df.match(/Dockerfile\.[\w]+/))
+    dockerfiles = dockerfiles.filter(df => df.match(/Dockerfile\.[\w]+$/))
   } else {
     dockerfiles = dockerfiles.filter(df => df.match(/Dockerfile$/))
   }


### PR DESCRIPTION
Discovered on a repo where https://github.com/gobuffalo/buffalo/blob/master/Dockerfile.slim.build is vendored.  Easy to replicate by adding a Dockerfile.web.tmp to any repo with a Dockerfile.web

Without matching the end of the line, the result of the map step in getJobs includes a null value, which breaks the reduce reduce step.