### PR TITLE
Revert "fix(pg-v5): improve pg:copy confirm message"

### DIFF
--- a/packages/pg-v5/commands/copy.js
+++ b/packages/pg-v5/commands/copy.js
@@ -61,7 +61,7 @@ function * run (context, heroku) {
 
   yield cli.confirmApp(target.confirm, flags.confirm, `WARNING: Destructive action
 This command will remove all data from ${cli.color.yellow(target.name)}
-Data from ${cli.color.yellow(source.name)} on ${cli.color.app(source.confirm)} will then be transferred to ${cli.color.yellow(target.name)} on ${cli.color.app(target.confirm)}`)
+Data from ${cli.color.yellow(source.name)} will then be transferred to ${cli.color.yellow(target.name)}`)
 
   let copy
   let attachment


### PR DESCRIPTION
Reverts heroku/cli#1422

There are a couple issues with the confirmation message

## Issue 1 ## 

```
heroku pg:copy app1::HEROKU_POSTGRESQL_BLACK_URL DATABASE_URL -a app2
```

Expected Output:
```
Data from BLACK on ⬢ app1 will then be transferred...
```

Current Output:
```
Data from BLACK on ⬢ app2 will then be transferred...
```

The confirm is just using the app argument, but it should use the attachments app name, as they may differ. 

## Issue 2 ##

For postgres URLS (dummy example: `postgres://heroku/otherdb`)

```
heroku pg:copy postgres://heroku/otherdb DATABASE_URL -a app2
```

Expected Output (I think something like this?):
```
Data from otherdb on heroku:5432 will then be transferred...
```

Current Output:
```
Data from database otherdb on heroku:5432 on ⬢otherdb  will then be transferred...
```

