### PR TITLE
chore(buildpacks): use `Number.isNan` instead of `isNan`

### DIFF
--- a/packages/buildpacks/src/buildpacks.ts
+++ b/packages/buildpacks/src/buildpacks.ts
@@ -182,7 +182,7 @@ export class BuildpackCommand {
   }
 
   validateIndex(index: number) {
-    if (isNaN(index) || index <= 0) {
+    if (Number.isNaN(index) || index <= 0) {
       cli.error('Invalid index. Must be greater than 0.', {exit: 1})
     }
   }


### PR DESCRIPTION
run forked PR with env vars
Supersedes #1502 