### PR TITLE
feat(pg-v5): add pg:repoint command

### DIFF
--- a/packages/pg-v5/commands/repoint.js
+++ b/packages/pg-v5/commands/repoint.js
@@ -20,14 +20,14 @@ function * run (context, heroku) {
 
   let origin = util.databaseNameFromUrl(replica.following, yield heroku.get(`/apps/${app}/config-vars`))
 
-  let new_leader = yield fetcher.addon(app, flags.follow)
+  let newLeader = yield fetcher.addon(app, flags.follow)
 
   yield cli.confirmApp(app, flags.confirm, `WARNING: Destructive action
-${cli.color.addon(db.name)} will be repointed to follow ${new_leader.name}, and stop following ${origin}.
+${cli.color.addon(db.name)} will be repointed to follow ${newLeader.name}, and stop following ${origin}.
 
 This cannot be undone.`)
 
-  let data = { follow: new_leader.id }
+  let data = { follow: newLeader.id }
   yield cli.action(`Starting repoint of ${cli.color.addon(db.name)}`, co(function * () {
     yield heroku.post(`/client/v11/databases/${db.id}/repoint`, { host: host(db), body: data })
     cli.action.done(`${cli.color.cmd('heroku pg:wait')} to track status`)

--- a/packages/pg-v5/commands/repoint.js
+++ b/packages/pg-v5/commands/repoint.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const cli = require('heroku-cli-util')
+const co = require('co')
+
+function * run (context, heroku) {
+  const host = require('../lib/host')
+  const util = require('../lib/util')
+  const fetcher = require('../lib/fetcher')(heroku)
+  let { app, args, flags } = context
+  let db = yield fetcher.addon(app, args.database)
+
+  if (util.starterPlan(db)) throw new Error('pg:repoint is only available for follower production databases')
+
+  let replica = yield heroku.get(`/client/v11/databases/${db.id}`, { host: host(db) })
+
+  if (!replica.following) {
+    throw new Error('pg:repoint is only available for follower production databases')
+  }
+
+  let origin = util.databaseNameFromUrl(replica.following, yield heroku.get(`/apps/${app}/config-vars`))
+
+  let new_leader = yield fetcher.addon(app, flags.follow)
+
+  yield cli.confirmApp(app, flags.confirm, `WARNING: Destructive action
+${cli.color.addon(db.name)} will be repointed to follow ${new_leader.name}, and stop following ${origin}.
+
+This cannot be undone.`)
+
+  let data = { follow: new_leader.id }
+  yield cli.action(`Starting repoint of ${cli.color.addon(db.name)}`, co(function * () {
+    yield heroku.post(`/client/v11/databases/${db.id}/repoint`, { host: host(db), body: data })
+    cli.action.done(`${cli.color.cmd('heroku pg:wait')} to track status`)
+  }))
+}
+
+module.exports = {
+  topic: 'pg',
+  command: 'repoint',
+  description: 'changes which leader a follower is following',
+  help: 'TODO',
+  needsApp: true,
+  needsAuth: true,
+  args: [{ name: 'database', optional: true }],
+  flags: [
+    { name: 'confirm', char: 'c', hasValue: true },
+    { name: 'follow', description: 'leader database to follow', hasValue: true }
+  ],
+  run: cli.command({ preauth: true }, co.wrap(run))
+}

--- a/packages/pg-v5/commands/repoint.js
+++ b/packages/pg-v5/commands/repoint.js
@@ -38,7 +38,10 @@ module.exports = {
   topic: 'pg',
   command: 'repoint',
   description: 'changes which leader a follower is following',
-  help: 'TODO',
+  help: `Example:
+
+    heroku pg:repoint postgresql-transparent-56874 --follow postgresql-lucid-59103 -a woodstock-production
+`,
   needsApp: true,
   needsAuth: true,
   args: [{ name: 'database', optional: true }],

--- a/packages/pg-v5/index.js
+++ b/packages/pg-v5/index.js
@@ -44,6 +44,7 @@ exports.commands = flatten([
   require('./commands/ps'),
   require('./commands/psql'),
   require('./commands/pull'),
+  require('./commands/repoint'),
   require('./commands/reset'),
   require('./commands/settings'),
   require('./commands/settings/log_lock_waits'),

--- a/packages/pg-v5/test/commands/repoint.js
+++ b/packages/pg-v5/test/commands/repoint.js
@@ -58,7 +58,7 @@ describe('pg:repoint', () => {
     api.get('/apps/myapp/config-vars').reply(200, { DATABASE_URL: 'postgres://db1' })
     pg.get('/client/v11/databases/1').reply(200, { following: 'postgres://db1' })
     pg.post('/client/v11/databases/1/repoint').reply(200)
-    return cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp', follow: 'NEW_LEADER'} })
+    return cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp', follow: 'NEW_LEADER' } })
       .then(() => expect(cli.stderr, 'to equal', 'Starting repoint of postgres-1... heroku pg:wait to track status\n'))
   })
 })

--- a/packages/pg-v5/test/commands/repoint.js
+++ b/packages/pg-v5/test/commands/repoint.js
@@ -1,0 +1,64 @@
+'use strict'
+/* global describe it beforeEach afterEach */
+
+const cli = require('heroku-cli-util')
+const expect = require('unexpected')
+const nock = require('nock')
+const proxyquire = require('proxyquire')
+
+let addon
+const fetcher = () => {
+  return {
+    addon: () => addon
+  }
+}
+
+const cmd = proxyquire('../../commands/repoint', {
+  '../lib/fetcher': fetcher
+})
+
+describe('pg:repoint', () => {
+  let api, pg
+
+  beforeEach(() => {
+    addon = {
+      id: 1,
+      name: 'postgres-1',
+      plan: { name: 'heroku-postgresql:standard-0' }
+    }
+
+    api = nock('https://api.heroku.com')
+    pg = nock('https://postgres-api.heroku.com')
+    cli.mockConsole()
+  })
+
+  afterEach(() => {
+    nock.cleanAll()
+    api.done()
+    pg.done()
+  })
+
+  it('refuses to repoint hobby dbs', () => {
+    addon.plan = { name: 'heroku-postgresql:hobby-dev' }
+
+    return expect(cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp' } }),
+      'to be rejected with',
+      new Error('pg:repoint is only available for follower production databases'))
+  })
+
+  it('refuses to repoint non-follower dbs', () => {
+    pg.get('/client/v11/databases/1').reply(200, { forked_from: 'postgres://db1' })
+
+    return expect(cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp' } }),
+      'to be rejected with',
+      new Error('pg:repoint is only available for follower production databases'))
+  })
+
+  it('repoints db', () => {
+    api.get('/apps/myapp/config-vars').reply(200, { DATABASE_URL: 'postgres://db1' })
+    pg.get('/client/v11/databases/1').reply(200, { following: 'postgres://db1' })
+    pg.post('/client/v11/databases/1/repoint').reply(200)
+    return cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp', follow: 'NEW_LEADER'} })
+      .then(() => expect(cli.stderr, 'to equal', 'Starting repoint of postgres-1... heroku pg:wait to track status\n'))
+  })
+})


### PR DESCRIPTION
This adds a `pg:repoint` command. The command itself is relatively simple, it hits up an endpoint on the postgres api.