### PR TITLE
fix: team flag prioritized over org flag

### DIFF
--- a/packages/apps-v5/src/commands/apps/create.js
+++ b/packages/apps-v5/src/commands/apps/create.js
@@ -17,7 +17,7 @@ function createText (name, space) {
 async function createApp (context, heroku, name, stack) {
   let params = {
     name,
-    team: context.org || context.team || context.flags.team,
+    team: context.flags.team,
     region: context.flags.region,
     space: context.flags.space,
     stack,

--- a/packages/apps-v5/src/commands/apps/index.js
+++ b/packages/apps-v5/src/commands/apps/index.js
@@ -8,7 +8,7 @@ const { SpaceCompletion } = require('@heroku-cli/command/lib/completions')
 function * run (context, heroku) {
   const { sortBy, partition } = require('lodash')
 
-  let teamIdentifier = context.org || context.team || context.flags.team
+  let teamIdentifier = context.flags.team
   let team = (!context.flags.personal && teamIdentifier) ? teamIdentifier : null
   let space = context.flags.space
   let internalRouting = context.flags['internal-routing']

--- a/packages/apps-v5/test/commands/apps/create.js
+++ b/packages/apps-v5/test/commands/apps/create.js
@@ -16,6 +16,10 @@ describe('apps:create', function () {
     nock.cleanAll()
   })
 
+  it('is is configured for an optional team/org flag', function () {
+    expect(apps).to.have.own.property('wantsOrg', true)
+  })
+
   it('creates an app', function () {
     let mock = nock('https://api.heroku.com')
       .post('/apps', {

--- a/packages/apps-v5/test/commands/apps/create.js
+++ b/packages/apps-v5/test/commands/apps/create.js
@@ -16,7 +16,7 @@ describe('apps:create', function () {
     nock.cleanAll()
   })
 
-  it('is is configured for an optional team/org flag', function () {
+  it('is configured for an optional team flag', function () {
     expect(apps).to.have.own.property('wantsOrg', true)
   })
 

--- a/packages/apps-v5/test/commands/apps/index.js
+++ b/packages/apps-v5/test/commands/apps/index.js
@@ -263,7 +263,7 @@ internal-app [internal/locked] (eu)
 
     it('displays a message when the team has no apps', function () {
       let mock = stubteamApps('test-team', [])
-      return apps.run({ org: 'test-team', flags: {}, args: {} }).then(function () {
+      return apps.run({ flags: { team: 'test-team' }, args: {} }).then(function () {
         mock.done()
         expect(cli.stderr).to.equal('')
         expect(cli.stdout).to.equal(`There are no apps in team test-team.
@@ -273,7 +273,7 @@ internal-app [internal/locked] (eu)
 
     it('list all in a team', function () {
       let mock = stubteamApps('test-team', [teamApp1, teamApp2])
-      return apps.run({ org: 'test-team', flags: {}, args: {} }).then(function () {
+      return apps.run({ flags: { team: 'test-team' }, args: {} }).then(function () {
         mock.done()
         expect(cli.stderr).to.equal('')
         expect(cli.stdout).to.equal(
@@ -289,7 +289,7 @@ team-app-2
   describe('with team', function () {
     it('displays a message when the team has no apps', function () {
       let mock = stubteamApps('test-team', [])
-      return apps.run({ team: 'test-team', flags: {}, args: {} }).then(function () {
+      return apps.run({ flags: { team: 'test-team' }, args: {} }).then(function () {
         mock.done()
         expect(cli.stderr).to.equal('')
         expect(cli.stdout).to.equal(`There are no apps in team test-team.
@@ -299,7 +299,7 @@ team-app-2
 
     it('list all in an team', function () {
       let mock = stubteamApps('test-team', [teamApp1, teamApp2])
-      return apps.run({ team: 'test-team', flags: {}, args: {} }).then(function () {
+      return apps.run({ flags: { team: 'test-team' }, args: {} }).then(function () {
         mock.done()
         expect(cli.stderr).to.equal('')
         expect(cli.stdout).to.equal(

--- a/packages/apps-v5/test/commands/apps/index.js
+++ b/packages/apps-v5/test/commands/apps/index.js
@@ -257,6 +257,11 @@ internal-app [internal/locked] (eu)
   })
 
   describe('with team', function () {
+
+    it('is configured for an optional team/org flag', function () {
+      expect(apps).to.have.own.property('wantsOrg', true)
+    })
+
     it('displays a message when the team has no apps', function () {
       let mock = stubteamApps('test-team', [])
       return apps.run({ org: 'test-team', flags: {}, args: {} }).then(function () {

--- a/packages/apps-v5/test/commands/apps/index.js
+++ b/packages/apps-v5/test/commands/apps/index.js
@@ -257,7 +257,6 @@ internal-app [internal/locked] (eu)
   })
 
   describe('with team', function () {
-
     it('is configured for an optional team/org flag', function () {
       expect(apps).to.have.own.property('wantsOrg', true)
     })

--- a/packages/orgs-v5/commands/members/add.js
+++ b/packages/orgs-v5/commands/members/add.js
@@ -8,7 +8,7 @@ const { RoleCompletion } = require('@heroku-cli/command/lib/completions')
 
 function * run (context, heroku) {
   let teamInfo = yield Utils.teamInfo(context, heroku)
-  let groupName = context.org || context.team || context.flags.team
+  let groupName = context.flags.team
   let email = context.args.email
   let role = context.flags.role
   let groupFeatures = yield heroku.get(`/teams/${groupName}/features`)

--- a/packages/orgs-v5/commands/members/add.js
+++ b/packages/orgs-v5/commands/members/add.js
@@ -35,7 +35,6 @@ function * run (context, heroku) {
   }
 
   yield Utils.warnIfAtTeamMemberLimit(teamInfo, groupName, context, heroku)
-  Utils.warnUsingOrgFlagInTeams(teamInfo, context)
 }
 
 let add = {

--- a/packages/orgs-v5/commands/members/index.js
+++ b/packages/orgs-v5/commands/members/index.js
@@ -9,7 +9,7 @@ const { RoleCompletion } = require('@heroku-cli/command/lib/completions')
 
 function * run (context, heroku) {
   let teamInfo = yield Utils.teamInfo(context, heroku)
-  let groupName = context.org || context.team || context.flags.team
+  let groupName = context.flags.team
   let teamInvites = []
 
   if (teamInfo.type === 'team') {

--- a/packages/orgs-v5/commands/members/index.js
+++ b/packages/orgs-v5/commands/members/index.js
@@ -51,8 +51,6 @@ function * run (context, heroku) {
       ]
     })
   }
-
-  Utils.warnUsingOrgFlagInTeams(teamInfo, context)
 }
 
 module.exports = {

--- a/packages/orgs-v5/commands/members/remove.js
+++ b/packages/orgs-v5/commands/members/remove.js
@@ -7,7 +7,7 @@ const { flags } = require('@heroku-cli/command')
 
 function * run (context, heroku) {
   let teamInfo = yield Utils.teamInfo(context, heroku)
-  let groupName = context.org || context.team || context.flags.team
+  let groupName = context.flags.team
   let teamInviteFeatureEnabled = false
   let isInvitedUser = false
   let email = context.args.email

--- a/packages/orgs-v5/commands/members/remove.js
+++ b/packages/orgs-v5/commands/members/remove.js
@@ -53,8 +53,6 @@ function * run (context, heroku) {
   } else {
     yield removeUserMembership()
   }
-
-  Utils.warnUsingOrgFlagInTeams(teamInfo, context)
 }
 
 module.exports = {

--- a/packages/orgs-v5/commands/members/set.js
+++ b/packages/orgs-v5/commands/members/set.js
@@ -8,7 +8,7 @@ const { RoleCompletion } = require('@heroku-cli/command/lib/completions')
 
 function * run (context, heroku) {
   let teamInfo = yield Utils.teamInfo(context, heroku)
-  let groupName = context.org || context.team || context.flags.team
+  let groupName = context.flags.team
   let email = context.args.email
   let role = context.flags.role
 

--- a/packages/orgs-v5/commands/members/set.js
+++ b/packages/orgs-v5/commands/members/set.js
@@ -14,7 +14,6 @@ function * run (context, heroku) {
 
   yield Utils.addMemberToTeam(email, role, groupName, heroku, 'PATCH')
   yield Utils.warnIfAtTeamMemberLimit(teamInfo, groupName, context, heroku)
-  Utils.warnUsingOrgFlagInTeams(teamInfo, context)
 }
 
 let set = {

--- a/packages/orgs-v5/commands/orgs/open.js
+++ b/packages/orgs-v5/commands/orgs/open.js
@@ -5,7 +5,7 @@ let co = require('co')
 const { flags } = require('@heroku-cli/command')
 
 function * run (context, heroku) {
-  let team = context.org || context.team || context.flags.team
+  let team = context.flags.team
   if (!team) throw new Error('No team specified')
   let org = yield heroku.get(`/teams/${team}`)
   yield cli.open(`https://dashboard.heroku.com/teams/${org.name}`)

--- a/packages/orgs-v5/lib/utils.js
+++ b/packages/orgs-v5/lib/utils.js
@@ -33,9 +33,9 @@ let printGroupsJSON = function (group) {
 }
 
 let teamInfo = function * (context, heroku) {
-  let teamOrOrgName = context.org || context.flags.team
-  if (!teamOrOrgName) error.exit(1, 'No team or org specified.\nRun this command with --team or --org')
-  return yield heroku.get(`/teams/${context.org || context.flags.team}`)
+  let teamName = context.flags.team
+  if (!teamName) error.exit(1, 'No team or org specified.\nRun this command with --team')
+  return yield heroku.get(`/teams/${teamName}`)
 }
 
 let warnUsingOrgFlagInTeams = function (teamInfo, context) {

--- a/packages/orgs-v5/lib/utils.js
+++ b/packages/orgs-v5/lib/utils.js
@@ -38,12 +38,6 @@ let teamInfo = function * (context, heroku) {
   return yield heroku.get(`/teams/${teamName}`)
 }
 
-let warnUsingOrgFlagInTeams = function (teamInfo, context) {
-  if ((teamInfo.type === 'team') && (!context.flags.team)) {
-    cli.warn(`${cli.color.cmd(context.org)} is a Heroku Team\nHeroku CLI now supports Heroku Teams.\nUse ${cli.color.cmd('-t')} or ${cli.color.cmd('--team')} for teams like ${cli.color.cmd(context.org)}`)
-  }
-}
-
 let addMemberToTeam = function * (email, role, groupName, heroku, method = 'PUT') {
   let request = heroku.request({
     method: method,
@@ -81,6 +75,5 @@ module.exports = {
   teamInfo,
   printGroups,
   printGroupsJSON,
-  warnIfAtTeamMemberLimit,
-  warnUsingOrgFlagInTeams
+  warnIfAtTeamMemberLimit
 }

--- a/packages/orgs-v5/test/commands/members/add.js
+++ b/packages/orgs-v5/test/commands/members/add.js
@@ -62,21 +62,6 @@ You'll be billed monthly for teams over 5 members.
 `))
           .then(() => apiUpdateMemberRole.done())
       })
-
-      context('using --org instead of --team', () => {
-        it('adds the member, but it shows a warning about the usage of -t instead', () => {
-          stubGet.variableSizeTeamMembers(1)
-          stubGet.variableSizeTeamInvites(0)
-
-          apiUpdateMemberRole = stubPut.updateMemberRole('foo@foo.com', 'admin')
-          return cmd.run({ org: 'myteam', args: { email: 'foo@foo.com' }, flags: { role: 'admin' } })
-            .then(() => expect('').to.eq(cli.stdout))
-            .then(() => expect(unwrap(cli.stderr)).to.equal(`Adding foo@foo.com to myteam as admin... done myteam is a \
-Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team for teams like myteam
-`))
-            .then(() => apiUpdateMemberRole.done())
-        })
-      })
     })
 
     context('and group is an enterprise org', () => {

--- a/packages/orgs-v5/test/commands/members/add.js
+++ b/packages/orgs-v5/test/commands/members/add.js
@@ -12,6 +12,10 @@ describe('heroku members:add', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
+  it('is is configured for an optional team/org flag', function () {
+    expect(cmd).to.have.own.property('wantsOrg', true)
+  })
+
   context('without the feature flag team-invite-acceptance', () => {
     beforeEach(() => {
       stubGet.teamFeatures([])

--- a/packages/orgs-v5/test/commands/members/add.js
+++ b/packages/orgs-v5/test/commands/members/add.js
@@ -12,7 +12,7 @@ describe('heroku members:add', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
-  it('is is configured for an optional team/org flag', function () {
+  it('is configured for an optional team flag', function () {
     expect(cmd).to.have.own.property('wantsOrg', true)
   })
 

--- a/packages/orgs-v5/test/commands/members/add.js
+++ b/packages/orgs-v5/test/commands/members/add.js
@@ -88,7 +88,7 @@ Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team for teams lik
       it('adds a member to an org', () => {
         apiUpdateMemberRole = stubPut.updateMemberRole('foo@foo.com', 'admin')
 
-        return cmd.run({ org: 'myteam', args: { email: 'foo@foo.com' }, flags: { role: 'admin' } })
+        return cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myteam', role: 'admin' } })
           .then(() => expect('').to.eq(cli.stdout))
           .then(() => expect(`Adding foo@foo.com to myteam as admin... done
 `).to.eq(cli.stderr))

--- a/packages/orgs-v5/test/commands/members/index.js
+++ b/packages/orgs-v5/test/commands/members/index.js
@@ -22,7 +22,7 @@ describe('heroku members', () => {
 
     it('shows there are not team members if it is an orphan team', () => {
       apiGetOrgMembers = stubGet.teamMembers([])
-      return cmd.run({ org: 'myteam', flags: {} })
+      return cmd.run({ flags: { team: 'myteam' } })
         .then(() => expect(
           `No members in myteam
 `).to.eq(cli.stdout))
@@ -34,7 +34,7 @@ describe('heroku members', () => {
       apiGetOrgMembers = stubGet.teamMembers([
         { email: 'a@heroku.com', role: 'admin' }, { email: 'b@heroku.com', role: 'collaborator' }
       ])
-      return cmd.run({ org: 'myteam', flags: {} })
+      return cmd.run({ flags: { team: 'myteam' } })
         .then(() => expect(
           `a@heroku.com  admin
 b@heroku.com  collaborator
@@ -47,7 +47,7 @@ b@heroku.com  collaborator
 
     it('filters members by role', () => {
       apiGetOrgMembers = stubGet.teamMembers(expectedOrgMembers)
-      return cmd.run({ org: 'myteam', flags: { role: 'member' } })
+      return cmd.run({ flags: { team: 'myteam', role: 'member' } })
         .then(() => expect(
           `b@heroku.com  member
 `).to.eq(cli.stdout))
@@ -57,7 +57,7 @@ b@heroku.com  collaborator
 
     it("shows the right message when filter doesn't return results", () => {
       apiGetOrgMembers = stubGet.teamMembers(expectedOrgMembers)
-      return cmd.run({ org: 'myteam', flags: { role: 'collaborator' } })
+      return cmd.run({ flags: { team: 'myteam', role: 'collaborator' } })
         .then(() => expect(
           `No members in myteam with role collaborator
 `).to.eq(cli.stdout))
@@ -67,7 +67,7 @@ b@heroku.com  collaborator
 
     it('filters members by role', () => {
       apiGetOrgMembers = stubGet.teamMembers(expectedOrgMembers)
-      return cmd.run({ org: 'myteam', flags: { role: 'member' } })
+      return cmd.run({ flags: { team: 'myteam', role: 'member' } })
         .then(() => expect(
           `b@heroku.com  member
 `).to.eq(cli.stdout))

--- a/packages/orgs-v5/test/commands/members/index.js
+++ b/packages/orgs-v5/test/commands/members/index.js
@@ -3,7 +3,6 @@
 
 let cmd = require('../../../commands/members')
 let stubGet = require('../../stub/get')
-const unwrap = require('../../unwrap')
 
 describe('heroku members', () => {
   beforeEach(() => cli.mockConsole())

--- a/packages/orgs-v5/test/commands/members/index.js
+++ b/packages/orgs-v5/test/commands/members/index.js
@@ -85,22 +85,6 @@ b@heroku.com  collaborator
       beforeEach(() => {
         stubGet.teamFeatures([])
       })
-
-      context('using --org instead of --team', () => {
-        it('shows members either way including a warning', () => {
-          apiGetOrgMembers = stubGet.teamMembers([
-            { email: 'a@heroku.com', role: 'admin' }, { email: 'b@heroku.com', role: 'collaborator' }
-          ])
-          return cmd.run({ org: 'myteam', flags: {} })
-            .then(() => expect(
-              `a@heroku.com  admin
-b@heroku.com  collaborator\n`).to.eq(cli.stdout))
-            .then(() => expect(unwrap(cli.stderr)).to.equal(`myteam is a Heroku Team Heroku CLI now supports Heroku Teams. \
-Use -t or --team for teams like myteam
-`))
-            .then(() => apiGetOrgMembers.done())
-        })
-      })
     })
 
     context('with the feature flag team-invite-acceptance', () => {

--- a/packages/orgs-v5/test/commands/members/index.js
+++ b/packages/orgs-v5/test/commands/members/index.js
@@ -11,6 +11,10 @@ describe('heroku members', () => {
 
   let apiGetOrgMembers
 
+  it('is is configured for an optional team/org flag', function () {
+    expect(cmd).to.have.own.property('wantsOrg', true)
+  })
+
   context('when it is an Enterprise team', () => {
     beforeEach(() => {
       stubGet.teamInfo('enterprise')

--- a/packages/orgs-v5/test/commands/members/index.js
+++ b/packages/orgs-v5/test/commands/members/index.js
@@ -10,7 +10,7 @@ describe('heroku members', () => {
 
   let apiGetOrgMembers
 
-  it('is is configured for an optional team/org flag', function () {
+  it('is configured for an optional team flag', function () {
     expect(cmd).to.have.own.property('wantsOrg', true)
   })
 

--- a/packages/orgs-v5/test/commands/members/remove.js
+++ b/packages/orgs-v5/test/commands/members/remove.js
@@ -21,7 +21,7 @@ describe('heroku members:remove', () => {
 
     it('removes a member from an org', () => {
       let apiRemoveMemberFromOrg = stubDelete.memberFromTeam()
-      return cmd.run({ org: 'myteam', args: { email: 'foo@foo.com' } })
+      return cmd.run({ flags: { team: 'myteam' }, args: { email: 'foo@foo.com' } })
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Removing foo@foo.com from myteam... done\n`).to.eq(cli.stderr))
         .then(() => apiRemoveMemberFromOrg.done())

--- a/packages/orgs-v5/test/commands/members/remove.js
+++ b/packages/orgs-v5/test/commands/members/remove.js
@@ -38,18 +38,6 @@ describe('heroku members:remove', () => {
         stubGet.teamFeatures([])
       })
 
-      context('using --org instead of --team', () => {
-        it('removes the member, but it shows a warning about the usage of -t instead', () => {
-          let apiRemoveMemberFromOrg = stubDelete.memberFromTeam()
-          return cmd.run({ org: 'myteam', args: { email: 'foo@foo.com' }, flags: {} })
-            .then(() => expect('').to.eq(cli.stdout))
-            .then(() => expect(unwrap(cli.stderr)).to.equal(`Removing foo@foo.com from myteam... done \
-myteam is a Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team for teams like myteam
-`))
-            .then(() => apiRemoveMemberFromOrg.done())
-        })
-      })
-
       it('removes a member from an org', () => {
         let apiRemoveMemberFromOrg = stubDelete.memberFromTeam()
         return cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myteam' } })

--- a/packages/orgs-v5/test/commands/members/remove.js
+++ b/packages/orgs-v5/test/commands/members/remove.js
@@ -9,7 +9,7 @@ describe('heroku members:remove', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
-  it('is is configured for an optional team/org flag', function () {
+  it('is configured for an optional team flag', function () {
     expect(cmd).to.have.own.property('wantsOrg', true)
   })
 

--- a/packages/orgs-v5/test/commands/members/remove.js
+++ b/packages/orgs-v5/test/commands/members/remove.js
@@ -10,6 +10,10 @@ describe('heroku members:remove', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
+  it('is is configured for an optional team/org flag', function () {
+    expect(cmd).to.have.own.property('wantsOrg', true)
+  })
+
   context('from an org', () => {
     beforeEach(() => {
       stubGet.teamInfo('enterprise')

--- a/packages/orgs-v5/test/commands/members/remove.js
+++ b/packages/orgs-v5/test/commands/members/remove.js
@@ -4,7 +4,6 @@
 let cmd = require('../../../commands/members/remove')
 let stubDelete = require('../../stub/delete')
 let stubGet = require('../../stub/get')
-const unwrap = require('../../unwrap')
 
 describe('heroku members:remove', () => {
   beforeEach(() => cli.mockConsole())

--- a/packages/orgs-v5/test/commands/members/set.js
+++ b/packages/orgs-v5/test/commands/members/set.js
@@ -60,21 +60,6 @@ You'll be billed monthly for teams over 5 members.
 `))
         .then(() => apiUpdateMemberRole.done())
     })
-
-    context('using --org instead of --team', () => {
-      it('adds the member, but it shows a warning about the usage of -t instead', () => {
-        stubGet.variableSizeTeamMembers(1)
-        stubGet.variableSizeTeamInvites(0)
-
-        apiUpdateMemberRole = stubPatch.updateMemberRole('foo@foo.com', 'admin')
-        return cmd.run({ org: 'myteam', args: { email: 'foo@foo.com' }, flags: { role: 'admin' } })
-          .then(() => expect('').to.eq(cli.stdout))
-          .then(() => expect(unwrap(cli.stderr)).to.equal(`Adding foo@foo.com to myteam as admin... done \
-myteam is a Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team for teams like myteam
-`))
-          .then(() => apiUpdateMemberRole.done())
-      })
-    })
   })
 
   context('and group is an enterprise org', () => {

--- a/packages/orgs-v5/test/commands/members/set.js
+++ b/packages/orgs-v5/test/commands/members/set.js
@@ -15,6 +15,10 @@ describe('heroku members:set', () => {
   })
   afterEach(() => nock.cleanAll())
 
+  it('is is configured for an optional team/org flag', function () {
+    expect(cmd).to.have.own.property('wantsOrg', true)
+  })
+
   context('and group is a team', () => {
     beforeEach(() => {
       stubGet.teamInfo('team')

--- a/packages/orgs-v5/test/commands/members/set.js
+++ b/packages/orgs-v5/test/commands/members/set.js
@@ -86,7 +86,7 @@ myteam is a Heroku Team Heroku CLI now supports Heroku Teams. Use -t or --team f
     it('adds a member to an org', () => {
       apiUpdateMemberRole = stubPatch.updateMemberRole('foo@foo.com', 'admin')
 
-      return cmd.run({ org: 'myteam', args: { email: 'foo@foo.com' }, flags: { role: 'admin' } })
+      return cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myteam', role: 'admin' } })
         .then(() => expect('').to.eq(cli.stdout))
         .then(() => expect(`Adding foo@foo.com to myteam as admin... done
 `).to.eq(cli.stderr))

--- a/packages/orgs-v5/test/commands/members/set.js
+++ b/packages/orgs-v5/test/commands/members/set.js
@@ -15,7 +15,7 @@ describe('heroku members:set', () => {
   })
   afterEach(() => nock.cleanAll())
 
-  it('is is configured for an optional team/org flag', function () {
+  it('is configured for an optional team flag', function () {
     expect(cmd).to.have.own.property('wantsOrg', true)
   })
 

--- a/packages/orgs-v5/test/commands/orgs/open.js
+++ b/packages/orgs-v5/test/commands/orgs/open.js
@@ -1,0 +1,8 @@
+let cmd = require('../../../commands/orgs/open')
+const expect = require('chai').expect
+
+describe('heroku org:open', () => {
+  it('is is configured for an optional team/org flag', function () {
+    expect(cmd).to.have.own.property('wantsOrg', true)
+  })
+})

--- a/packages/orgs-v5/test/commands/orgs/open.js
+++ b/packages/orgs-v5/test/commands/orgs/open.js
@@ -2,7 +2,7 @@ const cmd = require('../../../commands/orgs/open')
 const expect = require('chai').expect
 
 describe('heroku org:open', () => {
-  it('is is configured for an optional team/org flag', function () {
+  it('is configured for an optional team flag', function () {
     expect(cmd).to.have.own.property('wantsOrg', true)
   })
 })

--- a/packages/orgs-v5/test/commands/orgs/open.js
+++ b/packages/orgs-v5/test/commands/orgs/open.js
@@ -1,4 +1,4 @@
-let cmd = require('../../../commands/orgs/open')
+const cmd = require('../../../commands/orgs/open')
 const expect = require('chai').expect
 
 describe('heroku org:open', () => {

--- a/packages/pipelines-v5/commands/pipelines/create.js
+++ b/packages/pipelines-v5/commands/pipelines/create.js
@@ -39,7 +39,7 @@ function * run (context, heroku) {
     })
   }
 
-  const teamName = context.org || context.team || context.flags.team
+  const teamName = context.flags.team
   ownerType = teamName ? 'team' : 'user'
 
   // If team or org is not specified, we assign ownership to the user creating

--- a/packages/pipelines-v5/commands/pipelines/setup.js
+++ b/packages/pipelines-v5/commands/pipelines/setup.js
@@ -68,17 +68,17 @@ View your new pipeline by running \`heroku pipelines:open e5a55ffa-de3f-11e6-a24
     const kolkrabbi = new KolkrabbiAPI(context.version, heroku.options.token)
     const github = new GitHubAPI(context.version, yield getGitHubToken(kolkrabbi))
 
-    const organization = context.org || context.team || context.flags.team || context.flags.organization
+    const team = context.flags.team
     const { name: pipelineName, repo: repoName } = yield getNameAndRepo(context.args)
     const stagingAppName = pipelineName + Validate.STAGING_APP_INDICATOR
     const repo = yield getRepo(github, repoName)
     const settings = yield getSettings(context.flags.yes, repo.default_branch)
 
-    let ciSettings = yield getCISettings(context.flags.yes, organization)
-    let ownerType = organization ? 'team' : 'user'
+    let ciSettings = yield getCISettings(context.flags.yes, team)
+    let ownerType = team ? 'team' : 'user'
 
     // If team or org is not specified, we assign ownership to the user creating
-    let owner = organization ? yield api.getTeam(heroku, organization) : yield api.getAccountInfo(heroku)
+    let owner = team ? yield api.getTeam(heroku, team) : yield api.getAccountInfo(heroku)
     let ownerID = owner.id
 
     owner = { id: ownerID, type: ownerType }
@@ -94,7 +94,7 @@ View your new pipeline by running \`heroku pipelines:open e5a55ffa-de3f-11e6-a24
     )
 
     const archiveURL = yield kolkrabbi.getArchiveURL(repoName, repo.default_branch)
-    const appSetups = yield createApps(heroku, archiveURL, pipeline, pipelineName, stagingAppName, organization)
+    const appSetups = yield createApps(heroku, archiveURL, pipeline, pipelineName, stagingAppName, team)
 
     yield cli.action(
       `Creating production and staging apps (${cli.color.app(pipelineName)} and ${cli.color.app(stagingAppName)})`,

--- a/packages/pipelines-v5/test/commands/pipelines/create.js
+++ b/packages/pipelines-v5/test/commands/pipelines/create.js
@@ -3,6 +3,7 @@
 let cli = require('heroku-cli-util')
 let nock = require('nock')
 let cmd = require('../../../commands/pipelines/create')
+const expect = require('chai').expect
 
 describe('pipelines:create', function () {
   let heroku, coupling, pipeline
@@ -46,6 +47,10 @@ describe('pipelines:create', function () {
         .reply(200, { id: '89-0123-456' })
         .post('/pipelines')
         .reply(201, pipeline)
+    })
+
+    it('is is configured for an optional team/org flag', function () {
+      expect(cmd).to.have.own.property('wantsOrg', true)
     })
 
     it('displays the pipeline name and app stage', function () {

--- a/packages/pipelines-v5/test/commands/pipelines/create.js
+++ b/packages/pipelines-v5/test/commands/pipelines/create.js
@@ -50,6 +50,9 @@ describe('pipelines:create', function () {
     })
 
     it('is is configured for an optional team/org flag', function () {
+      // skip nock assertions
+      nock.cleanAll()
+
       expect(cmd).to.have.own.property('wantsOrg', true)
     })
 

--- a/packages/pipelines-v5/test/commands/pipelines/create.js
+++ b/packages/pipelines-v5/test/commands/pipelines/create.js
@@ -49,7 +49,7 @@ describe('pipelines:create', function () {
         .reply(201, pipeline)
     })
 
-    it('is is configured for an optional team/org flag', function () {
+    it('is configured for an optional team flag', function () {
       // skip nock assertions
       nock.cleanAll()
 

--- a/packages/pipelines-v5/test/commands/pipelines/setup.js
+++ b/packages/pipelines-v5/test/commands/pipelines/setup.js
@@ -162,7 +162,7 @@ describe('pipelines:setup', function () {
           stubCI({ name: pipeline.name, repo: repo.name, organization: team, ci: true })
         })
 
-        it('is is configured for an optional team/org flag', function () {
+        it('is configured for an optional team flag', function () {
           expect(cmd).to.have.own.property('wantsOrg', true)
         })
 

--- a/packages/pipelines-v5/test/commands/pipelines/setup.js
+++ b/packages/pipelines-v5/test/commands/pipelines/setup.js
@@ -162,6 +162,10 @@ describe('pipelines:setup', function () {
           stubCI({ name: pipeline.name, repo: repo.name, organization: team, ci: true })
         })
 
+        it('is is configured for an optional team/org flag', function () {
+          expect(cmd).to.have.own.property('wantsOrg', true)
+        })
+
         it('creates apps in a team with CI enabled', function * () {
           return cmd.run({ args: {}, flags: { team } }).then(() => { nockDone() })
         })

--- a/packages/spaces/commands/create.js
+++ b/packages/spaces/commands/create.js
@@ -13,7 +13,7 @@ function * run (context, heroku) {
   let spaceType = 'Standard'
   if (context.flags['shield']) { dollarAmount = '$3000'; spaceType = 'Shield' }
   if (!space) throw new Error('Space name required.\nUSAGE: heroku spaces:create --space my-space --team my-team')
-  let team = context.org || context.team || context.flags.team
+  let team = context.flags.team
   if (!team) throw new Error('No team specified')
   let request = heroku.request({
     method: 'POST',

--- a/packages/spaces/commands/index.js
+++ b/packages/spaces/commands/index.js
@@ -22,7 +22,7 @@ function displayJSON (spaces) {
 }
 
 function * run (context, heroku) {
-  let team = context.org || context.team || context.flags.team
+  let team = context.flags.team
 
   let spaces = yield heroku.get('/spaces')
   if (team) {

--- a/packages/spaces/test/commands/create.js
+++ b/packages/spaces/test/commands/create.js
@@ -12,6 +12,10 @@ let features = [ 'one', 'two' ]
 describe('spaces:create', function () {
   beforeEach(() => cli.mockConsole())
 
+  it('is is configured for an optional team/org flag', function () {
+    expect(cmd).to.have.own.property('wantsOrg', true)
+  })
+
   it('creates a Standard space', function () {
     let api = nock('https://api.heroku.com:443')
       .post('/spaces', {

--- a/packages/spaces/test/commands/create.js
+++ b/packages/spaces/test/commands/create.js
@@ -27,7 +27,7 @@ describe('spaces:create', function () {
       .reply(201,
         { shield: false, name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, features: [ 'one', 'two' ], state: 'enabled', created_at: now, cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' }
       )
-    return cmd.run({ team: 'my-team', flags: { space: 'my-space', region: 'my-region', features: 'one, two' } })
+    return cmd.run({ flags: { team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two' } })
       .then(() => expect(cli.stdout).to.equal(
         `=== my-space
 Team:       my-team
@@ -52,7 +52,7 @@ Created at: ${now.toISOString()}
       .reply(201,
         { shield: false, name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, features: [ 'one', 'two' ], state: 'enabled', created_at: now, cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' }
       )
-    return cmd.run({ team: 'my-team', flags: { space: 'my-space', region: 'my-region', features: 'one, two' } })
+    return cmd.run({ flags: { team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two' } })
       .then(() => expect(cli.stderr).to.include(
         `Each Heroku Standard Private Space costs $1000`))
       .then(() => api.done())
@@ -70,7 +70,7 @@ Created at: ${now.toISOString()}
       .reply(201,
         { shield: true, name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, features: [ 'one', 'two' ], state: 'enabled', created_at: now, cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' }
       )
-    return cmd.run({ team: 'my-team', flags: { space: 'my-space', region: 'my-region', features: 'one, two', shield: true }, log_drain_url: 'https://logs.cheetah.com' })
+    return cmd.run({ flags: { team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two', shield: true }, log_drain_url: 'https://logs.cheetah.com' })
       .then(() => expect(cli.stdout).to.equal(
         `=== my-space
 Team:       my-team
@@ -96,7 +96,7 @@ Created at: ${now.toISOString()}
       .reply(201,
         { shield: true, name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, features: [ 'one', 'two' ], state: 'enabled', created_at: now, cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' }
       )
-    return cmd.run({ team: 'my-team', flags: { space: 'my-space', region: 'my-region', features: 'one, two', shield: true }, log_drain_url: 'https://logs.cheetah.com' })
+    return cmd.run({ flags: { team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two', shield: true }, log_drain_url: 'https://logs.cheetah.com' })
       .then(() => expect(cli.stderr).to.include(
         `Each Heroku Shield Private Space costs $3000`))
       .then(() => api.done())
@@ -115,7 +115,7 @@ Created at: ${now.toISOString()}
       .reply(201,
         { shield: false, name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, features: [ 'one', 'two' ], state: 'enabled', created_at: now, cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' }
       )
-    return cmd.run({ team: 'my-team', flags: { space: 'my-space', region: 'my-region', features: 'one, two', cidr: '10.0.0.0/16', 'data-cidr': '172.23.0.0/20' }, shield: true, log_drain_url: 'https://logs.cheetah.com', cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' })
+    return cmd.run({ flags: { team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two', cidr: '10.0.0.0/16', 'data-cidr': '172.23.0.0/20' }, shield: true, log_drain_url: 'https://logs.cheetah.com', cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' })
       .then(() => expect(cli.stdout).to.equal(
         `=== my-space
 Team:       my-team
@@ -135,19 +135,5 @@ Created at: ${now.toISOString()}
         expect(reason.message).to.equal('No team specified')
         done()
       })
-  })
-
-  it('org option maps to team', function () {
-    let api = nock('https://api.heroku.com:443')
-      .post('/spaces', {
-        name: 'my-space',
-        team: 'my-team',
-        features: []
-      })
-      .reply(201,
-        { shield: false, name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, features: [ 'one', 'two' ], state: 'enabled', created_at: now }
-      )
-    return cmd.run({ org: 'my-team', flags: { space: 'my-space' } })
-      .then(() => api.done())
   })
 })

--- a/packages/spaces/test/commands/create.js
+++ b/packages/spaces/test/commands/create.js
@@ -12,7 +12,7 @@ let features = [ 'one', 'two' ]
 describe('spaces:create', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('is is configured for an optional team/org flag', function () {
+  it('is configured for an optional team flag', function () {
     expect(cmd).to.have.own.property('wantsOrg', true)
   })
 

--- a/packages/spaces/test/commands/index.js
+++ b/packages/spaces/test/commands/index.js
@@ -17,7 +17,7 @@ let now = new Date()
 describe('spaces', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('is is configured for an optional team/org flag', function () {
+  it('is configured for an optional team flag', function () {
     expect(cmd).to.have.own.property('wantsOrg', true)
   })
 

--- a/packages/spaces/test/commands/index.js
+++ b/packages/spaces/test/commands/index.js
@@ -17,6 +17,10 @@ let now = new Date()
 describe('spaces', function () {
   beforeEach(() => cli.mockConsole())
 
+  it('is is configured for an optional team/org flag', function () {
+    expect(cmd).to.have.own.property('wantsOrg', true)
+  })
+
   it('shows spaces', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces')

--- a/packages/spaces/test/commands/index.js
+++ b/packages/spaces/test/commands/index.js
@@ -53,7 +53,7 @@ my-space  my-team  my-region  enabled  ${now.toISOString()}
         { name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, state: 'enabled', created_at: now },
         { name: 'other-space', team: { name: 'other-team' }, region: { name: 'my-region' }, state: 'enabled', created_at: now }
       ])
-    return cmd.run({ flags: {}, team: 'my-team' })
+    return cmd.run({ flags: { team: 'my-team' } })
       .then(() => expect(cli.stdout).to.equal(
         `Name      Team     Region     State    Created At
 ────────  ───────  ─────────  ───────  ────────────────────────
@@ -69,7 +69,7 @@ my-space  my-team  my-region  enabled  ${now.toISOString()}
         { name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, state: 'enabled', created_at: now },
         { name: 'other-space', team: { name: 'other-team' }, region: { name: 'my-region' }, state: 'enabled', created_at: now }
       ])
-    return cmd.run({ flags: {}, org: 'my-team' })
+    return cmd.run({ flags: { team: 'my-team' } })
       .then(() => expect(cli.stdout).to.equal(
         `Name      Team     Region     State    Created At
 ────────  ───────  ─────────  ───────  ────────────────────────
@@ -82,7 +82,7 @@ my-space  my-team  my-region  enabled  ${now.toISOString()}
     nock('https://api.heroku.com:443')
       .get('/spaces')
       .reply(200, [])
-    return chai.assert.isRejected(cmd.run({ flags: {}, team: 'my-team' }), /^No spaces in my-team.$/)
+    return chai.assert.isRejected(cmd.run({ flags: { team: 'my-team' } }), /^No spaces in my-team.$/)
   })
 
   it('shows spaces error message', function () {


### PR DESCRIPTION
Relates to:
* Issue #1245 
* Pull Request [`heroku/heroku-cli-command` \#61](https://github.com/heroku/heroku-cli-command/pull/61)

## 1. `heroku/heroku-cli-command`

The fix starts with the [Pull Request \#61 on `heroku/heroku-cli-command`](Pull Request [`heroku/heroku-cli-command` \#61](https://github.com/heroku/heroku-cli-command/pull/61)).

Which prioritizes flags over environment variables for the team flag specifically. The team flag will take priority if set, or falling back to its `default` which will go through and check for:
1. `flags.org` (fixed  in PR to be above env variables)
2. `HEROKU_TEAM`
3. `HEROKU_ORGANIZATION`

## 2. `oclif/plugin-legacy`

The second part of this is where this team flag gets used. If a v5 legacy command has a `needOrg` or `wantsOrg` the *team and org* flags will **both** be [setup as `team` flags](https://github.com/oclif/plugin-legacy/blob/master/src/index.ts#L167-L171) imported from `heroku-cli-command`. The minor difference is that the org flag `V5.flags.org = Flags.team({char: 'o', hidden: true})` has a different `char` specified and is hidden.

The [oclif command](https://github.com/oclif/plugin-legacy/blob/master/src/index.ts#L87) when [ran](https://github.com/oclif/plugin-legacy/blob/master/src/index.ts#L104) will [setup a `ctx` object](https://github.com/oclif/plugin-legacy/blob/master/src/index.ts#L107-L126) to [pass into the legacy plugin](https://github.com/oclif/plugin-legacy/blob/master/src/index.ts#L134).

This `ctx` object will have the `flags` object which if set via `needsOrg` or `wantsOrg` will contain the `team` and `org` flags based on the work from `convertFlagsFromV5`. But these `team` and `org` flags also get [reattached to the `ctx` object itself](https://github.com/oclif/plugin-legacy/blob/master/src/index.ts#L116-L117).

This means if set, the ctx object has
* `ctx.team`
* `ctx.flags.team`
* `ctx.org`
* `ctx.flags.org`

With `ctx.org` and `ctx.flags.org` being the same, and `ctx.team` and `ctx.flags.team` being the same. And all of them are based on the team flag with the org flag having the previously mentioned `char` and `hidden` properties different.

## 3. Usage of ctx in v5 legacy plugins

That means that the commands that v5 commands using `needsOrg` or `wantsOrg` will have these four properties available on the `ctx` object passed into the run function.

## A possible solution

In many places within our V5 legacy plugins we are determining the team value to use based on:
`context.org || context.team || context.flags.team` when I think we can just check `context.flags.team`, since it would:
1. Check the `-t` or `--team` flag
2. If unset it would default to checking based on the `default` function which would check for `flags.org` (after [`heroku/heroku-cli-command` \#61](https://github.com/heroku/heroku-cli-command/pull/61)), then the environment variables.

I think this would cover all the checks needed within a single value. In this PR I've also added tests to ensure that the v5 legacy plugins are configured with `wantsOrg` to ensure that when these plugins get upgraded via `oclif/plugin-legacy` that it gets the `team` flag, but that was already the case for these plugins. I've found usages and tried to replace them to only use a single value, which has also meant upgrading tests to be consistent on using `flags.team`.

# Testing these changes
*If there's an easier way to test these changes, please let me know!*

1. Pull down this branch into your locally cloned `heroku/cli` repo.
2. Also pull down the branch `cc/fix-team-flags-usage` for your locally cloned `heroku-cli-command` repo.
3. In your local `heroku-cli-command` repo, run `npm run build`, this will make sure that the typescript is compiled into javascript and put in the `lib` directory.
4. In your local `heroku-cli-command` repo, run `npm link`, this will make this package available to be globally linked.
5. In your local `heroku/cli` repo, from the root, run `lerna bootstrap` to make sure everything is setup.
6. In your local `heroku/cli` repo, from the root, run `cd node_modules/@oclif/plugin-legacy`, then run `npm link @heroku-cli/command`. This will link `@heroku-cli/command` from our local repo as a dependency for `@oclif/plugin-legacy` which bootstraps any v5 plugins into oclif plugins.
7. In your local `heroku/cli` repo, from the root, you should be able to `cd ./packages/cli`, and run `./bin run [any command]` as if it were `heroku [any command]`

## Clean up
After running the test scenarios run you can unlink and install fresh dependencies by:
* `npm unlink` in the`heroku-cli-command` repo root
* `npm unlink @heroku-cli/command` in the `heroku/cli` repo root
* `lerna clean` in the `heroku/cli` root
* `yarn` in the `heroku/cli` root
* `lerna bootstrap` in the `heroku/cli` repo root

## Test Scenarios
Replace: `real-team-name` with the name of your heroku team

### Before
```
$ HEROKU_TEAM=foo heroku apps -t real-team-name
 ▸    Couldn't find that organization.
```
Would fail

### After
```
$ HEROKU_TEAM=foo heroku apps -t real-team-name
```
Should work and show the list of apps. This should work given the flag/env variable priorities as described above.

# Important 🚨
This PR should be merged along with the [PR fix for `heroku-cli-command`](https://github.com/heroku/heroku-cli-command/pull/61)