### PR TITLE
fix(addons-v5): Use os.tmpdir() rather than /tmp for cross-platform support - fixes #1506

### DIFF
--- a/packages/addons-v5/commands/addons/open.js
+++ b/packages/addons-v5/commands/addons/open.js
@@ -3,13 +3,14 @@
 let cli = require('heroku-cli-util')
 let co = require('co')
 let fs = require('fs')
+let os = require('os')
 
 function open (url) {
   cli.log(`Opening ${cli.color.cyan(url)}...`)
   return cli.open(url)
 }
 
-const ssoPath = '/tmp/heroku-sso.html'
+const ssoPath = os.tmpdir() + '/heroku-sso.html'
 
 function writeSudoTemplate (ctx, sso, path) {
   return new Promise(function (resolve, reject) {

--- a/packages/addons-v5/commands/addons/open.js
+++ b/packages/addons-v5/commands/addons/open.js
@@ -4,13 +4,14 @@ let cli = require('heroku-cli-util')
 let co = require('co')
 let fs = require('fs')
 let os = require('os')
+let path = require('path')
 
 function open (url) {
   cli.log(`Opening ${cli.color.cyan(url)}...`)
   return cli.open(url)
 }
 
-const ssoPath = os.tmpdir() + '/heroku-sso.html'
+const ssoPath = path.join(os.tmpdir(), 'heroku-sso.html')
 
 function writeSudoTemplate (ctx, sso, path) {
   return new Promise(function (resolve, reject) {


### PR DESCRIPTION
Using `addons:open` with sudo on windows shows `ENOENT: no such file or directory, open 'C:\tmp\heroku-sso.html'`. `/tmp` is not available by default in windows. This change uses [os.tmpdir()](https://nodejs.org/api/os.html#os_os_tmpdir) rather than `/tmp`.