### PR TITLE
chore: skip running cli smoke tests on windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,9 +75,9 @@ jobs:
       - run:
           name: Test and Lint
           command: yarn --cwd packages/ci test
-      - run:
-          name: Test and Lint
-          command: yarn --cwd packages/cli test
+      # - run:
+      #     name: Test and Lint
+      #     command: yarn --cwd packages/cli test
       - run:
           name: Test and Lint
           command: yarn --cwd packages/config test


### PR DESCRIPTION
The windows smoke tests step is causing a bunch of downstream headaches (compliance warning from failed CI, broken releases, etc). We have an epic in planning to address these. For now, as the smoke tests are run in other jobs, lets suspend running them on windows.