### PR TITLE
feat: add spaces:hosts command

### DIFF
--- a/packages/spaces/commands/hosts/index.js
+++ b/packages/spaces/commands/hosts/index.js
@@ -1,0 +1,32 @@
+'use strict'
+
+let cli = require('heroku-cli-util')
+let co = require('co')
+
+function displayJSON (hosts) {
+  cli.log(JSON.stringify(hosts, null, 2))
+}
+
+function * run (context, heroku) {
+  let lib = require('../../lib/hosts')(heroku)
+  let space = context.flags.space || context.args.space
+  if (!space) throw new Error('Space name required.\nUSAGE: heroku spaces:hosts --space my-space')
+  let hosts = yield lib.getHosts(space)
+  if (context.flags.json) displayJSON(hosts)
+  else lib.displayHosts(space, hosts)
+}
+
+module.exports = {
+  topic: 'spaces',
+  command: 'hosts',
+  hidden: true,
+  description: 'list dedicated hosts for a space',
+  needsApp: false,
+  needsAuth: true,
+  args: [{ name: 'space', optional: true, hidden: true }],
+  flags: [
+    { name: 'space', char: 's', hasValue: true, description: 'space to get host list from' },
+    { name: 'json', description: 'output in json format' }
+  ],
+  run: cli.command(co.wrap(run))
+}

--- a/packages/spaces/index.js
+++ b/packages/spaces/index.js
@@ -32,5 +32,6 @@ exports.commands = [
   require('./commands/trusted-ips/remove'),
   require('./commands/outbound-rules'),
   require('./commands/outbound-rules/add'),
-  require('./commands/outbound-rules/remove')
+  require('./commands/outbound-rules/remove'),
+  require('./commands/hosts')
 ]

--- a/packages/spaces/lib/format.js
+++ b/packages/spaces/lib/format.js
@@ -14,46 +14,38 @@ module.exports = function () {
   }
 
   function VPNStatus (s) {
-    let colored = s
     switch (s) {
       case 'UP':
       case 'available':
-        colored = `${cli.color.green(colored)}`
-        break
+        return `${cli.color.green(s)}`
       case 'pending':
       case 'provisioning':
       case 'deprovisioning':
-        colored = `${cli.color.yellow(colored)}`
-        break
+        return `${cli.color.yellow(s)}`
       case 'DOWN':
       case 'deleting':
       case 'deleted':
-        colored = `${cli.color.red(colored)}`
-        break
+        return `${cli.color.red(s)}`
+      default:
+        return s
     }
-
-    return colored
   }
 
   function PeeringStatus (s) {
-    var colored = s
     switch (s) {
       case 'active':
-        colored = `${cli.color.green(colored)}`
-        break
+        return `${cli.color.green(s)}`
       case 'pending-acceptance':
       case 'provisioning':
-        colored = `${cli.color.yellow(colored)}`
-        break
+        return `${cli.color.yellow(s)}`
       case 'expired':
       case 'failed':
       case 'deleted':
       case 'rejected':
-        colored = `${cli.color.red(colored)}`
-        break
+        return `${cli.color.red(s)}`
+      default:
+        return s
     }
-
-    return colored
   }
 
   return {

--- a/packages/spaces/lib/format.js
+++ b/packages/spaces/lib/format.js
@@ -48,10 +48,42 @@ module.exports = function () {
     }
   }
 
+  function HostStatus (s) {
+    switch (s) {
+      case 'available':
+        return `${cli.color.green(s)}`
+      case 'under-assessment':
+        return `${cli.color.yellow(s)}`
+      case 'permanent-failure':
+      case 'released-permanent-failure':
+        return `${cli.color.red(s)}`
+      case 'released':
+        return `${cli.color.gray(s)}`
+      default:
+        return s
+    }
+  }
+
+  function Percent (v) {
+    const fmt = () => `${v}%`
+
+    switch (typeof v) {
+      case 'number':
+      case 'bigint':
+        return fmt()
+      case 'string':
+        return v.length > 0 ? fmt() : v
+      default:
+        return v
+    }
+  }
+
   return {
     CIDR,
     CIDRBlocksOrCIDRBlock,
     PeeringStatus,
-    VPNStatus
+    VPNStatus,
+    HostStatus,
+    Percent
   }
 }

--- a/packages/spaces/lib/hosts.js
+++ b/packages/spaces/lib/hosts.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const cli = require('heroku-cli-util')
+const format = require('./format')()
+
+module.exports = function (heroku) {
+  function getHosts (space) {
+    return request('GET', `/spaces/${space}/hosts`)
+  }
+
+  function displayHosts (space, hosts) {
+    cli.styledHeader(`${space} Hosts`)
+    cli.table(hosts, {
+      columns: [
+        { key: 'host_id', label: 'Host ID' },
+        { key: 'state', label: 'State', format: format.HostStatus },
+        { key: 'available_capacity_percentage', label: 'Available Capacity', format: format.Percent },
+        { key: 'allocated_at', label: 'Allocated At' },
+        { key: 'released_at', label: 'Released At' }
+      ]
+    })
+  }
+
+  function request (method, path, body) {
+    return heroku.request({
+      method: method,
+      path: path,
+      body: body,
+      headers: { Accept: 'application/vnd.heroku+json; version=3.dogwood' }
+    })
+  }
+
+  return {
+    getHosts,
+    displayHosts
+  }
+}

--- a/packages/spaces/test/commands/hosts/index.js
+++ b/packages/spaces/test/commands/hosts/index.js
@@ -1,0 +1,54 @@
+'use strict'
+/* globals describe beforeEach it */
+
+let nock = require('nock')
+let cmd = require('../../../commands/hosts/index')
+let expect = require('chai').expect
+let cli = require('heroku-cli-util')
+let hosts = [
+  {
+    'host_id': 'h-0f927460a59aac18e',
+    'state': 'available',
+    'available_capacity_percentage': 72,
+    'allocated_at': '2020-05-28T04:15:59Z',
+    'released_at': null
+  },
+  {
+    'host_id': 'h-0e927460a59aac18f',
+    'state': 'released',
+    'available_capacity_percentage': 0,
+    'allocated_at': '2020-03-28T04:15:59Z',
+    'released_at': '2020-04-28T04:15:59Z'
+  }
+]
+
+describe('spaces:hosts', function () {
+  beforeEach(() => cli.mockConsole())
+
+  it('lists space hosts', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/hosts')
+      .reply(200,
+        hosts
+      )
+    return cmd.run({ flags: { space: 'my-space' } })
+      .then(() => expect(cli.stdout).to.equal(
+        `=== my-space Hosts
+Host ID              State      Available Capacity  Allocated At          Released At
+───────────────────  ─────────  ──────────────────  ────────────────────  ────────────────────
+h-0f927460a59aac18e  available  72%                 2020-05-28T04:15:59Z
+h-0e927460a59aac18f  released   0%                  2020-03-28T04:15:59Z  2020-04-28T04:15:59Z
+`))
+      .then(() => api.done())
+  })
+
+  it('shows hosts:info --json', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/hosts')
+      .reply(200, hosts)
+
+    return cmd.run({ flags: { space: 'my-space', json: true } })
+      .then(() => expect(JSON.parse(cli.stdout)).to.eql(hosts))
+      .then(() => api.done())
+  })
+})

--- a/packages/spaces/test/lib/format.js
+++ b/packages/spaces/test/lib/format.js
@@ -27,3 +27,29 @@ describe('CIDRBlocksOrCIDRBlock', function () {
     return expect(format.CIDRBlocksOrCIDRBlock([], peer)).to.eq('a')
   })
 })
+
+describe('Percent', function () {
+  it('formats a truthy number', function () {
+    return expect(format.Percent(100)).to.eq('100%')
+  })
+
+  it('formats a falsey number', function () {
+    return expect(format.Percent(0)).to.eq('0%')
+  })
+
+  it('formats a non-empty string', function () {
+    return expect(format.Percent('100')).to.eq('100%')
+  })
+
+  it('does not format a empty string', function () {
+    return expect(format.Percent('')).to.eq('')
+  })
+
+  it('does not format null', function () {
+    return expect(format.Percent(null)).to.eq(null)
+  })
+
+  it('does not format undefined', function () {
+    return expect(format.Percent(undefined)).to.eq(undefined)
+  })
+})


### PR DESCRIPTION
This adds a new `heroku spaces:hosts` command to list dedicated hosts of a space. It uses a new endpoint that was deployed to API in https://github.com/heroku/api/pull/11648.  

It is currently hidden because it is under development and is only available for one customer. If another customer happens to find it, it's ok, but just something we want to advertise. 

https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07B00000088oJUIAY