### PR TITLE
chore(cli): change logs request path color from blue to green

### DIFF
--- a/packages/run-v5/lib/colorize.js
+++ b/packages/run-v5/lib/colorize.js
@@ -33,7 +33,7 @@ let lineRegex = /^(.*?\[([\w-]+)([\d.]+)?]:)(.*)?$/
 const red = c.red
 const dim = i => c.dim(i)
 const other = dim
-const path = i => c.blue(i)
+const path = i => c.green(i)
 const method = i => c.bold.magenta(i)
 const status = code => {
   if (code < 200) return code


### PR DESCRIPTION
Totally my personal opinion on this, but I thought I'd throw it out there to see if anyone else felt the same way. I propose changing the request path color in `heroku logs` from blue to green for better readability on dark terminal backgrounds. This change, in my opinion, is also readable on light backgrounds.

From:
![Screen Shot 2019-03-28 at 6 07 44 PM](https://user-images.githubusercontent.com/2424906/55202695-b4f58400-5185-11e9-97f1-7753d2d947c3.png)
![Screen Shot 2019-03-28 at 6 25 08 PM](https://user-images.githubusercontent.com/2424906/55203001-05211600-5187-11e9-9919-4fe6e5a4b110.png)

To:
![Screen Shot 2019-03-28 at 6 07 03 PM](https://user-images.githubusercontent.com/2424906/55202747-f1c17b00-5185-11e9-89db-1b101d03f25d.png)
![Screen Shot 2019-03-28 at 6 25 00 PM](https://user-images.githubusercontent.com/2424906/55203023-19651300-5187-11e9-9402-01ff457e0d85.png)

Cheers!