### PR TITLE
chore(redis-v5): use `String.endsWith` instead of a regex

### DIFF
--- a/packages/redis-v5/commands/promote.js
+++ b/packages/redis-v5/commands/promote.js
@@ -25,7 +25,7 @@ module.exports = {
     // private Redis plans which may have bastion config vars.
     // (the right way to do this is check attachments for the
     // current REDIS_URL but that's a bigger refactor).
-    if (redis.length === 1 && redis[0].config_vars.filter(c => /_URL$/.test(c)).length === 1) {
+    if (redis.length === 1 && redis[0].config_vars.filter(c => c.endsWith('_URL'))) {
       let attachment = redis[0]
       await heroku.post('/addon-attachments', { body: {
         app: { name: context.app },


### PR DESCRIPTION
run forked PR with env vars
Supersedes #1500 