### PR TITLE
chore: suspend macos releasing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,13 +306,18 @@ workflows:
               ignore: /.*/
             tags:
               <<: *version_tags
-      - trigger_macos: &trigger_macos
+#       - trigger_macos: &trigger_macos
+#           requires:
+#             - node12-test
+#             - node10-test
+#           filters:
+#             <<: *only_version_tags
+      - release_snap:
           requires:
             - node12-test
             - node10-test
           filters:
-            <<: *only_version_tags
-      - release_snap: *trigger_macos
+            <<: *only_version_tags 
       - invalidate_cdn_cache:
           requires:
             - install_scripts


### PR DESCRIPTION
Causing compliance failure issues. We are currently not releasing macos builds as we work through the Salesforce Apple Dev release process.