### PR TITLE
fix(pg:backups:schedules): don't throw error when there are no backup schedules present

### DIFF
--- a/packages/pg-v5/commands/backups/schedules.js
+++ b/packages/pg-v5/commands/backups/schedules.js
@@ -12,13 +12,13 @@ function * run (context, heroku) {
   let schedules = yield heroku.get(`/client/v11/databases/${db.id}/transfer-schedules`, { host: host(db) })
 
   if (!schedules.length) {
-    throw new Error(`No backup schedules found on ${cli.color.app(app)}
+    cli.log(`No backup schedules found on ${cli.color.app(app)}
 Use ${cli.color.cmd('heroku pg:backups:schedule')} to set one up`)
-  }
-
-  cli.styledHeader('Backup Schedules')
-  for (let s of schedules) {
-    cli.log(`${cli.color.configVar(s.name)}: daily at ${s.hour}:00 ${s.timezone}`)
+  } else {
+    cli.styledHeader('Backup Schedules')
+    for (let s of schedules) {
+      cli.log(`${cli.color.configVar(s.name)}: daily at ${s.hour}:00 ${s.timezone}`)
+    }
   }
 }
 

--- a/packages/pg-v5/commands/backups/schedules.js
+++ b/packages/pg-v5/commands/backups/schedules.js
@@ -12,7 +12,7 @@ function * run (context, heroku) {
   let schedules = yield heroku.get(`/client/v11/databases/${db.id}/transfer-schedules`, { host: host(db) })
 
   if (!schedules.length) {
-    cli.log(`No backup schedules found on ${cli.color.app(app)}
+    cli.warn(`No backup schedules found on ${cli.color.app(app)}
 Use ${cli.color.cmd('heroku pg:backups:schedule')} to set one up`)
   } else {
     cli.styledHeader('Backup Schedules')

--- a/packages/pg-v5/test/commands/backups/schedules.js
+++ b/packages/pg-v5/test/commands/backups/schedules.js
@@ -42,9 +42,9 @@ const shouldSchedules = function (cmdRun) {
       pg.get('/client/v11/databases/1/transfer-schedules').reply(200, [])
       return cmd.run({ app: 'myapp' }).then(() => {
         expect(
-          cli.stdout,
-          'to equal',
-          'No backup schedules found on myapp\nUse heroku pg:backups:schedule to set one up\n'
+          cli.stderr,
+          'to contain',
+          ' ▸    No backup schedules found on myapp\n ▸    Use heroku pg:backups:schedule to set one up\n'
         )
       })
     })

--- a/packages/pg-v5/test/commands/backups/schedules.js
+++ b/packages/pg-v5/test/commands/backups/schedules.js
@@ -44,7 +44,13 @@ const shouldSchedules = function (cmdRun) {
         expect(
           cli.stderr,
           'to contain',
-          ' ▸    No backup schedules found on myapp\n ▸    Use heroku pg:backups:schedule to set one up\n'
+          'No backup schedules found on myapp\n'
+        )
+
+        expect(
+          cli.stderr,
+          'to contain',
+          'Use heroku pg:backups:schedule to set one up\n'
         )
       })
     })

--- a/packages/pg-v5/test/commands/backups/schedules.js
+++ b/packages/pg-v5/test/commands/backups/schedules.js
@@ -28,33 +28,46 @@ const shouldSchedules = function (cmdRun) {
 
   context('with databases', () => {
     beforeEach(() => {
-      api.get('/apps/myapp/addons').reply(200, [{
-        id: 1,
-        name: 'postgres-1',
-        plan: { name: 'heroku-postgresql:standard-0' },
-        app: { name: 'myapp' }
-      }])
+      api.get('/apps/myapp/addons').reply(200, [
+        {
+          id: 1,
+          name: 'postgres-1',
+          plan: { name: 'heroku-postgresql:standard-0' },
+          app: { name: 'myapp' }
+        }
+      ])
     })
 
     it('shows empty message with no schedules', () => {
       pg.get('/client/v11/databases/1/transfer-schedules').reply(200, [])
-      return expect(cmdRun({ app: 'myapp' }), 'to be rejected with', 'No backup schedules found on myapp\nUse heroku pg:backups:schedule to set one up')
+      return cmd.run({ app: 'myapp' }).then(() => {
+        expect(
+          cli.stdout,
+          'to equal',
+          'No backup schedules found on myapp\nUse heroku pg:backups:schedule to set one up\n'
+        )
+      })
     })
 
     it('shows schedule', () => {
       pg.get('/client/v11/databases/1/transfer-schedules').reply(200, [
         { name: 'DATABASE_URL', hour: 5, timezone: 'UTC' }
       ])
-      return cmdRun({ app: 'myapp' })
-        .then(() => expect(cli.stdout, 'to equal', `=== Backup Schedules
+      return cmdRun({ app: 'myapp' }).then(() =>
+        expect(
+          cli.stdout,
+          'to equal',
+          `=== Backup Schedules
 DATABASE_URL: daily at 5:00 UTC
-`))
+`
+        )
+      )
     })
   })
 }
 
 describe('pg:backups:schedules', () => {
-  shouldSchedules((args) => cmd.run(args))
+  shouldSchedules(args => cmd.run(args))
 })
 
 describe('pg:backups schedules', () => {


### PR DESCRIPTION
Support reported an issue where `pg:backups:schedules` returned an exit code of `1` when there were no schedules present, and pointed out that this isn't really an error since not having any schedules is a valid state.

https://heroku.slack.com/archives/CANLMQU3F/p1564667996111100

This PR tweaks the `schedules` command to simply log the error message rather than throw an error.