### PR TITLE
chore: update README with clearer instructions around publishing

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -93,7 +93,8 @@ Releasing
 2. Ensure your current working directory is clean.
 3. Run `lerna bootstrap` to ensure that all dependencies and are installed and linked.
 4. Make sure you are logged in with the correct user by running: `npm whoami`.
-5. Run `lerna publish`. It will create a CHANGELOG from the pending commits using [Conventional Commits](http://conventionalcommits.org), and also take care of bumping packages, tagging and pushing the commit. Upon the git tag being pushed a series of CI release jobs will start.
-6. Monitor CircleCI, Appveyor and Snapcraft jobs to ensure that all the builds are successful.
+5. Run `npm org ls heroku-cli YOUR_ACCOUNT_NAME` and ensure that your npm account has appropriate access for publishing.
+6. Run `lerna publish`. It will create a CHANGELOG from the pending commits using [Conventional Commits](http://conventionalcommits.org), and also take care of bumping packages, tagging and pushing the commit. Upon the git tag being pushed a series of CI release jobs will start.
+7. Monitor CircleCI, Appveyor and Snapcraft jobs to ensure that all the builds are successful.
 
 Review our [PR guidelines](./.github/PULL_REQUEST_TEMPLATE.md).


### PR DESCRIPTION
In order to publish the package members should have access to the correct npm org.