### PR TITLE
fix(pg-v5): #1294 attempt to access logs of an invalid API response object.

### DIFF
--- a/packages/pg-v5/lib/pgbackups.js
+++ b/packages/pg-v5/lib/pgbackups.js
@@ -95,7 +95,7 @@ module.exports = (context, heroku) => ({
         } catch (err) {
           if (failures++ > 20) throw err
         }
-        if (verbose) {
+        if (backup && verbose) {
           displayLogs(backup.logs)
         } else if (tty) {
           let msg = backup.started_at ? pgbackups.filesize(backup.processed_bytes) : 'pending'


### PR DESCRIPTION
This fixes the issue described in #1294, where running `pg:backups:capture` in verbose mode will give a TypeError when we receive an error from the API (such as when trying to backup a service you don't have permissions for).