### PR TITLE
fix(ci-v5): update tests using generator functions

### DIFF
--- a/packages/ci-v5/test/commands/ci/config-get-test.js
+++ b/packages/ci-v5/test/commands/ci/config-get-test.js
@@ -16,27 +16,27 @@ describe('heroku ci:config:get', function () {
     pipeline = Factory.pipeline
   })
 
-  it('displays the config value', function * () {
+  it('displays the config value', async function () {
     const api = nock('https://api.heroku.com')
       .get(`/pipelines/${pipeline.id}`)
       .reply(200, pipeline)
       .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
       .reply(200, { [key]: value })
 
-    yield cmd.run({ args: { key }, flags: { pipeline: pipeline.id } })
+    await cmd.run({ args: { key }, flags: { pipeline: pipeline.id } })
 
     expect(cli.stdout).to.equal(`${value}\n`)
     api.done()
   })
 
-  it('displays config formatted for shell', function * () {
+  it('displays config formatted for shell', async function () {
     const api = nock('https://api.heroku.com')
       .get(`/pipelines/${pipeline.id}`)
       .reply(200, pipeline)
       .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
       .reply(200, { [key]: value })
 
-    yield cmd.run({ args: { key }, flags: { shell: true, pipeline: pipeline.id } })
+    await cmd.run({ args: { key }, flags: { shell: true, pipeline: pipeline.id } })
 
     expect(cli.stdout).to.equal(`${key}=${value}\n`)
     api.done()

--- a/packages/ci-v5/test/commands/ci/config-index-test.js
+++ b/packages/ci-v5/test/commands/ci/config-index-test.js
@@ -16,40 +16,40 @@ describe('heroku ci:config', function () {
     pipeline = Factory.pipeline
   })
 
-  it('displays config', function * () {
+  it('displays config', async function () {
     const api = nock('https://api.heroku.com')
       .get(`/pipelines/${pipeline.id}`)
       .reply(200, pipeline)
       .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
       .reply(200, { [key]: value })
 
-    yield cmd.run({ flags: { pipeline: pipeline.id } })
+    await cmd.run({ flags: { pipeline: pipeline.id } })
 
     expect(cli.stdout).to.include(`${key}: ${value}`)
     api.done()
   })
 
-  it('displays config formatted for shell', function * () {
+  it('displays config formatted for shell', async function () {
     const api = nock('https://api.heroku.com')
       .get(`/pipelines/${pipeline.id}`)
       .reply(200, pipeline)
       .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
       .reply(200, { [key]: value })
 
-    yield cmd.run({ flags: { shell: true, pipeline: pipeline.id } })
+    await cmd.run({ flags: { shell: true, pipeline: pipeline.id } })
 
     expect(cli.stdout).to.include(`${key}=${value}`)
     api.done()
   })
 
-  it('displays config formatted as JSON', function * () {
+  it('displays config formatted as JSON', async function () {
     const api = nock('https://api.heroku.com')
       .get(`/pipelines/${pipeline.id}`)
       .reply(200, pipeline)
       .get(`/pipelines/${pipeline.id}/stage/test/config-vars`)
       .reply(200, { [key]: value })
 
-    yield cmd.run({ flags: { json: true, pipeline: pipeline.id } })
+    await cmd.run({ flags: { json: true, pipeline: pipeline.id } })
 
     expect(cli.stdout).to.include('{\n  "FOO": "bar"\n}')
     api.done()

--- a/packages/ci-v5/test/commands/ci/config-set-test.js
+++ b/packages/ci-v5/test/commands/ci/config-set-test.js
@@ -16,14 +16,14 @@ describe('heroku ci:config:set', function () {
     pipeline = Factory.pipeline
   })
 
-  it('sets new config', function * () {
+  it('sets new config', async function () {
     const api = nock('https://api.heroku.com')
       .get(`/pipelines/${pipeline.id}`)
       .reply(200, pipeline)
       .patch(`/pipelines/${pipeline.id}/stage/test/config-vars`)
       .reply(200, { [key]: value })
 
-    yield cmd.run({ args: [ `${key}=${value}` ], flags: { pipeline: pipeline.id } })
+    await cmd.run({ args: [ `${key}=${value}` ], flags: { pipeline: pipeline.id } })
 
     expect(cli.stdout).to.include(key)
     expect(cli.stdout).to.include(value)

--- a/packages/ci-v5/test/commands/ci/config-unset-test.js
+++ b/packages/ci-v5/test/commands/ci/config-unset-test.js
@@ -14,14 +14,14 @@ describe('heroku ci:config:unset', function () {
     pipeline = Factory.pipeline
   })
 
-  it('unsets config', function * () {
+  it('unsets config', async function () {
     const api = nock('https://api.heroku.com')
       .get(`/pipelines/${pipeline.id}`)
       .reply(200, pipeline)
       .patch(`/pipelines/${pipeline.id}/stage/test/config-vars`)
       .reply(200, { [key]: null })
 
-    yield cmd.run({ args: [ key ], flags: { pipeline: pipeline.id } })
+    await cmd.run({ args: [ key ], flags: { pipeline: pipeline.id } })
     api.done()
   })
 })

--- a/packages/ci-v5/test/lib/heroku-api-test.js
+++ b/packages/ci-v5/test/lib/heroku-api-test.js
@@ -5,12 +5,13 @@ const nock = require('nock')
 const expect = require('chai').expect
 const Heroku = require('heroku-client')
 const herokuAPI = require('../../lib/heroku-api')
+const co = require('co');
 
 describe('heroku-api', function () {
   afterEach(() => nock.cleanAll())
 
   describe('#pipelineCoupling', function () {
-    it('gets the pipeline coupling given an app', function * () {
+    it('gets the pipeline coupling given an app', co.wrap(function * () {
       const app = 'sausages'
       const coupling = { pipeline: { id: '123-abc' } }
       const api = nock(`https://api.heroku.com`)
@@ -20,11 +21,11 @@ describe('heroku-api', function () {
       const response = yield herokuAPI.pipelineCoupling(new Heroku(), app)
       expect(response).to.deep.eq(coupling)
       api.done()
-    })
+    }))
   })
 
   describe('#pipelineRepository', function () {
-    it('gets the pipeline repository given a pipeline', function * () {
+    it('gets the pipeline repository given a pipeline', co.wrap(function * () {
       const pipeline = '123-abc'
       const repo = { repository: { name: 'heroku/heroku' } }
       const api = nock(`https://kolkrabbi.heroku.com`)
@@ -34,11 +35,11 @@ describe('heroku-api', function () {
       const response = yield herokuAPI.pipelineRepository(new Heroku(), pipeline)
       expect(response).to.deep.eq(repo)
       api.done()
-    })
+    }))
   })
 
   describe('#getDyno', function () {
-    it('returns dyno information', function * () {
+    it('returns dyno information', co.wrap(function * () {
       const appID = '123-456-67-89'
       const dynoID = '01234567-89ab-cdef-0123-456789abcdef'
       const dyno = {
@@ -54,11 +55,11 @@ describe('heroku-api', function () {
       const response = yield herokuAPI.getDyno(new Heroku(), appID, dynoID)
       expect(response).to.deep.eq(dyno)
       api.done()
-    })
+    }))
   })
 
   describe('#githubArchiveLink', function () {
-    it('gets a GitHub archive link', function * () {
+    it('gets a GitHub archive link', co.wrap(function * () {
       const { user, repository } = ['heroku', 'heroku-ci']
       const ref = '123-abc'
       const archiveLink = { archive_link: 'https://example.com' }
@@ -69,77 +70,69 @@ describe('heroku-api', function () {
       const response = yield herokuAPI.githubArchiveLink(new Heroku(), user, repository, ref)
       expect(response).to.deep.eq(archiveLink)
       api.done()
-    })
+    }))
   })
 
   describe('#testRun', function () {
-    it('gets a test run given a pipeline and number', function * () {
+    it('gets a test run given a pipeline and number', co.wrap(function * () {
       const pipeline = '123-abc'
       const number = 1
       const testRun = { number }
       const api = nock(`https://api.heroku.com`, { reqheaders: { Accept: 'application/vnd.heroku+json; version=3.ci' } })
         .get(`/pipelines/${pipeline}/test-runs/${number}`)
-        // nock node 8 bug https://github.com/node-nock/nock/issues/925
-        // .matchHeader('Accept', 'application/vnd.heroku+json; version=3.ci')
         .reply(200, testRun)
 
       const response = yield herokuAPI.testRun(new Heroku(), pipeline, number)
       expect(response).to.deep.eq(testRun)
       api.done()
-    })
+    }))
   })
 
   describe('#testNodes', function () {
-    it('gets a test run given a pipeline and number', function * () {
+    it('gets a test run given a pipeline and number', co.wrap(function * () {
       const testRun = { id: 'uuid-999' }
       const testNode = { test_run: { id: testRun.id } }
 
       const api = nock(`https://api.heroku.com`, { reqheaders: { Accept: 'application/vnd.heroku+json; version=3.ci' } })
         .get(`/test-runs/${testRun.id}/test-nodes`)
-        // nock node 8 bug https://github.com/node-nock/nock/issues/925
-        // .matchHeader('Accept', 'application/vnd.heroku+json; version=3.ci')
         .reply(200, [testNode])
 
       const response = yield herokuAPI.testNodes(new Heroku(), testRun.id)
       expect(response).to.deep.eq([testNode])
       api.done()
-    })
+    }))
   })
 
   describe('#testRuns', function () {
-    it('gets test runs given a pipeline', function * () {
+    it('gets test runs given a pipeline', co.wrap(function * () {
       const pipeline = '123-abc'
       const testRuns = [{ id: '123' }]
       const api = nock(`https://api.heroku.com`, { reqheaders: { Accept: 'application/vnd.heroku+json; version=3.ci' } })
         .get(`/pipelines/${pipeline}/test-runs`)
-        // nock node 8 bug https://github.com/node-nock/nock/issues/925
-        // .matchHeader('Accept', 'application/vnd.heroku+json; version=3.ci')
         .reply(200, testRuns)
 
       const response = yield herokuAPI.testRuns(new Heroku(), pipeline)
       expect(response).to.deep.eq(testRuns)
       api.done()
-    })
+    }))
   })
 
   describe('#latestTestRun', function () {
-    it('gets the latest test run given a pipeline', function * () {
+    it('gets the latest test run given a pipeline', co.wrap(function * () {
       const pipeline = '123-abc'
       const testRuns = [{ number: 123 }, { number: 122 }]
       const api = nock(`https://api.heroku.com`, { reqheaders: { Accept: 'application/vnd.heroku+json; version=3.ci' } })
         .get(`/pipelines/${pipeline}/test-runs`)
-        // nock node 8 bug https://github.com/node-nock/nock/issues/925
-        // .matchHeader('Accept', 'application/vnd.heroku+json; version=3.ci')
         .reply(200, testRuns)
 
       const response = yield herokuAPI.latestTestRun(new Heroku(), pipeline)
       expect(response).to.deep.eq(testRuns[0])
       api.done()
-    })
+    }))
   })
 
   describe('#createSource', function () {
-    it('creates a source', function * () {
+    it('creates a source', co.wrap(function * () {
       const source = { source_blob: { get_url: 'https://example.com/get', put_url: 'https://example.com/put' } }
       const api = nock(`https://api.heroku.com`)
         .post(`/sources`)
@@ -148,11 +141,11 @@ describe('heroku-api', function () {
       const response = yield herokuAPI.createSource(new Heroku())
       expect(response).to.deep.eq(source)
       api.done()
-    })
+    }))
   })
 
   describe('#configVars', function () {
-    it('gets config vars', function * () {
+    it('gets config vars', co.wrap(function * () {
       const id = '123'
       const config = { FOO: 'bar' }
       const api = nock(`https://api.heroku.com`)
@@ -162,11 +155,11 @@ describe('heroku-api', function () {
       const response = yield herokuAPI.configVars(new Heroku(), id)
       expect(response).to.deep.eq(config)
       api.done()
-    })
+    }))
   })
 
   describe('#setConfigVars', function () {
-    it('patches config vars', function * () {
+    it('patches config vars', co.wrap(function * () {
       const id = '123'
       const config = { FOO: 'bar' }
       const api = nock(`https://api.heroku.com`)
@@ -175,7 +168,8 @@ describe('heroku-api', function () {
 
       const response = yield herokuAPI.setConfigVars(new Heroku(), id, config)
       expect(response).to.deep.eq(config)
+
       api.done()
-    })
+    }))
   })
 })

--- a/packages/ci-v5/test/lib/utils-test.js
+++ b/packages/ci-v5/test/lib/utils-test.js
@@ -5,12 +5,13 @@ const expect = require('chai').expect
 const Heroku = require('heroku-client')
 const Utils = require('../../lib/utils')
 const Factory = require('./factory')
+const co = require('co')
 
 describe('Utils', function () {
   afterEach(() => nock.cleanAll())
 
   describe('#getPipeline', function () {
-    it('disambiguates when passing a pipeline', function * () {
+    it('disambiguates when passing a pipeline', co.wrap(function * () {
       const pipeline = Factory.pipeline
       const context = { flags: { pipeline: pipeline.id } }
       const api = nock(`https://api.heroku.com`)
@@ -20,9 +21,9 @@ describe('Utils', function () {
       const response = yield Utils.getPipeline(context, new Heroku())
       expect(response).to.deep.eq(Factory.pipeline)
       api.done()
-    })
+    }))
 
-    it('uses pipeline-couplings when passing an application', function * () {
+    it('uses pipeline-couplings when passing an application', co.wrap(function * () {
       const app = '123-app'
 
       const coupling = { pipeline: Factory.pipeline }
@@ -35,7 +36,7 @@ describe('Utils', function () {
       const response = yield Utils.getPipeline(context, new Heroku())
       expect(response).to.deep.eq(Factory.pipeline)
       api.done()
-    })
+    }))
   })
 
   describe('#dig', function () {


### PR DESCRIPTION
Generator functions that are being used for tests don't get ran by the test runner way that is expected. The test using a generator function doesn't run *and* it also won't fail creating a false positive.

The assertion `expect(true).to.be.false()` should fail within a test but with generator function it doesn't.

## Generator functions`it('this test should fail', function * ()`
[
e1f43a0
<img width="904" alt="Screen Shot 2019-07-05 at 1 33 35 PM" src="https://user-images.githubusercontent.com/2770198/60737747-d5be3a00-9f29-11e9-8f96-ff4f835dd002.png">
](https://github.com/heroku/cli/commit/e1f43a0a3ca37a015a60a8fc776ed05d0b2d3db8)

## Regular functions`it('this test should fail', function ()`
[
b18f7ce
<img width="900" alt="Screen Shot 2019-07-05 at 1 33 42 PM" src="https://user-images.githubusercontent.com/2770198/60737734-cdfe9580-9f29-11e9-9204-1e354a726246.png">
](https://github.com/heroku/cli/commit/b18f7ce2a0a0ca85af88b7121fd04eb9d3502ca2)

## Learnings
* Use regular or `async` functions or returning a promise should work okay, too.
* If yielding promises is required, use `co.wrap` on the function