### PR TITLE
feat(domains:add): fix feature flag usage

### DIFF
--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -10,6 +10,7 @@
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "cli-ux": "^5.3.2",
+    "inquirer": "^7.0.1",
     "shell-escape": "^0.2.0",
     "tslib": "^1",
     "urijs": "^1.19.1"

--- a/packages/apps/src/commands/domains/add.ts
+++ b/packages/apps/src/commands/domains/add.ts
@@ -93,15 +93,15 @@ export default class DomainsAdd extends Command {
     const {args, flags} = this.parse(DomainsAdd)
     const {hostname} = args
 
-    const {body: featureFlag} = await this.heroku.get<Heroku.AppFeature>(
-      `/apps/${flags.app}/features/${MULTIPLE_SNI_ENDPOINT_FLAG}`
-    )
+    const {body: featureList} = await this.heroku.get<Array<Heroku.AppFeature>>(`/apps/${flags.app}/features`)
+
+    const multipleSniEndpointFeature = featureList.find(feature => feature.name === MULTIPLE_SNI_ENDPOINT_FLAG)
 
     const domainCreatePayload: DomainCreatePayload = {
       hostname
     }
 
-    if (featureFlag.enabled) {
+    if (multipleSniEndpointFeature && multipleSniEndpointFeature.enabled) {
       // multiple SNI endpoints is enabled
       if (flags.cert) {
         domainCreatePayload.sni_endpoint = flags.cert

--- a/packages/apps/test/commands/domains/add.test.ts
+++ b/packages/apps/test/commands/domains/add.test.ts
@@ -1,3 +1,5 @@
+import * as inquirer from 'inquirer'
+
 import {expect, test} from '../../test'
 
 describe('domains:add', () => {
@@ -17,14 +19,96 @@ describe('domains:add', () => {
     status: 'pending'
   }
 
-  test
-    .stderr()
-    .nock('https://api.heroku.com', (api: any) => api
-      .post('/apps/myapp/domains', {hostname: 'example.com'})
-      .reply(200, domainsResponse)
-    )
-    .command(['domains:add', 'example.com', '--app', 'myapp'])
-    .it('adds the domain to the app', ctx => {
-      expect(ctx.stderr).to.contain('Adding example.com to myapp... done')
+  describe('adding a domain without the feature flag on (the old way)', () => {
+    test
+      .stderr()
+      .nock('https://api.heroku.com', api => api
+        .get('/apps/myapp/features/allow-multiple-sni-endpoints')
+        .reply(200, {
+          enabled: false
+        })
+        .post('/apps/myapp/domains', {hostname: 'example.com'})
+        .reply(200, domainsResponse)
+      )
+      .command(['domains:add', 'example.com', '--app', 'myapp'])
+      .it('adds the domain to the app', ctx => {
+        expect(ctx.stderr).to.contain('Adding example.com to myapp... done')
+      })
+  })
+
+  describe('adding a domain to an app with multiple certs', () => {
+    describe('using the --cert flag', () => {
+      test
+        .stderr()
+        .nock('https://api.heroku.com', api => api
+          .get('/apps/myapp/features/allow-multiple-sni-endpoints')
+          .reply(200, {
+            enabled: true
+          })
+          .post('/apps/myapp/domains', {
+            hostname: 'example.com',
+            sni_endpoint: 'my-cert'
+          })
+          .reply(200, domainsResponse)
+        )
+        .command(['domains:add', 'example.com', '--app', 'myapp', '--cert', 'my-cert'])
+        .it('adds the domain to the app', ctx => {
+          expect(ctx.stderr).to.contain('Adding example.com to myapp... done')
+        })
     })
+
+    describe('without passing a cert', () => {
+      const certsResponse = [
+        {
+          app: {
+            name: 'myapp',
+          },
+          name: 'cert1',
+          displayName: 'Best Cert Ever',
+          ssl_cert: {
+            cert_domains: ['foo.com', 'bar.com', 'baz.com', 'baq.com', 'blah.com', 'rejairieja.com'],
+          },
+        },
+        {
+          app: {
+            name: 'myapp',
+          },
+          name: 'cert2',
+          ssl_cert: {
+            cert_domains: ['foo.com', 'bar.com', 'baz.com', 'baq.com', 'blah.com', 'rejairieja.com'],
+          },
+        },
+      ]
+
+      test
+        .stderr()
+        .stub(inquirer, 'prompt', () => {
+          return Promise.resolve({cert: 'my-cert'})
+        })
+        .nock('https://api.heroku.com', api => api
+          .get('/apps/myapp/features/allow-multiple-sni-endpoints')
+          .reply(200, {
+            enabled: true
+          })
+          .post('/apps/myapp/domains', {
+            hostname: 'example.com',
+          })
+          .reply(422, {
+            id: 'invalid_params',
+            message: '\'sni_endpoint\' param is required when adding a domain to an app with multiple SSL certs.'
+          })
+          .post('/apps/myapp/domains', {
+            hostname: 'example.com',
+            sni_endpoint: 'my-cert'
+          })
+          .reply(200, domainsResponse)
+          .get('/apps/myapp/sni-endpoints')
+          .reply(200, certsResponse)
+        )
+        .command(['domains:add', 'example.com', '--app', 'myapp'])
+        .it('adds the domain to the app', ctx => {
+          expect(ctx.stderr).to.contain('Adding example.com to myapp... done')
+        })
+    })
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5258,6 +5258,25 @@ inquirer@^7.0.0:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
+inquirer@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.0.1.tgz#13f7980eedc73c689feff3994b109c4e799c6ebb"
+  integrity sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^2.4.2"
+    cli-cursor "^3.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.15"
+    mute-stream "0.0.8"
+    run-async "^2.2.0"
+    rxjs "^6.5.3"
+    string-width "^4.1.0"
+    strip-ansi "^5.1.0"
+    through "^2.3.6"
+
 into-stream@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
@@ -8179,7 +8198,7 @@ rxjs@^5.5.2:
   dependencies:
     symbol-observable "1.0.1"
 
-rxjs@^6.1.0:
+rxjs@^6.1.0, rxjs@^6.5.3:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a"
   integrity sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==


### PR DESCRIPTION
This PR is a follow up to https://github.com/heroku/cli/pull/1412

That PR checked for the multiple sni endpoint feature flag by querying the flag directly. Since this feature flag is not publicly available, the request would straight up fail rather than returning a disabled feature flag, causing the command to exit.

This PR addresses that issue by instead querying the list of feature flags for the given app and first checking if the feature is even included before checking if it's enabled.