### PR TITLE
fix(run-v5): Join parsed router logs correctly

### DIFF
--- a/packages/run-v5/lib/colorize.js
+++ b/packages/run-v5/lib/colorize.js
@@ -76,7 +76,7 @@ function colorizeRouter (body) {
       } else if (parts.length === 2) {
         return encodeColor(parts)
       } else {
-        return encodeColor([parts[0], parts.splice(1).join()])
+        return encodeColor([parts[0], parts.splice(1).join("=")])
       }
     })
 

--- a/packages/run-v5/test/colorize.test.js
+++ b/packages/run-v5/test/colorize.test.js
@@ -6,7 +6,7 @@ describe('colorize', () => {
     console.log(colorize(`2018-01-01T00:00:00.00+00:00 heroku[${type}]: ${input}`))
   }
   it('colorizes router logs', () => {
-    test('router', 'works with bare words at=info method=POST path="/record" host=cli-analytics.heroku.com request_id=0fb9c505-5d65-4e63-8fee-fa18da33ee47 fwd="50.233.199.252" dyno=web.1 connect=1ms service=14ms status=201 bytes=255 protocol=https')
+    test('router', 'works with bare words at=info method=POST path="/record?start=123&end=321" host=cli-analytics.heroku.com request_id=0fb9c505-5d65-4e63-8fee-fa18da33ee47 fwd="50.233.199.252" dyno=web.1 connect=1ms service=14ms status=201 bytes=255 protocol=https')
     test('router', 'at=error code=H12 desc="Request timeout" method=GET path=/ host=myapp.herokuapp.com request_id=8601b555-6a83-4c12-8269-97c8e32cdb22 fwd="204.204.204.204" dyno=web.1 connect= service=30000ms status=503 bytes=0 protocol=http')
     test('web.1', '186.141.134.146 - - [07/May/2018:22:43:54 +0000] "POST /record HTTP/1.1" 201 20 "-" "http-call/3.0.2 node-v8.7.0"')
     test('web.1', '2018/05/07 22:32:24 [cc1a13bb-1427-4085-a632-57095b016c94/7PUOz5O3BG-000001] "POST http://heroku-cli-auth-staging.herokuapp.com/auth HTTP/1.1" from 24.22.53.209 - 201 344B in 403.241µs')


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](http://conventionalcommits.org).
-->

Router logs are currently being joined with comma's so a url log looks like this:

```
path="/foo?start,123&next,456"
```

when it should actually be displayed like this

```
path="/foo?start=123&next=456"
```
