### PR TITLE
fix(certs-v5): correct certs-v5 timezone handling in date formatting

### DIFF
--- a/packages/certs-v5/lib/format_date.js
+++ b/packages/certs-v5/lib/format_date.js
@@ -2,6 +2,19 @@
 
 const format = require('date-fns/format')
 
+function getUTCDate (dateString = Date.now()) {
+  const date = new Date(dateString);
+
+  return new Date(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds()
+  );
+};
+
 module.exports = function (date) {
-  return format(new Date(date).toISOString(), 'YYYY-MM-DD HH:mm UTC')
+  return format(getUTCDate(date), 'YYYY-MM-DD HH:mm UTC')
 }


### PR DESCRIPTION
This commit adds an extra step in formatting a given date object
in to a string UTC representation. This extra step is required
as `date-fns/format` uses the local time when converting.

For example, my machine is currently in BST (UTC+1):

```js
const obj = {"expires_at":"2018-10-20T21:24:01Z"}

console.log(dateFns.format(new Date(obj.expires_at), "YYYY-MM-DD HH:mm UTC"))
// 2018-10-20 22:24 UTC
```

This results in misleading CLI output. For example:

```
Name        Endpoint                  Common Name(s)  Expires               Trusted  Type
──────────  ────────────────────────  ──────────────  ────────────────────  ───────  ────────
tokyo-1050  tokyo-1050.herokussl.com  example.org     2013-08-01 22:24 UTC  False    Endpoint
```

Here, although the format claims the timestamp is in UTC, it is really
in BST. For users using this to determine certificate expiry, this may
result in certificates expiring before they expect it to.

To rectify this, this commit adds a manual extraction of UTC date parts,
which is then passed to `date-fns/format`.

Tests did not require updating.

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](http://conventionalcommits.org).
-->
