### PR TITLE
fix(certs-v5): handle private spaces sni migrated apps

### DIFF
--- a/packages/certs-v5/commands/certs/add.js
+++ b/packages/certs-v5/commands/certs/add.js
@@ -14,7 +14,7 @@ let isWildcard = require('../../lib/is_wildcard.js')
 let isWildcardMatch = require('../../lib/is_wildcard_match.js')
 let getCertAndKey = require('../../lib/get_cert_and_key.js')
 let matchDomains = require('../../lib/match_domains.js')
-
+let checkMultiSniFeature = require('../../lib/features.js')
 let { waitForDomains, printDomains } = require('../../lib/domains')
 
 function Domains (domains) {
@@ -231,7 +231,7 @@ function * configureDomains (context, heroku, meta, cert) {
 
 function * run (context, heroku) {
   let features = yield heroku.get(`/apps/${context.app}/features`)
-  let canMultiSni = !!features.find(feature => feature.name === 'allow-multiple-sni-endpoints' && feature.enabled === true)
+  let canMultiSni = checkMultiSniFeature(features)
   context.canMultiSni = canMultiSni
 
   let meta = yield getMeta(context, heroku)

--- a/packages/certs-v5/commands/certs/index.js
+++ b/packages/certs-v5/commands/certs/index.js
@@ -4,16 +4,16 @@ let co = require('co')
 let cli = require('heroku-cli-util')
 let _ = require('lodash')
 
-let endpoints = require('../../lib/endpoints.js').certsAndDomains
+let endpoints = require('../../lib/endpoints.js').all
 let displayTable = require('../../lib/display_table.js')
 
 function * run (context, heroku) {
-  let certsAndDomains = yield endpoints(context.app, heroku)
+  let certs = yield endpoints(context.app, heroku)
 
-  if (certsAndDomains.certs.length === 0) {
+  if (certs.length === 0) {
     cli.log(`${cli.color.app(context.app)} has no SSL certificates.\nUse ${cli.color.cmd('heroku certs:add CRT KEY')} to add one.`)
   } else {
-    displayTable(_.sortBy(certsAndDomains.certs, 'name'))
+    displayTable(_.sortBy(certs, 'name'))
   }
 }
 

--- a/packages/certs-v5/lib/endpoints.js
+++ b/packages/certs-v5/lib/endpoints.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const MULTIPLE_SNI_ENDPOINT_FLAG = 'allow-multiple-sni-endpoints'
+
 function sslCertsPromise (app, heroku) {
   return heroku.request({
     path: `/apps/${app}/ssl-endpoints`,
@@ -55,21 +57,25 @@ function tagAndSort (app, allCerts) {
 }
 
 function * all (app, heroku) {
-  let allCerts = yield {
-    ssl_certs: sslCertsPromise(app, heroku),
-    sni_certs: sniCertsPromise(app, heroku)
+  const featureList = yield heroku.get(`/apps/${app}/features`)
+  const multipleSniEndpointFeature = featureList.find(feature => feature.name === MULTIPLE_SNI_ENDPOINT_FLAG)
+
+  let allCerts;
+
+  if (multipleSniEndpointFeature && multipleSniEndpointFeature.enabled) {
+    // use SNI endpoints only
+    allCerts = yield {
+      ssl_certs: [],
+      sni_certs: sniCertsPromise(app, heroku),
+    }
+  } else {
+    allCerts = yield {
+      ssl_certs: sslCertsPromise(app, heroku),
+      sni_certs: sniCertsPromise(app, heroku)
+    }
   }
 
   return tagAndSort(app, allCerts)
-}
-
-function * certsAndDomains (app, heroku) {
-  let requests = yield {
-    ssl_certs: sslCertsPromise(app, heroku),
-    sni_certs: sniCertsPromise(app, heroku)
-  }
-
-  return {certs: tagAndSort(app, requests), domains: requests.domains}
 }
 
 function * hasAddon (app, heroku) {
@@ -98,6 +104,5 @@ module.exports = {
   hasSpace,
   hasAddon,
   meta,
-  all,
-  certsAndDomains
+  all
 }

--- a/packages/certs-v5/lib/endpoints.js
+++ b/packages/certs-v5/lib/endpoints.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const MULTIPLE_SNI_ENDPOINT_FLAG = 'allow-multiple-sni-endpoints'
+let checkMultiSniFeature = require('./features.js')
 
 function sslCertsPromise (app, heroku) {
   return heroku.request({
@@ -58,7 +58,7 @@ function tagAndSort (app, allCerts) {
 
 function * all (app, heroku) {
   const featureList = yield heroku.get(`/apps/${app}/features`)
-  const multipleSniEndpointFeature = featureList.find(feature => feature.name === MULTIPLE_SNI_ENDPOINT_FLAG)
+  const multipleSniEndpointFeature = checkMultiSniFeature(featureList)
 
   let allCerts;
 

--- a/packages/certs-v5/lib/features.js
+++ b/packages/certs-v5/lib/features.js
@@ -1,0 +1,7 @@
+const MULTIPLE_SNI_ENDPOINT_FLAG = 'allow-multiple-sni-endpoints'
+
+function checkMultiSniFeature(featureList) {
+  return featureList.some(feature => feature.name === MULTIPLE_SNI_ENDPOINT_FLAG && feature.enabled === true)
+}
+
+module.exports = checkMultiSniFeature

--- a/packages/certs-v5/test/commands/certs/add.js
+++ b/packages/certs-v5/test/commands/certs/add.js
@@ -26,6 +26,7 @@ let certificateDetails = require('../../stubs/sni-endpoints.js').certificate_det
 let error = require('../../../lib/error.js')
 let assertExit = require('../../assert_exit.js')
 let unwrap = require('../../unwrap.js')
+const mockSniFeatureFlag = require('../../lib/mock_sni_feature')
 
 let lolex = require('lolex')
 
@@ -207,6 +208,7 @@ ${certificateDetails}
   })
 
   it('# errors out when args < 2', function () {
+    mockSniFeatureFlag(nock, 'example')
     nock('https://api.heroku.com')
       .get('/apps/example')
       .reply(200, { 'space': null })
@@ -455,13 +457,10 @@ ${certificateDetails}
   })
 
   it('# shows the configure prompt when flagged in', function () {
+    mockSniFeatureFlag(nock, 'example', true)
     nock('https://api.heroku.com')
       .get('/apps/example')
       .reply(200, { 'space': null })
-
-    nock('https://api.heroku.com')
-      .get('/apps/example/features')
-      .reply(200, [{ name: 'allow-multiple-sni-endpoints', enabled: true }])
 
     nock('https://api.heroku.com')
       .get('/apps/example/addons/ssl%3Aendpoint')
@@ -1274,6 +1273,7 @@ SSL certificate is self signed.
   })
 
   it('# errors out if there is an SSL addon and no flags set', function () {
+    mockSniFeatureFlag(nock, 'example')
     nock('https://api.heroku.com')
       .get('/apps/example')
       .reply(200, { 'space': null })
@@ -1290,6 +1290,7 @@ SSL certificate is self signed.
   })
 
   it('# errors out if type is not known', function () {
+    mockSniFeatureFlag(nock, 'example')
     return assertExit(1, certs.run({ app: 'example', args: ['pem_file', 'key_file'], flags: { bypass: true, type: 'foo' } })).then(function () {
       expect(unwrap(cli.stderr)).to.equal("Must pass --type with either 'endpoint' or 'sni'\n")
       expect(cli.stdout).to.equal('')

--- a/packages/certs-v5/test/commands/certs/generate.js
+++ b/packages/certs-v5/test/commands/certs/generate.js
@@ -14,6 +14,7 @@ let childProcess = require('child_process')
 
 let certs = require('../../../commands/certs/generate.js')
 let endpoint = require('../../stubs/sni-endpoints.js').endpoint
+const mockSniFeatureFlag = require('../../lib/mock_sni_feature')
 
 let EventEmitter = require('events').EventEmitter
 
@@ -26,6 +27,7 @@ function mockPrompt (arg, returns) {
 describe('heroku certs:generate', function () {
   beforeEach(function () {
     cli.mockConsole()
+    mockSniFeatureFlag(nock, 'example')
 
     nock('https://api.heroku.com')
       .get('/apps/example/sni-endpoints')
@@ -153,6 +155,8 @@ $ heroku certs:update CERTFILE example.org.key
 
   it('# suggests next step should be certs:update when domain is known in ssl', function () {
     nock.cleanAll()
+
+    mockSniFeatureFlag(nock, 'example')
 
     nock('https://api.heroku.com')
       .get('/apps/example/ssl-endpoints')

--- a/packages/certs-v5/test/commands/certs/index.js
+++ b/packages/certs-v5/test/commands/certs/index.js
@@ -11,11 +11,12 @@ let endpointStables = require('../../stubs/sni-endpoints.js').endpoint_stables
 let endpointWildcard = require('../../stubs/sni-endpoints.js').endpoint_wildcard
 let endpointWildcardBug = require('../../stubs/sni-endpoints.js').endpoint_wildcard_bug
 let endpointAcm = require('../../stubs/sni-endpoints.js').endpoint_acm
-
 let endpointSpace = require('../../stubs/ssl-endpoints.js').endpoint_space
+const mockSniFeatureFlag = require('../../lib/mock_sni_feature')
 
 describe('heroku certs', function () {
   beforeEach(function () {
+    mockSniFeatureFlag(nock, 'example')
     cli.mockConsole()
   })
 

--- a/packages/certs-v5/test/commands/certs/info.js
+++ b/packages/certs-v5/test/commands/certs/info.js
@@ -12,9 +12,11 @@ let endpoint = require('../../stubs/sni-endpoints.js').endpoint
 let endpointUntrusted = require('../../stubs/sni-endpoints.js').endpoint_untrusted
 let endpointTrusted = require('../../stubs/sni-endpoints.js').endpoint_trusted
 let certificateDetails = require('../../stubs/sni-endpoints.js').certificate_details
+const mockSniFeatureFlag = require('../../lib/mock_sni_feature')
 
 describe('heroku certs:info ported', function () {
   beforeEach(function () {
+    mockSniFeatureFlag(nock, 'example')
     cli.mockConsole()
   })
 

--- a/packages/certs-v5/test/commands/certs/remove.js
+++ b/packages/certs-v5/test/commands/certs/remove.js
@@ -10,12 +10,14 @@ let endpoint = require('../../stubs/sni-endpoints.js').endpoint
 let shared = require('./shared.js')
 let sharedSsl = require('./shared_ssl.js')
 let sharedSni = require('./shared_sni.js')
+const mockSniFeatureFlag = require('../../lib/mock_sni_feature')
 
 describe('heroku certs:remove', function () {
   beforeEach(function () {
     cli.mockConsole()
     error.exit.mock()
     nock.cleanAll()
+    mockSniFeatureFlag(nock, 'example')
   })
 
   it('# requires confirmation', function () {

--- a/packages/certs-v5/test/commands/certs/shared.js
+++ b/packages/certs-v5/test/commands/certs/shared.js
@@ -10,6 +10,7 @@ let endpoint2 = require('../../stubs/sni-endpoints.js').endpoint2
 let assertExit = require('../../assert_exit.js')
 let certificateDetails = require('../../stubs/sni-endpoints.js').certificate_details
 const unwrap = require('../../unwrap')
+const mockSniFeatureFlag = require('../../lib/mock_sni_feature')
 
 exports.shouldHandleArgs = function (command, txt, certs, callback, options) {
   let args = options.args || {}
@@ -22,6 +23,7 @@ exports.shouldHandleArgs = function (command, txt, certs, callback, options) {
       cli.mockConsole()
       error.exit.mock()
       nock.cleanAll()
+      mockSniFeatureFlag(nock, 'example')
     })
 
     it('# shows an error if an app has no endpoints', function () {

--- a/packages/certs-v5/test/commands/certs/shared_sni.js
+++ b/packages/certs-v5/test/commands/certs/shared_sni.js
@@ -11,6 +11,7 @@ let endpointCname = require('../../stubs/sni-endpoints.js').endpoint_cname
 let assertExit = require('../../assert_exit.js')
 let certificateDetails = require('../../stubs/sni-endpoints.js').certificate_details
 const unwrap = require('../../unwrap')
+const mockSniFeatureFlag = require('../../lib/mock_sni_feature')
 
 exports.shouldHandleArgs = function (command, txt, certs, callback, options) {
   let args = options.args || {}
@@ -23,6 +24,7 @@ exports.shouldHandleArgs = function (command, txt, certs, callback, options) {
       cli.mockConsole()
       error.exit.mock()
       nock.cleanAll()
+      mockSniFeatureFlag(nock, 'example')
     })
 
     it('allows an SNI --endpoint to be specified using --name', function () {

--- a/packages/certs-v5/test/commands/certs/shared_ssl.js
+++ b/packages/certs-v5/test/commands/certs/shared_ssl.js
@@ -10,6 +10,7 @@ let endpoint2 = require('../../stubs/sni-endpoints.js').endpoint2
 let assertExit = require('../../assert_exit.js')
 let certificateDetails = require('../../stubs/sni-endpoints.js').certificate_details
 const unwrap = require('../../unwrap')
+const mockSniFeatureFlag = require('../../lib/mock_sni_feature')
 
 exports.shouldHandleArgs = function (command, txt, certs, callback, options) {
   let args = options.args || {}
@@ -22,6 +23,7 @@ exports.shouldHandleArgs = function (command, txt, certs, callback, options) {
       cli.mockConsole()
       error.exit.mock()
       nock.cleanAll()
+      mockSniFeatureFlag(nock, 'example')
     })
 
     it('allows an SSL certificate to be specified using --name', function () {

--- a/packages/certs-v5/test/commands/certs/update.js
+++ b/packages/certs-v5/test/commands/certs/update.js
@@ -18,6 +18,7 @@ let endpointStable = require('../../stubs/sni-endpoints.js').endpoint_stable
 let endpointWarning = require('../../stubs/sni-endpoints.js').endpoint_warning
 let certificateDetails = require('../../stubs/sni-endpoints.js').certificate_details
 let unwrap = require('../../unwrap.js')
+const mockSniFeatureFlag = require('../../lib/mock_sni_feature')
 
 function mockFile (fs, file, content) {
   fs.readFile
@@ -39,6 +40,8 @@ describe('heroku certs:update', function () {
     nock('https://api.heroku.com')
       .get('/apps/example/sni-endpoints')
       .reply(200, [endpointStable])
+
+    mockSniFeatureFlag(nock, 'example')
   })
 
   afterEach(function () {
@@ -250,6 +253,7 @@ describe('heroku certs:update (dogwood)', function () {
     cli.mockConsole()
     sinon.stub(fs, 'readFile')
     nock.cleanAll()
+    mockSniFeatureFlag(nock, 'example')
   })
 
   afterEach(function () {

--- a/packages/certs-v5/test/lib/mock_sni_feature.js
+++ b/packages/certs-v5/test/lib/mock_sni_feature.js
@@ -1,0 +1,12 @@
+function mockSniFeatureFlag (nock, appName, enabled = false) {
+  return nock('https://api.heroku.com')
+    .get(`/apps/${appName}/features`)
+    .reply(200, [
+      {
+        name: 'allow-multiple-sni-endpoints',
+        enabled
+      }
+    ])
+}
+
+module.exports = mockSniFeatureFlag


### PR DESCRIPTION
closes https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B00000081661IAA/view

This PR updates the `certs` commands to correctly handle cases where a private space app has been migrated to use SNI endpoints instead of the legacy SSL endpoints.  This change is largely accomplished by checking for the `allow-multiple-sni-endpoints` flag, since any time that flag is true, the app will be using SNI endpoints and not SSL endpoint (even if it's a private space app).

This PR makes the following changes:

- Remove the `certsAndDomains` function from `endpoints.js` since it wasn't actually being used in a way that was functionally different from `all`
- Updates the `all` function from `endpoints.js` to only request sni endpoints when the multiple sni endpoints flag is enabled
- Adds a mock for the feature flag endpoint that, optionally, enables the multiple sni flag