### PR TITLE
feat(pg): integrate the most used pg-extras commands

### DIFF
--- a/packages/pg-v5/commands/bloat.js
+++ b/packages/pg-v5/commands/bloat.js
@@ -7,7 +7,7 @@ function * run (context, heroku) {
   const fetcher = require('../lib/fetcher')(heroku)
   const psql = require('../lib/psql')
 
-  let db = yield fetcher(heroku).database(context.app, context.args.database)
+  let db = yield fetcher.database(context.app, context.args.database)
 
   let query = `
 WITH constants AS (

--- a/packages/pg-v5/commands/bloat.js
+++ b/packages/pg-v5/commands/bloat.js
@@ -1,0 +1,88 @@
+'use strict'
+
+const co = require('co')
+const cli = require('heroku-cli-util')
+const pg = require('heroku-pg')
+
+function * run (context, heroku) {
+  let db = yield pg.fetcher(heroku).database(context.app, context.args.database)
+
+  let query = `
+WITH constants AS (
+  SELECT current_setting('block_size')::numeric AS bs, 23 AS hdr, 4 AS ma
+), bloat_info AS (
+  SELECT
+    ma,bs,schemaname,tablename,
+    (datawidth+(hdr+ma-(case when hdr%ma=0 THEN ma ELSE hdr%ma END)))::numeric AS datahdr,
+    (maxfracsum*(nullhdr+ma-(case when nullhdr%ma=0 THEN ma ELSE nullhdr%ma END))) AS nullhdr2
+  FROM (
+    SELECT
+      schemaname, tablename, hdr, ma, bs,
+      SUM((1-null_frac)*avg_width) AS datawidth,
+      MAX(null_frac) AS maxfracsum,
+      hdr+(
+        SELECT 1+count(*)/8
+        FROM pg_stats s2
+        WHERE null_frac<>0 AND s2.schemaname = s.schemaname AND s2.tablename = s.tablename
+      ) AS nullhdr
+    FROM pg_stats s, constants
+    GROUP BY 1,2,3,4,5
+  ) AS foo
+), table_bloat AS (
+  SELECT
+    schemaname, tablename, cc.relpages, bs,
+    CEIL((cc.reltuples*((datahdr+ma-
+      (CASE WHEN datahdr%ma=0 THEN ma ELSE datahdr%ma END))+nullhdr2+4))/(bs-20::float)) AS otta
+  FROM bloat_info
+  JOIN pg_class cc ON cc.relname = bloat_info.tablename
+  JOIN pg_namespace nn ON cc.relnamespace = nn.oid AND nn.nspname = bloat_info.schemaname AND nn.nspname <> 'information_schema'
+), index_bloat AS (
+  SELECT
+    schemaname, tablename, bs,
+    COALESCE(c2.relname,'?') AS iname, COALESCE(c2.reltuples,0) AS ituples, COALESCE(c2.relpages,0) AS ipages,
+    COALESCE(CEIL((c2.reltuples*(datahdr-12))/(bs-20::float)),0) AS iotta -- very rough approximation, assumes all cols
+  FROM bloat_info
+  JOIN pg_class cc ON cc.relname = bloat_info.tablename
+  JOIN pg_namespace nn ON cc.relnamespace = nn.oid AND nn.nspname = bloat_info.schemaname AND nn.nspname <> 'information_schema'
+  JOIN pg_index i ON indrelid = cc.oid
+  JOIN pg_class c2 ON c2.oid = i.indexrelid
+)
+SELECT
+  type, schemaname, object_name, bloat, pg_size_pretty(raw_waste) as waste
+FROM
+(SELECT
+  'table' as type,
+  schemaname,
+  tablename as object_name,
+  ROUND(CASE WHEN otta=0 THEN 0.0 ELSE table_bloat.relpages/otta::numeric END,1) AS bloat,
+  CASE WHEN relpages < otta THEN '0' ELSE (bs*(table_bloat.relpages-otta)::bigint)::bigint END AS raw_waste
+FROM
+  table_bloat
+    UNION
+SELECT
+  'index' as type,
+  schemaname,
+  tablename || '::' || iname as object_name,
+  ROUND(CASE WHEN iotta=0 OR ipages=0 THEN 0.0 ELSE ipages/iotta::numeric END,1) AS bloat,
+  CASE WHEN ipages < iotta THEN '0' ELSE (bs*(ipages-iotta))::bigint END AS raw_waste
+FROM
+  index_bloat) bloat_summary
+ORDER BY raw_waste DESC, bloat DESC
+`
+
+  let output = yield pg.psql.exec(db, query)
+  process.stdout.write(output)
+}
+
+const cmd = {
+  topic: 'pg',
+  description: 'show table and index bloat in your database ordered by most wasteful',
+  needsApp: true,
+  needsAuth: true,
+  args: [{name: 'database', optional: true}],
+  run: cli.command({preauth: true}, co.wrap(run))
+}
+
+module.exports = [
+  Object.assign({command: 'bloat'}, cmd)
+]

--- a/packages/pg-v5/commands/bloat.js
+++ b/packages/pg-v5/commands/bloat.js
@@ -2,10 +2,12 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
 
 function * run (context, heroku) {
-  let db = yield pg.fetcher(heroku).database(context.app, context.args.database)
+  const fetcher = require('../lib/fetcher')(heroku)
+  const psql = require('../lib/psql')
+
+  let db = yield fetcher(heroku).database(context.app, context.args.database)
 
   let query = `
 WITH constants AS (
@@ -70,7 +72,7 @@ FROM
 ORDER BY raw_waste DESC, bloat DESC
 `
 
-  let output = yield pg.psql.exec(db, query)
+  let output = yield psql.exec(db, query)
   process.stdout.write(output)
 }
 
@@ -79,10 +81,10 @@ const cmd = {
   description: 'show table and index bloat in your database ordered by most wasteful',
   needsApp: true,
   needsAuth: true,
-  args: [{name: 'database', optional: true}],
-  run: cli.command({preauth: true}, co.wrap(run))
+  args: [{ name: 'database', optional: true }],
+  run: cli.command({ preauth: true }, co.wrap(run))
 }
 
 module.exports = [
-  Object.assign({command: 'bloat'}, cmd)
+  Object.assign({ command: 'bloat' }, cmd)
 ]

--- a/packages/pg-v5/commands/blocking.js
+++ b/packages/pg-v5/commands/blocking.js
@@ -2,7 +2,6 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
 
 const query = `
 SELECT bl.pid AS blocked_pid,
@@ -22,8 +21,11 @@ WHERE NOT bl.granted
 `
 
 function * run (context, heroku) {
-  let db = yield pg.fetcher(heroku).database(context.app, context.args.database)
-  let output = yield pg.psql.exec(db, query)
+  const fetcher = require('../lib/fetcher')(heroku)
+  const psql = require('../lib/psql')
+
+  let db = yield fetcher.database(context.app, context.args.database)
+  let output = yield psql.exec(db, query)
   process.stdout.write(output)
 }
 
@@ -32,10 +34,10 @@ const cmd = {
   description: 'display queries holding locks other queries are waiting to be released',
   needsApp: true,
   needsAuth: true,
-  args: [{name: 'database', optional: true}],
-  run: cli.command({preauth: true}, co.wrap(run))
+  args: [{ name: 'database', optional: true }],
+  run: cli.command({ preauth: true }, co.wrap(run))
 }
 
 module.exports = [
-  Object.assign({command: 'blocking'}, cmd)
+  Object.assign({ command: 'blocking' }, cmd)
 ]

--- a/packages/pg-v5/commands/blocking.js
+++ b/packages/pg-v5/commands/blocking.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const co = require('co')
+const cli = require('heroku-cli-util')
+const pg = require('heroku-pg')
+
+const query = `
+SELECT bl.pid AS blocked_pid,
+  ka.query AS blocking_statement,
+  now() - ka.query_start AS blocking_duration,
+  kl.pid AS blocking_pid,
+  a.query AS blocked_statement,
+  now() - a.query_start AS blocked_duration
+FROM pg_catalog.pg_locks bl
+JOIN pg_catalog.pg_stat_activity a
+  ON bl.pid = a.pid
+JOIN pg_catalog.pg_locks kl
+  JOIN pg_catalog.pg_stat_activity ka
+    ON kl.pid = ka.pid
+ON bl.transactionid = kl.transactionid AND bl.pid != kl.pid
+WHERE NOT bl.granted
+`
+
+function * run (context, heroku) {
+  let db = yield pg.fetcher(heroku).database(context.app, context.args.database)
+  let output = yield pg.psql.exec(db, query)
+  process.stdout.write(output)
+}
+
+const cmd = {
+  topic: 'pg',
+  description: 'display queries holding locks other queries are waiting to be released',
+  needsApp: true,
+  needsAuth: true,
+  args: [{name: 'database', optional: true}],
+  run: cli.command({preauth: true}, co.wrap(run))
+}
+
+module.exports = [
+  Object.assign({command: 'blocking'}, cmd)
+]

--- a/packages/pg-v5/commands/locks.js
+++ b/packages/pg-v5/commands/locks.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const co = require('co')
+const cli = require('heroku-cli-util')
+const pg = require('heroku-pg')
+
+function * run (context, heroku) {
+  let db = yield pg.fetcher(heroku).database(context.app, context.args.database)
+
+  let truncatedQueryString = prefix => {
+    let column = `${prefix}query`
+    if (context.flags.truncate) {
+      return `CASE WHEN length(${column}) <= 40 THEN ${column} ELSE substr(${column}, 0, 39) || '…' END`
+    } else {
+      return column
+    }
+  }
+
+  let query = `
+  SELECT
+    pg_stat_activity.pid,
+    pg_class.relname,
+    pg_locks.transactionid,
+    pg_locks.granted,
+    ${truncatedQueryString('pg_stat_activity.')} AS query_snippet,
+    age(now(),pg_stat_activity.query_start) AS "age"
+  FROM pg_stat_activity,pg_locks left
+  OUTER JOIN pg_class
+    ON (pg_locks.relation = pg_class.oid)
+  WHERE pg_stat_activity.query <> '<insufficient privilege>'
+    AND pg_locks.pid = pg_stat_activity.pid
+    AND pg_locks.mode = 'ExclusiveLock'
+    AND pg_stat_activity.pid <> pg_backend_pid() order by query_start;
+  `
+
+  let output = yield pg.psql.exec(db, query)
+  process.stdout.write(output)
+}
+
+const cmd = {
+  topic: 'pg',
+  description: 'display queries with active locks',
+  needsApp: true,
+  needsAuth: true,
+  args: [{name: 'database', optional: true}],
+  flags: [{name: 'truncate', char: 't', description: 'truncates queries to 40 charaters'}],
+  run: cli.command({preauth: true}, co.wrap(run))
+}
+
+module.exports = [
+  Object.assign({command: 'locks'}, cmd)
+]

--- a/packages/pg-v5/commands/locks.js
+++ b/packages/pg-v5/commands/locks.js
@@ -2,10 +2,12 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
 
 function * run (context, heroku) {
-  let db = yield pg.fetcher(heroku).database(context.app, context.args.database)
+  const fetcher = require('../lib/fetcher')(heroku)
+  const psql = require('../lib/psql')
+
+  let db = yield fetcher.database(context.app, context.args.database)
 
   let truncatedQueryString = prefix => {
     let column = `${prefix}query`
@@ -33,7 +35,7 @@ function * run (context, heroku) {
     AND pg_stat_activity.pid <> pg_backend_pid() order by query_start;
   `
 
-  let output = yield pg.psql.exec(db, query)
+  let output = yield psql.exec(db, query)
   process.stdout.write(output)
 }
 
@@ -42,11 +44,11 @@ const cmd = {
   description: 'display queries with active locks',
   needsApp: true,
   needsAuth: true,
-  args: [{name: 'database', optional: true}],
-  flags: [{name: 'truncate', char: 't', description: 'truncates queries to 40 charaters'}],
-  run: cli.command({preauth: true}, co.wrap(run))
+  args: [{ name: 'database', optional: true }],
+  flags: [{ name: 'truncate', char: 't', description: 'truncates queries to 40 charaters' }],
+  run: cli.command({ preauth: true }, co.wrap(run))
 }
 
 module.exports = [
-  Object.assign({command: 'locks'}, cmd)
+  Object.assign({ command: 'locks' }, cmd)
 ]

--- a/packages/pg-v5/commands/vacuum_stats.js
+++ b/packages/pg-v5/commands/vacuum_stats.js
@@ -2,10 +2,12 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
 
 function * run (context, heroku) {
-  let db = yield pg.fetcher(heroku).database(context.app, context.args.database)
+  const fetcher = require('../lib/fetcher')(heroku)
+  const psql = require('../lib/psql')
+
+  let db = yield fetcher.database(context.app, context.args.database)
 
   let query = `
 WITH table_opts AS (
@@ -48,7 +50,7 @@ FROM
 ORDER BY 1
 `
 
-  let output = yield pg.psql.exec(db, query)
+  let output = yield psql.exec(db, query)
   process.stdout.write(output)
 }
 
@@ -57,11 +59,11 @@ const cmd = {
   description: 'show dead rows and whether an automatic vacuum is expected to be triggered',
   needsApp: true,
   needsAuth: true,
-  args: [{name: 'database', optional: true}],
-  run: cli.command({preauth: true}, co.wrap(run))
+  args: [{ name: 'database', optional: true }],
+  run: cli.command({ preauth: true }, co.wrap(run))
 }
 
 module.exports = [
-  Object.assign({command: 'vacuum-stats'}, cmd),
-  Object.assign({command: 'vacuum_stats', hidden: true}, cmd)
+  Object.assign({ command: 'vacuum-stats' }, cmd),
+  Object.assign({ command: 'vacuum_stats', hidden: true }, cmd)
 ]

--- a/packages/pg-v5/commands/vacuum_stats.js
+++ b/packages/pg-v5/commands/vacuum_stats.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const co = require('co')
+const cli = require('heroku-cli-util')
+const pg = require('heroku-pg')
+
+function * run (context, heroku) {
+  let db = yield pg.fetcher(heroku).database(context.app, context.args.database)
+
+  let query = `
+WITH table_opts AS (
+  SELECT
+    pg_class.oid, relname, nspname, array_to_string(reloptions, '') AS relopts
+  FROM
+     pg_class INNER JOIN pg_namespace ns ON relnamespace = ns.oid
+), vacuum_settings AS (
+  SELECT
+    oid, relname, nspname,
+    CASE
+      WHEN relopts LIKE '%autovacuum_vacuum_threshold%'
+        THEN substring(relopts, '.*autovacuum_vacuum_threshold=([0-9.]+).*')::integer
+        ELSE current_setting('autovacuum_vacuum_threshold')::integer
+      END AS autovacuum_vacuum_threshold,
+    CASE
+      WHEN relopts LIKE '%autovacuum_vacuum_scale_factor%'
+        THEN substring(relopts, '.*autovacuum_vacuum_scale_factor=([0-9.]+).*')::real
+        ELSE current_setting('autovacuum_vacuum_scale_factor')::real
+      END AS autovacuum_vacuum_scale_factor
+  FROM
+    table_opts
+)
+SELECT
+  vacuum_settings.nspname AS schema,
+  vacuum_settings.relname AS table,
+  to_char(psut.last_vacuum, 'YYYY-MM-DD HH24:MI') AS last_vacuum,
+  to_char(psut.last_autovacuum, 'YYYY-MM-DD HH24:MI') AS last_autovacuum,
+  to_char(pg_class.reltuples, '9G999G999G999') AS rowcount,
+  to_char(psut.n_dead_tup, '9G999G999G999') AS dead_rowcount,
+  to_char(autovacuum_vacuum_threshold
+       + (autovacuum_vacuum_scale_factor::numeric * pg_class.reltuples), '9G999G999G999') AS autovacuum_threshold,
+  CASE
+    WHEN autovacuum_vacuum_threshold + (autovacuum_vacuum_scale_factor::numeric * pg_class.reltuples) < psut.n_dead_tup
+    THEN 'yes'
+  END AS expect_autovacuum
+FROM
+  pg_stat_user_tables psut INNER JOIN pg_class ON psut.relid = pg_class.oid
+    INNER JOIN vacuum_settings ON pg_class.oid = vacuum_settings.oid
+ORDER BY 1
+`
+
+  let output = yield pg.psql.exec(db, query)
+  process.stdout.write(output)
+}
+
+const cmd = {
+  topic: 'pg',
+  description: 'show dead rows and whether an automatic vacuum is expected to be triggered',
+  needsApp: true,
+  needsAuth: true,
+  args: [{name: 'database', optional: true}],
+  run: cli.command({preauth: true}, co.wrap(run))
+}
+
+module.exports = [
+  Object.assign({command: 'vacuum-stats'}, cmd),
+  Object.assign({command: 'vacuum_stats', hidden: true}, cmd)
+]

--- a/packages/pg-v5/index.js
+++ b/packages/pg-v5/index.js
@@ -52,7 +52,7 @@ exports.commands = flatten([
   require('./commands/unfollow'),
   require('./commands/upgrade'),
   require('./commands/vacuum_stats'),
-  require('./commands/wait'),
+  require('./commands/wait')
 ])
 
 exports.host = require('./lib/host')

--- a/packages/pg-v5/index.js
+++ b/packages/pg-v5/index.js
@@ -20,7 +20,7 @@ exports.commands = flatten([
   require('./commands/backups/url'),
   require('./commands/bloat'),
   require('./commands/blocking'),
-  require('./commands/connection_pooling')
+  require('./commands/connection_pooling'),
   require('./commands/copy'),
   require('./commands/credentials'),
   require('./commands/credentials/create'),

--- a/packages/pg-v5/index.js
+++ b/packages/pg-v5/index.js
@@ -18,6 +18,9 @@ exports.commands = flatten([
   require('./commands/backups/schedules'),
   require('./commands/backups/unschedule'),
   require('./commands/backups/url'),
+  require('./commands/bloat'),
+  require('./commands/blocking'),
+  require('./commands/connection_pooling')
   require('./commands/copy'),
   require('./commands/credentials'),
   require('./commands/credentials/create'),
@@ -29,13 +32,14 @@ exports.commands = flatten([
   require('./commands/info'),
   require('./commands/kill'),
   require('./commands/killall'),
-  require('./commands/outliers'),
   require('./commands/links'),
   require('./commands/links/create'),
   require('./commands/links/destroy'),
+  require('./commands/locks'),
   require('./commands/maintenance'),
   require('./commands/maintenance/run'),
   require('./commands/maintenance/window'),
+  require('./commands/outliers'),
   require('./commands/promote'),
   require('./commands/ps'),
   require('./commands/psql'),
@@ -47,8 +51,8 @@ exports.commands = flatten([
   require('./commands/settings/log_statement'),
   require('./commands/unfollow'),
   require('./commands/upgrade'),
+  require('./commands/vacuum_stats'),
   require('./commands/wait'),
-  require('./commands/connection_pooling')
 ])
 
 exports.host = require('./lib/host')


### PR DESCRIPTION
This integrates some of the most used commands from `heroku-pg-extras`, a separate plugin we maintain.

We often point customers to these commands in support tickets, and there's some minor frustration about having to install an additional plugin each time.

I haven't changed the code, just copied it over. The original code didn't have tests, and this stuff changes very rarely, so I have not added any.

https://trello.com/c/MlPn5g4g/1639-move-some-pg-extras-commands-over-to-the-main-cli