### PR TITLE
fix(ci): update ci:last examples

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -176,7 +176,7 @@ OPTIONS
   --node=node              the node number to show its setup and output
 
 EXAMPLE
-  $ heroku ci:last --app murmuring-headland-14719 --node 100
+  $ heroku ci:last --pipeline=my-pipeline --node 100
 ```
 
 _See code: [@heroku-cli/plugin-ci](https://github.com/heroku/cli/blob/v7.18.10/packages/ci/src/commands/ci/last.ts)_

--- a/packages/ci/README.md
+++ b/packages/ci/README.md
@@ -89,7 +89,7 @@ OPTIONS
   --node=node              the node number to show its setup and output
 
 EXAMPLE
-  $ heroku ci:last --app murmuring-headland-14719 --node 100
+  $ heroku ci:last --pipeline=my-pipeline --node 100
 ```
 
 _See code: [src/commands/ci/last.ts](https://github.com/heroku/cli/blob/v7.18.10/packages/ci/src/commands/ci/last.ts)_

--- a/packages/ci/src/commands/ci/last.ts
+++ b/packages/ci/src/commands/ci/last.ts
@@ -9,7 +9,7 @@ export default class CiLast extends Command {
   static description = 'looks for the most recent run and returns the output of that run'
 
   static examples = [
-    `$ heroku ci:last --app murmuring-headland-14719 --node 100
+    `$ heroku ci:last --pipeline=my-pipeline --node 100
 `,
   ]
 


### PR DESCRIPTION
update ci:last examples to use `--pipeline` instead of the deprecated `--app` flag (#1137)