### PR TITLE
fix(local): Remove composite flag from tsconfig.json

### DIFF
--- a/packages/local/tsconfig.json
+++ b/packages/local/tsconfig.json
@@ -6,11 +6,9 @@
     "outDir": "lib",
     "rootDir": "src",
     "strict": true,
-    "target": "es2017",
-    "composite": true
+    "target": "es2017"
   },
   "include": [
-    "src/**/*",
-    "typings/**/*.ts"
+    "src/**/*"
   ]
 }


### PR DESCRIPTION
The `composite` flag is removed from other oclif templates, but the `local` plugin was generated with it. For consistency we will remove it in this PR.

See for the removal of the `composite` flag from the template: https://github.com/oclif/oclif/pull/247