### PR TITLE
chore(domains): tweak api signature for domains

### DIFF
--- a/packages/apps/test/commands/domains/add.test.ts
+++ b/packages/apps/test/commands/domains/add.test.ts
@@ -55,6 +55,13 @@ describe('domains:add', () => {
   })
 
   describe('adding a domain to an app with multiple certs', () => {
+    const domainsResponseWithEndpoint = {
+      ...domainsResponse,
+      sni_endpoint: {
+        name: 'my-cert',
+      },
+    }
+
     describe('using the --cert flag', () => {
       test
       .stderr()
@@ -70,7 +77,7 @@ describe('domains:add', () => {
         hostname: 'example.com',
         sni_endpoint: 'my-cert',
       })
-      .reply(200, domainsResponse),
+      .reply(200, domainsResponseWithEndpoint),
       )
       .command(['domains:add', 'example.com', '--app', 'myapp', '--cert', 'my-cert'])
       .it('adds the domain to the app', ctx => {
@@ -125,7 +132,7 @@ describe('domains:add', () => {
         hostname: 'example.com',
         sni_endpoint: 'my-cert',
       })
-      .reply(200, domainsResponse)
+      .reply(200, domainsResponseWithEndpoint)
       .get('/apps/myapp/sni-endpoints')
       .reply(200, certsResponse),
       )

--- a/packages/apps/test/commands/domains/update.test.ts
+++ b/packages/apps/test/commands/domains/update.test.ts
@@ -11,7 +11,10 @@ describe('domains:update', () => {
     id: '7ac15e30-6460-48e1-919a-e794bf3512ac',
     kind: 'custom',
     status: 'succeeded',
-    sni_endpoint_id: '8cae023a-d8f1-4aca-9929-e516dc011694'}
+    sni_endpoint: {
+      id: '8cae023a-d8f1-4aca-9929-e516dc011694',
+    },
+  }
 
   test
   .stderr()


### PR DESCRIPTION
Updates tests and commands to account for the slightly different API shape for the `domains` endpoint (changed in https://github.com/heroku/api/pull/11426)