### PR TITLE
fix(redis-v5): use addon's billing app attachment to look up connection

### DIFF
--- a/packages/redis-v5/test/commands/cli.js
+++ b/packages/redis-v5/test/commands/cli.js
@@ -8,7 +8,7 @@ let expect = require('chai').expect
 let Duplex = require('stream').Duplex
 let EventEmitter = require('events').EventEmitter
 
-let command, net, tls
+let command, net, tls, tunnel
 
 describe('heroku redis:cli', function () {
   let command = proxyquire('../../commands/cli.js', { net: {}, tls: {}, ssh2: {} })
@@ -16,6 +16,9 @@ describe('heroku redis:cli', function () {
 })
 
 describe('heroku redis:cli', function () {
+  const addonId = '1dcb269b-8be5-4132-8aeb-e3f3c7364958'
+  const appId = '7b0ae612-8775-4502-a5b5-2b45a4d18b2d'
+
   beforeEach(function () {
     cli.mockConsole()
 
@@ -33,12 +36,13 @@ describe('heroku redis:cli', function () {
     }
 
     class Tunnel extends EventEmitter {
-      connect () {
-        this.emit('ready')
-      }
-
-      forwardOut (localHost, localPort, hostname, port, cb) {
-        cb(null, new Client())
+      constructor () {
+        super()
+        tunnel = this
+        this.forwardOut = sinon.stub().yields(null, new Client())
+        this.connect = sinon.stub().callsFake(() => {
+          this.emit('ready')
+        })
       }
     }
 
@@ -50,7 +54,16 @@ describe('heroku redis:cli', function () {
   it('# for hobby it uses net.connect', function () {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
+        {
+          id: addonId,
+          name: 'redis-haiku',
+          addon_service: { name: 'heroku-redis' },
+          config_vars: ['REDIS_FOO', 'REDIS_BAR'],
+          billing_entity: {
+            id: appId,
+            name: 'example'
+          }
+        }
       ])
 
     let configVars = nock('https://api.heroku.com:443')
@@ -73,7 +86,16 @@ describe('heroku redis:cli', function () {
   it('# for premium it uses tls.connect', function () {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
+        {
+          id: addonId,
+          name: 'redis-haiku',
+          addon_service: { name: 'heroku-redis' },
+          config_vars: ['REDIS_FOO', 'REDIS_BAR'],
+          billing_entity: {
+            id: appId,
+            name: 'example'
+          }
+        }
       ])
 
     let configVars = nock('https://api.heroku.com:443')
@@ -97,9 +119,16 @@ describe('heroku redis:cli', function () {
   it('# for bastion it uses tunnel.connect', function () {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku',
+        {
+          id: addonId,
+          name: 'redis-haiku',
           addon_service: { name: 'heroku-redis' },
-          config_vars: ['REDIS_URL', 'REDIS_BASTIONS', 'REDIS_BASTION_KEY', 'REDIS_BASTION_REKEYS_AFTER'] }
+          config_vars: ['REDIS_URL', 'REDIS_BASTIONS', 'REDIS_BASTION_KEY', 'REDIS_BASTION_REKEYS_AFTER'],
+          billing_entity: {
+            id: appId,
+            name: 'example'
+          }
+        }
       ])
 
     let configVars = nock('https://api.heroku.com:443')
@@ -122,9 +151,15 @@ describe('heroku redis:cli', function () {
   it('# for private spaces bastion with prefer_native_tls, it uses tls.connect', function () {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku',
+        { id: addonId,
+          name: 'redis-haiku',
           addon_service: { name: 'heroku-redis' },
-          config_vars: ['REDIS_URL', 'REDIS_BASTIONS', 'REDIS_BASTION_KEY', 'REDIS_BASTION_REKEYS_AFTER'] }
+          config_vars: ['REDIS_URL', 'REDIS_BASTIONS', 'REDIS_BASTION_KEY', 'REDIS_BASTION_REKEYS_AFTER'],
+          billing_entity: {
+            id: appId,
+            name: 'example'
+          }
+        }
       ])
 
     let configVars = nock('https://api.heroku.com:443')
@@ -144,5 +179,80 @@ describe('heroku redis:cli', function () {
       .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_URL):\n'))
       .then(() => expect(cli.stderr).to.equal(''))
       .then(() => expect(tls.connect.called).to.equal(true))
+  })
+
+  it('# selects correct connection information when multiple redises are present across multiple apps', async () => {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        {
+          id: addonId,
+          name: 'redis-haiku',
+          addon_service: { name: 'heroku-redis' },
+          config_vars: ['REDIS_URL', 'REDIS_BASTIONS', 'REDIS_BASTION_KEY', 'REDIS_BASTION_REKEYS_AFTER'],
+          billing_entity: {
+            id: appId,
+            name: 'example'
+          }
+        },
+        {
+          id: 'heroku-redis-addon-id-2',
+          name: 'redis-sonnet',
+          addon_service: { name: 'heroku-redis' },
+          config_vars: ['REDIS_6_URL', 'REDIS_6_BASTIONS', 'REDIS_6_BASTION_KEY', 'REDIS_6_BASTION_REKEYS_AFTER'],
+          billing_entity: {
+            id: 'app-2-id',
+            name: 'example-app-2'
+          }
+        }
+      ])
+
+    let configVars = nock('https://api.heroku.com:443')
+      .get('/apps/example-app-2/config-vars').reply(200, {
+        'REDIS_6_URL': 'redis-user@redis6-example.com',
+        'REDIS_6_BASTIONS': 'redis-6-bastion.example.com',
+        'REDIS_6_BASTION_KEY': 'key2'
+      })
+
+    let redis = nock('https://redis-api.heroku.com:443')
+      .get('/redis/v0/databases/redis-sonnet').reply(200, {
+        resource_url: 'redis://foobar:password@redis-6.example.com:8649',
+        plan: 'private-7',
+        prefer_native_tls: true
+      })
+
+    await command.run({ app: 'example', flags: { confirm: 'example' }, args: { database: 'redis-sonnet' }, auth: { username: 'foobar', password: 'password' } })
+    app.done()
+    configVars.done()
+    redis.done()
+
+    expect(cli.stdout).to.equal('Connecting to redis-sonnet (REDIS_6_URL):\n')
+    expect(cli.stderr).to.equal('')
+
+    const connectArgs = tunnel.connect.args[0]
+    expect(connectArgs).to.have.length(1)
+    expect(connectArgs[0]).to.deep.equal({
+      host: 'redis-6-bastion.example.com',
+      privateKey: 'key2',
+      username: 'bastion'
+    })
+
+    const tunnelArgs = tunnel.forwardOut.args[0]
+    const [localAddr, localPort, remoteAddr, remotePort] = tunnelArgs
+    expect(localAddr).to.equal('localhost')
+    expect(localPort).to.be.a('number')
+    expect(remoteAddr).to.equal('redis-6.example.com')
+    expect(remotePort).to.equal('8649')
+
+    const tlsConnectArgs = tls.connect.args[0]
+    expect(tlsConnectArgs).to.have.length(1)
+    const tlsConnectOptions = {
+      ...tlsConnectArgs[0]
+    }
+    delete tlsConnectOptions.socket
+    expect(tlsConnectOptions).to.deep.equal({
+      port: 8649,
+      host: 'redis-6.example.com',
+      rejectUnauthorized: false
+    })
   })
 })


### PR DESCRIPTION
If an app has several redis addon attachments from different redis addons (which have different billing entities than the app in question), the Heroku Redis addons service will namespace the config vars on the app based on the attachment name.

For example, if we had two attachments for an app (we'll say this is the response from `GET /apps/:app/addon-attachments` for an app with a name of `app-a`):

```json
[
  {
    "addon": { "name": "heroku-redis-a" },
    "app": { "name": "app-a" },
    "name": "REDIS"
  },
  {
    "addon": { "name": "heroku-redis-a" },
    "app": { "name": "app-b" },
    "name": "REDIS_6"
  }
]
```

Then the config vars on `app-a` would look something like:

```json
{
  "REDIS_URL": "username:password@example.com",
  "REDIS_6_URL": "username-redis-6:password-redis-6@redis-6.example.com"
}
```

However, since these addons are shared by different apps, their `CONFIG_VARS` field returned by `/addons/:id` or `/apps/:id/addons/:addon_id` will both have the same list of config variables.

In order to figure out which config variables we need to use to connect, we now use **billing app's** config vars to look up the connection. As far as I can tell, this shouldn't break existing use cases as the call to `GET `/redis/v0/databases/:addon_name` would return a 401 if someone had access to the billing app but not the attaching app.

## Testing this out

You'll want to create some apps in a private space:

```bash
heroku apps:create redis-test-app-1 --space=myspace
heroku apps:create redis-test-app-2 --space=myspace
```

Then, create a heroku redis (private) in each one:

```
heroku addons:create -a redis-test-app-1 heroku-redis:private-7 --version=6
heroku addons:create -a redis-test-app-2 heroku-redis:private-7 
```

Wait for addons to provision:

```
heroku addons:wait -a redis-test-app-1 && heroku addons:wait -a redis-test-app-2
```

Get the list of addons for the first app so we can get the newly created addon name:

```
heroku addons -a redis-test-app-1
```

Attach the addon from the first app to the second app:

```
heroku addons:attach -a redis-test-app-2 redis-addon-name-from-test-app-1
```

Ok, finally we're ready to test. Pull down this branch, run `yarn`. Then `cd packages/run-v5` and then `heroku plugins:link`. Then run:

```
heroku keys:add
```

This will make sure you have SSH keys setup.

Now run:

```
heroku redis:cli -a redis-test-app-2 redis-addon-name-from-test-app-1
```

We can test this from the other side too:

```
heroku addons:attach -a redis-test-app-1 redis-addon-name-from-test-app-2
heroku redis:cli -a redis-test-app-1 redis-addon-name-from-test-app-2
```

You should get a Redis CLI.

**Remember to run `heroku plugins:unlink` after testing so that your heroku cli will continue to update instead of use the local version**