### PR TITLE
feat(apps): add domains:update command

### DIFF
--- a/packages/apps/src/commands/domains/add.ts
+++ b/packages/apps/src/commands/domains/add.ts
@@ -25,6 +25,7 @@ export default class DomainsAdd extends Command {
     cert: flags.string({description: 'the name of the SSL cert you want to use for this domain', char: 'c'}),
     json: flags.boolean({description: 'output in json format', char: 'j'}),
     wait: flags.boolean(),
+    remote: flags.remote(),
   }
 
   static args = [{name: 'hostname'}]

--- a/packages/apps/src/commands/domains/add.ts
+++ b/packages/apps/src/commands/domains/add.ts
@@ -28,7 +28,7 @@ export default class DomainsAdd extends Command {
     remote: flags.remote(),
   }
 
-  static args = [{name: 'hostname'}]
+  static args = [{name: 'hostname', required: true}]
 
   createDomain = async (appName: string, payload: DomainCreatePayload): Promise<Heroku.Domain> => {
     cli.action.start(`Adding ${color.green(payload.hostname)} to ${color.app(appName)}`)

--- a/packages/apps/src/commands/domains/clear.ts
+++ b/packages/apps/src/commands/domains/clear.ts
@@ -11,6 +11,7 @@ export default class DomainsClear extends Command {
   static flags = {
     help: flags.help({char: 'h'}),
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   async run() {

--- a/packages/apps/src/commands/domains/index.ts
+++ b/packages/apps/src/commands/domains/index.ts
@@ -26,6 +26,7 @@ www.example.com  CNAME            www.example.herokudns.com
   static flags = {
     help: flags.help({char: 'h'}),
     app: flags.app({required: true}),
+    remote: flags.remote(),
     ...cli.table.flags({except: 'no-truncate'}),
   }
 

--- a/packages/apps/src/commands/domains/index.ts
+++ b/packages/apps/src/commands/domains/index.ts
@@ -27,6 +27,7 @@ www.example.com  CNAME            www.example.herokudns.com
     help: flags.help({char: 'h'}),
     app: flags.app({required: true}),
     remote: flags.remote(),
+    json: flags.boolean({description: 'output in json format', char: 'j'}),
     ...cli.table.flags({except: 'no-truncate'}),
   }
 
@@ -36,26 +37,30 @@ www.example.com  CNAME            www.example.herokudns.com
     const herokuDomain = domains.find(domain => domain.kind === 'heroku')
     const customDomains = domains.filter(domain => domain.kind === 'custom')
 
-    cli.styledHeader(`${flags.app} Heroku Domain`)
-    cli.log(herokuDomain && herokuDomain.hostname)
-    if (customDomains && customDomains.length > 0) {
-      cli.log()
-      cli.styledHeader(`${flags.app} Custom Domains`)
-      cli.table(customDomains, {
-        hostname: {header: 'Domain Name'},
-        kind: {header: 'DNS Record Type',
-          get: domain => {
+    if (flags.json) {
+      cli.styledJSON(domains)
+    } else {
+      cli.styledHeader(`${flags.app} Heroku Domain`)
+      cli.log(herokuDomain && herokuDomain.hostname)
+      if (customDomains && customDomains.length > 0) {
+        cli.log()
+        cli.styledHeader(`${flags.app} Custom Domains`)
+        cli.table(customDomains, {
+          hostname: {header: 'Domain Name'},
+          kind: {header: 'DNS Record Type', get: domain => {
             if (domain.hostname) {
               return isApexDomain(domain.hostname) ? 'ALIAS or ANAME' : 'CNAME'
             }
           }},
-        cname: {header: 'DNS Target'},
-        acm_status: {header: 'ACM Status', extended: true},
-        acm_status_reason: {header: 'ACM Status', extended: true},
-      }, {
-        ...flags,
-        'no-truncate': true,
-      })
+          cname: {header: 'DNS Target'},
+          acm_status: {header: 'ACM Status', extended: true},
+          acm_status_reason: {header: 'ACM Status', extended: true},
+        }, {
+          ...flags,
+          'no-truncate': true,
+        })
+      }
     }
+
   }
 }

--- a/packages/apps/src/commands/domains/index.ts
+++ b/packages/apps/src/commands/domains/index.ts
@@ -47,11 +47,12 @@ www.example.com  CNAME            www.example.herokudns.com
         cli.styledHeader(`${flags.app} Custom Domains`)
         cli.table(customDomains, {
           hostname: {header: 'Domain Name'},
-          kind: {header: 'DNS Record Type', get: domain => {
-            if (domain.hostname) {
-              return isApexDomain(domain.hostname) ? 'ALIAS or ANAME' : 'CNAME'
-            }
-          }},
+          kind: {header: 'DNS Record Type',
+            get: domain => {
+              if (domain.hostname) {
+                return isApexDomain(domain.hostname) ? 'ALIAS or ANAME' : 'CNAME'
+              }
+            }},
           cname: {header: 'DNS Target'},
           acm_status: {header: 'ACM Status', extended: true},
           acm_status_reason: {header: 'ACM Status', extended: true},
@@ -61,6 +62,5 @@ www.example.com  CNAME            www.example.herokudns.com
         })
       }
     }
-
   }
 }

--- a/packages/apps/src/commands/domains/info.ts
+++ b/packages/apps/src/commands/domains/info.ts
@@ -12,6 +12,7 @@ export default class DomainsInfo extends Command {
   static flags = {
     help: flags.help({char: 'h'}),
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   static args = [{name: 'hostname'}]

--- a/packages/apps/src/commands/domains/info.ts
+++ b/packages/apps/src/commands/domains/info.ts
@@ -15,7 +15,7 @@ export default class DomainsInfo extends Command {
     remote: flags.remote(),
   }
 
-  static args = [{name: 'hostname'}]
+  static args = [{name: 'hostname', required: true}]
 
   async run() {
     const {args, flags} = this.parse(DomainsInfo)

--- a/packages/apps/src/commands/domains/remove.ts
+++ b/packages/apps/src/commands/domains/remove.ts
@@ -10,6 +10,7 @@ export default class DomainsRemove extends Command {
   static flags = {
     help: flags.help({char: 'h'}),
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   static args = [{name: 'hostname'}]

--- a/packages/apps/src/commands/domains/remove.ts
+++ b/packages/apps/src/commands/domains/remove.ts
@@ -13,7 +13,7 @@ export default class DomainsRemove extends Command {
     remote: flags.remote(),
   }
 
-  static args = [{name: 'hostname'}]
+  static args = [{name: 'hostname', required: true}]
 
   async run() {
     const {args, flags} = this.parse(DomainsRemove)

--- a/packages/apps/src/commands/domains/update.ts
+++ b/packages/apps/src/commands/domains/update.ts
@@ -1,0 +1,37 @@
+import {color} from '@heroku-cli/color'
+import {Command, flags} from '@heroku-cli/command'
+import cli from 'cli-ux'
+
+export default class DomainsUpdate extends Command {
+  static description = 'update a domain to use a different SSL certificate on an app'
+
+  static examples = ['heroku domains:update www.example.com --cert-id mycert']
+  static hidden = true
+
+  static flags = {
+    help: flags.help({char: 'h'}),
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+    'cert-id': flags.string({required: true})
+  }
+
+  static args = [{name: 'hostname'}]
+
+  async run() {
+    const {args, flags} = this.parse(DomainsUpdate)
+    const {hostname} = args
+    try {
+      cli.action.start(`Updating ${color.cyan(hostname)} to use ${color.cyan(flags['cert-id'])} certificate`)
+      await this.heroku.patch<string>(`/apps/${flags.app}/domains/${hostname}`, {
+        headers: {
+          Accept: 'application/vnd.heroku+json; version=3.allow_multiple_sni_endpoints'
+        },
+        body: {sni_endpoint: flags['cert-id']}
+      })
+    } catch (e) {
+      cli.error(e)
+    } finally {
+      cli.action.stop()
+    }
+  }
+}

--- a/packages/apps/src/commands/domains/update.ts
+++ b/packages/apps/src/commands/domains/update.ts
@@ -12,7 +12,7 @@ export default class DomainsUpdate extends Command {
     help: flags.help({char: 'h'}),
     app: flags.app({required: true}),
     remote: flags.remote(),
-    'cert-id': flags.string({required: true})
+    'cert-id': flags.string({required: true}),
   }
 
   static args = [{name: 'hostname'}]

--- a/packages/apps/src/commands/domains/update.ts
+++ b/packages/apps/src/commands/domains/update.ts
@@ -6,6 +6,7 @@ export default class DomainsUpdate extends Command {
   static description = 'update a domain to use a different SSL certificate on an app'
 
   static examples = ['heroku domains:update www.example.com --cert-id mycert']
+
   static hidden = true
 
   static flags = {
@@ -24,12 +25,12 @@ export default class DomainsUpdate extends Command {
       cli.action.start(`Updating ${color.cyan(hostname)} to use ${color.cyan(flags['cert-id'])} certificate`)
       await this.heroku.patch<string>(`/apps/${flags.app}/domains/${hostname}`, {
         headers: {
-          Accept: 'application/vnd.heroku+json; version=3.allow_multiple_sni_endpoints'
+          Accept: 'application/vnd.heroku+json; version=3.allow_multiple_sni_endpoints',
         },
-        body: {sni_endpoint: flags['cert-id']}
+        body: {sni_endpoint: flags['cert-id']},
       })
-    } catch (e) {
-      cli.error(e)
+    } catch (error) {
+      cli.error(error)
     } finally {
       cli.action.stop()
     }

--- a/packages/apps/src/commands/domains/wait.ts
+++ b/packages/apps/src/commands/domains/wait.ts
@@ -9,6 +9,7 @@ export default class DomainsWait extends Command {
   static flags = {
     help: flags.help({char: 'h'}),
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   static args = [{name: 'hostname'}]

--- a/packages/apps/src/commands/domains/wait.ts
+++ b/packages/apps/src/commands/domains/wait.ts
@@ -12,7 +12,7 @@ export default class DomainsWait extends Command {
     remote: flags.remote(),
   }
 
-  static args = [{name: 'hostname', required: true}]
+  static args = [{name: 'hostname'}]
 
   async run() {
     const {args, flags} = this.parse(DomainsWait)

--- a/packages/apps/src/commands/domains/wait.ts
+++ b/packages/apps/src/commands/domains/wait.ts
@@ -12,7 +12,7 @@ export default class DomainsWait extends Command {
     remote: flags.remote(),
   }
 
-  static args = [{name: 'hostname'}]
+  static args = [{name: 'hostname', required: true}]
 
   async run() {
     const {args, flags} = this.parse(DomainsWait)

--- a/packages/apps/test/commands/domains/update.test.ts
+++ b/packages/apps/test/commands/domains/update.test.ts
@@ -1,0 +1,26 @@
+import {expect, test} from '../../test'
+
+describe('domains:update', () => {
+  const responseBody = {
+    acm_status: null,
+    acm_status_reason: null,
+    app: {id: '9b688aae-2873-419a-9ec6-f4076d945436', name: 'multi-sni-testing'},
+    cname: 'powerful-quail-4c0079v4aa19q90x6kz2m7qk.herokudns.com',
+    created_at: '2019-12-10T17:53:01Z',
+    hostname: 'example.com',
+    id: '7ac15e30-6460-48e1-919a-e794bf3512ac',
+    kind: 'custom',
+    status: 'succeeded',
+    sni_endpoint_id: '8cae023a-d8f1-4aca-9929-e516dc011694' }
+
+  test
+    .stderr()
+    .nock('https://api.heroku.com', api => api
+      .patch('/apps/myapp/domains/example.com', {sni_endpoint: 'sniendpoint-id'})
+      .reply(200, responseBody)
+    )
+    .command(['domains:update', 'example.com', '--cert-id', 'sniendpoint-id', '--app', 'myapp'])
+    .it('updates the domain to use a different certificate', ctx => {
+      expect(ctx.stderr).to.contain('Updating example.com to use sniendpoint-id certificate... done')
+    })
+})

--- a/packages/apps/test/commands/domains/update.test.ts
+++ b/packages/apps/test/commands/domains/update.test.ts
@@ -11,16 +11,16 @@ describe('domains:update', () => {
     id: '7ac15e30-6460-48e1-919a-e794bf3512ac',
     kind: 'custom',
     status: 'succeeded',
-    sni_endpoint_id: '8cae023a-d8f1-4aca-9929-e516dc011694' }
+    sni_endpoint_id: '8cae023a-d8f1-4aca-9929-e516dc011694'}
 
   test
-    .stderr()
-    .nock('https://api.heroku.com', api => api
-      .patch('/apps/myapp/domains/example.com', {sni_endpoint: 'sniendpoint-id'})
-      .reply(200, responseBody)
-    )
-    .command(['domains:update', 'example.com', '--cert-id', 'sniendpoint-id', '--app', 'myapp'])
-    .it('updates the domain to use a different certificate', ctx => {
-      expect(ctx.stderr).to.contain('Updating example.com to use sniendpoint-id certificate... done')
-    })
+  .stderr()
+  .nock('https://api.heroku.com', api => api
+  .patch('/apps/myapp/domains/example.com', {sni_endpoint: 'sniendpoint-id'})
+  .reply(200, responseBody),
+  )
+  .command(['domains:update', 'example.com', '--cert-id', 'sniendpoint-id', '--app', 'myapp'])
+  .it('updates the domain to use a different certificate', ctx => {
+    expect(ctx.stderr).to.contain('Updating example.com to use sniendpoint-id certificate... done')
+  })
 })

--- a/packages/apps/test/commands/domains/wait.test.ts
+++ b/packages/apps/test/commands/domains/wait.test.ts
@@ -2,32 +2,32 @@ import {expect, test} from '../../test'
 
 describe('domains:wait', () => {
   test
-    .stderr()
-    .nock('https://api.heroku.com', api => api
-      .get('/apps/myapp/domains/example.com')
-      .reply(200, {id: 123, hostname: 'example.com', status: 'pending'}),
-    )
-    .nock('https://api.heroku.com', api => api
-      .get('/apps/myapp/domains/123')
-      .reply(200, {id: 123, hostname: 'example.com', status: 'succeeded'}),
-    )
-    .command(['domains:wait', 'example.com', '--app', 'myapp'])
-    .it('waits on domain status succeeded', ctx => {
-      expect(ctx.stderr).to.contain('Waiting for example.com... done')
-    })
+  .stderr()
+  .nock('https://api.heroku.com', api => api
+  .get('/apps/myapp/domains/example.com')
+  .reply(200, {id: 123, hostname: 'example.com', status: 'pending'}),
+  )
+  .nock('https://api.heroku.com', api => api
+  .get('/apps/myapp/domains/123')
+  .reply(200, {id: 123, hostname: 'example.com', status: 'succeeded'}),
+  )
+  .command(['domains:wait', 'example.com', '--app', 'myapp'])
+  .it('waits on domain status succeeded', ctx => {
+    expect(ctx.stderr).to.contain('Waiting for example.com... done')
+  })
 
   test
-    .stderr()
-    .nock('https://api.heroku.com', (api: any) => api
-      .get('/apps/myapp/domains')
-      .reply(200, [{id: 123, hostname: 'example.com', status: 'pending'}])
-    )
-    .nock('https://api.heroku.com', (api: any) => api
-      .get('/apps/myapp/domains/123')
-      .reply(200, {id: 123, hostname: 'example.com', status: 'succeeded'})
-    )
-    .command(['domains:wait', '--app', 'myapp'])
-    .it('waits on domains when no hostname is provided', ctx => {
-      expect(ctx.stderr).to.contain('Waiting for example.com... done')
-    })
+  .stderr()
+  .nock('https://api.heroku.com', (api: any) => api
+  .get('/apps/myapp/domains')
+  .reply(200, [{id: 123, hostname: 'example.com', status: 'pending'}]),
+  )
+  .nock('https://api.heroku.com', (api: any) => api
+  .get('/apps/myapp/domains/123')
+  .reply(200, {id: 123, hostname: 'example.com', status: 'succeeded'}),
+  )
+  .command(['domains:wait', '--app', 'myapp'])
+  .it('waits on domains when no hostname is provided', ctx => {
+    expect(ctx.stderr).to.contain('Waiting for example.com... done')
+  })
 })

--- a/packages/apps/test/commands/domains/wait.test.ts
+++ b/packages/apps/test/commands/domains/wait.test.ts
@@ -2,17 +2,32 @@ import {expect, test} from '../../test'
 
 describe('domains:wait', () => {
   test
-  .stderr()
-  .nock('https://api.heroku.com', api => api
-  .get('/apps/myapp/domains/example.com')
-  .reply(200, {id: 123, hostname: 'example.com', status: 'pending'}),
-  )
-  .nock('https://api.heroku.com', api => api
-  .get('/apps/myapp/domains/123')
-  .reply(200, {id: 123, hostname: 'example.com', status: 'succeeded'}),
-  )
-  .command(['domains:wait', 'example.com', '--app', 'myapp'])
-  .it('waits on domain status succeeded', ctx => {
-    expect(ctx.stderr).to.contain('Waiting for example.com... done')
-  })
+    .stderr()
+    .nock('https://api.heroku.com', api => api
+      .get('/apps/myapp/domains/example.com')
+      .reply(200, {id: 123, hostname: 'example.com', status: 'pending'}),
+    )
+    .nock('https://api.heroku.com', api => api
+      .get('/apps/myapp/domains/123')
+      .reply(200, {id: 123, hostname: 'example.com', status: 'succeeded'}),
+    )
+    .command(['domains:wait', 'example.com', '--app', 'myapp'])
+    .it('waits on domain status succeeded', ctx => {
+      expect(ctx.stderr).to.contain('Waiting for example.com... done')
+    })
+
+  test
+    .stderr()
+    .nock('https://api.heroku.com', (api: any) => api
+      .get('/apps/myapp/domains')
+      .reply(200, [{id: 123, hostname: 'example.com', status: 'pending'}])
+    )
+    .nock('https://api.heroku.com', (api: any) => api
+      .get('/apps/myapp/domains/123')
+      .reply(200, {id: 123, hostname: 'example.com', status: 'succeeded'})
+    )
+    .command(['domains:wait', '--app', 'myapp'])
+    .it('waits on domains when no hostname is provided', ctx => {
+      expect(ctx.stderr).to.contain('Waiting for example.com... done')
+    })
 })


### PR DESCRIPTION
This PR is a followup to #1407 

Adds a domains:update command to allow for using different certs.

This command also fixes the issue we had with domains:wait, because we accidentally made hostname required which broke a direwolf test script.

GUS item: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000007rFIsIAM/view