### PR TITLE
chore(buildpacks): use `Number.isNan` instead of `isNan`

### DIFF
--- a/packages/buildpacks/src/buildpacks.ts
+++ b/packages/buildpacks/src/buildpacks.ts
@@ -182,7 +182,7 @@ export class BuildpackCommand {
   }
 
   validateIndex(index: number) {
-    if (isNaN(index) || index <= 0) {
+    if (Number.isNaN(index) || index <= 0) {
       cli.error('Invalid index. Must be greater than 0.', {exit: 1})
     }
   }


### PR DESCRIPTION
Assuming `index` is a number, then this should be a safe replacement.

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](http://conventionalcommits.org).
-->
