### PR TITLE
chore: split test & release CI workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,6 +201,9 @@ workflows:
     jobs:
       - node12-test: &node12_test
           filters:
+            branches:
+              only:
+                - master
             tags: &version_tags
               only: /^v.*/
       - node10-test: *node12_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,14 +189,21 @@ jobs:
       - run: ./scripts/release/snap
 workflows:
   version: 2.1
-  heroku_cli:
+  heroku_cli_tests:
     jobs:
-      - windows-test: &windows_test
+      - node12-test: &node12_test
           filters:
             tags: &version_tags
               only: /^v.*/
-      - node12-test: *windows_test
-      - node10-test: *windows_test
+      - node10-test: *node12_test
+      - windows-test: *node12_test
+  heroku_cli_releases:
+    jobs:
+      - node12-test: &node12_test
+          filters:
+            tags: &version_tags
+              only: /^v.*/
+      - node10-test: *node12_test
       - release_tarballs: &release_tarballs
           requires:
             - node12-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,13 +191,13 @@ workflows:
   version: 2.1
   heroku_cli_tests:
     jobs:
-      - node12-test: &node12_test
+      - windows-test: &windows_test
           filters:
             tags: &version_tags
               only: /^v.*/
-      - node10-test: *node12_test
-      - windows-test: *node12_test
-  heroku_cli_releases:
+      - node12-test: *windows_test
+      - node10-test: *windows_test
+  heroku_cli_release:
     jobs:
       - node12-test: &node12_test
           filters:


### PR DESCRIPTION
This prevents compliance failing when a release job fails. 