### PR TITLE
fix(pg-v5) normalise casing for pg:copy

### DIFF
--- a/packages/pg-v5/commands/copy.js
+++ b/packages/pg-v5/commands/copy.js
@@ -11,6 +11,14 @@ function * run (context, heroku) {
   const { app, args, flags } = context
   const interval = Math.max(3, parseInt(flags['wait-interval'])) || 3
 
+  const upperCaseConfig = function (config) {
+    const output = {}
+    for (const key in config) {
+      output[key.toUpperCase()] = config[key]
+    }
+    return output
+  }
+
   let resolve = co.wrap(function * (db) {
     if (db.match(/^postgres:\/\//)) {
       // For the case an input is URL format
@@ -31,9 +39,10 @@ function * run (context, heroku) {
         heroku.get(`/apps/${attachment.app.name}/config-vars`)
       ]
       attachment.addon = addon
+      config = upperCaseConfig(config) // Upper case config var keys
       return {
         name: attachment.name.replace(/^HEROKU_POSTGRESQL_/, '').replace(/_URL$/, ''),
-        url: config[attachment.name + '_URL'],
+        url: config[attachment.name.toUpperCase() + '_URL'], // Upper case attachment name
         attachment,
         confirm: app
       }


### PR DESCRIPTION
This commit normalises the casing for both config vars and
attachment names when performing a pg:copy. This is required because
it is possible for config vars and/or attachment names to be of
differing cases, resulting in value fetch against the `config` option
failing.

When the request does not contain the expected keys in JSON,
a 500 is returned from Transferatu without explaining the problem,
resulting in poor user experience. This commit attempts to address
one cause of missing `to_url` and `from_url` keys.
