### PR TITLE
fix(spaces): remove owner_pool

### DIFF
--- a/packages/spaces/commands/create.js
+++ b/packages/spaces/commands/create.js
@@ -26,7 +26,6 @@ function * run (context, heroku) {
       features: parsers.splitCsv(context.flags.features),
       log_drain_url: context.flags['log-drain-url'],
       shield: context.flags['shield'],
-      owner_pool: context.flags['owner-pool'],
       cidr: context.flags['cidr'],
       kpi_url: context.flags['kpi-url'],
       data_cidr: context.flags['data-cidr']
@@ -76,7 +75,6 @@ module.exports = {
     { name: 'region', hasValue: true, description: 'region name', completion: RegionCompletion },
     { name: 'features', hasValue: true, hidden: true, description: 'a list of features separated by commas' },
     { name: 'log-drain-url', hasValue: true, hidden: true, description: 'direct log drain url' },
-    { name: 'owner-pool', hasValue: true, hidden: true, description: 'owner pool name' },
     { name: 'shield', hasValue: false, hidden: true, description: 'create a Shield space' },
     { name: 'cidr', hasValue: true, description: 'RFC-1918 CIDR the space will use' },
     { name: 'kpi-url', hasValue: true, hidden: true, description: 'self-managed KPI endpoint to use' },

--- a/packages/spaces/test/commands/create.js
+++ b/packages/spaces/test/commands/create.js
@@ -18,13 +18,12 @@ describe('spaces:create', function () {
         name: 'my-space',
         team: 'my-team',
         region: 'my-region',
-        owner_pool: 'party',
         features: features
       })
       .reply(201,
         { shield: false, name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, features: [ 'one', 'two' ], state: 'enabled', created_at: now, cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' }
       )
-    return cmd.run({ team: 'my-team', flags: { space: 'my-space', region: 'my-region', features: 'one, two', 'owner-pool': 'party' } })
+    return cmd.run({ team: 'my-team', flags: { space: 'my-space', region: 'my-region', features: 'one, two' } })
       .then(() => expect(cli.stdout).to.equal(
         `=== my-space
 Team:       my-team
@@ -44,13 +43,12 @@ Created at: ${now.toISOString()}
         name: 'my-space',
         team: 'my-team',
         region: 'my-region',
-        owner_pool: 'party',
         features: features
       })
       .reply(201,
         { shield: false, name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, features: [ 'one', 'two' ], state: 'enabled', created_at: now, cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' }
       )
-    return cmd.run({ team: 'my-team', flags: { space: 'my-space', region: 'my-region', features: 'one, two', 'owner-pool': 'party' } })
+    return cmd.run({ team: 'my-team', flags: { space: 'my-space', region: 'my-region', features: 'one, two' } })
       .then(() => expect(cli.stderr).to.include(
         `Each Heroku Standard Private Space costs $1000`))
       .then(() => api.done())


### PR DESCRIPTION
Runtime is removing the concept of owner pools from space creation. 

This commit should **not** be merged until changes are first made to spacemgr and API.

https://github.com/heroku/runtime-issues/issues/465
https://github.com/heroku/spacemgr/pull/1257
https://github.com/heroku/api/pull/10468
