### PR TITLE
docs(apps-v5): Update create/stack:set examples to use Heroku-18

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -71,7 +71,7 @@ OPTIONS
 
 EXAMPLES
   $ heroku apps:create
-  Creating app... done, stack is cedar-14
+  Creating app... done, stack is heroku-18
   https://floating-dragon-42.heroku.com/ | https://git.heroku.com/floating-dragon-42.git
 
   # or just
@@ -299,8 +299,8 @@ OPTIONS
   -r, --remote=remote  git remote of app to use
 
 EXAMPLES
-  $ heroku stack:set cedar-14 -a myapp
-  Stack set. Next release on myapp will use cedar-14.
+  $ heroku stack:set heroku-18 -a myapp
+  Stack set. Next release on myapp will use heroku-18.
   Run git push heroku master to create a new release on myapp.
 ```
 

--- a/packages/apps-v5/README.md
+++ b/packages/apps-v5/README.md
@@ -126,7 +126,7 @@ OPTIONS
 
 EXAMPLES
   $ heroku apps:create
-  Creating app... done, stack is cedar-14
+  Creating app... done, stack is heroku-18
   https://floating-dragon-42.heroku.com/ | https://git.heroku.com/floating-dragon-42.git
 
   # or just
@@ -315,8 +315,8 @@ OPTIONS
   -r, --remote=remote  git remote of app to use
 
 EXAMPLES
-  $ heroku stack:set cedar-14 -a myapp
-  Stack set. Next release on myapp will use cedar-14.
+  $ heroku stack:set heroku-18 -a myapp
+  Stack set. Next release on myapp will use heroku-18.
   Run git push heroku master to create a new release on myapp.
 ```
 

--- a/packages/apps-v5/src/commands/apps/create.js
+++ b/packages/apps-v5/src/commands/apps/create.js
@@ -151,7 +151,7 @@ function run (context, heroku) {
 let cmd = {
   description: 'creates a new app',
   examples: `$ heroku apps:create
-Creating app... done, stack is cedar-14
+Creating app... done, stack is heroku-18
 https://floating-dragon-42.heroku.com/ | https://git.heroku.com/floating-dragon-42.git
 
 # or just

--- a/packages/apps-v5/src/commands/apps/stacks/set.js
+++ b/packages/apps-v5/src/commands/apps/stacks/set.js
@@ -23,8 +23,8 @@ let cmd = {
   needsApp: true,
   needsAuth: true,
   description: 'set the stack of an app',
-  examples: `$ heroku stack:set cedar-14 -a myapp
-Stack set. Next release on myapp will use cedar-14.
+  examples: `$ heroku stack:set heroku-18 -a myapp
+Stack set. Next release on myapp will use heroku-18.
 Run git push heroku master to create a new release on myapp.`,
   args: [{ name: 'stack' }],
   run: cli.command(co.wrap(run))


### PR DESCRIPTION
Since the Cedar-14 stack is EOL, and there might be some users that follow the examples verbatim, without realising it should not be used.