### PR TITLE
fix(config): preserve keys whose value is empty

### DIFF
--- a/packages/config/src/commands/config/edit.ts
+++ b/packages/config/src/commands/config/edit.ts
@@ -24,7 +24,7 @@ function configToString(config: Config): string {
     .join('\n')
 }
 
-function stringToConfig(s: string): Config {
+export function stringToConfig(s: string): Config {
   return s.split('\n').reduce((config: Config, line: string): Config => {
     const error = () => {
       throw new Error(`Invalid line: ${line}`)
@@ -32,7 +32,7 @@ function stringToConfig(s: string): Config {
     if (!line) return config
     let i = line.indexOf('=')
     if (i === -1) error()
-    config[line.slice(0, i)] = parse(line.slice(i + 1))
+    config[line.slice(0, i)] = parse(line.slice(i + 1)) || ''
     return config
   }, {})
 }

--- a/packages/config/test/commands/config/edit.test.ts
+++ b/packages/config/test/commands/config/edit.test.ts
@@ -1,0 +1,12 @@
+import {stringToConfig} from '../../../src/commands/config/edit'
+import {expect} from '../../test'
+
+describe('config:edit', () => {
+  describe('stringToConfig', () => {
+    it('handles config vars with empty string values', () => {
+      expect(stringToConfig("foo=''")).to.deep.equal({foo: ''})
+      expect(stringToConfig('foo=""')).to.deep.equal({foo: ''})
+      expect(stringToConfig('foo=')).to.deep.equal({foo: ''})
+    })
+  })
+})


### PR DESCRIPTION
If a user has the following config already set up in heroku:

```
NAME=ALICE
EMAIL=
```

and if they used `heroku config:edit` and saved without making any changes, the
`EMAIL` variable would disappear. This commit updates `config:edit` to preserve
any keys with empty strings as values when saving

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](http://conventionalcommits.org).
-->
