### PR TITLE
fix(pg-v5): improve pg:copy confirm message

### DIFF
--- a/packages/pg-v5/commands/copy.js
+++ b/packages/pg-v5/commands/copy.js
@@ -61,7 +61,7 @@ function * run (context, heroku) {
 
   yield cli.confirmApp(target.confirm, flags.confirm, `WARNING: Destructive action
 This command will remove all data from ${cli.color.yellow(target.name)}
-Data from ${cli.color.yellow(source.name)} will then be transferred to ${cli.color.yellow(target.name)}`)
+Data from ${cli.color.yellow(source.name)} on ${cli.color.app(source.confirm)} will then be transferred to ${cli.color.yellow(target.name)} on ${cli.color.app(target.confirm)}`)
 
   let copy
   let attachment


### PR DESCRIPTION
The confirmation message when copying databases was ambiguous and needed more clarification.