### PR TITLE
run tests using `concurrently` / fix process SIGINT leaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,9 @@ jobs:
           key: node-modules-v1-win-{{ checksum "yarn.lock" }}
       - run:
           name: Test and Lint
-          command: yarn test
+          # using node directly here instead of yarn;
+          # yarn seems to not exit on windows after tests are done running
+          command: node scripts/test-all.js
   node12-test: &test
     <<: *defaults
     resource_class: xlarge
@@ -212,7 +214,7 @@ workflows:
             - node12-test
             - node10-test
           filters: &master_dev_and_version_tags
-            tags: 
+            tags:
               <<: *version_tags
             branches:
               only:

--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
   "devDependencies": {
+    "concurrently": "^5.2.0",
     "eslint": "5.13.0",
     "eslint-config-standard": "12.0.0",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
+    "glob": "^7.1.6",
     "promise-request-retry": "^1.0.2",
     "standard": "12.0.1"
   },
@@ -21,7 +23,7 @@
   },
   "private": true,
   "scripts": {
-    "test": "lerna run test --concurrency 4",
+    "test": "node scripts/test-all",
     "version": "cp packages/cli/CHANGELOG.md CHANGELOG.md && git add CHANGELOG.md"
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "eslint-plugin-standard": "^4.0.0",
     "glob": "^7.1.6",
     "promise-request-retry": "^1.0.2",
-    "standard": "12.0.1"
+    "standard": "12.0.1",
+    "why-is-node-running": "^2.2.0"
   },
   "standard": {
     "env": "mocha",

--- a/packages/apps/test/helpers/init.js
+++ b/packages/apps/test/helpers/init.js
@@ -1,7 +1,5 @@
 const chalk = require('chalk')
 chalk.enabled = false
-const {color} = require('@heroku-cli/color')
-color.enabled = false
 
 process.stdout.columns = 80
 process.stderr.columns = 80

--- a/packages/apps/test/helpers/init.js
+++ b/packages/apps/test/helpers/init.js
@@ -1,5 +1,7 @@
 const chalk = require('chalk')
 chalk.enabled = false
+const {color} = require('@heroku-cli/color')
+color.enabled = false
 
 process.stdout.columns = 80
 process.stderr.columns = 80

--- a/scripts/test-all.js
+++ b/scripts/test-all.js
@@ -17,10 +17,15 @@ const commands = packages.map(packagePath => {
 });
 
 async function run() {
-  await concurrently(commands, {
-    maxProcesses: process.env.CI ? os.cpus() : 4,
-    killOthers: ['failure']
-  })
+  try {
+    await concurrently(commands, {
+      maxProcesses: process.env.CI ? os.cpus() : 4,
+      killOthers: ['failure']
+    })
+  } catch (err) {
+    console.log('Error running tests: ', err);
+    process.exit(1);
+  }
 }
 
 run()

--- a/scripts/test-all.js
+++ b/scripts/test-all.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+const glob = require('glob')
+const concurrently = require('concurrently')
+const path = require('path')
+const os = require('os')
+
+const root = path.join(__dirname, '..')
+const packages = glob.sync(`${root}/packages/*`)
+
+const commands = packages.map(packagePath => {
+  const packageName = path.relative(root, path.basename(packagePath));
+  return {
+    name: `packages/${packageName}`,
+    command: `yarn --cwd="${path.normalize(packagePath)}" test`
+  }
+});
+
+async function run() {
+  await concurrently(commands, {
+    maxProcesses: process.env.CI ? os.cpus() : 4,
+    killOthers: ['failure']
+  })
+}
+
+run()
+

--- a/scripts/test-all.js
+++ b/scripts/test-all.js
@@ -26,18 +26,19 @@ async function run() {
     process.stdout.write('\n');
     process.exit(1)
   }
+  let exitCode = 0;
   try {
     process.once('SIGINT', SIGINT_HANDLER);
     await concurrently(commands, {
       maxProcesses: process.env.CI ? os.cpus() : 4,
       killOthers: ['failure']
     })
-    process.exit();
   } catch (err) {
     console.log('Error running tests: ', err);
-    process.exit(1);
+    exitCode = 1;
   } finally {
     process.removeListener('SIGINT', SIGINT_HANDLER);
+    process.exit(exitCode);
   }
 }
 

--- a/scripts/test-all.js
+++ b/scripts/test-all.js
@@ -18,6 +18,10 @@ const commands = packages.map(packagePath => {
 
 async function run() {
   try {
+    process.once('SIGINT', () => {
+      console.log('Received ctrl+c. Stopping scripts/test-all.js');
+      process.exit(1)
+    })
     await concurrently(commands, {
       maxProcesses: process.env.CI ? os.cpus() : 4,
       killOthers: ['failure']

--- a/scripts/test-all.js
+++ b/scripts/test-all.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+const whyIsNodeRunning = require('why-is-node-running')
 const glob = require('glob')
 const concurrently = require('concurrently')
 const path = require('path')
@@ -33,12 +33,18 @@ async function run() {
       maxProcesses: process.env.CI ? os.cpus() : 4,
       killOthers: ['failure']
     })
+    console.log('scripts/test-all: done running concurrently')
+    whyIsNodeRunning()
   } catch (err) {
+    console.log('scripts/test-all: catch')
     console.log('Error running tests: ', err);
     exitCode = 1;
+    whyIsNodeRunning()
   } finally {
+    console.log('scripts/test-all: finally')
     process.removeListener('SIGINT', SIGINT_HANDLER);
     process.exit(exitCode);
+    whyIsNodeRunning()
   }
 }
 

--- a/scripts/test-all.js
+++ b/scripts/test-all.js
@@ -17,18 +17,23 @@ const commands = packages.map(packagePath => {
 });
 
 async function run() {
+  const SIGINT_HANDLER = () => {
+    console.log('Received ctrl+c. Stopping scripts/test-all.js');
+    process.stdout.write('\n');
+    process.exit(1)
+  }
   try {
-    process.once('SIGINT', () => {
-      console.log('Received ctrl+c. Stopping scripts/test-all.js');
-      process.exit(1)
-    })
+    process.once('SIGINT', SIGINT_HANDLER);
     await concurrently(commands, {
       maxProcesses: process.env.CI ? os.cpus() : 4,
-      killOthers: ['failure']
+      killOthers: ['failure'],
+      raw: true
     })
   } catch (err) {
     console.log('Error running tests: ', err);
     process.exit(1);
+  } finally {
+    process.removeEventListener('SIGINT', SIGINT_HANDLER);
   }
 }
 

--- a/scripts/test-all.js
+++ b/scripts/test-all.js
@@ -32,6 +32,7 @@ async function run() {
       maxProcesses: process.env.CI ? os.cpus() : 4,
       killOthers: ['failure']
     })
+    process.exit();
   } catch (err) {
     console.log('Error running tests: ', err);
     process.exit(1);

--- a/scripts/test-all.js
+++ b/scripts/test-all.js
@@ -12,7 +12,11 @@ const commands = packages.map(packagePath => {
   const packageName = path.relative(root, path.basename(packagePath));
   return {
     name: `packages/${packageName}`,
-    command: `yarn --cwd="${path.normalize(packagePath)}" test`
+    command: `yarn --cwd="${path.normalize(packagePath)}" test`,
+    env: {
+      FORCE_COLOR: '0'
+    },
+    prefixColor: 'white'
   }
 });
 
@@ -26,14 +30,13 @@ async function run() {
     process.once('SIGINT', SIGINT_HANDLER);
     await concurrently(commands, {
       maxProcesses: process.env.CI ? os.cpus() : 4,
-      killOthers: ['failure'],
-      raw: true
+      killOthers: ['failure']
     })
   } catch (err) {
     console.log('Error running tests: ', err);
     process.exit(1);
   } finally {
-    process.removeEventListener('SIGINT', SIGINT_HANDLER);
+    process.removeListener('SIGINT', SIGINT_HANDLER);
   }
 }
 

--- a/scripts/test-all.js
+++ b/scripts/test-all.js
@@ -20,11 +20,20 @@ const commands = packages.map(packagePath => {
   }
 });
 
+function exit(exitCode) {
+  process.nextTick(() => {
+    whyIsNodeRunning()
+    process.nextTick(() => {
+      process.exit(exitCode)
+    })
+  })
+}
+
 async function run() {
   const SIGINT_HANDLER = () => {
     console.log('Received ctrl+c. Stopping scripts/test-all.js');
     process.stdout.write('\n');
-    process.exit(1)
+    exit(1);
   }
   let exitCode = 0;
   try {
@@ -43,8 +52,8 @@ async function run() {
   } finally {
     console.log('scripts/test-all: finally')
     process.removeListener('SIGINT', SIGINT_HANDLER);
-    process.exit(exitCode);
     whyIsNodeRunning()
+    exit(exitCode)
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8722,6 +8722,11 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -9089,6 +9094,11 @@ stack-trace@0.0.x:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
   integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
+
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha1-Gsig2Ug4SNFpXkGLbQMaPDzmjjs=
 
 standard-engine@~9.0.0:
   version "9.0.0"
@@ -10103,6 +10113,14 @@ which@1, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
+
+why-is-node-running@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.2.0.tgz#fd0a73ea9303920fbb45457c6ecc392ebec90bd2"
+  integrity sha512-rxtN9D0lJaYyP92BR5yoyWecK2txBKmBIuS7GRbOPP5bXsT37/hBqcmTrlrt25DBr9p4WJb6c9LuYSJd89vHRQ==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 wide-align@^1.1.0:
   version "1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2993,6 +2993,21 @@ concat-stream@^2.0.0:
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
+concurrently@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-5.2.0.tgz#ead55121d08a0fc817085584c123cedec2e08975"
+  integrity sha512-XxcDbQ4/43d6CxR7+iV8IZXhur4KbmEJk1CetVMUqCy34z9l0DkszbY+/9wvmSnToTej0SYomc2WSRH+L0zVJw==
+  dependencies:
+    chalk "^2.4.2"
+    date-fns "^2.0.1"
+    lodash "^4.17.15"
+    read-pkg "^4.0.1"
+    rxjs "^6.5.2"
+    spawn-command "^0.0.2-1"
+    supports-color "^6.1.0"
+    tree-kill "^1.2.2"
+    yargs "^13.3.0"
+
 config-chain@^1.1.11:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa"
@@ -3226,6 +3241,11 @@ date-fns@^2.0.0-alpha.8:
   version "2.0.0-alpha.26"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.0.0-alpha.26.tgz#e46afd73a2b50e0359446309ee7cb631d7467227"
   integrity sha512-UAptCZ53MVimUFR8MXTyHED51AVGIqFlBfWgiS/KIoSYiJGrWScx4PYQVNSWfK2Js+43OlokCW1ttnexBTJ5Bg==
+
+date-fns@^2.0.1:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.14.0.tgz#359a87a265bb34ef2e38f93ecf63ac453f9bc7ba"
+  integrity sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw==
 
 date-time@^0.1.1:
   version "0.1.1"
@@ -5214,15 +5234,16 @@ http-cache-semantics@^4.0.0:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz#6c2ef57e22090b177828708a52eaeae9d1d63e1b"
   integrity sha512-OO/9K7uFN30qwAKvslzmCTbimZ/uRjtdN5S50vvWLwUKqFuZj0n96XyCzF5tHRHEO/Q4JYC01hv41gkX06gmHA==
 
-http-call@5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/http-call/-/http-call-5.2.3.tgz#4b59df8c313c92056e2004e666330b46f7d0532b"
-  integrity sha512-IkwGruHVHATmnonLKMGX5tkpM0KSn/C240o8/OfBsESRaJacykSia+akhD0d3fljQ5rQPXtBvSrVShAsj+EOUQ==
+http-call@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/http-call/-/http-call-5.3.0.tgz#4ded815b13f423de176eb0942d69c43b25b148db"
+  integrity sha512-ahwimsC23ICE4kPl9xTBjKB4inbRaeLyZeRunC/1Jy/Z6X8tv22MEAjK+KBOMSVLaqXPTTmd8638waVIKLGx2w==
   dependencies:
     content-type "^1.0.4"
-    debug "^3.1.0"
+    debug "^4.1.1"
     is-retry-allowed "^1.1.0"
-    is-stream "^1.1.0"
+    is-stream "^2.0.0"
+    parse-json "^4.0.0"
     tunnel-agent "^0.6.0"
 
 http-call@^5.1.2, http-call@^5.2.3:
@@ -8570,6 +8591,13 @@ rxjs@^6.4.0:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^6.5.2:
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
+  integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
@@ -8928,6 +8956,11 @@ sparkline@^0.2.0:
   dependencies:
     here "0.0.2"
     nopt "~4.0.1"
+
+spawn-command@^0.0.2-1:
+  version "0.0.2-1"
+  resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
+  integrity sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=
 
 spawn-wrap@^1.4.2:
   version "1.4.2"
@@ -9314,7 +9347,7 @@ supports-color@^5.0.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-co
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^6.0.0:
+supports-color@^6.0.0, supports-color@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
@@ -9629,6 +9662,11 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+tree-kill@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+
 treeify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/treeify/-/treeify-1.1.0.tgz#4e31c6a463accd0943879f30667c4fdaff411bb8"
@@ -9907,12 +9945,7 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-urijs@1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.1.tgz#5b0ff530c0cbde8386f6342235ba5ca6e995d25a"
-  integrity sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg==
-
-urijs@^1.19.1:
+urijs@1.19.2, urijs@^1.19.1:
   version "1.19.2"
   resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.2.tgz#f9be09f00c4c5134b7cb3cf475c1dd394526265a"
   integrity sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w==
@@ -10290,6 +10323,14 @@ yargs-parser@^11.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
+  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^15.0.0:
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.0.tgz#cdd7a97490ec836195f59f3f4dbe5ea9e8f75f08"
@@ -10315,6 +10356,22 @@ yargs@^12.0.1, yargs@^12.0.5:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
+
+yargs@^13.3.0:
+  version "13.3.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
+  integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
+  dependencies:
+    cliui "^5.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.1.2"
 
 yargs@^14.2.0:
   version "14.2.0"


### PR DESCRIPTION
Run tests using the [concurrently](https://github.com/kimmobrunfeldt/concurrently) module, which has pretty good support for windows.

- windows support
- run with as many cores as the CI box has available
- fail fast (via `killOthers` option). If one test fails while running in parallel, it will stop all the other commands, meaning less waiting.
- fix process.on('SIGINT') leaks that I think may have been the original cause of the inconsistent windows results