### PR TITLE
chore: increase mocha timeout in all packages to 50s

### DIFF
--- a/packages/buildpacks/test/mocha.opts
+++ b/packages/buildpacks/test/mocha.opts
@@ -4,4 +4,4 @@
 --watch-extensions ts
 --recursive
 --reporter spec
---timeout 100000
+--timeout 50000

--- a/packages/cli/test/mocha.opts
+++ b/packages/cli/test/mocha.opts
@@ -4,4 +4,4 @@
 --watch-extensions ts
 --recursive
 --reporter spec
---timeout 100000
+--timeout 50000

--- a/packages/heroku-cli-plugin-apps/test/mocha.opts
+++ b/packages/heroku-cli-plugin-apps/test/mocha.opts
@@ -3,4 +3,4 @@
 --watch-extensions ts
 --recursive
 --reporter spec
---timeout 10000
+--timeout 50000

--- a/packages/oauth/test/mocha.opts
+++ b/packages/oauth/test/mocha.opts
@@ -2,4 +2,4 @@
 --watch-extensions ts
 --recursive
 --reporter spec
---timeout 10000
+--timeout 50000

--- a/packages/webhooks/test/mocha.opts
+++ b/packages/webhooks/test/mocha.opts
@@ -3,4 +3,4 @@
 --watch-extensions ts
 --recursive
 --reporter spec
---timeout 10000
+--timeout 50000


### PR DESCRIPTION
mocha timeouts of >10secs keep happening frequently enough causing us to have to rerun CI