### PR TITLE
fix(pipelines-v5): only validate repo name for pipelines:connect

### DIFF
--- a/packages/pipelines-v5/commands/pipelines/connect.js
+++ b/packages/pipelines-v5/commands/pipelines/connect.js
@@ -34,10 +34,10 @@ Configuring pipeline... done`,
   ],
   run: cli.command(co.wrap(function * (context, heroku) {
     const args = { name: context.args.name, repo: context.flags.repo }
-    const errors = Validate.nameAndRepo(args)
+    const error = Validate.repoName(args.repo)
 
-    if (errors.length) {
-      cli.error(errors.join(', '))
+    if (!error[0]) {
+      cli.error(error[1])
       return
     }
 

--- a/packages/pipelines-v5/commands/pipelines/connect.js
+++ b/packages/pipelines-v5/commands/pipelines/connect.js
@@ -34,10 +34,11 @@ Configuring pipeline... done`,
   ],
   run: cli.command(co.wrap(function * (context, heroku) {
     const args = { name: context.args.name, repo: context.flags.repo }
-    const error = Validate.repoName(args.repo)
+    // Ignore validating pipeline name b/c it already exists
+    const errors = Validate.nameAndRepo({repo: args.repo})
 
-    if (!error[0]) {
-      cli.error(error[1])
+    if (errors.length) {
+      cli.error(errors.join(', '))
       return
     }
 

--- a/packages/pipelines-v5/commands/pipelines/connect.js
+++ b/packages/pipelines-v5/commands/pipelines/connect.js
@@ -35,7 +35,7 @@ Configuring pipeline... done`,
   run: cli.command(co.wrap(function * (context, heroku) {
     const args = { name: context.args.name, repo: context.flags.repo }
     // Ignore validating pipeline name b/c it already exists
-    const errors = Validate.nameAndRepo({repo: args.repo})
+    const errors = Validate.nameAndRepo({ repo: args.repo })
 
     if (errors.length) {
       cli.error(errors.join(', '))


### PR DESCRIPTION
https://heroku.support/770115

Looks like we really only have to validate the repo name, not the pipeline name too. 

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](http://conventionalcommits.org).
-->
