### PR TITLE
chore(cli): Update lerna domain in readme

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -84,7 +84,7 @@ For other issues, [submit a support ticket](https://help.heroku.com/).
 Developing
 ==========
 
-This project is built with [lerna](http://lernajs.io). The core plugins are located in [./packages](./packages). Run `lerna bootstrap` after cloning the repository to set it up.
+This project is built with [lerna](https://lerna.js.org/). The core plugins are located in [./packages](./packages). Run `lerna bootstrap` after cloning the repository to set it up.
 
 To cut a release, simply run `lerna publish` and it will create a CHANGELOG from the pending commits using [Conventional Commits](http://conventionalcommits.org). CircleCI will run the jobs to publish the CLI once it receives the git tag.
 


### PR DESCRIPTION
Lerna has changed their domain: https://github.com/lerna/lerna/issues/2033
