### PR TITLE
fix(run): force login first if necessary

### DIFF
--- a/packages/run/src/commands/run/index.ts
+++ b/packages/run/src/commands/run/index.ts
@@ -2,6 +2,7 @@ import {Command, flags} from '@heroku-cli/command'
 import {DynoSizeCompletion, ProcessTypeCompletion} from '@heroku-cli/command/lib/completions'
 import cli from 'cli-ux'
 import debugFactory from 'debug'
+import * as Heroku from '@heroku-cli/schema'
 
 import Dyno from '../../lib/dyno'
 import {buildCommand} from '../../lib/helpers'
@@ -51,7 +52,7 @@ export default class Run extends Command {
     if (!opts.command) {
       throw new Error('Usage: heroku run COMMAND\n\nExample: heroku run bash')
     }
-
+    await this.heroku.get<Heroku.Account>('/account')
     const dyno = new Dyno(opts)
     try {
       await dyno.start()


### PR DESCRIPTION
Currently, if you run `heroku run <command>` without already being logged in, the CLI freezes and leaves a dyno hanging. This adds a simple API request prior to starting up a dyno in order to force the login flow if needed.