### PR TITLE
fix(container): exit with status code 1 for errors

### DIFF
--- a/packages/container-registry-v5/commands/login.js
+++ b/packages/container-registry-v5/commands/login.js
@@ -26,7 +26,7 @@ async function login (context, heroku) {
   try {
     await dockerLogin(registry, password)
   } catch (err) {
-    cli.error(`Login failed with: ${err.message}`, 1)
+    cli.exit(1, `Login failed with: ${err.message}`)
   }
 }
 

--- a/packages/container-registry-v5/commands/pull.js
+++ b/packages/container-registry-v5/commands/pull.js
@@ -1,4 +1,5 @@
 const cli = require('heroku-cli-util')
+
 const Sanbashi = require('../lib/sanbashi')
 const debug = require('../lib/debug')
 
@@ -12,8 +13,7 @@ let pull = async function (context, heroku) {
   if (context.flags.verbose) debug.enabled = true
 
   if (context.args.length === 0) {
-    cli.error(`Error: Requires one or more process types\n ${usage} `, 1)
-    return
+    cli.exit(1, `Error: Requires one or more process types\n ${usage}`)
   }
 
   let herokuHost = process.env.HEROKU_HOST || 'heroku.com'

--- a/packages/container-registry-v5/commands/push.js
+++ b/packages/container-registry-v5/commands/push.js
@@ -49,11 +49,11 @@ let push = async function (context, heroku) {
   if (context.flags.verbose) debug.enabled = true
   const recurse = !!context.flags.recursive
   if (context.args.length === 0 && !recurse) {
-    cli.error(`Error: Requires either --recursive or one or more process types`, 1)
+    cli.exit(1, `Error: Requires either --recursive or one or more process types`)
     return
   }
   if (context.args.length > 1 && !recurse) {
-    cli.error(`Error: Requires exactly one target process type, or --recursive option`, 1)
+    cli.exit(1, `Error: Requires exactly one target process type, or --recursive option`)
     return
   }
   await heroku.get(`/apps/${context.app}`)
@@ -74,7 +74,7 @@ let push = async function (context, heroku) {
     jobs = possibleJobs.standard || []
   }
   if (!jobs.length) {
-    cli.error('No images to push', 1)
+    cli.exit(1, 'No images to push')
     return
   }
 
@@ -91,7 +91,7 @@ let push = async function (context, heroku) {
       await Sanbashi.buildImage(job.dockerfile, job.resource, buildArg, context.flags['context-path'])
     }
   } catch (err) {
-    cli.error(`Error: docker build exited with ${err}`, 1)
+    cli.exit(1, `Error: docker build exited with ${err}`)
     return
   }
 
@@ -108,7 +108,7 @@ let push = async function (context, heroku) {
     cli.log(`Your image${plural ? 's have' : ' has'} been successfully pushed. You can now release ${plural ? 'them' : 'it'} with the 'container:release' command.`)
     warnThatReleaseIsRequired(plural)
   } catch (err) {
-    cli.error(`Error: docker push exited with ${err}`, 1)
+    cli.exit(1, `Error: docker push exited with ${err}`)
   }
 }
 

--- a/packages/container-registry-v5/commands/release.js
+++ b/packages/container-registry-v5/commands/release.js
@@ -31,7 +31,7 @@ let release = async function (context, heroku) {
   if (context.flags.verbose) debug.enabled = true
 
   if (context.args.length === 0) {
-    cli.error(`Error: Requires one or more process types\n ${usage} `, 1)
+    cli.exit(1, `Error: Requires one or more process types\n ${usage}`)
     return
   }
   await heroku.get(`/apps/${context.app}`)

--- a/packages/container-registry-v5/commands/rm.js
+++ b/packages/container-registry-v5/commands/rm.js
@@ -21,7 +21,7 @@ module.exports = function (topic) {
 
 let rm = async function (context, heroku) {
   if (context.args.length === 0) {
-    cli.error(`Error: Please specify at least one target process type\n ${usage} `, 1)
+    cli.exit(1, `Error: Please specify at least one target process type\n ${usage} `)
   }
 
   for (let container of context.args) {

--- a/packages/container-registry-v5/commands/run.js
+++ b/packages/container-registry-v5/commands/run.js
@@ -36,8 +36,7 @@ module.exports = function (topic) {
 let run = async function (context, heroku) {
   if (context.flags.verbose) debug.enabled = true
   if (context.args.length === 0) {
-    cli.error(`Error: Requires one process type\n ${usage} `, 1)
-    return
+    cli.exit(1, `Error: Requires one process type\n ${usage}`)
   }
 
   let processType = context.args.shift()
@@ -67,6 +66,6 @@ let run = async function (context, heroku) {
   try {
     await Sanbashi.runImage(job.resource, command, context.flags.port || 5000)
   } catch (err) {
-    cli.error(`Error: docker run exited with ${err}`, 1)
+    cli.exit(1, `Error: docker run exited with ${err}`)
   }
 }

--- a/packages/container-registry-v5/package.json
+++ b/packages/container-registry-v5/package.json
@@ -52,7 +52,7 @@
     "depcheck": "depcheck || true",
     "postpublish": "rm oclif.manifest.json",
     "prepack": "oclif-dev manifest",
-    "test": "cross-env TZ=utc nyc mocha",
+    "test": "cross-env TZ=utc mocha",
     "version": "oclif-dev readme && git add README.md"
   },
   "topic": "container"

--- a/packages/container-registry-v5/test/commands/login.js
+++ b/packages/container-registry-v5/test/commands/login.js
@@ -1,4 +1,5 @@
 'use strict'
+/* globals describe it beforeEach afterEach */
 
 const cli = require('heroku-cli-util')
 const cmd = require('../..').commands.find(c => c.topic === 'container' && c.command === 'login')
@@ -6,7 +7,7 @@ const expect = require('unexpected')
 const sinon = require('sinon')
 
 const Sanbashi = require('../../lib/sanbashi')
-var sandbox
+let sandbox
 
 describe('container login', () => {
   beforeEach(() => {

--- a/packages/container-registry-v5/test/commands/logout.js
+++ b/packages/container-registry-v5/test/commands/logout.js
@@ -1,4 +1,5 @@
 'use strict'
+/* globals describe it beforeEach afterEach */
 
 const cli = require('heroku-cli-util')
 const cmd = require('../..').commands.find(c => c.topic === 'container' && c.command === 'logout')
@@ -6,7 +7,7 @@ const expect = require('unexpected')
 const sinon = require('sinon')
 
 const Sanbashi = require('../../lib/sanbashi')
-var sandbox
+let sandbox
 
 describe('container logout', () => {
   beforeEach(() => {

--- a/packages/container-registry-v5/test/commands/pull.js
+++ b/packages/container-registry-v5/test/commands/pull.js
@@ -1,4 +1,5 @@
 'use strict'
+/* globals describe it beforeEach afterEach */
 
 const cli = require('heroku-cli-util')
 const cmd = require('../..').commands.find(c => c.topic === 'container' && c.command === 'pull')
@@ -6,7 +7,7 @@ const expect = require('unexpected')
 const sinon = require('sinon')
 
 const Sanbashi = require('../../lib/sanbashi')
-var sandbox
+let sandbox
 
 describe('container pull', () => {
   beforeEach(() => {
@@ -15,10 +16,13 @@ describe('container pull', () => {
   })
   afterEach(() => sandbox.restore())
 
-  it('requires a process type', () => {
-    return cmd.run({ app: 'testapp', args: [], flags: {} })
+  it('requires a process type', async () => {
+    sandbox.stub(process, 'exit')
+
+    await cmd.run({ app: 'testapp', args: [], flags: {} })
       .then(() => expect(cli.stderr, 'to contain', 'Requires one or more process types'))
       .then(() => expect(cli.stdout, 'to be empty'))
+      .then(() => expect(process.exit.calledWith(1), 'to equal', true))
   })
 
   it('pulls from the docker registry', () => {

--- a/packages/container-registry-v5/test/commands/release.js
+++ b/packages/container-registry-v5/test/commands/release.js
@@ -1,4 +1,5 @@
 'use strict'
+/* globals describe it beforeEach afterEach */
 
 const cli = require('heroku-cli-util')
 const cmd = require('../..').commands.find(c => c.topic === 'container' && c.command === 'release')
@@ -7,7 +8,7 @@ const sinon = require('sinon')
 const nock = require('nock')
 const stdMocks = require('std-mocks')
 
-var sandbox
+let sandbox
 
 describe('container release', () => {
   beforeEach(() => {
@@ -17,9 +18,12 @@ describe('container release', () => {
   afterEach(() => sandbox.restore())
 
   it('has no process type specified', () => {
+    sandbox.stub(process, 'exit')
+
     return cmd.run({ app: 'testapp', args: [], flags: {} })
       .then(() => expect(cli.stderr, 'to contain', 'Requires one or more process types'))
       .then(() => expect(cli.stdout, 'to be empty'))
+      .then(() => expect(process.exit.calledWith(1), 'to equal', true))
   })
 
   it('releases a single process type', () => {

--- a/packages/container-registry-v5/test/commands/rm.js
+++ b/packages/container-registry-v5/test/commands/rm.js
@@ -1,9 +1,11 @@
 'use strict'
+/* globals describe it beforeEach */
 
 const cli = require('heroku-cli-util')
 const cmd = require('../..').commands.find(c => c.topic === 'container' && c.command === 'rm')
 const expect = require('unexpected')
 const nock = require('nock')
+const sinon = require('sinon')
 
 describe('container removal', () => {
   beforeEach(() => cli.mockConsole())
@@ -34,8 +36,13 @@ describe('container removal', () => {
   })
 
   it('requires a container to be specified', () => {
+    const sandbox = sinon.createSandbox()
+    sandbox.stub(process, 'exit')
+
     return cmd.run({ app: 'testapp', args: [], flags: {} })
       .then(() => expect(cli.stdout, 'to be empty'))
       .then(() => expect(cli.stderr, 'to contain', 'Please specify at least one target process type'))
+      .then(() => expect(process.exit.calledWith(1), 'to equal', true))
+      .finally(() => sandbox.restore())
   })
 })

--- a/packages/container-registry-v5/test/commands/run.js
+++ b/packages/container-registry-v5/test/commands/run.js
@@ -1,4 +1,5 @@
 'use strict'
+/* globals describe it beforeEach afterEach */
 
 const cli = require('heroku-cli-util')
 const cmd = require('../..').commands.find(c => c.topic === 'container' && c.command === 'run')
@@ -6,7 +7,7 @@ const expect = require('unexpected')
 const sinon = require('sinon')
 
 const Sanbashi = require('../../lib/sanbashi')
-var sandbox
+let sandbox
 
 describe('container run', () => {
   beforeEach(() => {
@@ -17,9 +18,12 @@ describe('container run', () => {
   afterEach(() => sandbox.restore())
 
   it('requires a process type', () => {
+    sandbox.stub(process, 'exit')
+
     return cmd.run({ app: 'testapp', args: [], flags: {} })
       .then(() => expect(cli.stdout, 'to be empty'))
       .then(() => expect(cli.stderr, 'to contain', 'Requires one process type'))
+      .then(() => expect(process.exit.calledWith(1), 'to equal', true))
   })
 
   it('runs a container', () => {


### PR DESCRIPTION
When docker command fails with exit code 1, the CLI still returns 0, creating issues around scripting.  `error` no longer (if it ever did) accepts and error code value, which is why we're NOT returning 1 for failures.  As a result, `error` has been replaced with a call to `exit`, which accepts an exit code.