### PR TITLE
fix(apps-v5): Fix the stack upgrade confirmation message for add-on only apps

### DIFF
--- a/packages/apps-v5/test/commands/apps/stack/set.js
+++ b/packages/apps-v5/test/commands/apps/stack/set.js
@@ -6,32 +6,63 @@ const cli = require('heroku-cli-util')
 const nock = require('nock')
 const cmd = commands.find((c) => c.topic === 'stack' && c.command === 'set')
 
+const pendingUpgradeApp = {
+  name: 'myapp',
+  stack: {
+    name: 'heroku-16'
+  },
+  build_stack: {
+    name: 'heroku-18'
+  }
+}
+
+const completedUpgradeApp = {
+  name: 'myapp',
+  stack: {
+    name: 'heroku-18'
+  },
+  build_stack: {
+    name: 'heroku-18'
+  }
+}
+
 describe('stack:set', function () {
   beforeEach(() => cli.mockConsole())
 
   it('sets the stack', function () {
     let api = nock('https://api.heroku.com:443')
-      .patch('/apps/myapp', { build_stack: 'cedar-14' })
-      .reply(200, { name: 'myapp', stack: { name: 'cedar-14' } })
+      .patch('/apps/myapp', { build_stack: 'heroku-18' })
+      .reply(200, pendingUpgradeApp)
 
-    return cmd.run({ app: 'myapp', args: { stack: 'cedar-14' }, flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`Stack set. Next release on myapp will use cedar-14.
+    return cmd.run({ app: 'myapp', args: { stack: 'heroku-18' }, flags: {} })
+      .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-18... done\n'))
+      .then(() => expect(cli.stdout).to.equal(`You will need to redeploy myapp for the change to take effect.
 Run git push heroku master to create a new release on myapp.
 `))
-      .then(() => expect(cli.stderr).to.equal(''))
       .then(() => api.done())
   })
 
   it('sets the stack on a different remote', function () {
     let api = nock('https://api.heroku.com:443')
-      .patch('/apps/myapp', { build_stack: 'cedar-14' })
-      .reply(200, { name: 'myapp', stack: { name: 'cedar-14' } })
+      .patch('/apps/myapp', { build_stack: 'heroku-18' })
+      .reply(200, pendingUpgradeApp)
 
-    return cmd.run({ app: 'myapp', args: { stack: 'cedar-14' }, flags: { remote: 'staging' } })
-      .then(() => expect(cli.stdout).to.equal(`Stack set. Next release on myapp will use cedar-14.
+    return cmd.run({ app: 'myapp', args: { stack: 'heroku-18' }, flags: { remote: 'staging' } })
+      .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-18... done\n'))
+      .then(() => expect(cli.stdout).to.equal(`You will need to redeploy myapp for the change to take effect.
 Run git push staging master to create a new release on myapp.
 `))
-      .then(() => expect(cli.stderr).to.equal(''))
+      .then(() => api.done())
+  })
+
+  it('does not show the redeploy message if the stack was immediately updated by API', function () {
+    let api = nock('https://api.heroku.com:443')
+      .patch('/apps/myapp', { build_stack: 'heroku-18' })
+      .reply(200, completedUpgradeApp)
+
+    return cmd.run({ app: 'myapp', args: { stack: 'heroku-18' }, flags: {} })
+      .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-18... done\n'))
+      .then(() => expect(cli.stdout).to.equal(''))
       .then(() => api.done())
   })
 })


### PR DESCRIPTION
Apps that have never had a deploy (eg empty apps or those that are used to hold add-ons only) switch stacks instantly without the need for a re-deploy of the app (as of heroku/api#10754).

However when upgrading an app's stack via the CLI, the console output previously always indicated a re-deploy was necessary, even for apps where this is now not true.

This has been seen to cause confusion in support tickets.

As such, the redeploy message is now only shown when the response from API indicates that the upgrade is still pending (ie: when `build_stack`, the requested stack, differs from the `stack`, the current app stack).

The `stacks:set` command has also been updated to use `cli.action()`, to prevent the existing lack of output until the API request returns.

Refs [W-7249171](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B00000087BFAIA2/view).
