### PR TITLE
Bring ps:wait into the mainline ps plugin

### DIFF
--- a/packages/ps/src/commands/ps/wait.ts
+++ b/packages/ps/src/commands/ps/wait.ts
@@ -1,0 +1,87 @@
+import {Command, flags} from '@heroku-cli/command'
+import {cli} from 'cli-ux'
+
+import {Dyno, Release} from '@heroku-cli/schema'
+
+export default class Wait extends Command {
+  static description = 'wait for all dynos to be running latest version after a release'
+
+  static flags = {
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+    type: flags.string({
+      char: 't',
+      description: 'wait for one specific dyno type'
+    }),
+    'wait-interval': flags.integer({
+      char: 'w',
+      description: 'how frequently to poll in seconds (to avoid hitting Heroku API rate limits)',
+      parse: input => {
+        const w = parseInt(input, 10)
+        if (w < 10) {
+          cli.error('wait-interval must be at least 10', {exit: 1})
+        }
+        return w
+      },
+      default: 10
+    }),
+    'with-run': flags.boolean({
+      char: 'R',
+      description: 'whether to wait for one-off run dynos',
+      exclusive: ['type']
+    })
+  }
+
+  async run() {
+    const {flags} = this.parse(Wait)
+
+    const {body: releases} = await this.heroku.request<Release[]>(`/apps/${flags.app}/releases`, {
+      partial: true,
+      headers: {
+        Range: 'version ..; max=1, order=desc'
+      }
+    })
+
+    if (releases.length === 0) {
+      this.warn(`App ${flags.app} has no releases`)
+      return
+    }
+
+    const latestRelease = releases[0]
+
+    let released = true
+    const interval = flags['wait-interval'] as number
+
+    while (1 as any) {
+      const {body: dynos} = await this.heroku.get<Dyno[]>(`/apps/${flags.app}/dynos`)
+      const relevantDynos = dynos
+        .filter(dyno => dyno.type !== 'release')
+        .filter(dyno => flags['with-run'] || dyno.type !== 'run')
+        .filter(dyno => !flags.type || dyno.type === flags.type)
+
+      const onLatest = relevantDynos.filter((dyno: Dyno) => {
+        return dyno.state === 'up' &&
+          latestRelease.version !== undefined &&
+          dyno.release !== undefined &&
+          dyno.release.version !== undefined &&
+          dyno.release.version >= latestRelease.version
+      })
+      const releasedFraction = `${onLatest.length} / ${relevantDynos.length}`
+      if (onLatest.length === relevantDynos.length) {
+        if (!released) {
+          cli.action.stop(`${releasedFraction}, done`)
+        }
+        break
+      }
+
+      if (released) {
+        released = false
+        cli.action.start(`Waiting for every dyno to be running v${latestRelease.version}`)
+      }
+
+      cli.action.status = releasedFraction
+
+      await cli.wait(interval * 1000)
+    }
+  }
+}

--- a/packages/ps/test/commands/wait.test.ts
+++ b/packages/ps/test/commands/wait.test.ts
@@ -1,0 +1,134 @@
+import {expect, test} from '@oclif/test'
+import {cli} from 'cli-ux'
+
+const API_HOST = 'https://api.heroku.com'
+const APP_NAME = 'wubalubadubdub'
+
+const CURRENT = {
+  id: '00000000-0000-0000-0000-000000000002',
+  version: 23
+}
+
+const PREVIOUS = {
+  id: '00000000-0000-0000-0000-000000000001',
+  version: 22
+}
+
+const withRelease = test
+  .nock(API_HOST, api => api
+    .get(`/apps/${APP_NAME}/releases`)
+    .reply(200, [CURRENT])
+  )
+
+describe('heroku ps:wait', () => {
+  test
+    .nock(API_HOST, api => api
+      .get(`/apps/${APP_NAME}/releases`)
+      .reply(200, [])
+  )
+    .stderr()
+    .command(['ps:wait', '--app', APP_NAME])
+    .it('warns and exits 0 if no releases', ctx => {
+      expect(ctx.stderr).to.include(`Warning: App ${APP_NAME} has no releases`)
+    })
+
+  withRelease
+    .stderr()
+    .nock(API_HOST, api => api
+      .get(`/apps/${APP_NAME}/dynos`)
+      .reply(200, [
+        {release: CURRENT, state: 'up', type: 'web'}
+      ])
+  )
+    .command(['ps:wait', '--app', APP_NAME])
+    .it('exits with no output if app is already on the latest release', ctx => {
+      expect(ctx.stderr).to.be.empty
+    })
+
+  withRelease
+    .stderr()
+    .nock(API_HOST, api => api
+      .get(`/apps/${APP_NAME}/dynos`)
+      .reply(200, [
+        {release: PREVIOUS, state: 'up', type: 'web'},
+        {release: CURRENT, state: 'up', type: 'web'}
+      ])
+      .get(`/apps/${APP_NAME}/dynos`)
+      .reply(200, [
+        {release: CURRENT, state: 'starting', type: 'web'},
+        {release: CURRENT, state: 'up', type: 'web'}
+      ])
+      .get(`/apps/${APP_NAME}/dynos`)
+      .reply(200, [
+        {release: CURRENT, state: 'up', type: 'web'},
+        {release: CURRENT, state: 'up', type: 'web'}
+      ])
+    )
+    .stub(cli, 'wait', () => () => {})
+    .command(['ps:wait', '--app', APP_NAME])
+    .it('waits for all dynos to be on latest release', ctx => {
+      expect(ctx.stderr).to.contain('Waiting for every dyno to be running v23... 2 / 2, done')
+    })
+
+  withRelease
+    .stderr()
+    .nock(API_HOST, api => api
+      .get(`/apps/${APP_NAME}/dynos`)
+      .reply(200, [
+        {release: CURRENT, state: 'up', type: 'web'},
+        {release: PREVIOUS, state: 'up', type: 'release'},
+      ])
+  )
+    .command(['ps:wait', '--app', APP_NAME])
+    .it('ignores release process dynos', ctx => {
+      expect(ctx.stderr).to.be.empty
+    })
+
+  withRelease
+    .stderr()
+    .nock(API_HOST, api => api
+      .get(`/apps/${APP_NAME}/dynos`)
+      .reply(200, [
+        {release: CURRENT, state: 'up', type: 'web'},
+        {release: PREVIOUS, state: 'up', type: 'run'},
+      ])
+  )
+    .command(['ps:wait', '--app', APP_NAME])
+    .it('ignores run dynos by default', ctx => {
+      expect(ctx.stderr).to.be.empty
+    })
+
+  withRelease
+    .stderr()
+    .nock(API_HOST, api => api
+      .get(`/apps/${APP_NAME}/dynos`)
+      .reply(200, [
+        {release: CURRENT, state: 'up', type: 'web'},
+        {release: PREVIOUS, state: 'up', type: 'run'},
+      ])
+      .get(`/apps/${APP_NAME}/dynos`)
+      .reply(200, [
+        {release: CURRENT, state: 'up', type: 'web'},
+        {release: CURRENT, state: 'up', type: 'run'},
+      ])
+  )
+    .stub(cli, 'wait', () => () => {})
+    .command(['ps:wait', '--with-run', '--app', APP_NAME])
+    .it('includes run dynos with the --with-run flag', ctx => {
+      expect(ctx.stderr).to.contain('Waiting for every dyno to be running v23... 2 / 2, done')
+    })
+
+  withRelease
+    .stderr()
+    .nock(API_HOST, api => api
+      .get(`/apps/${APP_NAME}/dynos`)
+      .reply(200, [
+        {release: CURRENT, state: 'up', type: 'worker'},
+        {release: PREVIOUS, state: 'up', type: 'web'},
+      ])
+  )
+    .command(['ps:wait', '--type=worker', '--app', APP_NAME])
+    .it('waits only for dynos of specific type with the --type flag', ctx => {
+      expect(ctx.stderr).to.be.empty
+    })
+})


### PR DESCRIPTION
This is a first stab at bringing [ps:wait](https://github.com/uhoh-itsmaciek/heroku-ps-wait/) into the mainline CLI. It's pretty rough because I'm not familiar with oclif plugins or TypeScript and didn't find that much in the way of docs, but it's a start--I hope with some feedback I can turn this into something mergeable.
