### PR TITLE
fix(redis-v5): update bastionConnect function to use prefer_native_tls when true

### DIFF
--- a/packages/redis-v5/commands/cli.js
+++ b/packages/redis-v5/commands/cli.js
@@ -96,7 +96,7 @@ function redisCLI (uri, client) {
   })
 }
 
-function bastionConnect ({ uri, bastions, config, prefer_native_tls}) {
+function bastionConnect ({ uri, bastions, config, prefer_native_tls }) {
   return new Promise((resolve, reject) => {
     let tunnel = new Client()
     tunnel.on('ready', function () {
@@ -143,7 +143,7 @@ function maybeTunnel (redis, config) {
   let prefer_native_tls = redis.prefer_native_tls
 
   if (bastions != null) {
-    return bastionConnect({ uri, bastions, config, prefer_native_tls})
+    return bastionConnect({ uri, bastions, config, prefer_native_tls })
   } else {
     let client
     if (prefer_native_tls) {

--- a/packages/redis-v5/commands/cli.js
+++ b/packages/redis-v5/commands/cli.js
@@ -96,7 +96,7 @@ function redisCLI (uri, client) {
   })
 }
 
-function bastionConnect ({ uri, bastions, config }) {
+function bastionConnect ({ uri, bastions, config, prefer_native_tls}) {
   return new Promise((resolve, reject) => {
     let tunnel = new Client()
     tunnel.on('ready', function () {
@@ -104,10 +104,22 @@ function bastionConnect ({ uri, bastions, config }) {
       tunnel.forwardOut('localhost', localPort, uri.hostname, uri.port, function (err, stream) {
         if (err) return reject(err)
         stream.on('close', () => tunnel.end())
-        redisCLI(uri, stream).then(resolve).catch(reject)
+
+        let client
+        if (prefer_native_tls) {
+          client = tls.connect({
+            socket: stream,
+            port: parseInt(uri.port, 10),
+            host: uri.hostname,
+            rejectUnauthorized: false
+          })
+        } else {
+          client = stream
+        }
+
+        redisCLI(uri, client).then(resolve).catch(reject)
       })
-    })
-    tunnel.connect({
+    }).connect({
       host: bastions.split(',')[0],
       username: 'bastion',
       privateKey: match(config, /_BASTION_KEY/)
@@ -131,7 +143,7 @@ function maybeTunnel (redis, config) {
   let prefer_native_tls = redis.prefer_native_tls
 
   if (bastions != null) {
-    return bastionConnect({ uri, bastions, config })
+    return bastionConnect({ uri, bastions, config, prefer_native_tls})
   } else {
     let client
     if (prefer_native_tls) {

--- a/packages/redis-v5/test/commands/cli.js
+++ b/packages/redis-v5/test/commands/cli.js
@@ -118,4 +118,32 @@ describe('heroku redis:cli', function () {
       .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_URL):\n'))
       .then(() => expect(cli.stderr).to.equal(''))
   })
+
+  it('# for private spaces bastion with prefer_native_tls, it uses tls.connect', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        { name: 'redis-haiku',
+          addon_service: { name: 'heroku-redis' },
+          config_vars: ['REDIS_URL', 'REDIS_BASTIONS', 'REDIS_BASTION_KEY', 'REDIS_BASTION_REKEYS_AFTER'] }
+      ])
+
+    let configVars = nock('https://api.heroku.com:443')
+      .get('/apps/example/config-vars').reply(200, { 'REDIS_BASTIONS': 'example.com' })
+
+    let redis = nock('https://redis-api.heroku.com:443')
+      .get('/redis/v0/databases/redis-haiku').reply(200, {
+        resource_url: 'redis://foobar:password@example.com:8649',
+        plan: 'private-7',
+        prefer_native_tls: true
+      })
+
+    return command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
+      .then(() => app.done())
+      .then(() => configVars.done())
+      .then(() => redis.done())
+      .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_URL):\n'))
+      .then(() => expect(cli.stderr).to.equal(''))
+      .then(() => expect(ssh2.Client.connect.called).to.equal(true))
+      .then(() => expect(tls.connect.called).to.equal(true))
+  })
 })

--- a/packages/redis-v5/test/commands/cli.js
+++ b/packages/redis-v5/test/commands/cli.js
@@ -143,7 +143,6 @@ describe('heroku redis:cli', function () {
       .then(() => redis.done())
       .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_URL):\n'))
       .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(ssh2.Client.connect.called).to.equal(true))
       .then(() => expect(tls.connect.called).to.equal(true))
   })
 })


### PR DESCRIPTION
Customers using Redis 6 cannot use `heroku redis:cli` to connect to their service. This is because we do not attempt a TLS connection inside the SSH tunnel. This PR checks for the `prefer_native_tls` flag and initializes a TLS client connection, allowing the customer to properly connect.