### PR TITLE
fix(pipelines): Use assert from node instead of chai

### DIFF
--- a/packages/pipelines/src/commands/pipelines/promote.ts
+++ b/packages/pipelines/src/commands/pipelines/promote.ts
@@ -1,7 +1,7 @@
 import color from '@heroku-cli/color'
 import {APIClient, Command, flags} from '@heroku-cli/command'
 import Heroku from '@heroku-cli/schema'
-import {assert} from 'chai'
+import assert from 'assert'
 import cli from 'cli-ux'
 import got from 'got'
 


### PR DESCRIPTION
There is currently an error being thrown about a missing `chai` dependency. While we could use `chai` for assertions, the code assertions we're making in `pipelines:promote` are the same functions that exist on the core `assert` node module, so we can use that instead.