### PR TITLE
fix(apps-v5): Parse router log path correctly

### DIFF
--- a/packages/run-v5/test/colorize.test.js
+++ b/packages/run-v5/test/colorize.test.js
@@ -6,7 +6,7 @@ describe('colorize', () => {
     console.log(colorize(`2018-01-01T00:00:00.00+00:00 heroku[${type}]: ${input}`))
   }
   it('colorizes router logs', () => {
-    test('router', 'at=info method=POST path="/record" host=cli-analytics.heroku.com request_id=0fb9c505-5d65-4e63-8fee-fa18da33ee47 fwd="50.233.199.252" dyno=web.1 connect=1ms service=14ms status=201 bytes=255 protocol=https')
+    test('router', 'works with bare words at=info method=POST path="/record" host=cli-analytics.heroku.com request_id=0fb9c505-5d65-4e63-8fee-fa18da33ee47 fwd="50.233.199.252" dyno=web.1 connect=1ms service=14ms status=201 bytes=255 protocol=https')
     test('router', 'at=error code=H12 desc="Request timeout" method=GET path=/ host=myapp.herokuapp.com request_id=8601b555-6a83-4c12-8269-97c8e32cdb22 fwd="204.204.204.204" dyno=web.1 connect= service=30000ms status=503 bytes=0 protocol=http')
     test('web.1', '186.141.134.146 - - [07/May/2018:22:43:54 +0000] "POST /record HTTP/1.1" 201 20 "-" "http-call/3.0.2 node-v8.7.0"')
     test('web.1', '2018/05/07 22:32:24 [cc1a13bb-1427-4085-a632-57095b016c94/7PUOz5O3BG-000001] "POST http://heroku-cli-auth-staging.herokuapp.com/auth HTTP/1.1" from 24.22.53.209 - 201 344B in 403.241µs')


### PR DESCRIPTION
This fixes: https://github.com/heroku/cli/issues/1158

If a router line has an extra equals such as `path=/foo?bar=baz` the colorization would parse this and colorize it incorrectly. This inverts the parsing to and then checks to see if there are more than one `=` in a part.