### PR TITLE
fix: Fix redis:promote for private plans

### DIFF
--- a/packages/redis-v5/test/commands/promote.js
+++ b/packages/redis-v5/test/commands/promote.js
@@ -38,10 +38,19 @@ describe('heroku redis:promote', function () {
       .then(() => expect(cli.stderr).to.equal(''))
   })
 
-  it('# promotes and attaches existing REDIS_URL', function () {
+  it('# promotes and replaces attachment of existing REDIS_URL if necessary', function () {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
-        { name: 'redis-silver-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_URL'] },
+        {
+          name: 'redis-silver-haiku',
+          addon_service: { name: 'heroku-redis' },
+          config_vars: [
+            'REDIS_URL',
+            'REDIS_BASTIONS',
+            'REDIS_BASTION_KEY',
+            'REDIS_BASTION_REKEYS_AFTER'
+          ]
+        },
         { name: 'redis-gold-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['HEROKU_REDIS_GOLD_URL'] }
       ])
 


### PR DESCRIPTION
If the user is attempting to promote a Redis add-on and there already
*is* a REDIS attachment *and* it's the last attachment for that
add-on, we need to first create an alternate attachment (since
creating a new attachment implicitly detaches what was there before,
and the API won't allow us to remove the last attachment implicitly
like this).

Our approach for doing this is naïve and breaks with private Redis
plans (or really any Redis configuration that has additional config
vars) because we rely on counting config vars.

The right solution is probably to look at attachment count for the
existing add-on attached at REDIS explicitly, but as a quick fix we
just look for config vars ending in '_URL' (rather than the total
count of config vars).