### PR TITLE
chore(ci): Update sed match for homebrew Formula

### DIFF
--- a/scripts/release/homebrew
+++ b/scripts/release/homebrew
@@ -53,7 +53,7 @@ TARBALL_PATH=$DIST_DIR/heroku-v${SHORT_VERSION}/$TARBALL_BASE
 SHA256XZ=$(shasum -a 256 "$TARBALL_PATH" | awk \{'print $1'\})
 
 cd tmp/homebrew-brew
-sed -i "s/heroku-v.*\\/heroku-v.*\\.tar\\.xz/heroku-v${SHORT_VERSION}\\/${TARBALL_BASE}/" Formula/heroku.rb
+sed -i "s/^\(\s*version: \"\).*\(\".*\)$/\1${SHORT_VERSION}\2/" Formula/heroku.rb
 sed -i "s/sha256 \".*\"/sha256 \"${SHA256XZ}\"/" Formula/heroku.rb
 git add Formula/heroku.rb
 git diff --cached


### PR DESCRIPTION
Depends on heroku/homebrew-brew#20 to add support for linuxbrew.

Pulls out the version variable so it can be replaced in one place that has a simpler regex match.
