### PR TITLE
chore(ci): Consolidate use of real heroku apps in test/

### DIFF
--- a/packages/run-v5/test/commands/console.js
+++ b/packages/run-v5/test/commands/console.js
@@ -16,7 +16,7 @@ describe('console', () => {
   })
 
   it('runs console', () => {
-    return cmd.run({ app: 'heroku-run-test-app', flags: {} })
+    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {} })
       .then(() => expect(dynoOpts.command, 'to equal', 'console'))
   })
 

--- a/packages/run-v5/test/commands/detached.js
+++ b/packages/run-v5/test/commands/detached.js
@@ -8,7 +8,7 @@ describe('run:detached', () => {
   beforeEach(() => cli.mockConsole())
 
   it('runs a command', () => {
-    return cmd.run({ app: 'heroku-run-test-app', flags: {}, auth: { password: global.apikey }, args: ['echo', '1', '2', '3'] })
-      .then(() => expect(cli.stdout, 'to begin with', 'Run heroku logs --app heroku-run-test-app --dyno'))
+    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey }, args: ['echo', '1', '2', '3'] })
+      .then(() => expect(cli.stdout, 'to begin with', 'Run heroku logs --app heroku-cli-ci-smoke-test-app --dyno'))
   })
 })

--- a/packages/run-v5/test/commands/logs.js
+++ b/packages/run-v5/test/commands/logs.js
@@ -8,7 +8,7 @@ describe('logs', () => {
   beforeEach(() => cli.mockConsole())
 
   it('shows the logs', () => {
-    return cmd.run({ app: 'heroku-run-test-app', flags: {}, auth: { password: global.apikey } })
+    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey } })
       .then(() => expect(cli.stdout, 'to begin with', '20')) // starts with the year
   })
 })

--- a/packages/run-v5/test/commands/rake.js
+++ b/packages/run-v5/test/commands/rake.js
@@ -16,7 +16,7 @@ describe('rake', () => {
   })
 
   it('runs rake', () => {
-    return cmd.run({ app: 'heroku-run-test-app', flags: {}, args: ['test'] })
+    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, args: ['test'] })
       .then(() => expect(dynoOpts.command, 'to equal', 'rake test'))
   })
 

--- a/packages/run-v5/test/commands/run.js
+++ b/packages/run-v5/test/commands/run.js
@@ -13,7 +13,7 @@ describe('run', () => {
     let stdout = ''
     let fixture = new StdOutFixture()
     fixture.capture(s => { stdout += s })
-    return cmd.run({ app: 'heroku-run-test-app', flags: {}, auth: { password: global.apikey }, args: ['echo', '1', '2', '3'] })
+    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey }, args: ['echo', '1', '2', '3'] })
       .then(() => fixture.release())
       .then(() => expect(stdout, 'to contain', '1 2 3\n'))
   })
@@ -22,7 +22,7 @@ describe('run', () => {
     let stdout = ''
     let fixture = new StdOutFixture()
     fixture.capture(s => { stdout += s })
-    return cmd.run({ app: 'heroku-run-test-app', flags: {}, auth: { password: global.apikey }, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo": "bar"} '] })
+    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey }, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo": "bar"} '] })
       .then(() => fixture.release())
       .then(() => expect(stdout, 'to equal', '{"foo": "bar"} \n'))
   })
@@ -31,7 +31,7 @@ describe('run', () => {
     let stdout = ''
     let fixture = new StdOutFixture()
     fixture.capture(s => { stdout += s })
-    return cmd.run({ app: 'heroku-run-test-app', flags: {}, auth: { password: global.apikey }, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo":"bar"}'] })
+    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey }, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo":"bar"}'] })
       .then(() => fixture.release())
       .then(() => expect(stdout, 'to equal', '{"foo":"bar"}\n'))
   })
@@ -40,7 +40,7 @@ describe('run', () => {
     let stdout = ''
     let fixture = new StdOutFixture()
     fixture.capture(s => { stdout += s })
-    return cmd.run({ app: 'heroku-run-test-app', flags: { env: 'FOO=bar' }, auth: { password: global.apikey }, args: ['env'] })
+    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: { env: 'FOO=bar' }, auth: { password: global.apikey }, args: ['env'] })
       .then(() => fixture.release())
       .then(() => expect(stdout, 'to contain', 'FOO=bar'))
   })
@@ -48,7 +48,7 @@ describe('run', () => {
   it('gets 127 status for invalid command', () => {
     cli.exit.mock()
     return assertExit(127, cmd.run({
-      app: 'heroku-run-test-app',
+      app: 'heroku-cli-ci-smoke-test-app',
       flags: { 'exit-code': true },
       auth: { password: global.apikey },
       args: ['invalid-command'] }))

--- a/packages/run/test/commands/console.test.ts
+++ b/packages/run/test/commands/console.test.ts
@@ -11,7 +11,7 @@ describe('console', () => {
     dynoOpts = this.opts
     return Promise.resolve()
   }))
-  .command(['console', '--app=heroku-run-test-app'])
+  .command(['console', '--app=heroku-cli-ci-smoke-test-app'])
   .it('runs console', () => {
     expect(dynoOpts.command).to.equal('console')
   })

--- a/packages/run/test/commands/logs.test.ts
+++ b/packages/run/test/commands/logs.test.ts
@@ -3,7 +3,7 @@ import {expect, test} from '@oclif/test'
 describe('logs', () => {
   test
   .stdout()
-  .command(['logs', '--app=heroku-run-test-app'])
+  .command(['logs', '--app=heroku-cli-ci-smoke-test-app'])
   .it('shows the logs', ctx => {
     // This is asserting that logs are returned by checking for the presence of the first two
     // digits of the year in the timetstamp

--- a/packages/run/test/commands/rake.test.ts
+++ b/packages/run/test/commands/rake.test.ts
@@ -11,7 +11,7 @@ describe('rake', () => {
     dynoOpts = this.opts
     return Promise.resolve()
   }))
-  .command(['rake', '--app=heroku-run-test-app', 'test'])
+  .command(['rake', '--app=heroku-cli-ci-smoke-test-app', 'test'])
   .it('runs rake', () => {
     expect(dynoOpts.command).to.equal('rake test')
   })

--- a/packages/run/test/commands/run.test.ts
+++ b/packages/run/test/commands/run.test.ts
@@ -12,31 +12,31 @@ describe('run', () => {
   }
 
   testFactory()
-  .command(['run', '--app=heroku-run-test-app', 'echo 1 2 3'])
+  .command(['run', '--app=heroku-cli-ci-smoke-test-app', 'echo 1 2 3'])
   .it('runs a command', async ctx => {
     expect(ctx.stdout).to.include('1 2 3\n')
   })
 
   testFactory()
-  .command(['run', '--app=heroku-run-test-app', 'ruby -e "puts ARGV[0]" "{"foo": "bar"} " '])
+  .command(['run', '--app=heroku-cli-ci-smoke-test-app', 'ruby -e "puts ARGV[0]" "{"foo": "bar"} " '])
   .it('runs a command with spaces', ctx => {
     expect(ctx.stdout).to.contain('{foo: bar} \n')
   })
 
   testFactory()
-  .command(['run', '--app=heroku-run-test-app', 'ruby -e "puts ARGV[0]" "{"foo":"bar"}"'])
+  .command(['run', '--app=heroku-cli-ci-smoke-test-app', 'ruby -e "puts ARGV[0]" "{"foo":"bar"}"'])
   .it('runs a command with quotes', ctx => {
     expect(ctx.stdout).to.contain('{foo:bar}\n')
   })
 
   testFactory()
-  .command(['run', '--app=heroku-run-test-app', '-e FOO=bar', 'env'])
+  .command(['run', '--app=heroku-cli-ci-smoke-test-app', '-e FOO=bar', 'env'])
   .it('runs a command with env vars', ctx => {
     expect(ctx.stdout).to.include('FOO=bar')
   })
 
   testFactory()
-  .command(['run', '--app=heroku-run-test-app', '--exit-code', 'invalid-command'])
+  .command(['run', '--app=heroku-cli-ci-smoke-test-app', '--exit-code', 'invalid-command'])
   .exit(127)
   .it('gets 127 status for invalid command', ctx => {
     expect(ctx.stdout).to.include('invalid-command: command not found')

--- a/packages/run/test/commands/run/detached.test.ts
+++ b/packages/run/test/commands/run/detached.test.ts
@@ -3,8 +3,8 @@ import {expect, test} from '@oclif/test'
 describe('run:detached', () => {
   test
   .stdout()
-  .command(['run:detached', '--app=heroku-run-test-app', 'echo 1 2 3'])
+  .command(['run:detached', '--app=heroku-cli-ci-smoke-test-app', 'echo 1 2 3'])
   .it('runs a command', ctx => {
-    expect(ctx.stdout).to.include('Run heroku logs --app heroku-run-test-app --dyno')
+    expect(ctx.stdout).to.include('Run heroku logs --app heroku-cli-ci-smoke-test-app --dyno')
   })
 })


### PR DESCRIPTION
Stop using `heroku-run-test-app` and use `heroku-cli-ci-smoke-test-app` instead.

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](http://conventionalcommits.org).
-->