### PR TITLE
chore: bump typescript in all packages

### DIFF
--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -34,7 +34,7 @@
     "mocha": "^5",
     "nyc": "^13",
     "ts-node": "^8",
-    "typescript": "3.3.3333"
+    "typescript": "3.7.5"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -33,7 +33,7 @@
     "nyc": "^13.2.0",
     "ts-node": "^8.0.2",
     "tslib": "^1.9.3",
-    "typescript": "3.3.3333"
+    "typescript": "3.7.5"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -34,7 +34,7 @@
     "nock": "^10.0.6",
     "nyc": "13.2.0",
     "ts-node": "8.0.2",
-    "typescript": "3.3.3333"
+    "typescript": "3.7.5"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/autocomplete/test/commands/autocomplete/create.test.ts
+++ b/packages/autocomplete/test/commands/autocomplete/create.test.ts
@@ -38,7 +38,7 @@ runtest('Create', () => {
       // eslint-disable-next-line require-atomic-updates
       plugin.manifest = await loadJSON(path.resolve(__dirname, '../../test.oclif.manifest.json'))
       // eslint-disable-next-line require-atomic-updates
-      plugin.commands = Object.entries(plugin.manifest.commands).map(([id, c]) => ({...c, load: () => plugin.findCommand(id, {must: true})}))
+      plugin.commands = Object.entries(plugin.manifest.commands).map(([id, c]) => ({...c as object, load: () => plugin.findCommand(id, {must: true})}))
       Klass = plugin.commands[1]
     })
 

--- a/packages/buildpacks/package.json
+++ b/packages/buildpacks/package.json
@@ -40,7 +40,7 @@
     "tmp": "^0.0.33",
     "ts-node": "^8.0.2",
     "tslib": "^1",
-    "typescript": "3.3.3333"
+    "typescript": "3.7.5"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/ci/package.json
+++ b/packages/ci/package.json
@@ -46,7 +46,7 @@
     "nock": "^9.6.1",
     "nyc": "^13.2.0",
     "ts-node": "^8.0.2",
-    "typescript": "3.3.3333"
+    "typescript": "3.7.5"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -85,7 +85,7 @@
     "read-pkg": "^4.0.1",
     "sinon": "^7.2.4",
     "ts-node": "^8.0.2",
-    "typescript": "3.3.3333"
+    "typescript": "3.7.5"
   },
   "engines": {
     "node": ">=8.3.0"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -37,7 +37,7 @@
     "sinon": "^7.2.4",
     "ts-node": "^8.0.2",
     "tslib": "^1.9.3",
-    "typescript": "3.3.3333"
+    "typescript": "3.7.5"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -33,7 +33,7 @@
     "nyc": "^13.2.0",
     "ts-node": "^8.0.2",
     "tslib": "^1.9.3",
-    "typescript": "3.3.3333"
+    "typescript": "3.7.5"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -33,7 +33,7 @@
     "mocha": "^5",
     "nyc": "^13",
     "ts-node": "^8",
-    "typescript": "3.3.3333"
+    "typescript": "3.7.5"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/pipelines/package.json
+++ b/packages/pipelines/package.json
@@ -40,7 +40,7 @@
     "sinon": "^7.4.1",
     "ts-node": "^8",
     "tslib": "^1",
-    "typescript": "3.3.3333"
+    "typescript": "3.7.5"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/ps/package.json
+++ b/packages/ps/package.json
@@ -33,7 +33,7 @@
     "nock": "^10.0.6",
     "ts-node": "8.0.2",
     "tslib": "^1.9.3",
-    "typescript": "3.3.3333"
+    "typescript": "3.7.5"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -33,7 +33,7 @@
     "nyc": "^13",
     "sinon": "^7.4.1",
     "ts-node": "^8",
-    "typescript": "3.3.3333"
+    "typescript": "3.7.5"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/status/package.json
+++ b/packages/status/package.json
@@ -47,7 +47,7 @@
     "mocha": "^5.1.1",
     "nock": "^10.0.6",
     "ts-node": "^8.0.2",
-    "typescript": "3.3.3333"
+    "typescript": "3.7.5"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -28,7 +28,7 @@
     "mocha": "^5",
     "nyc": "^13",
     "ts-node": "^8",
-    "typescript": "3.3.3333"
+    "typescript": "3.7.5"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9838,6 +9838,11 @@ typescript@3.3.3333:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3333.tgz#171b2c5af66c59e9431199117a3bcadc66fdcfd6"
   integrity sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==
 
+typescript@3.7.5:
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
+  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+
 uglify-js@^3.1.4:
   version "3.6.8"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.8.tgz#5edcbcf9d49cbb0403dc49f856fe81530d65145e"


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](http://conventionalcommits.org).
-->

Bumping typescript to 3.7.5 in all the packages. This was needed for https://github.com/heroku/cli/pull/1439

[GUS](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000007tnkAIAQ/view)