### PR TITLE
chore(ci): Remove use of the `org-global` context in circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,6 @@ workflows:
             tags:
               <<: *version_tags
       - release: &release_workflow
-          context: org-global
           filters:
             tags: 
               <<: *version_tags
@@ -191,7 +190,6 @@ workflows:
       - release_deb: *release_workflow
       - release_win: *release_workflow
       - postrelease:
-          context: org-global
           requires:
             - release
             - release_deb

--- a/packages/apps-v5/.circleci/config.yml
+++ b/packages/apps-v5/.circleci/config.yml
@@ -52,7 +52,6 @@ workflows:
       - node-latest
       - node-8
       - release:
-          context: org-global
           filters:
             branches: {only: master}
           requires:

--- a/packages/auth/.circleci/config.yml
+++ b/packages/auth/.circleci/config.yml
@@ -57,7 +57,6 @@ workflows:
       - node-latest
       - node-8
       - release:
-          context: org-global
           filters:
             branches: {only: master}
           requires:

--- a/packages/certs/.circleci/config.yml
+++ b/packages/certs/.circleci/config.yml
@@ -57,7 +57,6 @@ workflows:
       - node-latest
       - node-8
       - release:
-          context: org-global
           filters:
             branches: {only: master}
           requires:

--- a/packages/ci/.circleci/config.yml
+++ b/packages/ci/.circleci/config.yml
@@ -57,7 +57,6 @@ workflows:
       - node-latest
       - node-8
       - release:
-          context: org-global
           filters:
             branches: {only: master}
           requires:

--- a/packages/config/.circleci/config.yml
+++ b/packages/config/.circleci/config.yml
@@ -57,7 +57,6 @@ workflows:
       - node-latest
       - node-8
       - release:
-          context: org-global
           filters:
             branches: {only: master}
           requires:

--- a/packages/git/.circleci/config.yml
+++ b/packages/git/.circleci/config.yml
@@ -57,7 +57,6 @@ workflows:
       - node-latest
       - node-8
       - release:
-          context: org-global
           filters:
             branches: {only: master}
           requires:

--- a/packages/oauth-v5/.circleci/config.yml
+++ b/packages/oauth-v5/.circleci/config.yml
@@ -48,7 +48,6 @@ workflows:
       - node-latest
       - node-8
       - release:
-          context: org-global
           filters:
             branches: {only: master}
           requires:

--- a/packages/ps/.circleci/config.yml
+++ b/packages/ps/.circleci/config.yml
@@ -53,7 +53,6 @@ workflows:
       - node-latest
       - node-8
       - release:
-          context: org-global
           filters:
             branches: {only: master}
           requires:

--- a/packages/run-v5/.circleci/config.yml
+++ b/packages/run-v5/.circleci/config.yml
@@ -52,7 +52,6 @@ workflows:
       - node-latest
       - node-8
       - release:
-          context: org-global
           filters:
             branches: {only: master}
           requires:


### PR DESCRIPTION
Global contexts are less safe. The CLI does not appear to use any environment
variables found in  the `org-global` context so let's not use that.


<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](http://conventionalcommits.org).
-->