### PR TITLE
fix(certs-v5): fix logic for checking multiple sni flag

### DIFF
--- a/packages/certs-v5/lib/endpoints.js
+++ b/packages/certs-v5/lib/endpoints.js
@@ -58,11 +58,11 @@ function tagAndSort (app, allCerts) {
 
 function * all (app, heroku) {
   const featureList = yield heroku.get(`/apps/${app}/features`)
-  const multipleSniEndpointFeature = checkMultiSniFeature(featureList)
+  const multipleSniEndpointFeatureEnabled = checkMultiSniFeature(featureList)
 
   let allCerts;
 
-  if (multipleSniEndpointFeature && multipleSniEndpointFeature.enabled) {
+  if (multipleSniEndpointFeatureEnabled) {
     // use SNI endpoints only
     allCerts = yield {
       ssl_certs: [],


### PR DESCRIPTION
Fixes the issue described [here](https://heroku.slack.com/archives/CNB38GLV8/p1594646982051900).

There was an oversight in the logic for checking the multiple-sni-endpoints feature flag that was causing it to return false negatives.  This PR fixes that logic.
