### PR TITLE
Add tips & discoveries section of heroku cli readme

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -96,8 +96,9 @@ Tips & Discoveries
 Below is an ongoing list of new discoveries and tips found through the nuances of the heroku cli.
 
 * Lerna tests will strip the color symbol from apps whereas the local tests per package don't. If you’re using @heroku-cli/color, remember to update your init.js file in your local helpers directory with
-> // disable color for tests
-> const { color } = require('@heroku-cli/color')
-> color.enabled = false
-to strip the color.
-Otherwise, your tests will pass locally and fail lerna’s test
+   ```
+   // disable color for tests
+   const { color } = require('@heroku-cli/color')
+   color.enabled = false
+   ```
+   to strip the color. Otherwise, your tests will pass locally and fail lerna’s test

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -89,3 +89,8 @@ This project is built with [lerna](http://lernajs.io). The core plugins are loca
 To cut a release, simply run `lerna publish` and it will create a CHANGELOG from the pending commits using [Conventional Commits](http://conventionalcommits.org). CircleCI will run the jobs to publish the CLI once it receives the git tag.
 
 Review our [PR guidelines](./.github/PULL_REQUEST_TEMPLATE.md).
+
+Tips & Discoveries
+==================
+
+Below is an ongoing list of new discoveries and tips found through the nuances of the heroku cli.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -94,3 +94,10 @@ Tips & Discoveries
 ==================
 
 Below is an ongoing list of new discoveries and tips found through the nuances of the heroku cli.
+
+* Lerna tests will strip the color symbol from apps whereas the local tests per package don't. If you’re using @heroku-cli/color, remember to update your init.js file in your local helpers directory with
+> // disable color for tests
+> const { color } = require('@heroku-cli/color')
+> color.enabled = false
+to strip the color.
+Otherwise, your tests will pass locally and fail lerna’s test


### PR DESCRIPTION
Added a 'tips & discoveries' section to heroku cli readme
