### PR TITLE
feat(pg-v5): Add exposed pg:setting for toggling logging on connection attempts

### DIFF
--- a/docs/pg.md
+++ b/docs/pg.md
@@ -729,6 +729,22 @@ OPTIONS
   -r, --remote=remote  git remote of app to use
 ```
 
+## `heroku pg:settings:log-connections [VALUE] [DATABASE]`
+
+Controls whether a log message is produced when a login attempt is made. Default is true.
+
+```
+USAGE
+  $ heroku pg:settings:log-connections [VALUE] [DATABASE]
+
+OPTIONS
+  -a, --app=app        (required) app to run command against
+  -r, --remote=remote  git remote of app to use
+
+DESCRIPTION
+  Setting log_connections to false stops emitting log messages for all attempts to login to the database.
+```
+
 ## `heroku pg:settings:log-lock-waits [VALUE] [DATABASE]`
 
 Controls whether a log message is produced when a session waits longer than the deadlock_timeout to acquire a lock. deadlock_timeout is set to 1 second

--- a/packages/pg-v5/commands/settings/log_connections.js
+++ b/packages/pg-v5/commands/settings/log_connections.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const cli = require('heroku-cli-util')
+const settings = require('../../lib/setter')
+
+function explain (setting) {
+  if (setting.value) {
+    return `When login attempts are made, a log message will be emitted in your application's logs.`
+  }
+  return `When login attempts are made, no log message will be emitted in your application's logs.`
+}
+
+module.exports = {
+  topic: 'pg',
+  command: 'settings:log-connections',
+  description: `Controls whether a log message is produced when a login attempt is made. Default is true.`,
+  help: `Setting log_connections to false stops emitting log messages for all attempts to login to the database.`,
+  needsApp: true,
+  needsAuth: true,
+  args: [{ name: 'value', optional: true }, { name: 'database', optional: true }],
+  run: cli.command({ preauth: true }, settings.generate('log_connections', settings.boolean, explain))
+}


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](http://conventionalcommits.org).
-->
This exposes the support for toggling log_connections settings in Heroku Postgres now supported by the Heroku Data Team.