### PR TITLE
chore(cli): improve README instructions for releasing

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -85,6 +85,13 @@ Developing
 
 This project is built with [lerna](https://lerna.js.org/). The core plugins are located in [./packages](./packages). Run `lerna bootstrap` after cloning the repository to set it up.
 
-To cut a release, simply run `lerna publish` and it will create a CHANGELOG from the pending commits using [Conventional Commits](http://conventionalcommits.org). CircleCI will run the jobs to publish the CLI once it receives the git tag.
+Releasing
+=========
+1. Checkout the master branch and double-check you're on latest commit that you would like to release from.
+2. Ensure your current working directory is clean.
+3. Run `lerna bootstrap` to ensure that all dependencies and are installed and linked.
+4. Make sure you are logged in with the correct user by running: `npm whoami`.
+5. Run `lerna publish`. It will create a CHANGELOG from the pending commits using [Conventional Commits](http://conventionalcommits.org), and also take care of bumping packages, tagging and pushing the commit. Upon the git tag being pushed a series of CI release jobs will start.
+6. Monitor CircleCI, Appveyor and Snapcraft jobs to ensure that all the builds are successful.
 
 Review our [PR guidelines](./.github/PULL_REQUEST_TEMPLATE.md).


### PR DESCRIPTION
During the release process the `oclif-dev readme --multi` command failed to produce docs for a command that was missing a dependency. I think this would have been fixed with a `lerna bootstrap` before hand (and possibly with a `rm -rf node_modules` before hand but I'm leaving that out for now).

The other steps include a couple good things to check before running `lerna publish` since there isn't a way to resume when the command bails.