### PR TITLE
chore: remove unnecessary escape characters

### DIFF
--- a/packages/autocomplete/test/commands/autocomplete/index.test.ts
+++ b/packages/autocomplete/test/commands/autocomplete/index.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-useless-escape */
 import Nock from '@fancy-test/nock'
 import * as Test from '@oclif/test'
 
@@ -38,7 +37,7 @@ runtest('autocomplete:index', () => {
 Setup Instructions for HEROKU CLI Autocomplete ---
 
 1) Add the autocomplete env var to your bash profile and source it
-$ printf \"$(heroku autocomplete:script bash)\" >> ~/.bashrc; source ~/.bashrc
+$ printf "$(heroku autocomplete:script bash)" >> ~/.bashrc; source ~/.bashrc
 
 NOTE: If your terminal starts as a login shell you may need to print the init script into ~/.bash_profile or ~/.profile.
 
@@ -83,7 +82,7 @@ Enjoy!
 Setup Instructions for HEROKU CLI Autocomplete ---
 
 1) Add the autocomplete env var to your zsh profile and source it
-$ printf \"$(heroku autocomplete:script zsh)\" >> ~/.zshrc; source ~/.zshrc
+$ printf "$(heroku autocomplete:script zsh)" >> ~/.zshrc; source ~/.zshrc
 
 NOTE: After sourcing, you can run \`$ compaudit -D\` to ensure no permissions conflicts are present
 

--- a/packages/buildpacks/src/buildpacks.ts
+++ b/packages/buildpacks/src/buildpacks.ts
@@ -138,15 +138,13 @@ export class BuildpackCommand {
   }
 
   registryUrlToName(buildpack: string, registryOnly = false): string {
-    // eslint-disable-next-line no-useless-escape
-    let match = /^https:\/\/buildpack\-registry\.s3\.amazonaws\.com\/buildpacks\/([\w\-]+\/[\w\-]+).tgz$/.exec(buildpack)
+    let match = /^https:\/\/buildpack-registry\.s3\.amazonaws\.com\/buildpacks\/([\w-]+\/[\w-]+).tgz$/.exec(buildpack)
     if (match) {
       return match[1]
     }
 
     if (!registryOnly) {
-      // eslint-disable-next-line no-useless-escape
-      match = /^https:\/\/codon\-buildpacks\.s3\.amazonaws\.com\/buildpacks\/heroku\/([\w\-]+).tgz$/.exec(buildpack)
+      match = /^https:\/\/codon-buildpacks\.s3\.amazonaws\.com\/buildpacks\/heroku\/([\w-]+).tgz$/.exec(buildpack)
       if (match) {
         return `heroku/${match[1]}`
       }


### PR DESCRIPTION
I haven't run the tests, but if they fail after this patch, something is wrong in them, because these were indeed unneeded 🙂

* original regex: <https://regex101.com/r/KPU4by/1>
* this patch: <https://regex101.com/r/KPU4by/2>
