### PR TITLE
chore (apps/orgs): Stop using organization endpoints

### DIFF
--- a/docs/orgs.md
+++ b/docs/orgs.md
@@ -8,20 +8,20 @@ manage organizations
 
 ## `heroku orgs`
 
-list the organizations that you are a member of
+list the teams that you are a member of
 
 ```
 USAGE
   $ heroku orgs
 
 OPTIONS
-  --enterprise  filter by enterprise orgs
+  --enterprise  filter by enterprise teams
   --json        output in json format
 ```
 
 ## `heroku orgs:open`
 
-open the organization interface in a browser window
+open the team interface in a browser window
 
 ```
 USAGE

--- a/packages/apps-v5/src/commands/apps/create.js
+++ b/packages/apps-v5/src/commands/apps/create.js
@@ -17,7 +17,7 @@ function createText (name, space) {
 async function createApp (context, heroku, name, stack) {
   let params = {
     name,
-    organization: context.org || context.team || context.flags.team,
+    team: context.org || context.team || context.flags.team,
     region: context.flags.region,
     space: context.flags.space,
     stack,
@@ -29,7 +29,7 @@ async function createApp (context, heroku, name, stack) {
 
   let app = await heroku.request({
     method: 'POST',
-    path: (params.space || params.organization) ? '/organizations/apps' : '/apps',
+    path: (params.space || params.team) ? '/teams/apps' : '/apps',
     body: params
   })
 

--- a/packages/apps-v5/src/commands/apps/create.js
+++ b/packages/apps-v5/src/commands/apps/create.js
@@ -190,7 +190,6 @@ $ heroku apps:create --region eu`,
     { name: 'kernel', hidden: true, hasValue: true },
     { name: 'locked', hidden: true },
     { name: 'json', description: 'output in json format' },
-    // flags.org({name: 'org', hasValue: true}),
     flags.team({ name: 'team', hasValue: true })
   ],
   run: cli.command(run)

--- a/packages/apps-v5/src/commands/apps/create.js
+++ b/packages/apps-v5/src/commands/apps/create.js
@@ -172,7 +172,6 @@ $ heroku apps:create example-staging --remote staging
 # create an app in the eu region
 $ heroku apps:create --region eu`,
   needsAuth: true,
-  wantsOrg: true,
   args: [{ name: 'app', optional: true, description: 'name of app to create' }],
   flags: [
     { name: 'app', char: 'a', hasValue: true, hidden: true },

--- a/packages/apps-v5/src/commands/apps/index.js
+++ b/packages/apps-v5/src/commands/apps/index.js
@@ -8,11 +8,11 @@ const { SpaceCompletion } = require('@heroku-cli/command/lib/completions')
 function * run (context, heroku) {
   const { sortBy, partition } = require('lodash')
 
-  let team = context.org || context.team || context.flags.team
-  let org = (!context.flags.personal && team) ? team : null
+  let teamIdentifier = context.org || context.team || context.flags.team
+  let team = (!context.flags.personal && teamIdentifier) ? teamIdentifier : null
   let space = context.flags.space
   let internalRouting = context.flags['internal-routing']
-  if (space) org = (yield heroku.get(`/spaces/${space}`)).organization.name
+  if (space) team = (yield heroku.get(`/spaces/${space}`)).team.name
 
   function annotateAppName (app) {
     let name = `${app.name}`
@@ -43,13 +43,13 @@ function * run (context, heroku) {
   function print (apps, user) {
     if (apps.length === 0) {
       if (space) cli.log(`There are no apps in space ${cli.color.green(space)}.`)
-      else if (org) cli.log(`There are no apps in team ${cli.color.magenta(org)}.`)
+      else if (team) cli.log(`There are no apps in team ${cli.color.magenta(team)}.`)
       else cli.log('You have no apps.')
     } else if (space) {
       cli.styledHeader(`Apps in space ${cli.color.green(space)}`)
       listApps(apps)
-    } else if (org) {
-      cli.styledHeader(`Apps in team ${cli.color.magenta(org)}`)
+    } else if (team) {
+      cli.styledHeader(`Apps in team ${cli.color.magenta(team)}`)
       listApps(apps)
     } else {
       apps = partition(apps, (app) => app.owner.email === user.email)
@@ -72,7 +72,7 @@ function * run (context, heroku) {
   }
 
   let path = '/users/~/apps'
-  if (org) path = `/organizations/${org}/apps`
+  if (team) path = `/teams/${team}/apps`
   else if (context.flags.all) path = '/apps'
   let [apps, user] = yield [
     heroku.get(path),
@@ -110,7 +110,6 @@ theirapp   other@owner.name`,
     { name: 'space', char: 's', hasValue: true, description: 'filter by space', completion: SpaceCompletion },
     { name: 'personal', char: 'p', description: 'list apps in personal account when a default team is set' },
     { name: 'internal-routing', hidden: true, char: 'i', description: 'filter to Internal Web Apps' },
-    // flags.org({name: 'org', hasValue: true}),
     flags.team({ name: 'team', hasValue: true })
   ],
   run: cli.command(co.wrap(run))

--- a/packages/apps-v5/src/commands/apps/index.js
+++ b/packages/apps-v5/src/commands/apps/index.js
@@ -103,7 +103,6 @@ example2
 === Collaborated Apps
 theirapp   other@owner.name`,
   needsAuth: true,
-  wantsOrg: true,
   flags: [
     { name: 'all', char: 'A', description: 'include apps in all teams' },
     { name: 'json', description: 'output in json format' },

--- a/packages/apps-v5/src/commands/dashboard.js
+++ b/packages/apps-v5/src/commands/dashboard.js
@@ -130,7 +130,7 @@ function * run (context, heroku) {
     apps = yield favoriteApps()
 
     data = yield {
-      orgs: heroku.request({ path: '/organizations' }),
+      teams: heroku.request({ path: '/teams' }),
       notifications: heroku.request({ host: 'telex.heroku.com', path: '/user/notifications' }).catch(() => null),
       apps: apps.map((app) => ({
         app: heroku.get(`/apps/${app}`),
@@ -145,8 +145,8 @@ function * run (context, heroku) {
   else cli.warn(`Add apps to this dashboard by favoriting them with ${cli.color.cmd('heroku apps:favorites:add')}`)
 
   cli.log(`See all add-ons with ${cli.color.cmd('heroku addons')}`)
-  let sampleOrg = sortBy(data.orgs.filter((o) => o.role !== 'collaborator'), (o) => new Date(o.created_at))[0]
-  if (sampleOrg) cli.log(`See all apps in ${cli.color.yellow.dim(sampleOrg.name)} with ${cli.color.cmd('heroku apps --team ' + sampleOrg.name)}`)
+  let sampleTeam = sortBy(data.teams.filter((o) => o.role !== 'collaborator'), (o) => new Date(o.created_at))[0]
+  if (sampleTeam) cli.log(`See all apps in ${cli.color.yellow.dim(sampleTeam.name)} with ${cli.color.cmd('heroku apps --team ' + sampleTeam.name)}`)
   cli.log(`See all apps with ${cli.color.cmd('heroku apps --all')}`)
   displayNotifications(data.notifications)
   cli.log(`

--- a/packages/apps-v5/test/commands/apps/create.js
+++ b/packages/apps-v5/test/commands/apps/create.js
@@ -53,7 +53,7 @@ describe('apps:create', function () {
 
   it('creates an app in a space', function () {
     let mock = nock('https://api.heroku.com')
-      .post('/organizations/apps', {
+      .post('/teams/apps', {
         space: 'my-space-name'
       })
       .reply(200, {
@@ -71,7 +71,7 @@ describe('apps:create', function () {
 
   it('creates an Internal Web App in a space', function () {
     let mock = nock('https://api.heroku.com')
-      .post('/organizations/apps', {
+      .post('/teams/apps', {
         space: 'my-space-name',
         internal_routing: true
       })

--- a/packages/apps-v5/test/commands/apps/index.js
+++ b/packages/apps-v5/test/commands/apps/index.js
@@ -88,7 +88,7 @@ function stubUserApps (apps) {
     .reply(200, apps)
 }
 
-function stubOrgApps (team, apps) {
+function stubteamApps (team, apps) {
   return nock('https://api.heroku.com')
     .get(`/teams/${team}/apps`)
     .reply(200, apps)
@@ -258,7 +258,7 @@ internal-app [internal/locked] (eu)
 
   describe('with team', function () {
     it('displays a message when the team has no apps', function () {
-      let mock = stubOrgApps('test-team', [])
+      let mock = stubteamApps('test-team', [])
       return apps.run({ org: 'test-team', flags: {}, args: {} }).then(function () {
         mock.done()
         expect(cli.stderr).to.equal('')
@@ -268,7 +268,7 @@ internal-app [internal/locked] (eu)
     })
 
     it('list all in a team', function () {
-      let mock = stubOrgApps('test-team', [teamApp1, teamApp2])
+      let mock = stubteamApps('test-team', [teamApp1, teamApp2])
       return apps.run({ org: 'test-team', flags: {}, args: {} }).then(function () {
         mock.done()
         expect(cli.stderr).to.equal('')
@@ -284,7 +284,7 @@ team-app-2
 
   describe('with team', function () {
     it('displays a message when the team has no apps', function () {
-      let mock = stubOrgApps('test-team', [])
+      let mock = stubteamApps('test-team', [])
       return apps.run({ team: 'test-team', flags: {}, args: {} }).then(function () {
         mock.done()
         expect(cli.stderr).to.equal('')
@@ -294,7 +294,7 @@ team-app-2
     })
 
     it('list all in an team', function () {
-      let mock = stubOrgApps('test-team', [teamApp1, teamApp2])
+      let mock = stubteamApps('test-team', [teamApp1, teamApp2])
       return apps.run({ team: 'test-team', flags: {}, args: {} }).then(function () {
         mock.done()
         expect(cli.stderr).to.equal('')
@@ -316,7 +316,7 @@ team-app-2
     })
 
     it('displays a message when the space has no apps', function () {
-      let mock = stubOrgApps('test-team', [])
+      let mock = stubteamApps('test-team', [])
       return apps.run({ flags: { space: 'test-space' }, args: {} }).then(function () {
         mock.done()
         expect(cli.stderr).to.equal('')
@@ -326,7 +326,7 @@ team-app-2
     })
 
     it('lists only apps in spaces by name', function () {
-      let mock = stubOrgApps('test-team', [teamSpaceApp1, teamSpaceApp2, teamApp1])
+      let mock = stubteamApps('test-team', [teamSpaceApp1, teamSpaceApp2, teamApp1])
       return apps.run({ flags: { space: 'test-space' }, args: {} }).then(function () {
         mock.done()
         expect(cli.stderr).to.equal('')
@@ -341,7 +341,7 @@ space-app-2
     })
 
     it('lists only internal apps in spaces by name', function () {
-      let mock = stubOrgApps('test-team', [teamSpaceApp1, teamSpaceApp2, teamApp1, teamSpaceInternalApp])
+      let mock = stubteamApps('test-team', [teamSpaceApp1, teamSpaceApp2, teamApp1, teamSpaceInternalApp])
       return apps.run({ flags: { space: 'test-space', 'internal-routing': true }, args: {} }).then(function () {
         mock.done()
         expect(cli.stderr).to.equal('')

--- a/packages/apps-v5/test/commands/apps/index.js
+++ b/packages/apps-v5/test/commands/apps/index.js
@@ -47,31 +47,31 @@ let collabApp = {
   owner: { email: 'someone-else@bar.com' }
 }
 
-let orgApp1 = {
-  name: 'org-app-1',
-  owner: { email: 'test-org@herokumanager.com' }
+let teamApp1 = {
+  name: 'team-app-1',
+  owner: { email: 'test-team@herokumanager.com' }
 }
 
-let orgApp2 = {
-  name: 'org-app-2',
-  owner: { email: 'test-org@herokumanager.com' }
+let teamApp2 = {
+  name: 'team-app-2',
+  owner: { email: 'test-team@herokumanager.com' }
 }
 
-let orgSpaceApp1 = {
+let teamSpaceApp1 = {
   name: 'space-app-1',
-  owner: { email: 'test-org@herokumanager.com' },
+  owner: { email: 'test-team@herokumanager.com' },
   space: { id: 'test-space-id', name: 'test-space' }
 }
 
-let orgSpaceApp2 = {
+let teamSpaceApp2 = {
   name: 'space-app-2',
-  owner: { email: 'test-org@herokumanager.com' },
+  owner: { email: 'test-team@herokumanager.com' },
   space: { id: 'test-space-id', name: 'test-space' }
 }
 
-let orgSpaceInternalApp = {
+let teamSpaceInternalApp = {
   name: 'space-internal-app',
-  owner: { email: 'test-org@herokumanager.com' },
+  owner: { email: 'test-team@herokumanager.com' },
   space: { id: 'test-space-id', name: 'test-space' },
   internal_routing: true
 }
@@ -88,9 +88,9 @@ function stubUserApps (apps) {
     .reply(200, apps)
 }
 
-function stubOrgApps (org, apps) {
+function stubOrgApps (team, apps) {
   return nock('https://api.heroku.com')
-    .get(`/organizations/${org}/apps`)
+    .get(`/teams/${team}/apps`)
     .reply(200, apps)
 }
 
@@ -131,7 +131,7 @@ collab-app  someone-else@bar.com
     })
 
     it('lists all apps', function () {
-      let mock = stubApps([example, collabApp, orgApp1])
+      let mock = stubApps([example, collabApp, teamApp1])
       return apps.run({ flags: { all: true }, args: {} }).then(function () {
         mock.done()
         expect(cli.stderr).to.equal('')
@@ -141,7 +141,7 @@ example
 
 === Collaborated Apps
 collab-app  someone-else@bar.com
-org-app-1   test-org@herokumanager.com
+team-app-1  test-team@herokumanager.com
 `)
       })
     })
@@ -256,26 +256,26 @@ internal-app [internal/locked] (eu)
     })
   })
 
-  describe('with org', function () {
-    it('displays a message when the org has no apps', function () {
-      let mock = stubOrgApps('test-org', [])
-      return apps.run({ org: 'test-org', flags: {}, args: {} }).then(function () {
+  describe('with team', function () {
+    it('displays a message when the team has no apps', function () {
+      let mock = stubOrgApps('test-team', [])
+      return apps.run({ org: 'test-team', flags: {}, args: {} }).then(function () {
         mock.done()
         expect(cli.stderr).to.equal('')
-        expect(cli.stdout).to.equal(`There are no apps in team test-org.
+        expect(cli.stdout).to.equal(`There are no apps in team test-team.
 `)
       })
     })
 
-    it('list all in an organization', function () {
-      let mock = stubOrgApps('test-org', [orgApp1, orgApp2])
-      return apps.run({ org: 'test-org', flags: {}, args: {} }).then(function () {
+    it('list all in a team', function () {
+      let mock = stubOrgApps('test-team', [teamApp1, teamApp2])
+      return apps.run({ org: 'test-team', flags: {}, args: {} }).then(function () {
         mock.done()
         expect(cli.stderr).to.equal('')
         expect(cli.stdout).to.equal(
-          `=== Apps in team test-org
-org-app-1
-org-app-2
+          `=== Apps in team test-team
+team-app-1
+team-app-2
 
 `)
       })
@@ -294,14 +294,14 @@ org-app-2
     })
 
     it('list all in an team', function () {
-      let mock = stubOrgApps('test-team', [orgApp1, orgApp2])
+      let mock = stubOrgApps('test-team', [teamApp1, teamApp2])
       return apps.run({ team: 'test-team', flags: {}, args: {} }).then(function () {
         mock.done()
         expect(cli.stderr).to.equal('')
         expect(cli.stdout).to.equal(
           `=== Apps in team test-team
-org-app-1
-org-app-2
+team-app-1
+team-app-2
 
 `)
       })
@@ -312,11 +312,11 @@ org-app-2
     beforeEach(function () {
       return nock('https://api.heroku.com')
         .get('/spaces/test-space')
-        .reply(200, { organization: { name: 'test-org' } })
+        .reply(200, { team: { name: 'test-team' } })
     })
 
     it('displays a message when the space has no apps', function () {
-      let mock = stubOrgApps('test-org', [])
+      let mock = stubOrgApps('test-team', [])
       return apps.run({ flags: { space: 'test-space' }, args: {} }).then(function () {
         mock.done()
         expect(cli.stderr).to.equal('')
@@ -326,7 +326,7 @@ org-app-2
     })
 
     it('lists only apps in spaces by name', function () {
-      let mock = stubOrgApps('test-org', [orgSpaceApp1, orgSpaceApp2, orgApp1])
+      let mock = stubOrgApps('test-team', [teamSpaceApp1, teamSpaceApp2, teamApp1])
       return apps.run({ flags: { space: 'test-space' }, args: {} }).then(function () {
         mock.done()
         expect(cli.stderr).to.equal('')
@@ -341,7 +341,7 @@ space-app-2
     })
 
     it('lists only internal apps in spaces by name', function () {
-      let mock = stubOrgApps('test-org', [orgSpaceApp1, orgSpaceApp2, orgApp1, orgSpaceInternalApp])
+      let mock = stubOrgApps('test-team', [teamSpaceApp1, teamSpaceApp2, teamApp1, teamSpaceInternalApp])
       return apps.run({ flags: { space: 'test-space', 'internal-routing': true }, args: {} }).then(function () {
         mock.done()
         expect(cli.stderr).to.equal('')

--- a/packages/apps-v5/test/commands/dashboard.js
+++ b/packages/apps-v5/test/commands/dashboard.js
@@ -57,7 +57,7 @@ runtest('Dashboard', () => {
         let longboard = nock('https://particleboard.heroku.com:443')
           .get('/favorites?type=app').reply(200, [])
         let heroku = nock('https://api.heroku.com:443')
-          .get('/organizations').reply(200, [])
+          .get('/teams').reply(200, [])
         let telex = nock('https://telex.heroku.com:443')
           .get('/user/notifications').reply(200, [])
 
@@ -80,7 +80,7 @@ See other CLI commands with heroku help
         let longboard = nock('https://particleboard.heroku.com:443')
           .get('/favorites?type=app').reply(200, [])
         let heroku = nock('https://api.heroku.com:443')
-          .get('/organizations').reply(200, [])
+          .get('/teams').reply(200, [])
         let telex = nock('https://telex.heroku.com:443')
           .get('/user/notifications').reply(401, [])
 
@@ -103,7 +103,7 @@ See other CLI commands with heroku help
         let longboard = nock('https://particleboard.heroku.com:443')
           .get('/favorites?type=app').reply(200, [{ app_name: 'myapp' }])
         let heroku = nock('https://api.heroku.com:443')
-          .get('/organizations').reply(200, [])
+          .get('/teams').reply(200, [])
           .get('/apps/myapp').reply(200, {
             name: 'myapp',
             owner: { email: 'foo@bar.com' },

--- a/packages/orgs-v5/README.md
+++ b/packages/orgs-v5/README.md
@@ -122,7 +122,7 @@ EXAMPLES
 
 ## `heroku apps:join`
 
-add yourself to an organization app
+add yourself to a team app
 
 ```
 USAGE
@@ -135,7 +135,7 @@ OPTIONS
 
 ## `heroku apps:leave`
 
-remove yourself from an organization app
+remove yourself from a team app
 
 ```
 USAGE
@@ -148,7 +148,7 @@ OPTIONS
 
 ## `heroku apps:lock`
 
-prevent organization members from joining an app
+prevent team members from joining an app
 
 ```
 USAGE
@@ -189,7 +189,7 @@ EXAMPLES
 
 ## `heroku apps:unlock`
 
-unlock an app so any organization member can join
+unlock an app so any team member can join
 
 ```
 USAGE
@@ -202,7 +202,7 @@ OPTIONS
 
 ## `heroku join`
 
-add yourself to an organization app
+add yourself to a team app
 
 ```
 USAGE
@@ -215,7 +215,7 @@ OPTIONS
 
 ## `heroku leave`
 
-remove yourself from an organization app
+remove yourself from a team app
 
 ```
 USAGE
@@ -228,7 +228,7 @@ OPTIONS
 
 ## `heroku lock`
 
-prevent organization members from joining an app
+prevent team members from joining an app
 
 ```
 USAGE
@@ -241,7 +241,7 @@ OPTIONS
 
 ## `heroku members`
 
-list members of an organization or a team
+list members of a team or a team
 
 ```
 USAGE
@@ -256,7 +256,7 @@ OPTIONS
 
 ## `heroku members:add EMAIL`
 
-adds a user to an organization or a team
+adds a user to a team or a team
 
 ```
 USAGE
@@ -269,7 +269,7 @@ OPTIONS
 
 ## `heroku members:remove EMAIL`
 
-removes a user from an organization or a team
+removes a user from a team or a team
 
 ```
 USAGE
@@ -281,7 +281,7 @@ OPTIONS
 
 ## `heroku members:set EMAIL`
 
-sets a members role in an organization or a team
+sets a members role in a team
 
 ```
 USAGE
@@ -294,7 +294,7 @@ OPTIONS
 
 ## `heroku orgs`
 
-list the organizations that you are a member of
+list the teams that you are a member of
 
 ```
 USAGE
@@ -307,7 +307,7 @@ OPTIONS
 
 ## `heroku orgs:open`
 
-open the organization interface in a browser window
+open the team interface in a browser window
 
 ```
 USAGE
@@ -334,7 +334,7 @@ DESCRIPTION
 
 ## `heroku unlock`
 
-unlock an app so any organization member can join
+unlock an app so any team member can join
 
 ```
 USAGE

--- a/packages/orgs-v5/commands/access/add.js
+++ b/packages/orgs-v5/commands/access/add.js
@@ -11,14 +11,14 @@ async function run (context, heroku) {
   let appInfo = await heroku.get(`/apps/${appName}`)
   let output = `Adding ${cli.color.cyan(context.args.email)} access to the app ${cli.color.magenta(appName)}`
   let request
-  let orgFeatures = []
+  let teamFeatures = []
 
   if (Utils.isOrgApp(appInfo.owner.email)) {
-    let orgName = Utils.getOwner(appInfo.owner.email)
-    orgFeatures = await heroku.get(`/organizations/${orgName}/features`)
+    let teamName = Utils.getOwner(appInfo.owner.email)
+    teamFeatures = await heroku.get(`/teams/${teamName}/features`)
   }
 
-  if (orgFeatures.find(feature => feature.name === 'org-access-controls')) {
+  if (teamFeatures.find(feature => feature.name === 'org-access-controls')) {
     if (!permissions) error.exit(1, 'Missing argument: permissions')
 
     if (context.flags.privileges) cli.warn('DEPRECATION WARNING: use `--permissions` not `--privileges`')
@@ -30,7 +30,7 @@ async function run (context, heroku) {
     permissions = _.uniq(permissions.sort())
     output += ` with ${cli.color.green(permissions)} permissions`
 
-    request = heroku.post(`/organizations/apps/${appName}/collaborators`, {
+    request = heroku.post(`/teams/apps/${appName}/collaborators`, {
       body: { user: context.args.email, permissions: permissions }
     })
   } else {

--- a/packages/orgs-v5/commands/access/add.js
+++ b/packages/orgs-v5/commands/access/add.js
@@ -13,7 +13,7 @@ async function run (context, heroku) {
   let request
   let teamFeatures = []
 
-  if (Utils.isOrgApp(appInfo.owner.email)) {
+  if (Utils.isteamApp(appInfo.owner.email)) {
     let teamName = Utils.getOwner(appInfo.owner.email)
     teamFeatures = await heroku.get(`/teams/${teamName}/features`)
   }

--- a/packages/orgs-v5/commands/access/index.js
+++ b/packages/orgs-v5/commands/access/index.js
@@ -36,14 +36,14 @@ async function run (context, heroku) {
   let appName = context.app
 
   let app = await heroku.get(`/apps/${appName}`)
-  let isOrgApp = Utils.isOrgApp(app.owner.email)
+  let isTeamApp = Utils.isOrgApp(app.owner.email)
   let collaborators = await heroku.get(`/apps/${appName}/collaborators`)
 
-  if (isOrgApp) {
-    let orgName = Utils.getOwner(app.owner.email)
+  if (isTeamApp) {
+    let teamName = Utils.getOwner(app.owner.email)
 
     try {
-      const members = await heroku.get(`/teams/${orgName}/members`)
+      const members = await heroku.get(`/teams/${teamName}/members`)
       let admins = members.filter(member => member.role === 'admin')
 
       let adminPermissions = await heroku.get('/teams/permissions')

--- a/packages/orgs-v5/commands/access/index.js
+++ b/packages/orgs-v5/commands/access/index.js
@@ -9,7 +9,7 @@ function printJSON (collaborators) {
 }
 
 function printAccess (app, collaborators) {
-  let showPermissions = Utils.isOrgApp(app.owner.email)
+  let showPermissions = Utils.isteamApp(app.owner.email)
   collaborators = _.chain(collaborators)
     .sortBy(c => c.email || c.user.email)
     .reject(c => /herokumanager\.com$/.test(c.user.email))
@@ -36,7 +36,7 @@ async function run (context, heroku) {
   let appName = context.app
 
   let app = await heroku.get(`/apps/${appName}`)
-  let isTeamApp = Utils.isOrgApp(app.owner.email)
+  let isTeamApp = Utils.isteamApp(app.owner.email)
   let collaborators = await heroku.get(`/apps/${appName}/collaborators`)
 
   if (isTeamApp) {

--- a/packages/orgs-v5/commands/access/index.js
+++ b/packages/orgs-v5/commands/access/index.js
@@ -43,7 +43,7 @@ async function run (context, heroku) {
     let orgName = Utils.getOwner(app.owner.email)
 
     try {
-      const members = await heroku.get(`/organizations/${orgName}/members`)
+      const members = await heroku.get(`/teams/${orgName}/members`)
       let admins = members.filter(member => member.role === 'admin')
 
       let adminPermissions = await heroku.get('/organizations/permissions')

--- a/packages/orgs-v5/commands/access/index.js
+++ b/packages/orgs-v5/commands/access/index.js
@@ -46,7 +46,7 @@ async function run (context, heroku) {
       const members = await heroku.get(`/teams/${orgName}/members`)
       let admins = members.filter(member => member.role === 'admin')
 
-      let adminPermissions = await heroku.get('/organizations/permissions')
+      let adminPermissions = await heroku.get('/teams/permissions')
 
       admins = _.forEach(admins, function (admin) {
         admin.user = { email: admin.email }

--- a/packages/orgs-v5/commands/access/update.js
+++ b/packages/orgs-v5/commands/access/update.js
@@ -21,7 +21,7 @@ async function run (context, heroku) {
   permissions.push('view')
   permissions = _.uniq(permissions.sort())
 
-  let request = heroku.patch(`/organizations/apps/${appName}/collaborators/${context.args.email}`, {
+  let request = heroku.patch(`/teams/apps/${appName}/collaborators/${context.args.email}`, {
     body: { permissions: permissions }
   })
   await cli.action(`Updating ${context.args.email} in application ${cli.color.cyan(appName)} with ${permissions} permissions`, request)

--- a/packages/orgs-v5/commands/access/update.js
+++ b/packages/orgs-v5/commands/access/update.js
@@ -15,7 +15,7 @@ async function run (context, heroku) {
   let appInfo = await heroku.get(`/apps/${appName}`)
 
   if (context.flags.privileges) cli.warn('DEPRECATION WARNING: use `--permissions` not `--privileges`')
-  if (!Utils.isteamApp(appInfo.owner.email)) error.exit(1, `Error: cannot update permissions. The app ${cli.color.cyan(appName)} is not owned by an organization`)
+  if (!Utils.isteamApp(appInfo.owner.email)) error.exit(1, `Error: cannot update permissions. The app ${cli.color.cyan(appName)} is not owned by a team`)
 
   // Give implicit `view` access
   permissions.push('view')

--- a/packages/orgs-v5/commands/access/update.js
+++ b/packages/orgs-v5/commands/access/update.js
@@ -15,7 +15,7 @@ async function run (context, heroku) {
   let appInfo = await heroku.get(`/apps/${appName}`)
 
   if (context.flags.privileges) cli.warn('DEPRECATION WARNING: use `--permissions` not `--privileges`')
-  if (!Utils.isOrgApp(appInfo.owner.email)) error.exit(1, `Error: cannot update permissions. The app ${cli.color.cyan(appName)} is not owned by an organization`)
+  if (!Utils.isteamApp(appInfo.owner.email)) error.exit(1, `Error: cannot update permissions. The app ${cli.color.cyan(appName)} is not owned by an organization`)
 
   // Give implicit `view` access
   permissions.push('view')

--- a/packages/orgs-v5/commands/apps/join.js
+++ b/packages/orgs-v5/commands/apps/join.js
@@ -6,7 +6,7 @@ let co = require('co')
 function * run (context, heroku) {
   let request = heroku.get('/account')
     .then(function (user) {
-      return heroku.post(`/organizations/apps/${context.app}/collaborators`, {
+      return heroku.post(`/teams/apps/${context.app}/collaborators`, {
         body: { user: user.email }
       })
     })
@@ -17,7 +17,7 @@ function * run (context, heroku) {
 let cmd = {
   topic: 'apps',
   command: 'join',
-  description: 'add yourself to an organization app',
+  description: 'add yourself to a team app',
   needsAuth: true,
   needsApp: true,
   run: cli.command(co.wrap(run))

--- a/packages/orgs-v5/commands/apps/leave.js
+++ b/packages/orgs-v5/commands/apps/leave.js
@@ -17,7 +17,7 @@ function * run (context, heroku) {
 let cmd = {
   topic: 'apps',
   command: 'leave',
-  description: 'remove yourself from an organization app',
+  description: 'remove yourself from a team app',
   needsAuth: true,
   needsApp: true,
   run: cli.command(co.wrap(run))

--- a/packages/orgs-v5/commands/apps/lock.js
+++ b/packages/orgs-v5/commands/apps/lock.js
@@ -4,21 +4,21 @@ let cli = require('heroku-cli-util')
 let co = require('co')
 
 function * run (context, heroku) {
-  let app = yield heroku.get(`/organizations/apps/${context.app}`)
+  let app = yield heroku.get(`/teams/apps/${context.app}`)
   if (app.locked) {
     throw new Error(`Error: cannot lock ${cli.color.cyan(app.name)}
 This app is already locked.`)
   }
   let request = heroku.request({
     method: 'PATCH',
-    path: `/organizations/apps/${app.name}`,
+    path: `/teams/apps/${app.name}`,
     body: { locked: true }
   })
   yield cli.action(`Locking ${cli.color.cyan(app.name)}`, request)
 }
 
 let cmd = {
-  description: 'prevent organization members from joining an app',
+  description: 'prevent team members from joining an app',
   needsAuth: true,
   needsApp: true,
   run: cli.command(co.wrap(run))

--- a/packages/orgs-v5/commands/apps/transfer.js
+++ b/packages/orgs-v5/commands/apps/transfer.js
@@ -40,7 +40,7 @@ function * run (context, heroku) {
           heroku: heroku,
           appName: app.name,
           recipient: recipient,
-          personalToPersonal: Utils.isValidEmail(recipient) && !Utils.isOrgApp(app.owner),
+          personalToPersonal: Utils.isValidEmail(recipient) && !Utils.isteamApp(app.owner),
           bulk: true
         })
         yield appTransfer.start()
@@ -52,7 +52,7 @@ function * run (context, heroku) {
     let appInfo = yield heroku.get(`/apps/${app}`)
 
     // Shows warning when app is transferred from a team/org to a personal account
-    if (Utils.isValidEmail(recipient) && Utils.isOrgApp(appInfo.owner.email)) {
+    if (Utils.isValidEmail(recipient) && Utils.isteamApp(appInfo.owner.email)) {
       yield cli.confirmApp(app, context.flags.confirm, 'All collaborators will be removed from this app')
     }
 
@@ -60,7 +60,7 @@ function * run (context, heroku) {
       heroku: heroku,
       appName: appInfo.name,
       recipient: recipient,
-      personalToPersonal: Utils.isValidEmail(recipient) && !Utils.isOrgApp(appInfo.owner.email)
+      personalToPersonal: Utils.isValidEmail(recipient) && !Utils.isteamApp(appInfo.owner.email)
     })
     yield appTransfer.start()
 

--- a/packages/orgs-v5/commands/apps/unlock.js
+++ b/packages/orgs-v5/commands/apps/unlock.js
@@ -4,14 +4,14 @@ let cli = require('heroku-cli-util')
 let co = require('co')
 
 function * run (context, heroku) {
-  let app = yield heroku.get(`/organizations/apps/${context.app}`)
+  let app = yield heroku.get(`/teams/apps/${context.app}`)
   if (!app.locked) {
     throw new Error(`Error: cannot unlock ${cli.color.cyan(app.name)}
 This app is not locked.`)
   }
   let request = heroku.request({
     method: 'PATCH',
-    path: `/organizations/apps/${app.name}`,
+    path: `/teams/apps/${app.name}`,
     body: { locked: false }
   })
   yield cli.action(`Unlocking ${cli.color.cyan(app.name)}`, request)
@@ -20,7 +20,7 @@ This app is not locked.`)
 let cmd = {
   topic: 'apps',
   command: 'unlock',
-  description: 'unlock an app so any organization member can join',
+  description: 'unlock an app so any team member can join',
   needsAuth: true,
   needsApp: true,
   run: cli.command(co.wrap(run))

--- a/packages/orgs-v5/commands/members/add.js
+++ b/packages/orgs-v5/commands/members/add.js
@@ -31,7 +31,7 @@ function * run (context, heroku) {
   if (teamInfo.type === 'team' && groupFeatures.find(feature => { return feature.name === 'team-invite-acceptance' && feature.enabled })) {
     yield inviteMemberToTeam(email, role, groupName)
   } else {
-    yield Utils.addMemberToOrg(email, role, groupName, heroku)
+    yield Utils.addMemberToTeam(email, role, groupName, heroku)
   }
 
   yield Utils.warnIfAtTeamMemberLimit(teamInfo, groupName, context, heroku)

--- a/packages/orgs-v5/commands/members/add.js
+++ b/packages/orgs-v5/commands/members/add.js
@@ -7,7 +7,7 @@ const { flags } = require('@heroku-cli/command')
 const { RoleCompletion } = require('@heroku-cli/command/lib/completions')
 
 function * run (context, heroku) {
-  let orgInfo = yield Utils.orgInfo(context, heroku)
+  let teamInfo = yield Utils.teamInfo(context, heroku)
   let groupName = context.org || context.team || context.flags.team
   let email = context.args.email
   let role = context.flags.role
@@ -28,14 +28,14 @@ function * run (context, heroku) {
     yield cli.action(`Inviting ${cli.color.cyan(email)} to ${cli.color.magenta(groupName)} as ${cli.color.green(role)}`, request)
   }
 
-  if (orgInfo.type === 'team' && groupFeatures.find(feature => { return feature.name === 'team-invite-acceptance' && feature.enabled })) {
+  if (teamInfo.type === 'team' && groupFeatures.find(feature => { return feature.name === 'team-invite-acceptance' && feature.enabled })) {
     yield inviteMemberToTeam(email, role, groupName)
   } else {
     yield Utils.addMemberToOrg(email, role, groupName, heroku)
   }
 
-  yield Utils.warnIfAtTeamMemberLimit(orgInfo, groupName, context, heroku)
-  Utils.warnUsingOrgFlagInTeams(orgInfo, context)
+  yield Utils.warnIfAtTeamMemberLimit(teamInfo, groupName, context, heroku)
+  Utils.warnUsingOrgFlagInTeams(teamInfo, context)
 }
 
 let add = {

--- a/packages/orgs-v5/commands/members/add.js
+++ b/packages/orgs-v5/commands/members/add.js
@@ -47,7 +47,6 @@ let add = {
   args: [{ name: 'email' }],
   flags: [
     { name: 'role', char: 'r', hasValue: true, required: true, description: 'member role (admin, collaborator, member, owner)', completion: RoleCompletion },
-    // flags.org({name: 'org', hasValue: true, description: 'org to use', hidden: false}),
     flags.team({ name: 'team', hasValue: true, hidden: true })
   ],
   run: cli.command(co.wrap(run))

--- a/packages/orgs-v5/commands/members/add.js
+++ b/packages/orgs-v5/commands/members/add.js
@@ -11,7 +11,7 @@ function * run (context, heroku) {
   let groupName = context.org || context.team || context.flags.team
   let email = context.args.email
   let role = context.flags.role
-  let groupFeatures = yield heroku.get(`/organizations/${groupName}/features`)
+  let groupFeatures = yield heroku.get(`/teams/${groupName}/features`)
 
   let inviteMemberToTeam = function * (email, role, groupName) {
     let request = heroku.request({
@@ -19,7 +19,7 @@ function * run (context, heroku) {
         Accept: 'application/vnd.heroku+json; version=3.team-invitations'
       },
       method: 'PUT',
-      path: `/organizations/${groupName}/invitations`,
+      path: `/teams/${groupName}/invitations`,
       body: { email, role }
     }).then(request => {
       cli.action.done('email sent')
@@ -41,7 +41,7 @@ function * run (context, heroku) {
 let add = {
   topic: 'members',
   command: 'add',
-  description: 'adds a user to an organization or a team',
+  description: 'adds a user to a team',
   needsAuth: true,
   wantsOrg: true,
   args: [{ name: 'email' }],

--- a/packages/orgs-v5/commands/members/add.js
+++ b/packages/orgs-v5/commands/members/add.js
@@ -43,7 +43,6 @@ let add = {
   command: 'add',
   description: 'adds a user to a team',
   needsAuth: true,
-  wantsOrg: true,
   args: [{ name: 'email' }],
   flags: [
     { name: 'role', char: 'r', hasValue: true, required: true, description: 'member role (admin, collaborator, member, owner)', completion: RoleCompletion },

--- a/packages/orgs-v5/commands/members/index.js
+++ b/packages/orgs-v5/commands/members/index.js
@@ -59,7 +59,6 @@ module.exports = {
   topic: 'members',
   description: 'list members of a team',
   needsAuth: true,
-  wantsOrg: true,
   flags: [
     { name: 'role', char: 'r', hasValue: true, description: 'filter by role', completion: RoleCompletion },
     { name: 'pending', hasValue: false, description: 'filter by pending team invitations' },

--- a/packages/orgs-v5/commands/members/index.js
+++ b/packages/orgs-v5/commands/members/index.js
@@ -57,7 +57,7 @@ function * run (context, heroku) {
 
 module.exports = {
   topic: 'members',
-  description: 'list members of an organization or a team',
+  description: 'list members of a team',
   needsAuth: true,
   wantsOrg: true,
   flags: [

--- a/packages/orgs-v5/commands/members/index.js
+++ b/packages/orgs-v5/commands/members/index.js
@@ -8,11 +8,11 @@ const { flags } = require('@heroku-cli/command')
 const { RoleCompletion } = require('@heroku-cli/command/lib/completions')
 
 function * run (context, heroku) {
-  let orgInfo = yield Utils.orgInfo(context, heroku)
+  let teamInfo = yield Utils.teamInfo(context, heroku)
   let groupName = context.org || context.team || context.flags.team
   let teamInvites = []
 
-  if (orgInfo.type === 'team') {
+  if (teamInfo.type === 'team') {
     let orgFeatures = yield heroku.get(`/teams/${groupName}/features`)
 
     if (orgFeatures.find(feature => feature.name === 'team-invite-acceptance' && feature.enabled)) {
@@ -52,7 +52,7 @@ function * run (context, heroku) {
     })
   }
 
-  Utils.warnUsingOrgFlagInTeams(orgInfo, context)
+  Utils.warnUsingOrgFlagInTeams(teamInfo, context)
 }
 
 module.exports = {

--- a/packages/orgs-v5/commands/members/index.js
+++ b/packages/orgs-v5/commands/members/index.js
@@ -64,7 +64,6 @@ module.exports = {
     { name: 'role', char: 'r', hasValue: true, description: 'filter by role', completion: RoleCompletion },
     { name: 'pending', hasValue: false, description: 'filter by pending team invitations' },
     { name: 'json', description: 'output in json format' },
-    // flags.org({name: 'org', hasValue: true, description: 'org to use', hidden: false}),
     flags.team({ name: 'team', hasValue: true, hidden: true })
   ],
   run: cli.command(co.wrap(run))

--- a/packages/orgs-v5/commands/members/index.js
+++ b/packages/orgs-v5/commands/members/index.js
@@ -13,7 +13,7 @@ function * run (context, heroku) {
   let teamInvites = []
 
   if (orgInfo.type === 'team') {
-    let orgFeatures = yield heroku.get(`/organizations/${groupName}/features`)
+    let orgFeatures = yield heroku.get(`/teams/${groupName}/features`)
 
     if (orgFeatures.find(feature => feature.name === 'team-invite-acceptance' && feature.enabled)) {
       teamInvites = yield heroku.request({
@@ -21,7 +21,7 @@ function * run (context, heroku) {
           Accept: 'application/vnd.heroku+json; version=3.team-invitations'
         },
         method: 'GET',
-        path: `/organizations/${groupName}/invitations`
+        path: `/teams/${groupName}/invitations`
       })
       teamInvites = _.map(teamInvites, function (invite) {
         return { email: invite.user.email, role: invite.role, status: 'pending' }
@@ -29,7 +29,7 @@ function * run (context, heroku) {
     }
   }
 
-  let members = yield heroku.get(`/organizations/${groupName}/members`)
+  let members = yield heroku.get(`/teams/${groupName}/members`)
   // Set status '' to all existing members
   _.map(members, (member) => { member.status = '' })
   members = _.sortBy(_.union(members, teamInvites), 'email')

--- a/packages/orgs-v5/commands/members/remove.js
+++ b/packages/orgs-v5/commands/members/remove.js
@@ -62,7 +62,6 @@ module.exports = {
   command: 'remove',
   description: 'removes a user from a team',
   needsAuth: true,
-  wantsOrg: true,
   args: [{ name: 'email' }],
   flags: [
     flags.team({ name: 'team', hasValue: true, hidden: true })

--- a/packages/orgs-v5/commands/members/remove.js
+++ b/packages/orgs-v5/commands/members/remove.js
@@ -39,8 +39,8 @@ function * run (context, heroku) {
   }
 
   if (orgInfo.type === 'team') {
-    let orgFeatures = yield heroku.get(`/organizations/${groupName}/features`)
-    teamInviteFeatureEnabled = !!orgFeatures.find(feature => feature.name === 'team-invite-acceptance' && feature.enabled)
+    let teamFeatures = yield heroku.get(`/teams/${groupName}/features`)
+    teamInviteFeatureEnabled = !!teamFeatures.find(feature => feature.name === 'team-invite-acceptance' && feature.enabled)
 
     if (teamInviteFeatureEnabled) {
       let invites = yield teamInvites()

--- a/packages/orgs-v5/commands/members/remove.js
+++ b/packages/orgs-v5/commands/members/remove.js
@@ -18,7 +18,7 @@ function * run (context, heroku) {
         Accept: 'application/vnd.heroku+json; version=3.team-invitations'
       },
       method: 'GET',
-      path: `/organizations/${groupName}/invitations`
+      path: `/teams/${groupName}/invitations`
     })
   }
 
@@ -28,13 +28,13 @@ function * run (context, heroku) {
         Accept: 'application/vnd.heroku+json; version=3.team-invitations'
       },
       method: 'DELETE',
-      path: `/organizations/${groupName}/invitations/${email}`
+      path: `/teams/${groupName}/invitations/${email}`
     })
     yield cli.action(`Revoking invite for ${cli.color.cyan(email)} in ${cli.color.magenta(groupName)}`, request)
   }
 
   let removeUserMembership = function * () {
-    let request = heroku.delete(`/organizations/${groupName}/members/${encodeURIComponent(email)}`)
+    let request = heroku.delete(`/teams/${groupName}/members/${encodeURIComponent(email)}`)
     yield cli.action(`Removing ${cli.color.cyan(email)} from ${cli.color.magenta(groupName)}`, request)
   }
 
@@ -60,7 +60,7 @@ function * run (context, heroku) {
 module.exports = {
   topic: 'members',
   command: 'remove',
-  description: 'removes a user from an organization or a team',
+  description: 'removes a user from a team',
   needsAuth: true,
   wantsOrg: true,
   args: [{ name: 'email' }],

--- a/packages/orgs-v5/commands/members/remove.js
+++ b/packages/orgs-v5/commands/members/remove.js
@@ -65,7 +65,6 @@ module.exports = {
   wantsOrg: true,
   args: [{ name: 'email' }],
   flags: [
-    // flags.org({name: 'org', hasValue: true, description: 'org to use', hidden: false}),
     flags.team({ name: 'team', hasValue: true, hidden: true })
   ],
   run: cli.command(co.wrap(run))

--- a/packages/orgs-v5/commands/members/remove.js
+++ b/packages/orgs-v5/commands/members/remove.js
@@ -6,7 +6,7 @@ let Utils = require('../../lib/utils')
 const { flags } = require('@heroku-cli/command')
 
 function * run (context, heroku) {
-  let orgInfo = yield Utils.orgInfo(context, heroku)
+  let teamInfo = yield Utils.teamInfo(context, heroku)
   let groupName = context.org || context.team || context.flags.team
   let teamInviteFeatureEnabled = false
   let isInvitedUser = false
@@ -38,7 +38,7 @@ function * run (context, heroku) {
     yield cli.action(`Removing ${cli.color.cyan(email)} from ${cli.color.magenta(groupName)}`, request)
   }
 
-  if (orgInfo.type === 'team') {
+  if (teamInfo.type === 'team') {
     let teamFeatures = yield heroku.get(`/teams/${groupName}/features`)
     teamInviteFeatureEnabled = !!teamFeatures.find(feature => feature.name === 'team-invite-acceptance' && feature.enabled)
 
@@ -54,7 +54,7 @@ function * run (context, heroku) {
     yield removeUserMembership()
   }
 
-  Utils.warnUsingOrgFlagInTeams(orgInfo, context)
+  Utils.warnUsingOrgFlagInTeams(teamInfo, context)
 }
 
 module.exports = {

--- a/packages/orgs-v5/commands/members/set.js
+++ b/packages/orgs-v5/commands/members/set.js
@@ -12,7 +12,7 @@ function * run (context, heroku) {
   let email = context.args.email
   let role = context.flags.role
 
-  yield Utils.addMemberToOrg(email, role, groupName, heroku, 'PATCH')
+  yield Utils.addMemberToTeam(email, role, groupName, heroku, 'PATCH')
   yield Utils.warnIfAtTeamMemberLimit(teamInfo, groupName, context, heroku)
   Utils.warnUsingOrgFlagInTeams(teamInfo, context)
 }

--- a/packages/orgs-v5/commands/members/set.js
+++ b/packages/orgs-v5/commands/members/set.js
@@ -22,7 +22,6 @@ let set = {
   command: 'set',
   description: 'sets a members role in a team',
   needsAuth: true,
-  wantsOrg: true,
   args: [{ name: 'email' }],
   flags: [
     { name: 'role', char: 'r', hasValue: true, required: true, description: 'member role (admin, collaborator, member, owner)', completion: RoleCompletion },

--- a/packages/orgs-v5/commands/members/set.js
+++ b/packages/orgs-v5/commands/members/set.js
@@ -7,14 +7,14 @@ const { flags } = require('@heroku-cli/command')
 const { RoleCompletion } = require('@heroku-cli/command/lib/completions')
 
 function * run (context, heroku) {
-  let orgInfo = yield Utils.orgInfo(context, heroku)
+  let teamInfo = yield Utils.teamInfo(context, heroku)
   let groupName = context.org || context.team || context.flags.team
   let email = context.args.email
   let role = context.flags.role
 
   yield Utils.addMemberToOrg(email, role, groupName, heroku, 'PATCH')
-  yield Utils.warnIfAtTeamMemberLimit(orgInfo, groupName, context, heroku)
-  Utils.warnUsingOrgFlagInTeams(orgInfo, context)
+  yield Utils.warnIfAtTeamMemberLimit(teamInfo, groupName, context, heroku)
+  Utils.warnUsingOrgFlagInTeams(teamInfo, context)
 }
 
 let set = {

--- a/packages/orgs-v5/commands/members/set.js
+++ b/packages/orgs-v5/commands/members/set.js
@@ -20,13 +20,12 @@ function * run (context, heroku) {
 let set = {
   topic: 'members',
   command: 'set',
-  description: 'sets a members role in an organization or a team',
+  description: 'sets a members role in a team',
   needsAuth: true,
   wantsOrg: true,
   args: [{ name: 'email' }],
   flags: [
     { name: 'role', char: 'r', hasValue: true, required: true, description: 'member role (admin, collaborator, member, owner)', completion: RoleCompletion },
-    // flags.org({name: 'org', hasValue: true, description: 'org to use', hidden: false}),
     flags.team({ name: 'team', hasValue: true, hidden: true })
   ],
   run: cli.command(co.wrap(run))

--- a/packages/orgs-v5/commands/orgs/index.js
+++ b/packages/orgs-v5/commands/orgs/index.js
@@ -5,7 +5,7 @@ let co = require('co')
 let Utils = require('../../lib/utils')
 
 function * run (context, heroku) {
-  let orgs = yield heroku.get('/organizations')
+  let orgs = yield heroku.get('/teams')
 
   if (context.flags.enterprise) {
     orgs = orgs.filter(o => o.type === 'enterprise')
@@ -20,11 +20,11 @@ function * run (context, heroku) {
 
 module.exports = {
   topic: 'orgs',
-  description: 'list the organizations that you are a member of',
+  description: 'list the teams that you are a member of',
   needsAuth: true,
   flags: [
     { name: 'json', description: 'output in json format' },
-    { name: 'enterprise', hasValue: false, description: 'filter by enterprise orgs' },
+    { name: 'enterprise', hasValue: false, description: 'filter by enterprise teams' },
     { name: 'teams', hasValue: false, description: 'filter by teams', hidden: true }
   ],
   run: cli.command(co.wrap(run))

--- a/packages/orgs-v5/commands/orgs/index.js
+++ b/packages/orgs-v5/commands/orgs/index.js
@@ -14,7 +14,7 @@ function * run (context, heroku) {
   if (context.flags.json) {
     Utils.printGroupsJSON(orgs)
   } else {
-    Utils.printGroups(orgs, { label: 'Organizations' })
+    Utils.printGroups(orgs, { label: 'Teams' })
   }
 }
 

--- a/packages/orgs-v5/commands/orgs/open.js
+++ b/packages/orgs-v5/commands/orgs/open.js
@@ -6,15 +6,15 @@ const { flags } = require('@heroku-cli/command')
 
 function * run (context, heroku) {
   let team = context.org || context.team || context.flags.team
-  if (!team) throw new Error('No organization specified')
-  let org = yield heroku.get(`/organizations/${team}`)
-  yield cli.open(`https://dashboard.heroku.com/orgs/${org.name}`)
+  if (!team) throw new Error('No team specified')
+  let org = yield heroku.get(`/teams/${team}`)
+  yield cli.open(`https://dashboard.heroku.com/teams/${org.name}`)
 }
 
 module.exports = {
   topic: 'orgs',
   command: 'open',
-  description: 'open the organization interface in a browser window',
+  description: 'open the team interface in a browser window',
   needsAuth: true,
   wantsOrg: true,
   flags: [

--- a/packages/orgs-v5/commands/orgs/open.js
+++ b/packages/orgs-v5/commands/orgs/open.js
@@ -18,7 +18,6 @@ module.exports = {
   needsAuth: true,
   wantsOrg: true,
   flags: [
-    // flags.org({name: 'org', hasValue: true, description: 'org to use', hidden: false}),
     flags.team({ name: 'team', hasValue: true, hidden: true })
   ],
   run: cli.command(co.wrap(run))

--- a/packages/orgs-v5/commands/orgs/open.js
+++ b/packages/orgs-v5/commands/orgs/open.js
@@ -16,7 +16,6 @@ module.exports = {
   command: 'open',
   description: 'open the team interface in a browser window',
   needsAuth: true,
-  wantsOrg: true,
   flags: [
     flags.team({ name: 'team', hasValue: true, hidden: true })
   ],

--- a/packages/orgs-v5/index.js
+++ b/packages/orgs-v5/index.js
@@ -4,8 +4,8 @@ const flatten = require('lodash.flatten')
 
 exports.topics = [
   { name: 'access', description: 'manage user access to apps' },
-  { name: 'orgs', description: 'manage organizations' },
-  { name: 'members', description: 'manage organization members' },
+  { name: 'orgs', description: 'manage teams' },
+  { name: 'members', description: 'manage team members' },
   { name: 'teams', description: 'manage teams' },
   { name: 'sharing', hidden: true },
   { name: 'join', hidden: true },

--- a/packages/orgs-v5/lib/app_transfer.js
+++ b/packages/orgs-v5/lib/app_transfer.js
@@ -29,7 +29,7 @@ class AppTransfer {
       this.body = { owner: this.recipient }
       this.transferMsg = `Transferring ${cli.color.app(this.appName)}`
       if (!this.opts.bulk) this.transferMsg += ` to ${cli.color.magenta(this.recipient)}`
-      this.path = `/organizations/apps/${this.appName}`
+      this.path = `/teams/apps/${this.appName}`
       this.method = 'PATCH'
     }
   }

--- a/packages/orgs-v5/lib/utils.js
+++ b/packages/orgs-v5/lib/utils.js
@@ -35,7 +35,7 @@ let printGroupsJSON = function (group) {
 let orgInfo = function * (context, heroku) {
   let teamOrOrgName = context.org || context.flags.team
   if (!teamOrOrgName) error.exit(1, 'No team or org specified.\nRun this command with --team or --org')
-  return yield heroku.get(`/organizations/${context.org || context.flags.team}`)
+  return yield heroku.get(`/teams/${context.org || context.flags.team}`)
 }
 
 let warnUsingOrgFlagInTeams = function (orgInfo, context) {
@@ -47,7 +47,7 @@ let warnUsingOrgFlagInTeams = function (orgInfo, context) {
 let addMemberToOrg = function * (email, role, groupName, heroku, method = 'PUT') {
   let request = heroku.request({
     method: method,
-    path: `/organizations/${groupName}/members`,
+    path: `/teams/${groupName}/members`,
     body: {email, role}
   })
   yield cli.action(`Adding ${cli.color.cyan(email)} to ${cli.color.magenta(groupName)} as ${cli.color.green(role)}`, request)

--- a/packages/orgs-v5/lib/utils.js
+++ b/packages/orgs-v5/lib/utils.js
@@ -44,7 +44,7 @@ let warnUsingOrgFlagInTeams = function (teamInfo, context) {
   }
 }
 
-let addMemberToOrg = function * (email, role, groupName, heroku, method = 'PUT') {
+let addMemberToTeam = function * (email, role, groupName, heroku, method = 'PUT') {
   let request = heroku.request({
     method: method,
     path: `/teams/${groupName}/members`,
@@ -74,7 +74,7 @@ let warnIfAtTeamMemberLimit = async function (teamInfo, groupName, context, hero
 }
 
 module.exports = {
-  addMemberToOrg,
+  addMemberToTeam,
   getOwner,
   isteamApp,
   isValidEmail,

--- a/packages/orgs-v5/lib/utils.js
+++ b/packages/orgs-v5/lib/utils.js
@@ -32,14 +32,14 @@ let printGroupsJSON = function (group) {
   cli.log(JSON.stringify(group, null, 2))
 }
 
-let orgInfo = function * (context, heroku) {
+let teamInfo = function * (context, heroku) {
   let teamOrOrgName = context.org || context.flags.team
   if (!teamOrOrgName) error.exit(1, 'No team or org specified.\nRun this command with --team or --org')
   return yield heroku.get(`/teams/${context.org || context.flags.team}`)
 }
 
-let warnUsingOrgFlagInTeams = function (orgInfo, context) {
-  if ((orgInfo.type === 'team') && (!context.flags.team)) {
+let warnUsingOrgFlagInTeams = function (teamInfo, context) {
+  if ((teamInfo.type === 'team') && (!context.flags.team)) {
     cli.warn(`${cli.color.cmd(context.org)} is a Heroku Team\nHeroku CLI now supports Heroku Teams.\nUse ${cli.color.cmd('-t')} or ${cli.color.cmd('--team')} for teams like ${cli.color.cmd(context.org)}`)
   }
 }
@@ -53,11 +53,11 @@ let addMemberToOrg = function * (email, role, groupName, heroku, method = 'PUT')
   yield cli.action(`Adding ${cli.color.cyan(email)} to ${cli.color.magenta(groupName)} as ${cli.color.green(role)}`, request)
 }
 
-let warnIfAtTeamMemberLimit = async function (orgInfo, groupName, context, heroku) {
+let warnIfAtTeamMemberLimit = async function (teamInfo, groupName, context, heroku) {
   // Users receive `You'll be billed monthly for teams over 5 members.`
   const FREE_TEAM_LIMIT = 6
 
-  if (orgInfo.type === 'team') {
+  if (teamInfo.type === 'team') {
     let membersAndInvites = {
       invites: await heroku.request({
         headers: {
@@ -78,7 +78,7 @@ module.exports = {
   getOwner,
   isOrgApp,
   isValidEmail,
-  orgInfo,
+  teamInfo,
   printGroups,
   printGroupsJSON,
   warnIfAtTeamMemberLimit,

--- a/packages/orgs-v5/lib/utils.js
+++ b/packages/orgs-v5/lib/utils.js
@@ -3,13 +3,13 @@ let cli = require('heroku-cli-util')
 let error = require('./error')
 
 let getOwner = function (owner) {
-  if (isOrgApp(owner)) {
+  if (isteamApp(owner)) {
     return owner.split('@herokumanager.com')[0]
   }
   return owner
 }
 
-let isOrgApp = function (owner) {
+let isteamApp = function (owner) {
   return (/@herokumanager\.com$/.test(owner))
 }
 
@@ -76,7 +76,7 @@ let warnIfAtTeamMemberLimit = async function (teamInfo, groupName, context, hero
 module.exports = {
   addMemberToOrg,
   getOwner,
-  isOrgApp,
+  isteamApp,
   isValidEmail,
   teamInfo,
   printGroups,

--- a/packages/orgs-v5/lib/utils.js
+++ b/packages/orgs-v5/lib/utils.js
@@ -64,9 +64,9 @@ let warnIfAtTeamMemberLimit = async function (orgInfo, groupName, context, herok
           Accept: 'application/vnd.heroku+json; version=3.team-invitations'
         },
         method: 'GET',
-        path: `/organizations/${groupName}/invitations`
+        path: `/teams/${groupName}/invitations`
       }),
-      members: await heroku.get(`/organizations/${groupName}/members`)
+      members: await heroku.get(`/teams/${groupName}/members`)
     }
     const membersCount = membersAndInvites.invites.length + membersAndInvites.members.length
     if (membersCount === FREE_TEAM_LIMIT) cli.warn("You'll be billed monthly for teams over 5 members.")

--- a/packages/orgs-v5/lib/utils.js
+++ b/packages/orgs-v5/lib/utils.js
@@ -17,7 +17,7 @@ let isValidEmail = function (email) {
   return /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(email)
 }
 
-let printGroups = function (group, type = {label: 'Organization'}) {
+let printGroups = function (group, type = {label: 'Team'}) {
   group = _.sortBy(group, 'name')
   cli.table(group, {
     columns: [

--- a/packages/orgs-v5/test/commands/access/add.js
+++ b/packages/orgs-v5/test/commands/access/add.js
@@ -17,7 +17,7 @@ describe('heroku access:add', () => {
       cli.mockConsole()
       apiGet = stubGet.orgApp()
       apiPost = stubPost.teamAppCollaborators,('raulb@heroku.com', ['deploy', 'view'])
-      apiGetOrgFeatures = stubGet.orgFeatures([{ name: 'org-access-controls' }])
+      apiGetOrgFeatures = stubGet.teamFeatures([{ name: 'org-access-controls' }])
     })
     afterEach(() => nock.cleanAll())
 
@@ -69,7 +69,7 @@ Adding raulb@heroku.com access to the app myapp with deploy,view permissions... 
       cli.mockConsole()
       apiGet = stubGet.orgApp()
       apiPost = stubPost.collaborators()
-      apiGetOrgFeatures = stubGet.orgFeatures([])
+      apiGetOrgFeatures = stubGet.teamFeatures([])
     })
     afterEach(() => nock.cleanAll())
 

--- a/packages/orgs-v5/test/commands/access/add.js
+++ b/packages/orgs-v5/test/commands/access/add.js
@@ -15,7 +15,7 @@ describe('heroku access:add', () => {
   context('with a team app with user permissions', () => {
     beforeEach(() => {
       cli.mockConsole()
-      apiGet = stubGet.orgApp()
+      apiGet = stubGet.teamApp()
       apiPost = stubPost.teamAppCollaborators('raulb@heroku.com', ['deploy', 'view'])
       apiGetOrgFeatures = stubGet.teamFeatures([{ name: 'org-access-controls' }])
     })
@@ -67,7 +67,7 @@ Adding raulb@heroku.com access to the app myapp with deploy,view permissions... 
   context('with a team app without user permissions', () => {
     beforeEach(() => {
       cli.mockConsole()
-      apiGet = stubGet.orgApp()
+      apiGet = stubGet.teamApp()
       apiPost = stubPost.collaborators()
       apiGetOrgFeatures = stubGet.teamFeatures([])
     })

--- a/packages/orgs-v5/test/commands/access/add.js
+++ b/packages/orgs-v5/test/commands/access/add.js
@@ -12,11 +12,11 @@ let apiPost
 let apiGetOrgFeatures
 
 describe('heroku access:add', () => {
-  context('with an org app with user permissions', () => {
+  context('with a team app with user permissions', () => {
     beforeEach(() => {
       cli.mockConsole()
       apiGet = stubGet.orgApp()
-      apiPost = stubPost.orgAppcollaborators('raulb@heroku.com', ['deploy', 'view'])
+      apiPost = stubPost.teamAppCollaborators,('raulb@heroku.com', ['deploy', 'view'])
       apiGetOrgFeatures = stubGet.orgFeatures([{ name: 'org-access-controls' }])
     })
     afterEach(() => nock.cleanAll())
@@ -64,7 +64,7 @@ Adding raulb@heroku.com access to the app myapp with deploy,view permissions... 
     })
   })
 
-  context('with an org app without user permissions', () => {
+  context('with a team app without user permissions', () => {
     beforeEach(() => {
       cli.mockConsole()
       apiGet = stubGet.orgApp()
@@ -84,7 +84,7 @@ Adding raulb@heroku.com access to the app myapp with deploy,view permissions... 
     })
   })
 
-  context('with a non org app', () => {
+  context('with a non team app', () => {
     beforeEach(() => {
       cli.mockConsole()
       apiGet = stubGet.personalApp()

--- a/packages/orgs-v5/test/commands/access/add.js
+++ b/packages/orgs-v5/test/commands/access/add.js
@@ -16,7 +16,7 @@ describe('heroku access:add', () => {
     beforeEach(() => {
       cli.mockConsole()
       apiGet = stubGet.orgApp()
-      apiPost = stubPost.teamAppCollaborators,('raulb@heroku.com', ['deploy', 'view'])
+      apiPost = stubPost.teamAppCollaborators('raulb@heroku.com', ['deploy', 'view'])
       apiGetOrgFeatures = stubGet.teamFeatures([{ name: 'org-access-controls' }])
     })
     afterEach(() => nock.cleanAll())

--- a/packages/orgs-v5/test/commands/access/index.js
+++ b/packages/orgs-v5/test/commands/access/index.js
@@ -29,10 +29,10 @@ raulb@heroku.com  owner
     afterEach(() => nock.cleanAll())
 
     it('shows the app collaborators and hides the team collaborator record', () => {
-      let apiGetOrgApp = stubGet.orgApp()
+      let apiGetteamApp = stubGet.teamApp()
       let apiGetOrgMembers = stubGet.teamMembers()
       let apiGetAppPermissions = stubGet.appPermissions()
-      let apiGetOrgAppCollaboratorsWithPermissions = stubGet.orgAppCollaboratorsWithPermissions()
+      let apiGetteamAppCollaboratorsWithPermissions = stubGet.teamAppCollaboratorsWithPermissions()
 
       return cmd.run({ app: 'myapp', flags: {} })
         .then(() => expect(
@@ -40,10 +40,10 @@ raulb@heroku.com  owner
 raulb@heroku.com  admin   deploy,manage,operate,view
 `).to.eq(cli.stdout))
         .then(() => expect('').to.eq(cli.stderr))
-        .then(() => apiGetOrgApp.done())
+        .then(() => apiGetteamApp.done())
         .then(() => apiGetOrgMembers.done())
         .then(() => apiGetAppPermissions.done())
-        .then(() => apiGetOrgAppCollaboratorsWithPermissions.done())
+        .then(() => apiGetteamAppCollaboratorsWithPermissions.done())
     })
   })
 })

--- a/packages/orgs-v5/test/commands/access/index.js
+++ b/packages/orgs-v5/test/commands/access/index.js
@@ -24,11 +24,11 @@ raulb@heroku.com  owner
     })
   })
 
-  context('with organization/team', () => {
+  context('with team', () => {
     beforeEach(() => cli.mockConsole())
     afterEach(() => nock.cleanAll())
 
-    it('shows the app collaborators and hides the org collaborator record', () => {
+    it('shows the app collaborators and hides the team collaborator record', () => {
       let apiGetOrgApp = stubGet.orgApp()
       let apiGetOrgMembers = stubGet.teamMembers()
       let apiGetAppPermissions = stubGet.appPermissions()

--- a/packages/orgs-v5/test/commands/access/index.js
+++ b/packages/orgs-v5/test/commands/access/index.js
@@ -30,7 +30,7 @@ raulb@heroku.com  owner
 
     it('shows the app collaborators and hides the org collaborator record', () => {
       let apiGetOrgApp = stubGet.orgApp()
-      let apiGetOrgMembers = stubGet.orgMembers()
+      let apiGetOrgMembers = stubGet.teamMembers()
       let apiGetAppPermissions = stubGet.appPermissions()
       let apiGetOrgAppCollaboratorsWithPermissions = stubGet.orgAppCollaboratorsWithPermissions()
 

--- a/packages/orgs-v5/test/commands/access/update.js
+++ b/packages/orgs-v5/test/commands/access/update.js
@@ -11,7 +11,7 @@ let apiPatchAppCollaborators
 let apiGetApp
 
 describe('heroku access:update', () => {
-  context('with an org app with permissions', () => {
+  context('with a team app with permissions', () => {
     beforeEach(() => cli.mockConsole())
     afterEach(() => nock.cleanAll())
 
@@ -53,7 +53,7 @@ Updating raulb@heroku.com in application myapp with deploy,view permissions... d
     })
   })
 
-  context('with a non org app', () => {
+  context('with a non team app', () => {
     beforeEach(() => {
       cli.mockConsole()
       error.exit.mock()
@@ -68,7 +68,7 @@ Updating raulb@heroku.com in application myapp with deploy,view permissions... d
         args: { email: 'raulb@heroku.com' },
         flags: { permissions: 'view,deploy' }
       }).then(() => apiGetApp.done())).then(function () {
-        expect(unwrap(cli.stderr)).to.equal('Error: cannot update permissions. The app myapp is not owned by an organization\n')
+        expect(unwrap(cli.stderr)).to.equal('Error: cannot update permissions. The app myapp is not owned by a team\n')
       })
     })
   })

--- a/packages/orgs-v5/test/commands/access/update.js
+++ b/packages/orgs-v5/test/commands/access/update.js
@@ -16,7 +16,7 @@ describe('heroku access:update', () => {
     afterEach(() => nock.cleanAll())
 
     it('updates the app permissions, view being implicit', () => {
-      apiGetApp = stubGet.orgApp()
+      apiGetApp = stubGet.teamApp()
       apiPatchAppCollaborators = stubPatch.appCollaboratorWithPermissions({ email: 'raulb@heroku.com', permissions: ['deploy', 'view'] })
 
       return cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: { permissions: 'deploy' } })
@@ -28,7 +28,7 @@ describe('heroku access:update', () => {
     })
 
     it('updates the app permissions, even specifying view as a permission', () => {
-      apiGetApp = stubGet.orgApp()
+      apiGetApp = stubGet.teamApp()
       apiPatchAppCollaborators = stubPatch.appCollaboratorWithPermissions({ email: 'raulb@heroku.com', permissions: ['deploy', 'view'] })
 
       return cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: { permissions: 'deploy,view' } })
@@ -40,7 +40,7 @@ describe('heroku access:update', () => {
     })
 
     it('supports --privileges, but shows deprecation warning', () => {
-      apiGetApp = stubGet.orgApp()
+      apiGetApp = stubGet.teamApp()
       apiPatchAppCollaborators = stubPatch.appCollaboratorWithPermissions({ email: 'raulb@heroku.com', permissions: ['deploy', 'view'] })
 
       return cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: { privileges: 'deploy' } })

--- a/packages/orgs-v5/test/commands/apps/join.js
+++ b/packages/orgs-v5/test/commands/apps/join.js
@@ -39,7 +39,7 @@ describe('heroku apps:join', () => {
       .then(() => apiGetUserAccount.done())
       .catch(function (err) {
         thrown = true
-        expect(err.body.error).to.eq('You do not have access to the organization heroku-tools.')
+        expect(err.body.error).to.eq('You do not have access to the team heroku-tools.')
       })
       .then(function () {
         expect(thrown).to.eq(true)

--- a/packages/orgs-v5/test/commands/apps/join.js
+++ b/packages/orgs-v5/test/commands/apps/join.js
@@ -29,7 +29,7 @@ describe('heroku apps:join', () => {
   it('is forbidden from joining the app', () => {
     let response = {
       code: 403,
-      description: { id: 'forbidden', error: 'You do not have access to the organization heroku-tools.' }
+      description: { id: 'forbidden', error: 'You do not have access to the team heroku-tools.' }
     }
 
     apiPostCollaborators = stubPost.orgAppcollaborators('raulb@heroku.com', [], response)

--- a/packages/orgs-v5/test/commands/apps/join.js
+++ b/packages/orgs-v5/test/commands/apps/join.js
@@ -16,7 +16,7 @@ describe('heroku apps:join', () => {
   afterEach(() => nock.cleanAll())
 
   it('joins the app', () => {
-    apiPostCollaborators = stubPost.orgAppcollaborators('raulb@heroku.com')
+    apiPostCollaborators = stubPost.teamAppCollaborators('raulb@heroku.com')
 
     return cmd.run({ app: 'myapp' })
       .then(() => expect('').to.eq(cli.stdout))
@@ -32,7 +32,7 @@ describe('heroku apps:join', () => {
       description: { id: 'forbidden', error: 'You do not have access to the team heroku-tools.' }
     }
 
-    apiPostCollaborators = stubPost.orgAppcollaborators('raulb@heroku.com', [], response)
+    apiPostCollaborators = stubPost.teamAppCollaborators('raulb@heroku.com', [], response)
     let thrown = false
 
     return cmd.run({ app: 'myapp' })

--- a/packages/orgs-v5/test/commands/apps/lock.js
+++ b/packages/orgs-v5/test/commands/apps/lock.js
@@ -9,9 +9,9 @@ describe('heroku apps:lock', () => {
 
   it('locks the app', () => {
     let apiGetApp = nock('https://api.heroku.com:443')
-      .get('/organizations/apps/myapp')
+      .get('/teams/apps/myapp')
       .reply(200, { name: 'myapp', locked: false })
-      .patch('/organizations/apps/myapp', { locked: true })
+      .patch('/teams/apps/myapp', { locked: true })
       .reply(200)
     return cmd.run({ app: 'myapp' })
       .then(() => expect('').to.eq(cli.stdout))

--- a/packages/orgs-v5/test/commands/apps/transfer.js
+++ b/packages/orgs-v5/test/commands/apps/transfer.js
@@ -136,9 +136,9 @@ Initiating transfer of myapp... email sent
       let api = stubPatch.orgAppTransfer()
 
       let lockedAPI = nock('https://api.heroku.com:443')
-        .get('/organizations/apps/myapp')
+        .get('/teams/apps/myapp')
         .reply(200, { name: 'myapp', locked: false })
-        .patch('/organizations/apps/myapp', { locked: true })
+        .patch('/teams/apps/myapp', { locked: true })
         .reply(200)
 
       return cmd.run({ app: 'myapp', args: { recipient: 'team' }, flags: { locked: true } })

--- a/packages/orgs-v5/test/commands/apps/transfer.js
+++ b/packages/orgs-v5/test/commands/apps/transfer.js
@@ -27,10 +27,6 @@ describe('heroku apps:transfer', () => {
         let choices = prompts[0].choices
         expect(choices).to.eql([
           {
-            name: 'my-org-app (organization)',
-            value: { name: 'my-org-app', owner: 'team@herokumanager.com' }
-          },
-          {
             name: 'my-team-app (team)',
             value: { name: 'my-team-app', owner: 'team@herokumanager.com' }
           },

--- a/packages/orgs-v5/test/commands/apps/transfer.js
+++ b/packages/orgs-v5/test/commands/apps/transfer.js
@@ -91,7 +91,7 @@ Initiating transfer of myapp... email sent
         .then(() => api.done())
     })
 
-    it('transfers the app to an organization', () => {
+    it('transfers the app to a team', () => {
       let api = stubPatch.teamAppTransfer()
       return cmd.run({ app: 'myapp', args: { recipient: 'team' }, flags: {} })
         .then(() => expect('').to.eq(cli.stdout))
@@ -115,7 +115,7 @@ Initiating transfer of myapp... email sent
         .then(() => api.done())
     })
 
-    it('transfers the app to an organization', () => {
+    it('transfers the app to a team', () => {
       let api = stubPatch.teamAppTransfer()
       return cmd.run({ app: 'myapp', args: { recipient: 'team' }, flags: {} })
         .then(() => expect('').to.eq(cli.stdout))

--- a/packages/orgs-v5/test/commands/apps/transfer.js
+++ b/packages/orgs-v5/test/commands/apps/transfer.js
@@ -54,10 +54,6 @@ Transferring myapp... done
         let choices = prompts[0].choices
         expect(choices).to.eql([
           {
-            name: 'my-org-app (organization)',
-            value: { name: 'my-org-app', owner: 'team@herokumanager.com' }
-          },
-          {
             name: 'my-team-app (team)',
             value: { name: 'my-team-app', owner: 'team@herokumanager.com' }
           },

--- a/packages/orgs-v5/test/commands/apps/transfer.js
+++ b/packages/orgs-v5/test/commands/apps/transfer.js
@@ -28,7 +28,7 @@ describe('heroku apps:transfer', () => {
         expect(choices).to.eql([
           {
             name: 'my-org-app (organization)',
-            value: { name: 'my-org-app', owner: 'organization@herokumanager.com' }
+            value: { name: 'my-org-app', owner: 'team@herokumanager.com' }
           },
           {
             name: 'my-team-app (team)',
@@ -59,7 +59,7 @@ Transferring myapp... done
         expect(choices).to.eql([
           {
             name: 'my-org-app (organization)',
-            value: { name: 'my-org-app', owner: 'organization@herokumanager.com' }
+            value: { name: 'my-org-app', owner: 'team@herokumanager.com' }
           },
           {
             name: 'my-team-app (team)',

--- a/packages/orgs-v5/test/commands/apps/transfer.js
+++ b/packages/orgs-v5/test/commands/apps/transfer.js
@@ -42,7 +42,7 @@ describe('heroku apps:transfer', () => {
         return Promise.resolve({ choices: [{ name: 'myapp', owner: 'foo@foo.com' }] })
       }
 
-      let api = stubPatch.orgAppTransfer()
+      let api = stubPatch.teamAppTransfer()
       return cmd.run({ args: { recipient: 'team' }, flags: { bulk: true } })
         .then(function () {
           api.done()
@@ -100,7 +100,7 @@ Initiating transfer of myapp... email sent
     })
 
     it('transfers the app to an organization', () => {
-      let api = stubPatch.orgAppTransfer()
+      let api = stubPatch.teamAppTransfer()
       return cmd.run({ app: 'myapp', args: { recipient: 'team' }, flags: {} })
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Transferring myapp to team... done
@@ -111,11 +111,11 @@ Initiating transfer of myapp... email sent
 
   context('when it is an org app', () => {
     beforeEach(() => {
-      stubGet.orgApp()
+      stubGet.teamApp()
     })
 
     it('transfers the app to a personal account confirming app name', () => {
-      let api = stubPatch.orgAppTransfer()
+      let api = stubPatch.teamAppTransfer()
       return cmd.run({ app: 'myapp', args: { recipient: 'team' }, flags: { confirm: 'myapp' } })
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Transferring myapp to team... done
@@ -124,7 +124,7 @@ Initiating transfer of myapp... email sent
     })
 
     it('transfers the app to an organization', () => {
-      let api = stubPatch.orgAppTransfer()
+      let api = stubPatch.teamAppTransfer()
       return cmd.run({ app: 'myapp', args: { recipient: 'team' }, flags: {} })
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Transferring myapp to team... done
@@ -133,7 +133,7 @@ Initiating transfer of myapp... email sent
     })
 
     it('transfers and locks the app if --locked is passed', () => {
-      let api = stubPatch.orgAppTransfer()
+      let api = stubPatch.teamAppTransfer()
 
       let lockedAPI = nock('https://api.heroku.com:443')
         .get('/teams/apps/myapp')

--- a/packages/orgs-v5/test/commands/apps/unlock.js
+++ b/packages/orgs-v5/test/commands/apps/unlock.js
@@ -9,9 +9,9 @@ describe('heroku apps:unlock', () => {
 
   it('unlocks the app', () => {
     let api = nock('https://api.heroku.com:443')
-      .get('/organizations/apps/myapp')
+      .get('/teams/apps/myapp')
       .reply(200, { name: 'myapp', locked: true })
-      .patch('/organizations/apps/myapp', { locked: false })
+      .patch('/teams/apps/myapp', { locked: false })
       .reply(200)
     return cmd.run({ app: 'myapp' })
       .then(() => expect('').to.eq(cli.stdout))

--- a/packages/orgs-v5/test/commands/members/add.js
+++ b/packages/orgs-v5/test/commands/members/add.js
@@ -14,7 +14,7 @@ describe('heroku members:add', () => {
 
   context('without the feature flag team-invite-acceptance', () => {
     beforeEach(() => {
-      stubGet.orgFeatures([])
+      stubGet.teamFeatures([])
     })
 
     context('and group is a team', () => {
@@ -95,7 +95,7 @@ Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team for teams lik
 
   context('with the feature flag team-invite-acceptance for a team', () => {
     beforeEach(() => {
-      stubGet.orgFeatures([{ name: 'team-invite-acceptance', enabled: true }])
+      stubGet.teamFeatures([{ name: 'team-invite-acceptance', enabled: true }])
       stubGet.orgInfo('team')
     })
 

--- a/packages/orgs-v5/test/commands/members/add.js
+++ b/packages/orgs-v5/test/commands/members/add.js
@@ -23,7 +23,7 @@ describe('heroku members:add', () => {
       })
 
       it('does not warn the user when under the free org limit', () => {
-        stubGet.variableSizeOrgMembers(1)
+        stubGet.variableSizeTeamMembers(1)
         stubGet.variableSizeTeamInvites(0)
         apiUpdateMemberRole = stubPut.updateMemberRole('foo@foo.com', 'admin')
 
@@ -35,7 +35,7 @@ describe('heroku members:add', () => {
       })
 
       it('does not warn the user when over the free org limit', () => {
-        stubGet.variableSizeOrgMembers(7)
+        stubGet.variableSizeTeamMembers(7)
         stubGet.variableSizeTeamInvites(0)
         apiUpdateMemberRole = stubPut.updateMemberRole('foo@foo.com', 'admin')
 
@@ -47,7 +47,7 @@ describe('heroku members:add', () => {
       })
 
       it('does warn the user when at the free org limit', () => {
-        stubGet.variableSizeOrgMembers(6)
+        stubGet.variableSizeTeamMembers(6)
         stubGet.variableSizeTeamInvites(0)
         apiUpdateMemberRole = stubPut.updateMemberRole('foo@foo.com', 'admin')
 
@@ -61,7 +61,7 @@ You'll be billed monthly for teams over 5 members.
 
       context('using --org instead of --team', () => {
         it('adds the member, but it shows a warning about the usage of -t instead', () => {
-          stubGet.variableSizeOrgMembers(1)
+          stubGet.variableSizeTeamMembers(1)
           stubGet.variableSizeTeamInvites(0)
 
           apiUpdateMemberRole = stubPut.updateMemberRole('foo@foo.com', 'admin')
@@ -78,7 +78,7 @@ Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team for teams lik
     context('and group is an enterprise org', () => {
       beforeEach(() => {
         stubGet.orgInfo('enterprise')
-        stubGet.variableSizeOrgMembers(1)
+        stubGet.variableSizeTeamMembers(1)
       })
 
       it('adds a member to an org', () => {
@@ -102,7 +102,7 @@ Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team for teams lik
     it('does warn the user when free org limit is caused by invites', () => {
       let apiSendInvite = stubPut.sendInvite('foo@foo.com', 'admin')
 
-      let apiGetOrgMembers = stubGet.variableSizeOrgMembers(1)
+      let apiGetOrgMembers = stubGet.variableSizeTeamMembers(1)
       let apiGetTeamInvites = stubGet.variableSizeTeamInvites(5)
 
       return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myorg' } })
@@ -118,7 +118,7 @@ You'll be billed monthly for teams over 5 members.
     it('sends an invite when adding a new user to the team', () => {
       let apiSendInvite = stubPut.sendInvite('foo@foo.com', 'admin')
 
-      stubGet.variableSizeOrgMembers(1)
+      stubGet.variableSizeTeamMembers(1)
       stubGet.variableSizeTeamInvites(0)
 
       return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myorg' } })

--- a/packages/orgs-v5/test/commands/members/add.js
+++ b/packages/orgs-v5/test/commands/members/add.js
@@ -27,9 +27,9 @@ describe('heroku members:add', () => {
         stubGet.variableSizeTeamInvites(0)
         apiUpdateMemberRole = stubPut.updateMemberRole('foo@foo.com', 'admin')
 
-        return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myorg' } })
+        return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
           .then(() => expect('').to.eq(cli.stdout))
-          .then(() => expect(`Adding foo@foo.com to myorg as admin... done
+          .then(() => expect(`Adding foo@foo.com to myteam as admin... done
 `).to.eq(cli.stderr))
           .then(() => apiUpdateMemberRole.done())
       })
@@ -39,9 +39,9 @@ describe('heroku members:add', () => {
         stubGet.variableSizeTeamInvites(0)
         apiUpdateMemberRole = stubPut.updateMemberRole('foo@foo.com', 'admin')
 
-        return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myorg' } })
+        return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
           .then(() => expect('').to.eq(cli.stdout))
-          .then(() => expect(`Adding foo@foo.com to myorg as admin... done
+          .then(() => expect(`Adding foo@foo.com to myteam as admin... done
 `).to.eq(cli.stderr))
           .then(() => apiUpdateMemberRole.done())
       })
@@ -51,9 +51,9 @@ describe('heroku members:add', () => {
         stubGet.variableSizeTeamInvites(0)
         apiUpdateMemberRole = stubPut.updateMemberRole('foo@foo.com', 'admin')
 
-        return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myorg' } })
+        return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
           .then(() => expect('').to.eq(cli.stdout))
-          .then(() => expect(unwrap(cli.stderr)).to.equal(`Adding foo@foo.com to myorg as admin... done \
+          .then(() => expect(unwrap(cli.stderr)).to.equal(`Adding foo@foo.com to myteam as admin... done \
 You'll be billed monthly for teams over 5 members.
 `))
           .then(() => apiUpdateMemberRole.done())
@@ -65,10 +65,10 @@ You'll be billed monthly for teams over 5 members.
           stubGet.variableSizeTeamInvites(0)
 
           apiUpdateMemberRole = stubPut.updateMemberRole('foo@foo.com', 'admin')
-          return cmd.run({ org: 'myorg', args: { email: 'foo@foo.com' }, flags: { role: 'admin' } })
+          return cmd.run({ org: 'myteam', args: { email: 'foo@foo.com' }, flags: { role: 'admin' } })
             .then(() => expect('').to.eq(cli.stdout))
-            .then(() => expect(unwrap(cli.stderr)).to.equal(`Adding foo@foo.com to myorg as admin... done myorg is a \
-Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team for teams like myorg
+            .then(() => expect(unwrap(cli.stderr)).to.equal(`Adding foo@foo.com to myteam as admin... done myteam is a \
+Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team for teams like myteam
 `))
             .then(() => apiUpdateMemberRole.done())
         })
@@ -84,9 +84,9 @@ Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team for teams lik
       it('adds a member to an org', () => {
         apiUpdateMemberRole = stubPut.updateMemberRole('foo@foo.com', 'admin')
 
-        return cmd.run({ org: 'myorg', args: { email: 'foo@foo.com' }, flags: { role: 'admin' } })
+        return cmd.run({ org: 'myteam', args: { email: 'foo@foo.com' }, flags: { role: 'admin' } })
           .then(() => expect('').to.eq(cli.stdout))
-          .then(() => expect(`Adding foo@foo.com to myorg as admin... done
+          .then(() => expect(`Adding foo@foo.com to myteam as admin... done
 `).to.eq(cli.stderr))
           .then(() => apiUpdateMemberRole.done())
       })
@@ -105,12 +105,12 @@ Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team for teams lik
       let apiGetOrgMembers = stubGet.variableSizeTeamMembers(1)
       let apiGetTeamInvites = stubGet.variableSizeTeamInvites(5)
 
-      return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myorg' } })
+      return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
         .then(() => apiSendInvite.done())
         .then(() => apiGetOrgMembers.done())
         .then(() => apiGetTeamInvites.done())
         .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(unwrap(cli.stderr)).to.equal(`Inviting foo@foo.com to myorg as admin... email sent \
+        .then(() => expect(unwrap(cli.stderr)).to.equal(`Inviting foo@foo.com to myteam as admin... email sent \
 You'll be billed monthly for teams over 5 members.
 `))
     })
@@ -121,9 +121,9 @@ You'll be billed monthly for teams over 5 members.
       stubGet.variableSizeTeamMembers(1)
       stubGet.variableSizeTeamInvites(0)
 
-      return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myorg' } })
+      return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
         .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Inviting foo@foo.com to myorg as admin... email sent\n`).to.eq(cli.stderr))
+        .then(() => expect(`Inviting foo@foo.com to myteam as admin... email sent\n`).to.eq(cli.stderr))
         .then(() => apiSendInvite.done())
     })
   })

--- a/packages/orgs-v5/test/commands/members/add.js
+++ b/packages/orgs-v5/test/commands/members/add.js
@@ -19,7 +19,7 @@ describe('heroku members:add', () => {
 
     context('and group is a team', () => {
       beforeEach(() => {
-        stubGet.orgInfo('team')
+        stubGet.teamInfo('team')
       })
 
       it('does not warn the user when under the free org limit', () => {
@@ -77,7 +77,7 @@ Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team for teams lik
 
     context('and group is an enterprise org', () => {
       beforeEach(() => {
-        stubGet.orgInfo('enterprise')
+        stubGet.teamInfo('enterprise')
         stubGet.variableSizeTeamMembers(1)
       })
 
@@ -96,7 +96,7 @@ Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team for teams lik
   context('with the feature flag team-invite-acceptance for a team', () => {
     beforeEach(() => {
       stubGet.teamFeatures([{ name: 'team-invite-acceptance', enabled: true }])
-      stubGet.orgInfo('team')
+      stubGet.teamInfo('team')
     })
 
     it('does warn the user when free org limit is caused by invites', () => {

--- a/packages/orgs-v5/test/commands/members/index.js
+++ b/packages/orgs-v5/test/commands/members/index.js
@@ -18,9 +18,9 @@ describe('heroku members', () => {
 
     it('shows there are not team members if it is an orphan team', () => {
       apiGetOrgMembers = stubGet.teamMembers([])
-      return cmd.run({ org: 'myorg', flags: {} })
+      return cmd.run({ org: 'myteam', flags: {} })
         .then(() => expect(
-          `No members in myorg
+          `No members in myteam
 `).to.eq(cli.stdout))
         .then(() => expect('').to.eq(cli.stderr))
         .then(() => apiGetOrgMembers.done())
@@ -30,7 +30,7 @@ describe('heroku members', () => {
       apiGetOrgMembers = stubGet.teamMembers([
         { email: 'a@heroku.com', role: 'admin' }, { email: 'b@heroku.com', role: 'collaborator' }
       ])
-      return cmd.run({ org: 'myorg', flags: {} })
+      return cmd.run({ org: 'myteam', flags: {} })
         .then(() => expect(
           `a@heroku.com  admin
 b@heroku.com  collaborator
@@ -43,7 +43,7 @@ b@heroku.com  collaborator
 
     it('filters members by role', () => {
       apiGetOrgMembers = stubGet.teamMembers(expectedOrgMembers)
-      return cmd.run({ org: 'myorg', flags: { role: 'member' } })
+      return cmd.run({ org: 'myteam', flags: { role: 'member' } })
         .then(() => expect(
           `b@heroku.com  member
 `).to.eq(cli.stdout))
@@ -53,9 +53,9 @@ b@heroku.com  collaborator
 
     it("shows the right message when filter doesn't return results", () => {
       apiGetOrgMembers = stubGet.teamMembers(expectedOrgMembers)
-      return cmd.run({ org: 'myorg', flags: { role: 'collaborator' } })
+      return cmd.run({ org: 'myteam', flags: { role: 'collaborator' } })
         .then(() => expect(
-          `No members in myorg with role collaborator
+          `No members in myteam with role collaborator
 `).to.eq(cli.stdout))
         .then(() => expect('').to.eq(cli.stderr))
         .then(() => apiGetOrgMembers.done())
@@ -63,7 +63,7 @@ b@heroku.com  collaborator
 
     it('filters members by role', () => {
       apiGetOrgMembers = stubGet.teamMembers(expectedOrgMembers)
-      return cmd.run({ org: 'myorg', flags: { role: 'member' } })
+      return cmd.run({ org: 'myteam', flags: { role: 'member' } })
         .then(() => expect(
           `b@heroku.com  member
 `).to.eq(cli.stdout))
@@ -87,12 +87,12 @@ b@heroku.com  collaborator
           apiGetOrgMembers = stubGet.teamMembers([
             { email: 'a@heroku.com', role: 'admin' }, { email: 'b@heroku.com', role: 'collaborator' }
           ])
-          return cmd.run({ org: 'myorg', flags: {} })
+          return cmd.run({ org: 'myteam', flags: {} })
             .then(() => expect(
               `a@heroku.com  admin
 b@heroku.com  collaborator\n`).to.eq(cli.stdout))
-            .then(() => expect(unwrap(cli.stderr)).to.equal(`myorg is a Heroku Team Heroku CLI now supports Heroku Teams. \
-Use -t or --team for teams like myorg
+            .then(() => expect(unwrap(cli.stderr)).to.equal(`myteam is a Heroku Team Heroku CLI now supports Heroku Teams. \
+Use -t or --team for teams like myteam
 `))
             .then(() => apiGetOrgMembers.done())
         })
@@ -111,7 +111,7 @@ Use -t or --team for teams like myorg
           { email: 'a@heroku.com', role: 'admin' }, { email: 'b@heroku.com', role: 'collaborator' }
         ])
 
-        return cmd.run({ flags: { team: 'myorg' } })
+        return cmd.run({ flags: { team: 'myteam' } })
           .then(() => expect(
             `a@heroku.com           admin
 b@heroku.com           collaborator
@@ -129,7 +129,7 @@ invited-user@mail.com  admin         pending
           { email: 'a@heroku.com', role: 'admin' }, { email: 'b@heroku.com', role: 'collaborator' }
         ])
 
-        return cmd.run({ flags: { team: 'myorg', pending: true } })
+        return cmd.run({ flags: { team: 'myteam', pending: true } })
           .then(() => expect(
             `invited-user@mail.com  admin  pending
 `).to.eq(cli.stdout))

--- a/packages/orgs-v5/test/commands/members/index.js
+++ b/packages/orgs-v5/test/commands/members/index.js
@@ -13,7 +13,7 @@ describe('heroku members', () => {
 
   context('when it is an Enterprise team', () => {
     beforeEach(() => {
-      stubGet.orgInfo('enterprise')
+      stubGet.teamInfo('enterprise')
     })
 
     it('shows there are not team members if it is an orphan team', () => {
@@ -74,7 +74,7 @@ b@heroku.com  collaborator
 
   context('when it is a team', () => {
     beforeEach(() => {
-      stubGet.orgInfo('team')
+      stubGet.teamInfo('team')
     })
 
     context('without the feature flag team-invite-acceptance', () => {

--- a/packages/orgs-v5/test/commands/members/index.js
+++ b/packages/orgs-v5/test/commands/members/index.js
@@ -11,12 +11,12 @@ describe('heroku members', () => {
 
   let apiGetOrgMembers
 
-  context('when it is an Enterprise org', () => {
+  context('when it is an Enterprise team', () => {
     beforeEach(() => {
       stubGet.orgInfo('enterprise')
     })
 
-    it('shows there are not org members if it is an orphan org', () => {
+    it('shows there are not team members if it is an orphan team', () => {
       apiGetOrgMembers = stubGet.orgMembers([])
       return cmd.run({ org: 'myorg', flags: {} })
         .then(() => expect(
@@ -26,7 +26,7 @@ describe('heroku members', () => {
         .then(() => apiGetOrgMembers.done())
     })
 
-    it('shows all the org members', () => {
+    it('shows all the team members', () => {
       apiGetOrgMembers = stubGet.orgMembers([
         { email: 'a@heroku.com', role: 'admin' }, { email: 'b@heroku.com', role: 'collaborator' }
       ])
@@ -79,7 +79,7 @@ b@heroku.com  collaborator
 
     context('without the feature flag team-invite-acceptance', () => {
       beforeEach(() => {
-        stubGet.orgFeatures([])
+        stubGet.teamFeatures([])
       })
 
       context('using --org instead of --team', () => {
@@ -101,7 +101,7 @@ Use -t or --team for teams like myorg
 
     context('with the feature flag team-invite-acceptance', () => {
       beforeEach(() => {
-        stubGet.orgFeatures([{ name: 'team-invite-acceptance', enabled: true }])
+        stubGet.teamFeatures([{ name: 'team-invite-acceptance', enabled: true }])
       })
 
       it('shows all members including those with pending invites', () => {

--- a/packages/orgs-v5/test/commands/members/index.js
+++ b/packages/orgs-v5/test/commands/members/index.js
@@ -17,7 +17,7 @@ describe('heroku members', () => {
     })
 
     it('shows there are not team members if it is an orphan team', () => {
-      apiGetOrgMembers = stubGet.orgMembers([])
+      apiGetOrgMembers = stubGet.teamMembers([])
       return cmd.run({ org: 'myorg', flags: {} })
         .then(() => expect(
           `No members in myorg
@@ -27,7 +27,7 @@ describe('heroku members', () => {
     })
 
     it('shows all the team members', () => {
-      apiGetOrgMembers = stubGet.orgMembers([
+      apiGetOrgMembers = stubGet.teamMembers([
         { email: 'a@heroku.com', role: 'admin' }, { email: 'b@heroku.com', role: 'collaborator' }
       ])
       return cmd.run({ org: 'myorg', flags: {} })
@@ -42,7 +42,7 @@ b@heroku.com  collaborator
     let expectedOrgMembers = [{ email: 'a@heroku.com', role: 'admin' }, { email: 'b@heroku.com', role: 'member' }]
 
     it('filters members by role', () => {
-      apiGetOrgMembers = stubGet.orgMembers(expectedOrgMembers)
+      apiGetOrgMembers = stubGet.teamMembers(expectedOrgMembers)
       return cmd.run({ org: 'myorg', flags: { role: 'member' } })
         .then(() => expect(
           `b@heroku.com  member
@@ -52,7 +52,7 @@ b@heroku.com  collaborator
     })
 
     it("shows the right message when filter doesn't return results", () => {
-      apiGetOrgMembers = stubGet.orgMembers(expectedOrgMembers)
+      apiGetOrgMembers = stubGet.teamMembers(expectedOrgMembers)
       return cmd.run({ org: 'myorg', flags: { role: 'collaborator' } })
         .then(() => expect(
           `No members in myorg with role collaborator
@@ -62,7 +62,7 @@ b@heroku.com  collaborator
     })
 
     it('filters members by role', () => {
-      apiGetOrgMembers = stubGet.orgMembers(expectedOrgMembers)
+      apiGetOrgMembers = stubGet.teamMembers(expectedOrgMembers)
       return cmd.run({ org: 'myorg', flags: { role: 'member' } })
         .then(() => expect(
           `b@heroku.com  member
@@ -84,7 +84,7 @@ b@heroku.com  collaborator
 
       context('using --org instead of --team', () => {
         it('shows members either way including a warning', () => {
-          apiGetOrgMembers = stubGet.orgMembers([
+          apiGetOrgMembers = stubGet.teamMembers([
             { email: 'a@heroku.com', role: 'admin' }, { email: 'b@heroku.com', role: 'collaborator' }
           ])
           return cmd.run({ org: 'myorg', flags: {} })
@@ -107,7 +107,7 @@ Use -t or --team for teams like myorg
       it('shows all members including those with pending invites', () => {
         let apiGetTeamInvites = stubGet.teamInvites()
 
-        apiGetOrgMembers = stubGet.orgMembers([
+        apiGetOrgMembers = stubGet.teamMembers([
           { email: 'a@heroku.com', role: 'admin' }, { email: 'b@heroku.com', role: 'collaborator' }
         ])
 
@@ -125,7 +125,7 @@ invited-user@mail.com  admin         pending
       it('filters members by pending invites', () => {
         let apiGetTeamInvites = stubGet.teamInvites()
 
-        apiGetOrgMembers = stubGet.orgMembers([
+        apiGetOrgMembers = stubGet.teamMembers([
           { email: 'a@heroku.com', role: 'admin' }, { email: 'b@heroku.com', role: 'collaborator' }
         ])
 

--- a/packages/orgs-v5/test/commands/members/remove.js
+++ b/packages/orgs-v5/test/commands/members/remove.js
@@ -12,7 +12,7 @@ describe('heroku members:remove', () => {
 
   context('from an org', () => {
     beforeEach(() => {
-      stubGet.orgInfo('enterprise')
+      stubGet.teamInfo('enterprise')
     })
 
     it('removes a member from an org', () => {
@@ -26,7 +26,7 @@ describe('heroku members:remove', () => {
 
   context('from a team', () => {
     beforeEach(() => {
-      stubGet.orgInfo('team')
+      stubGet.teamInfo('team')
     })
 
     context('without the feature flag team-invite-acceptance', () => {

--- a/packages/orgs-v5/test/commands/members/remove.js
+++ b/packages/orgs-v5/test/commands/members/remove.js
@@ -31,7 +31,7 @@ describe('heroku members:remove', () => {
 
     context('without the feature flag team-invite-acceptance', () => {
       beforeEach(() => {
-        stubGet.orgFeatures([])
+        stubGet.teamFeatures([])
       })
 
       context('using --org instead of --team', () => {
@@ -59,7 +59,7 @@ myorg is a Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team fo
       let apiGetTeamInvites
 
       beforeEach(() => {
-        stubGet.orgFeatures([{ name: 'team-invite-acceptance', enabled: true }])
+        stubGet.teamFeatures([{ name: 'team-invite-acceptance', enabled: true }])
       })
 
       context('with no pending invites', () => {

--- a/packages/orgs-v5/test/commands/members/remove.js
+++ b/packages/orgs-v5/test/commands/members/remove.js
@@ -17,9 +17,9 @@ describe('heroku members:remove', () => {
 
     it('removes a member from an org', () => {
       let apiRemoveMemberFromOrg = stubDelete.memberFromTeam()
-      return cmd.run({ org: 'myorg', args: { email: 'foo@foo.com' } })
+      return cmd.run({ org: 'myteam', args: { email: 'foo@foo.com' } })
         .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Removing foo@foo.com from myorg... done\n`).to.eq(cli.stderr))
+        .then(() => expect(`Removing foo@foo.com from myteam... done\n`).to.eq(cli.stderr))
         .then(() => apiRemoveMemberFromOrg.done())
     })
   })
@@ -37,10 +37,10 @@ describe('heroku members:remove', () => {
       context('using --org instead of --team', () => {
         it('removes the member, but it shows a warning about the usage of -t instead', () => {
           let apiRemoveMemberFromOrg = stubDelete.memberFromTeam()
-          return cmd.run({ org: 'myorg', args: { email: 'foo@foo.com' }, flags: {} })
+          return cmd.run({ org: 'myteam', args: { email: 'foo@foo.com' }, flags: {} })
             .then(() => expect('').to.eq(cli.stdout))
-            .then(() => expect(unwrap(cli.stderr)).to.equal(`Removing foo@foo.com from myorg... done \
-myorg is a Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team for teams like myorg
+            .then(() => expect(unwrap(cli.stderr)).to.equal(`Removing foo@foo.com from myteam... done \
+myteam is a Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team for teams like myteam
 `))
             .then(() => apiRemoveMemberFromOrg.done())
         })
@@ -48,9 +48,9 @@ myorg is a Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team fo
 
       it('removes a member from an org', () => {
         let apiRemoveMemberFromOrg = stubDelete.memberFromTeam()
-        return cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myorg' } })
+        return cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myteam' } })
           .then(() => expect('').to.eq(cli.stdout))
-          .then(() => expect(`Removing foo@foo.com from myorg... done\n`).to.eq(cli.stderr))
+          .then(() => expect(`Removing foo@foo.com from myteam... done\n`).to.eq(cli.stderr))
           .then(() => apiRemoveMemberFromOrg.done())
       })
     })
@@ -69,9 +69,9 @@ myorg is a Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team fo
 
         it('removes a member', () => {
           let apiRemoveMemberFromOrg = stubDelete.memberFromTeam()
-          return cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myorg' } })
+          return cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myteam' } })
             .then(() => expect('').to.eq(cli.stdout))
-            .then(() => expect(`Removing foo@foo.com from myorg... done\n`).to.eq(cli.stderr))
+            .then(() => expect(`Removing foo@foo.com from myteam... done\n`).to.eq(cli.stderr))
             .then(() => apiGetTeamInvites.done())
             .then(() => apiRemoveMemberFromOrg.done())
         })
@@ -87,9 +87,9 @@ myorg is a Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team fo
         it('revokes the invite', () => {
           let apiRevokeTeamInvite = stubDelete.teamInvite('foo@foo.com')
 
-          return cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myorg' } })
+          return cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myteam' } })
             .then(() => expect('').to.eq(cli.stdout))
-            .then(() => expect(`Revoking invite for foo@foo.com in myorg... done\n`).to.eq(cli.stderr))
+            .then(() => expect(`Revoking invite for foo@foo.com in myteam... done\n`).to.eq(cli.stderr))
             .then(() => apiGetTeamInvites.done())
             .then(() => apiRevokeTeamInvite.done())
         })

--- a/packages/orgs-v5/test/commands/members/remove.js
+++ b/packages/orgs-v5/test/commands/members/remove.js
@@ -16,7 +16,7 @@ describe('heroku members:remove', () => {
     })
 
     it('removes a member from an org', () => {
-      let apiRemoveMemberFromOrg = stubDelete.memberFromOrg()
+      let apiRemoveMemberFromOrg = stubDelete.memberFromTeam()
       return cmd.run({ org: 'myorg', args: { email: 'foo@foo.com' } })
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Removing foo@foo.com from myorg... done\n`).to.eq(cli.stderr))
@@ -36,7 +36,7 @@ describe('heroku members:remove', () => {
 
       context('using --org instead of --team', () => {
         it('removes the member, but it shows a warning about the usage of -t instead', () => {
-          let apiRemoveMemberFromOrg = stubDelete.memberFromOrg()
+          let apiRemoveMemberFromOrg = stubDelete.memberFromTeam()
           return cmd.run({ org: 'myorg', args: { email: 'foo@foo.com' }, flags: {} })
             .then(() => expect('').to.eq(cli.stdout))
             .then(() => expect(unwrap(cli.stderr)).to.equal(`Removing foo@foo.com from myorg... done \
@@ -47,7 +47,7 @@ myorg is a Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team fo
       })
 
       it('removes a member from an org', () => {
-        let apiRemoveMemberFromOrg = stubDelete.memberFromOrg()
+        let apiRemoveMemberFromOrg = stubDelete.memberFromTeam()
         return cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myorg' } })
           .then(() => expect('').to.eq(cli.stdout))
           .then(() => expect(`Removing foo@foo.com from myorg... done\n`).to.eq(cli.stderr))
@@ -68,7 +68,7 @@ myorg is a Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team fo
         })
 
         it('removes a member', () => {
-          let apiRemoveMemberFromOrg = stubDelete.memberFromOrg()
+          let apiRemoveMemberFromOrg = stubDelete.memberFromTeam()
           return cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myorg' } })
             .then(() => expect('').to.eq(cli.stdout))
             .then(() => expect(`Removing foo@foo.com from myorg... done\n`).to.eq(cli.stderr))

--- a/packages/orgs-v5/test/commands/members/set.js
+++ b/packages/orgs-v5/test/commands/members/set.js
@@ -25,9 +25,9 @@ describe('heroku members:set', () => {
       stubGet.variableSizeTeamInvites(0)
       apiUpdateMemberRole = stubPatch.updateMemberRole('foo@foo.com', 'admin')
 
-      return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myorg' } })
+      return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
         .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Adding foo@foo.com to myorg as admin... done
+        .then(() => expect(`Adding foo@foo.com to myteam as admin... done
 `).to.eq(cli.stderr))
         .then(() => apiUpdateMemberRole.done())
     })
@@ -37,9 +37,9 @@ describe('heroku members:set', () => {
       stubGet.variableSizeTeamInvites(0)
       apiUpdateMemberRole = stubPatch.updateMemberRole('foo@foo.com', 'admin')
 
-      return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myorg' } })
+      return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
         .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Adding foo@foo.com to myorg as admin... done
+        .then(() => expect(`Adding foo@foo.com to myteam as admin... done
 `).to.eq(cli.stderr))
         .then(() => apiUpdateMemberRole.done())
     })
@@ -49,9 +49,9 @@ describe('heroku members:set', () => {
       stubGet.variableSizeTeamInvites(0)
       apiUpdateMemberRole = stubPatch.updateMemberRole('foo@foo.com', 'admin')
 
-      return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myorg' } })
+      return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
         .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(unwrap(cli.stderr)).to.equal(`Adding foo@foo.com to myorg as admin... done \
+        .then(() => expect(unwrap(cli.stderr)).to.equal(`Adding foo@foo.com to myteam as admin... done \
 You'll be billed monthly for teams over 5 members.
 `))
         .then(() => apiUpdateMemberRole.done())
@@ -63,10 +63,10 @@ You'll be billed monthly for teams over 5 members.
         stubGet.variableSizeTeamInvites(0)
 
         apiUpdateMemberRole = stubPatch.updateMemberRole('foo@foo.com', 'admin')
-        return cmd.run({ org: 'myorg', args: { email: 'foo@foo.com' }, flags: { role: 'admin' } })
+        return cmd.run({ org: 'myteam', args: { email: 'foo@foo.com' }, flags: { role: 'admin' } })
           .then(() => expect('').to.eq(cli.stdout))
-          .then(() => expect(unwrap(cli.stderr)).to.equal(`Adding foo@foo.com to myorg as admin... done \
-myorg is a Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team for teams like myorg
+          .then(() => expect(unwrap(cli.stderr)).to.equal(`Adding foo@foo.com to myteam as admin... done \
+myteam is a Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team for teams like myteam
 `))
           .then(() => apiUpdateMemberRole.done())
       })
@@ -82,9 +82,9 @@ myorg is a Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team fo
     it('adds a member to an org', () => {
       apiUpdateMemberRole = stubPatch.updateMemberRole('foo@foo.com', 'admin')
 
-      return cmd.run({ org: 'myorg', args: { email: 'foo@foo.com' }, flags: { role: 'admin' } })
+      return cmd.run({ org: 'myteam', args: { email: 'foo@foo.com' }, flags: { role: 'admin' } })
         .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Adding foo@foo.com to myorg as admin... done
+        .then(() => expect(`Adding foo@foo.com to myteam as admin... done
 `).to.eq(cli.stderr))
         .then(() => apiUpdateMemberRole.done())
     })

--- a/packages/orgs-v5/test/commands/members/set.js
+++ b/packages/orgs-v5/test/commands/members/set.js
@@ -11,7 +11,7 @@ describe('heroku members:set', () => {
 
   beforeEach(() => {
     cli.mockConsole()
-    stubGet.orgFeatures([])
+    stubGet.teamFeatures([])
   })
   afterEach(() => nock.cleanAll())
 

--- a/packages/orgs-v5/test/commands/members/set.js
+++ b/packages/orgs-v5/test/commands/members/set.js
@@ -21,7 +21,7 @@ describe('heroku members:set', () => {
     })
 
     it('does not warn the user when under the free org limit', () => {
-      stubGet.variableSizeOrgMembers(1)
+      stubGet.variableSizeTeamMembers(1)
       stubGet.variableSizeTeamInvites(0)
       apiUpdateMemberRole = stubPatch.updateMemberRole('foo@foo.com', 'admin')
 
@@ -33,7 +33,7 @@ describe('heroku members:set', () => {
     })
 
     it('does not warn the user when over the free org limit', () => {
-      stubGet.variableSizeOrgMembers(7)
+      stubGet.variableSizeTeamMembers(7)
       stubGet.variableSizeTeamInvites(0)
       apiUpdateMemberRole = stubPatch.updateMemberRole('foo@foo.com', 'admin')
 
@@ -45,7 +45,7 @@ describe('heroku members:set', () => {
     })
 
     it('does warn the user when at the free org limit', () => {
-      stubGet.variableSizeOrgMembers(6)
+      stubGet.variableSizeTeamMembers(6)
       stubGet.variableSizeTeamInvites(0)
       apiUpdateMemberRole = stubPatch.updateMemberRole('foo@foo.com', 'admin')
 
@@ -59,7 +59,7 @@ You'll be billed monthly for teams over 5 members.
 
     context('using --org instead of --team', () => {
       it('adds the member, but it shows a warning about the usage of -t instead', () => {
-        stubGet.variableSizeOrgMembers(1)
+        stubGet.variableSizeTeamMembers(1)
         stubGet.variableSizeTeamInvites(0)
 
         apiUpdateMemberRole = stubPatch.updateMemberRole('foo@foo.com', 'admin')
@@ -76,7 +76,7 @@ myorg is a Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team fo
   context('and group is an enterprise org', () => {
     beforeEach(() => {
       stubGet.orgInfo('enterprise')
-      stubGet.variableSizeOrgMembers(1)
+      stubGet.variableSizeTeamMembers(1)
     })
 
     it('adds a member to an org', () => {

--- a/packages/orgs-v5/test/commands/members/set.js
+++ b/packages/orgs-v5/test/commands/members/set.js
@@ -17,7 +17,7 @@ describe('heroku members:set', () => {
 
   context('and group is a team', () => {
     beforeEach(() => {
-      stubGet.orgInfo('team')
+      stubGet.teamInfo('team')
     })
 
     it('does not warn the user when under the free org limit', () => {
@@ -75,7 +75,7 @@ myorg is a Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team fo
 
   context('and group is an enterprise org', () => {
     beforeEach(() => {
-      stubGet.orgInfo('enterprise')
+      stubGet.teamInfo('enterprise')
       stubGet.variableSizeTeamMembers(1)
     })
 

--- a/packages/orgs-v5/test/commands/orgs/index.js
+++ b/packages/orgs-v5/test/commands/orgs/index.js
@@ -13,8 +13,8 @@ describe('heroku teams', () => {
 
     return cmd.run({ flags: { enterprise: true } })
       .then(() => expect(
-        `enterprise a    collaborator
-enterprise b    admin\n`).to.eq(cli.stdout))
+        `enterprise a   collaborator
+enterprise b   admin\n`).to.eq(cli.stdout))
       .then(() => expect('').to.eq(cli.stderr))
       .then(() => apiGetTeams.done())
   })
@@ -27,8 +27,8 @@ enterprise b    admin\n`).to.eq(cli.stdout))
 
     return cmd.run({ flags: {} })
       .then(() => expect(
-        `enterprise a    collaborator
-enterprise b    admin\n`).to.eq(cli.stdout))
+        `enterprise a   collaborator
+enterprise b   admin\n`).to.eq(cli.stdout))
       .then(() => expect('').to.eq(cli.stderr))
       .then(() => apiGetTeamsOnly.done())
   })

--- a/packages/orgs-v5/test/commands/orgs/index.js
+++ b/packages/orgs-v5/test/commands/orgs/index.js
@@ -4,32 +4,32 @@
 let cmd = require('../../../commands/orgs')
 let stubGet = require('../../stub/get')
 
-describe('heroku orgs', () => {
+describe('heroku teams', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
-  it('shows Enterprise orgs only when passing the --enterprise flag', () => {
-    let apiGetOrgs = stubGet.orgs()
+  it('shows Enterprise teams only when passing the --enterprise flag', () => {
+    let apiGetTeams = stubGet.teams()
 
     return cmd.run({ flags: { enterprise: true } })
       .then(() => expect(
-        `org a          collaborator
-org b          admin\n`).to.eq(cli.stdout))
+        `enterprise a          collaborator
+enterprise b          admin\n`).to.eq(cli.stdout))
       .then(() => expect('').to.eq(cli.stderr))
-      .then(() => apiGetOrgs.done())
+      .then(() => apiGetTeams.done())
   })
 
-  it('shows orgs (now called teams)', () => {
-    let apiGetOrgsOnly = stubGet.orgs([
-      { name: 'org a', role: 'collaborator', type: 'enterprise' },
-      { name: 'org b', role: 'admin', type: 'enterprise' }
+  it('shows teams', () => {
+    let apiGetTeamsOnly = stubGet.teams([
+      { name: 'enterprise a', role: 'collaborator', type: 'enterprise' },
+      { name: 'enterprise b', role: 'admin', type: 'enterprise' }
     ])
 
     return cmd.run({ flags: {} })
       .then(() => expect(
-        `org a          collaborator
-org b          admin\n`).to.eq(cli.stdout))
+        `enterprise a          collaborator
+enterprise b          admin\n`).to.eq(cli.stdout))
       .then(() => expect('').to.eq(cli.stderr))
-      .then(() => apiGetOrgsOnly.done())
+      .then(() => apiGetTeamsOnly.done())
   })
 })

--- a/packages/orgs-v5/test/commands/orgs/index.js
+++ b/packages/orgs-v5/test/commands/orgs/index.js
@@ -13,8 +13,8 @@ describe('heroku teams', () => {
 
     return cmd.run({ flags: { enterprise: true } })
       .then(() => expect(
-        `enterprise a          collaborator
-enterprise b          admin\n`).to.eq(cli.stdout))
+        `enterprise a                collaborator
+enterprise b                admin\n`).to.eq(cli.stdout))
       .then(() => expect('').to.eq(cli.stderr))
       .then(() => apiGetTeams.done())
   })
@@ -27,8 +27,8 @@ enterprise b          admin\n`).to.eq(cli.stdout))
 
     return cmd.run({ flags: {} })
       .then(() => expect(
-        `enterprise a          collaborator
-enterprise b          admin\n`).to.eq(cli.stdout))
+        `enterprise a                collaborator
+enterprise b                admin\n`).to.eq(cli.stdout))
       .then(() => expect('').to.eq(cli.stderr))
       .then(() => apiGetTeamsOnly.done())
   })

--- a/packages/orgs-v5/test/commands/orgs/index.js
+++ b/packages/orgs-v5/test/commands/orgs/index.js
@@ -13,8 +13,8 @@ describe('heroku teams', () => {
 
     return cmd.run({ flags: { enterprise: true } })
       .then(() => expect(
-        `enterprise a   collaborator
-enterprise b   admin\n`).to.eq(cli.stdout))
+        `enterprise a  collaborator
+enterprise b  admin\n`).to.eq(cli.stdout))
       .then(() => expect('').to.eq(cli.stderr))
       .then(() => apiGetTeams.done())
   })
@@ -27,8 +27,8 @@ enterprise b   admin\n`).to.eq(cli.stdout))
 
     return cmd.run({ flags: {} })
       .then(() => expect(
-        `enterprise a   collaborator
-enterprise b   admin\n`).to.eq(cli.stdout))
+        `enterprise a  collaborator
+enterprise b  admin\n`).to.eq(cli.stdout))
       .then(() => expect('').to.eq(cli.stderr))
       .then(() => apiGetTeamsOnly.done())
   })

--- a/packages/orgs-v5/test/commands/orgs/index.js
+++ b/packages/orgs-v5/test/commands/orgs/index.js
@@ -13,8 +13,8 @@ describe('heroku teams', () => {
 
     return cmd.run({ flags: { enterprise: true } })
       .then(() => expect(
-        `enterprise a                collaborator
-enterprise b                admin\n`).to.eq(cli.stdout))
+        `enterprise a    collaborator
+enterprise b    admin\n`).to.eq(cli.stdout))
       .then(() => expect('').to.eq(cli.stderr))
       .then(() => apiGetTeams.done())
   })
@@ -27,8 +27,8 @@ enterprise b                admin\n`).to.eq(cli.stdout))
 
     return cmd.run({ flags: {} })
       .then(() => expect(
-        `enterprise a                collaborator
-enterprise b                admin\n`).to.eq(cli.stdout))
+        `enterprise a    collaborator
+enterprise b    admin\n`).to.eq(cli.stdout))
       .then(() => expect('').to.eq(cli.stderr))
       .then(() => apiGetTeamsOnly.done())
   })

--- a/packages/orgs-v5/test/commands/teams/index.js
+++ b/packages/orgs-v5/test/commands/teams/index.js
@@ -8,13 +8,15 @@ describe('heroku teams', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
-  it('shows only the Heroku Teams', () => {
+  it('shows the teams you are a member of', () => {
     let apiGetOrgs = stubGet.teams()
 
     return cmd.run({ flags: {} })
       .then(() => expect(
-        `enterprise a        collaborator
-enterprise b        admin
+        `enterprise a  collaborator
+enterprise b  admin
+team a        collaborator
+team b        admin
 `).to.eq(cli.stdout))
       .then(() => expect('').to.eq(cli.stderr))
       .then(() => apiGetOrgs.done())

--- a/packages/orgs-v5/test/commands/teams/index.js
+++ b/packages/orgs-v5/test/commands/teams/index.js
@@ -13,8 +13,8 @@ describe('heroku teams', () => {
 
     return cmd.run({ flags: {} })
       .then(() => expect(
-        `enterprise a  collaborator
-enterprise b  admin
+        `enterprise a        collaborator
+enterprise b        admin
 `).to.eq(cli.stdout))
       .then(() => expect('').to.eq(cli.stderr))
       .then(() => apiGetOrgs.done())

--- a/packages/orgs-v5/test/commands/teams/index.js
+++ b/packages/orgs-v5/test/commands/teams/index.js
@@ -13,8 +13,8 @@ describe('heroku teams', () => {
 
     return cmd.run({ flags: {} })
       .then(() => expect(
-        `team a  collaborator
-team b  admin
+        `enterprise a  collaborator
+enterprise b  admin
 `).to.eq(cli.stdout))
       .then(() => expect('').to.eq(cli.stderr))
       .then(() => apiGetOrgs.done())

--- a/packages/orgs-v5/test/stub/delete.js
+++ b/packages/orgs-v5/test/stub/delete.js
@@ -2,7 +2,7 @@
 
 const nock = require('nock')
 
-function collaboratorsOrgApp (app, email) {
+function collaboratorsteamApp (app, email) {
   return nock('https://api.heroku.com:443', {
     reqheaders: { Accept: 'application/vnd.heroku+json; version=3' }
   })
@@ -27,7 +27,7 @@ function memberFromTeam () {
 }
 
 module.exports = {
-  collaboratorsOrgApp,
+  collaboratorsteamApp,
   collaboratorsPersonalApp,
   memberFromTeam,
   teamInvite

--- a/packages/orgs-v5/test/stub/delete.js
+++ b/packages/orgs-v5/test/stub/delete.js
@@ -6,7 +6,7 @@ function collaboratorsOrgApp (app, email) {
   return nock('https://api.heroku.com:443', {
     reqheaders: { Accept: 'application/vnd.heroku+json; version=3' }
   })
-    .delete(`/organizations/apps/${app}/collaborators/${email}`).reply(200, {})
+    .delete(`/teams/apps/${app}/collaborators/${email}`).reply(200, {})
 }
 
 function collaboratorsPersonalApp (app, email) {

--- a/packages/orgs-v5/test/stub/delete.js
+++ b/packages/orgs-v5/test/stub/delete.js
@@ -18,12 +18,12 @@ function teamInvite (email = 'foo@email.com') {
   return nock('https://api.heroku.com:443', {
     reqheaders: { Accept: 'application/vnd.heroku+json; version=3.team-invitations' }
   })
-    .delete(`/teams/myorg/invitations/${email}`).reply(200, {})
+    .delete(`/teams/myteam/invitations/${email}`).reply(200, {})
 }
 
 function memberFromTeam () {
   return nock('https://api.heroku.com:443', {})
-    .delete('/teams/myorg/members/foo%40foo.com').reply(200)
+    .delete('/teams/myteam/members/foo%40foo.com').reply(200)
 }
 
 module.exports = {

--- a/packages/orgs-v5/test/stub/delete.js
+++ b/packages/orgs-v5/test/stub/delete.js
@@ -18,7 +18,7 @@ function teamInvite (email = 'foo@email.com') {
   return nock('https://api.heroku.com:443', {
     reqheaders: { Accept: 'application/vnd.heroku+json; version=3.team-invitations' }
   })
-    .delete(`/organizations/myorg/invitations/${email}`).reply(200, {})
+    .delete(`/teams/myorg/invitations/${email}`).reply(200, {})
 }
 
 function memberFromOrg () {

--- a/packages/orgs-v5/test/stub/delete.js
+++ b/packages/orgs-v5/test/stub/delete.js
@@ -21,14 +21,14 @@ function teamInvite (email = 'foo@email.com') {
     .delete(`/teams/myorg/invitations/${email}`).reply(200, {})
 }
 
-function memberFromOrg () {
+function memberFromTeam () {
   return nock('https://api.heroku.com:443', {})
-    .delete('/organizations/myorg/members/foo%40foo.com').reply(200)
+    .delete('/teams/myorg/members/foo%40foo.com').reply(200)
 }
 
 module.exports = {
   collaboratorsOrgApp,
   collaboratorsPersonalApp,
-  memberFromOrg,
+  memberFromTeam,
   teamInvite
 }

--- a/packages/orgs-v5/test/stub/get.js
+++ b/packages/orgs-v5/test/stub/get.js
@@ -33,7 +33,7 @@ function appPermissions () {
     ])
 }
 
-function teams (orgs = [
+function teams (teams = [
   { name: 'enterprise a', role: 'collaborator', type: 'enterprise' },
   { name: 'team a', role: 'collaborator', type: 'team' },
   { name: 'enterprise b', role: 'admin', type: 'enterprise' },
@@ -41,7 +41,7 @@ function teams (orgs = [
 ]) {
   return nock('https://api.heroku.com:443')
     .get('/teams')
-    .reply(200, orgs)
+    .reply(200, teams)
 }
 
 function teamApp (locked = false) {
@@ -163,10 +163,10 @@ function variableSizeTeamInvites (teamSize) {
     .reply(200, invites)
 }
 
-function variableSizeTeamMembers (orgSize) {
-  orgSize = (typeof (orgSize) === 'undefined') ? 1 : orgSize
+function variableSizeTeamMembers (teamSize) {
+  teamSize = (typeof (teamSize) === 'undefined') ? 1 : teamSize
   let teamMembers = []
-  for (let i = 0; i < orgSize; i++) {
+  for (let i = 0; i < teamSize; i++) {
     teamMembers.push({ email: `test${i}@heroku.com`,
       role: 'admin',
       user: { email: `test${i}@heroku.com` } })

--- a/packages/orgs-v5/test/stub/get.js
+++ b/packages/orgs-v5/test/stub/get.js
@@ -168,7 +168,7 @@ function variableSizeTeamInvites (teamSize) {
   return nock('https://api.heroku.com:443', {
     reqheaders: { Accept: 'application/vnd.heroku+json; version=3.team-invitations' }
   })
-    .get('/organizations/myorg/invitations')
+    .get('/teams/myorg/invitations')
     .reply(200, invites)
 }
 

--- a/packages/orgs-v5/test/stub/get.js
+++ b/packages/orgs-v5/test/stub/get.js
@@ -7,7 +7,7 @@ function apps () {
     .get('/apps')
     .reply(200, [
       { name: 'my-team-app', owner: { email: 'team@herokumanager.com' } },
-      { name: 'my-org-app', owner: { email: 'organization@herokumanager.com' } },
+      { name: 'my-org-app', owner: { email: 'team@herokumanager.com' } },
       { name: 'myapp', owner: { email: 'foo@foo.com' } }
     ])
 }
@@ -49,7 +49,7 @@ function teamApp (locked = false) {
     .get('/apps/myapp')
     .reply(200, {
       name: 'myapp',
-      owner: { email: 'myorg@herokumanager.com' },
+      owner: { email: 'myteam@herokumanager.com' },
       locked: locked
     })
 }
@@ -62,7 +62,7 @@ function teamAppCollaboratorsWithPermissions () {
     .reply(200, [
       { permissions: [],
         role: 'owner',
-        user: { email: 'myorg@herokumanager.com' }
+        user: { email: 'myteam@herokumanager.com' }
       },
       {
         permissions: [ { name: 'deploy' }, { name: 'view' } ],
@@ -76,7 +76,7 @@ function teamFeatures (features) {
   return nock('https://api.heroku.com:443', {
     reqheaders: { Accept: 'application/vnd.heroku+json; version=3' }
   })
-    .get('/teams/myorg/features')
+    .get('/teams/myteam/features')
     .reply(200, features)
 }
 
@@ -84,9 +84,9 @@ function teamInfo (type = 'enterprise') {
   return nock('https://api.heroku.com:443', {
     reqheaders: { Accept: 'application/vnd.heroku+json; version=3' }
   })
-    .get('/teams/myorg')
+    .get('/teams/myteam')
     .reply(200, {
-      name: 'myorg',
+      name: 'myteam',
       role: 'admin',
       type: type
     })
@@ -101,7 +101,7 @@ function teamInvites (invites = [
   return nock('https://api.heroku.com:443', {
     reqheaders: { Accept: 'application/vnd.heroku+json; version=3.team-invitations' }
   })
-    .get('/teams/myorg/invitations')
+    .get('/teams/myteam/invitations')
     .reply(200, invites)
 }
 
@@ -123,7 +123,7 @@ function teamMembers (members = [
   }
 ]) {
   return nock('https://api.heroku.com:443')
-    .get('/teams/myorg/members')
+    .get('/teams/myteam/members')
     .reply(200, members)
 }
 
@@ -159,7 +159,7 @@ function variableSizeTeamInvites (teamSize) {
   return nock('https://api.heroku.com:443', {
     reqheaders: { Accept: 'application/vnd.heroku+json; version=3.team-invitations' }
   })
-    .get('/teams/myorg/invitations')
+    .get('/teams/myteam/invitations')
     .reply(200, invites)
 }
 
@@ -172,7 +172,7 @@ function variableSizeTeamMembers (orgSize) {
       user: { email: `test${i}@heroku.com` } })
   }
   return nock('https://api.heroku.com:443')
-    .get('/teams/myorg/members')
+    .get('/teams/myteam/members')
     .reply(200, teamMembers)
 }
 

--- a/packages/orgs-v5/test/stub/get.js
+++ b/packages/orgs-v5/test/stub/get.js
@@ -110,7 +110,7 @@ function teamInvites (invites = [
   return nock('https://api.heroku.com:443', {
     reqheaders: { Accept: 'application/vnd.heroku+json; version=3.team-invitations' }
   })
-    .get('/organizations/myorg/invitations')
+    .get('/teams/myorg/invitations')
     .reply(200, invites)
 }
 

--- a/packages/orgs-v5/test/stub/get.js
+++ b/packages/orgs-v5/test/stub/get.js
@@ -172,7 +172,7 @@ function variableSizeTeamInvites (teamSize) {
     .reply(200, invites)
 }
 
-function variableSizeOrgMembers (orgSize) {
+function variableSizeTeamMembers (orgSize) {
   orgSize = (typeof (orgSize) === 'undefined') ? 1 : orgSize
   let teamMembers = []
   for (let i = 0; i < orgSize; i++) {
@@ -181,7 +181,7 @@ function variableSizeOrgMembers (orgSize) {
       user: { email: `test${i}@heroku.com` } })
   }
   return nock('https://api.heroku.com:443')
-    .get('/organizations/myorg/members')
+    .get('/teams/myorg/members')
     .reply(200, teamMembers)
 }
 
@@ -200,6 +200,6 @@ module.exports = {
   teams,
   userAccount,
   userFeatureFlags,
-  variableSizeOrgMembers,
+  variableSizeTeamMembers,
   variableSizeTeamInvites
 }

--- a/packages/orgs-v5/test/stub/get.js
+++ b/packages/orgs-v5/test/stub/get.js
@@ -80,7 +80,7 @@ function teamFeatures (features) {
     .reply(200, features)
 }
 
-function orgInfo (type = 'enterprise') {
+function teamInfo (type = 'enterprise') {
   return nock('https://api.heroku.com:443', {
     reqheaders: { Accept: 'application/vnd.heroku+json; version=3' }
   })
@@ -182,14 +182,14 @@ module.exports = {
   apps,
   orgApp,
   orgAppCollaboratorsWithPermissions,
-  orgInfo,
   personalApp,
   teamFeatures,
+  teamInfo,
   teamInvites,
   teamMembers,
   teams,
   userAccount,
   userFeatureFlags,
-  variableSizeTeamMembers,
-  variableSizeTeamInvites
+  variableSizeTeamInvites,
+  variableSizeTeamMembers
 }

--- a/packages/orgs-v5/test/stub/get.js
+++ b/packages/orgs-v5/test/stub/get.js
@@ -44,7 +44,7 @@ function teams (orgs = [
     .reply(200, orgs)
 }
 
-function orgApp (locked = false) {
+function teamApp (locked = false) {
   return nock('https://api.heroku.com:443')
     .get('/apps/myapp')
     .reply(200, {
@@ -54,7 +54,7 @@ function orgApp (locked = false) {
     })
 }
 
-function orgAppCollaboratorsWithPermissions () {
+function teamAppCollaboratorsWithPermissions () {
   return nock('https://api.heroku.com:443', {
     reqheaders: { Accept: 'application/vnd.heroku+json; version=3' }
   })
@@ -180,9 +180,9 @@ module.exports = {
   appCollaborators,
   appPermissions,
   apps,
-  orgApp,
-  orgAppCollaboratorsWithPermissions,
   personalApp,
+  teamApp,
+  teamAppCollaboratorsWithPermissions,
   teamFeatures,
   teamInfo,
   teamInvites,

--- a/packages/orgs-v5/test/stub/get.js
+++ b/packages/orgs-v5/test/stub/get.js
@@ -7,7 +7,6 @@ function apps () {
     .get('/apps')
     .reply(200, [
       { name: 'my-team-app', owner: { email: 'team@herokumanager.com' } },
-      { name: 'my-org-app', owner: { email: 'team@herokumanager.com' } },
       { name: 'myapp', owner: { email: 'foo@foo.com' } }
     ])
 }

--- a/packages/orgs-v5/test/stub/get.js
+++ b/packages/orgs-v5/test/stub/get.js
@@ -84,7 +84,7 @@ function orgInfo (type = 'enterprise') {
   return nock('https://api.heroku.com:443', {
     reqheaders: { Accept: 'application/vnd.heroku+json; version=3' }
   })
-    .get('/organizations/myorg')
+    .get('/teams/myorg')
     .reply(200, {
       name: 'myorg',
       role: 'admin',

--- a/packages/orgs-v5/test/stub/get.js
+++ b/packages/orgs-v5/test/stub/get.js
@@ -72,11 +72,11 @@ function orgAppCollaboratorsWithPermissions () {
     ])
 }
 
-function orgFeatures (features) {
+function teamFeatures (features) {
   return nock('https://api.heroku.com:443', {
     reqheaders: { Accept: 'application/vnd.heroku+json; version=3' }
   })
-    .get('/organizations/myorg/features')
+    .get('/teams/myorg/features')
     .reply(200, features)
 }
 
@@ -193,7 +193,7 @@ module.exports = {
   orgApp,
   orgAppCollaboratorsWithPermissions,
   orgInfo,
-  orgFeatures,
+  teamFeatures,
   teamInvites,
   orgMembers,
   personalApp,

--- a/packages/orgs-v5/test/stub/get.js
+++ b/packages/orgs-v5/test/stub/get.js
@@ -114,7 +114,7 @@ function teamInvites (invites = [
     .reply(200, invites)
 }
 
-function orgMembers (members = [
+function teamMembers (members = [
   {
     email: 'raulb@heroku.com',
     role: 'admin',
@@ -132,7 +132,7 @@ function orgMembers (members = [
   }
 ]) {
   return nock('https://api.heroku.com:443')
-    .get('/organizations/myorg/members')
+    .get('/teams/myorg/members')
     .reply(200, members)
 }
 
@@ -174,29 +174,29 @@ function variableSizeTeamInvites (teamSize) {
 
 function variableSizeOrgMembers (orgSize) {
   orgSize = (typeof (orgSize) === 'undefined') ? 1 : orgSize
-  let orgMembers = []
+  let teamMembers = []
   for (let i = 0; i < orgSize; i++) {
-    orgMembers.push({ email: `test${i}@heroku.com`,
+    teamMembers.push({ email: `test${i}@heroku.com`,
       role: 'admin',
       user: { email: `test${i}@heroku.com` } })
   }
   return nock('https://api.heroku.com:443')
     .get('/organizations/myorg/members')
-    .reply(200, orgMembers)
+    .reply(200, teamMembers)
 }
 
 module.exports = {
-  apps,
   appCollaborators,
   appPermissions,
-  orgs,
+  apps,
   orgApp,
   orgAppCollaboratorsWithPermissions,
   orgInfo,
+  orgs,
+  personalApp,
   teamFeatures,
   teamInvites,
-  orgMembers,
-  personalApp,
+  teamMembers,
   teams,
   userAccount,
   userFeatureFlags,

--- a/packages/orgs-v5/test/stub/get.js
+++ b/packages/orgs-v5/test/stub/get.js
@@ -33,14 +33,14 @@ function appPermissions () {
     ])
 }
 
-function orgs (orgs = [
-  { name: 'org a', role: 'collaborator', type: 'enterprise' },
+function teams (orgs = [
+  { name: 'enterprise a', role: 'collaborator', type: 'enterprise' },
   { name: 'team a', role: 'collaborator', type: 'team' },
-  { name: 'org b', role: 'admin', type: 'enterprise' },
+  { name: 'enterprise b', role: 'admin', type: 'enterprise' },
   { name: 'team b', role: 'admin', type: 'team' }
 ]) {
   return nock('https://api.heroku.com:443')
-    .get('/organizations')
+    .get('/teams')
     .reply(200, orgs)
 }
 
@@ -90,15 +90,6 @@ function orgInfo (type = 'enterprise') {
       role: 'admin',
       type: type
     })
-}
-
-function teams (teams = [
-  { name: 'team a', role: 'collaborator', type: 'enterprise' },
-  { name: 'team b', role: 'admin', type: 'team' }
-]) {
-  return nock('https://api.heroku.com:443')
-    .get('/teams')
-    .reply(200, teams)
 }
 
 function teamInvites (invites = [
@@ -192,7 +183,6 @@ module.exports = {
   orgApp,
   orgAppCollaboratorsWithPermissions,
   orgInfo,
-  orgs,
   personalApp,
   teamFeatures,
   teamInvites,

--- a/packages/orgs-v5/test/stub/get.js
+++ b/packages/orgs-v5/test/stub/get.js
@@ -24,7 +24,7 @@ function appPermissions () {
   return nock('https://api.heroku.com:443', {
     reqheaders: { Accept: 'application/vnd.heroku+json; version=3' }
   })
-    .get('/organizations/permissions')
+    .get('/teams/permissions')
     .reply(200, [
       { name: 'deploy' },
       { name: 'manage' },

--- a/packages/orgs-v5/test/stub/patch.js
+++ b/packages/orgs-v5/test/stub/patch.js
@@ -9,7 +9,7 @@ function appCollaboratorWithPermissions (args) {
     }).reply(200)
 }
 
-function orgAppTransfer () {
+function teamAppTransfer () {
   return nock('https://api.heroku.com:443')
     .patch('/teams/apps/myapp', { owner: 'team' })
     .reply(200, { name: 'myapp', owner: { email: 'team@herokumanager.com' } })
@@ -29,7 +29,7 @@ function updateMemberRole (email = 'raulb@heroku.com', role = 'admin') {
 
 module.exports = {
   appCollaboratorWithPermissions,
-  orgAppTransfer,
+  teamAppTransfer,
   personalToPersonal,
   updateMemberRole
 }

--- a/packages/orgs-v5/test/stub/patch.js
+++ b/packages/orgs-v5/test/stub/patch.js
@@ -4,7 +4,7 @@ const nock = require('nock')
 
 function appCollaboratorWithPermissions (args) {
   return nock('https://api.heroku.com:443')
-    .patch(`/organizations/apps/myapp/collaborators/${args.email}`, {
+    .patch(`/teams/apps/myapp/collaborators/${args.email}`, {
       permissions: args.permissions
     }).reply(200)
 }

--- a/packages/orgs-v5/test/stub/patch.js
+++ b/packages/orgs-v5/test/stub/patch.js
@@ -11,19 +11,19 @@ function appCollaboratorWithPermissions (args) {
 
 function orgAppTransfer () {
   return nock('https://api.heroku.com:443')
-    .patch('/organizations/apps/myapp', { owner: 'team' })
+    .patch('/teams/apps/myapp', { owner: 'team' })
     .reply(200, { name: 'myapp', owner: { email: 'team@herokumanager.com' } })
 }
 
 function personalToPersonal () {
   return nock('https://api.heroku.com:443')
-    .patch('/organizations/apps/myapp', { owner: 'raulb@heroku.com' })
+    .patch('/teams/apps/myapp', { owner: 'raulb@heroku.com' })
     .reply(200, { name: 'myapp', owner: { email: 'raulb@heroku.com' } })
 }
 
 function updateMemberRole (email = 'raulb@heroku.com', role = 'admin') {
   return nock('https://api.heroku.com:443')
-    .patch('/organizations/myorg/members', { email, role })
+    .patch('/teams/myorg/members', { email, role })
     .reply(200)
 }
 

--- a/packages/orgs-v5/test/stub/patch.js
+++ b/packages/orgs-v5/test/stub/patch.js
@@ -23,7 +23,7 @@ function personalToPersonal () {
 
 function updateMemberRole (email = 'raulb@heroku.com', role = 'admin') {
   return nock('https://api.heroku.com:443')
-    .patch('/teams/myorg/members', { email, role })
+    .patch('/teams/myteam/members', { email, role })
     .reply(200)
 }
 

--- a/packages/orgs-v5/test/stub/post.js
+++ b/packages/orgs-v5/test/stub/post.js
@@ -30,5 +30,5 @@ function personalToPersonal () {
 module.exports = {
   collaborators,
   personalToPersonal,
-  teamAppCollaborators,
+  teamAppCollaborators
 }

--- a/packages/orgs-v5/test/stub/post.js
+++ b/packages/orgs-v5/test/stub/post.js
@@ -9,7 +9,7 @@ function collaborators () {
     }).reply(200)
 }
 
-function orgAppcollaborators (email = 'raulb@heroku.com', permissions = [], response = {}) {
+function teamAppCollaborators (email = 'raulb@heroku.com', permissions = [], response = {}) {
   let body = { user: email }
   if (permissions.length) {
     body.permissions = permissions
@@ -18,7 +18,7 @@ function orgAppcollaborators (email = 'raulb@heroku.com', permissions = [], resp
   return nock('https://api.heroku.com:443', {
     reqheaders: { Accept: 'application/vnd.heroku+json; version=3' }
   })
-    .post('/organizations/apps/myapp/collaborators', body).reply(response.code || 200, response.description)
+    .post('/teams/apps/myapp/collaborators', body).reply(response.code || 200, response.description)
 }
 
 function personalToPersonal () {
@@ -30,5 +30,5 @@ function personalToPersonal () {
 module.exports = {
   collaborators,
   personalToPersonal,
-  orgAppcollaborators
+  teamAppCollaborators,
 }

--- a/packages/orgs-v5/test/stub/put.js
+++ b/packages/orgs-v5/test/stub/put.js
@@ -10,7 +10,7 @@ function sendInvite (email = 'raulb@heroku.com', role = 'admin') {
 
 function updateMemberRole (email = 'raulb@heroku.com', role = 'admin') {
   return nock('https://api.heroku.com:443')
-    .put('/organizations/myorg/members', { email, role })
+    .put('/teams/myorg/members', { email, role })
     .reply(200)
 }
 

--- a/packages/orgs-v5/test/stub/put.js
+++ b/packages/orgs-v5/test/stub/put.js
@@ -4,7 +4,7 @@ const nock = require('nock')
 
 function sendInvite (email = 'raulb@heroku.com', role = 'admin') {
   return nock('https://api.heroku.com:443')
-    .put('/organizations/myorg/invitations', { email, role })
+    .put('/teams/myorg/invitations', { email, role })
     .reply(200)
 }
 

--- a/packages/orgs-v5/test/stub/put.js
+++ b/packages/orgs-v5/test/stub/put.js
@@ -4,13 +4,13 @@ const nock = require('nock')
 
 function sendInvite (email = 'raulb@heroku.com', role = 'admin') {
   return nock('https://api.heroku.com:443')
-    .put('/teams/myorg/invitations', { email, role })
+    .put('/teams/myteam/invitations', { email, role })
     .reply(200)
 }
 
 function updateMemberRole (email = 'raulb@heroku.com', role = 'admin') {
   return nock('https://api.heroku.com:443')
-    .put('/teams/myorg/members', { email, role })
+    .put('/teams/myteam/members', { email, role })
     .reply(200)
 }
 

--- a/packages/pipelines-v5/commands/pipelines/connect.js
+++ b/packages/pipelines-v5/commands/pipelines/connect.js
@@ -16,7 +16,6 @@ module.exports = {
 Configuring pipeline... done`,
   needsApp: false,
   needsAuth: true,
-  wantsOrg: false,
   args: [{
     name: 'name',
     description: 'name of pipeline',

--- a/packages/pipelines-v5/commands/pipelines/create.js
+++ b/packages/pipelines-v5/commands/pipelines/create.js
@@ -73,7 +73,6 @@ Creating example pipeline... done
 Adding example-staging to example pipeline as staging... done`,
   needsApp: true,
   needsAuth: true,
-  wantsOrg: true,
   args: [
     { name: 'name', description: 'name of pipeline, defaults to basename of app', optional: true }
   ],

--- a/packages/pipelines-v5/commands/pipelines/setup.js
+++ b/packages/pipelines-v5/commands/pipelines/setup.js
@@ -35,7 +35,6 @@ Configuring pipeline... done
 View your new pipeline by running \`heroku pipelines:open e5a55ffa-de3f-11e6-a245-3c15c2e6bc1e\``,
   needsApp: false,
   needsAuth: true,
-  wantsOrg: true,
   args: [
     {
       name: 'name',

--- a/packages/pipelines-v5/commands/review_apps/disable.js
+++ b/packages/pipelines-v5/commands/review_apps/disable.js
@@ -13,7 +13,6 @@ Disabling auto deployment ...
 Configuring pipeline... done`,
   needsApp: false,
   needsAuth: true,
-  wantsOrg: false,
   args: [],
   flags: [
     flags.pipeline({ name: 'pipeline', required: true, hasValue: true }),

--- a/packages/pipelines-v5/commands/review_apps/enable.js
+++ b/packages/pipelines-v5/commands/review_apps/enable.js
@@ -15,7 +15,6 @@ Enabling auto destroy ...
 Configuring pipeline... done`,
   needsApp: false,
   needsAuth: true,
-  wantsOrg: false,
   args: [],
   flags: [
     flags.pipeline({ name: 'pipeline', required: true, hasValue: true }),

--- a/packages/spaces/commands/create.js
+++ b/packages/spaces/commands/create.js
@@ -69,7 +69,6 @@ module.exports = {
   `,
   needsApp: false,
   needsAuth: true,
-  wantsOrg: true,
   args: [{ name: 'space', optional: true, hidden: true }],
   flags: [
     { name: 'space', char: 's', hasValue: true, description: 'name of space to create' },

--- a/packages/spaces/commands/index.js
+++ b/packages/spaces/commands/index.js
@@ -42,7 +42,6 @@ module.exports = {
   topic: 'spaces',
   description: 'list available spaces',
   needsAuth: true,
-  wantsOrg: true,
   flags: [
     { name: 'json', description: 'output in json format' },
     flags.team({ name: 'team', hasValue: true })


### PR DESCRIPTION
What this does:
* Removes any calls to endpoints that use `organizations`. This has been deprecated in API for some time but we have never officially removed them. Quite soon, we're going to try and remove them. In order to do that, CLI needs to use the teams endpoints. To be clear: none of the data coming back is any different, just removing the route.
* Tries to remove any references to orgs. This one is a bit trickier. I didn't want to disable any external interfaces that allows "org" to be used. I think that decision should lie with you all.

What it does not do:
* I did not rename the `orgs` package. I think this could be renamed to teams now but that's more of a job for the maintainers.
* It _should_ not change any of the externally facing commands. If a command used "org", it should still use that or accept that flag.

I split up the commits because the large change was miserable. I left them in case anyone has opinions and wanted to remove or change any of them. I would greatly appreciate squashing these commits down before they go in, nothing worse than having a bad git history attached to my name. If you'd prefer me to squash them, just ping me after review and I'll happily oblige!