### PR TITLE
chore(redis-v5) Add new maxmemory policies to the help text for redis

### DIFF
--- a/packages/redis-v5/commands/maxmemory.js
+++ b/packages/redis-v5/commands/maxmemory.js
@@ -13,6 +13,8 @@ module.exports = {
   help: `Set the key eviction policy when instance reaches its storage limit. Available policies for key eviction include:
 
     noeviction      # returns errors when memory limit is reached
+    allkeys-lfu     # removes less frequently used keys first
+    volatile-lfu    # removes less frequently used keys first that have an expiry set
     allkeys-lru     # removes less recently used keys first
     volatile-lru    # removes less recently used keys first that have an expiry set
     allkeys-random  # evicts random keys


### PR DESCRIPTION
Add the new policies (allkeys-lfu and volatile-lfu) to the help text of the redis subcommand.

These modes are new in redis version 4 and this version is now the default version for redis.

This option is available from this PR heroku/shogun#11388 and will be merged today.
