### PR TITLE
feat(redis-v5): use default port for Redis 6

### DIFF
--- a/packages/redis-v5/commands/cli.js
+++ b/packages/redis-v5/commands/cli.js
@@ -128,13 +128,13 @@ function maybeTunnel (redis, config) {
   let bastions = match(config, /_BASTIONS/)
   let hobby = redis.plan.indexOf('hobby') === 0
   let uri = url.parse(redis.resource_url)
-  let version = redis.version
+  let prefer_native_tls = redis.prefer_native_tls
 
   if (bastions != null) {
     return bastionConnect({ uri, bastions, config })
   } else {
     let client
-    if (version >= '6.0') {
+    if (prefer_native_tls) {
       client = tls.connect({
         port: parseInt(uri.port, 10),
         host: uri.hostname,

--- a/packages/redis-v5/commands/cli.js
+++ b/packages/redis-v5/commands/cli.js
@@ -128,13 +128,24 @@ function maybeTunnel (redis, config) {
   let bastions = match(config, /_BASTIONS/)
   let hobby = redis.plan.indexOf('hobby') === 0
   let uri = url.parse(redis.resource_url)
+  let version = redis.version
 
   if (bastions != null) {
     return bastionConnect({ uri, bastions, config })
   } else {
     let client
-    if (!hobby) {
-      client = tls.connect({ port: parseInt(uri.port, 10) + 1, host: uri.hostname, rejectUnauthorized: false })
+    if (version >= '6.0') {
+      client = tls.connect({
+        port: parseInt(uri.port, 10),
+        host: uri.hostname,
+        rejectUnauthorized: false
+      })
+    } else if (!hobby) {
+      client = tls.connect({
+        port: parseInt(uri.port, 10) + 1,
+        host: uri.hostname,
+        rejectUnauthorized: false
+      })
     } else {
       client = net.connect({ port: uri.port, host: uri.hostname })
     }


### PR DESCRIPTION
Redis 6 has support for native TLS connections. This PR updates the client connection to use the default port when the addon is using Redis 6 (or greater). 