### PR TITLE
chore: don't install bats twice

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,12 +137,6 @@ jobs:
             - v4-yarn-{{ checksum ".circleci/config.yml" }}
             - v4-yarn
       - run:
-          name: Installing bats
-          command: |
-            git clone https://github.com/sstephenson/bats.git
-            cd bats
-            ./install.sh /usr/local
-      - run:
           name: Installing dependencies
           command: yarn
       - run:
@@ -290,7 +284,7 @@ workflows:
             - node12-test
             - node10-test
           filters: &master_dev_and_version_tags
-            tags: 
+            tags:
               <<: *version_tags
             branches:
               only:
@@ -317,7 +311,7 @@ workflows:
             - node12-test
             - node10-test
           filters:
-            <<: *only_version_tags 
+            <<: *only_version_tags
       - invalidate_cdn_cache:
           requires:
             - install_scripts

--- a/packages/local/bin/bats-test-runner.js
+++ b/packages/local/bin/bats-test-runner.js
@@ -4,4 +4,4 @@ const os = require('os')
 const {spawn} = require('child_process')
 
 if (os.platform() === 'win32' || os.platform() === 'windows') console.log('skipping on windows')
-else spawn('npx bats test/integration/*.bats', {stdio: 'inherit', shell: true})
+else spawn('yarn bats test/integration/*.bats', {stdio: 'inherit', shell: true})

--- a/packages/run/bin/bats-test-runner.js
+++ b/packages/run/bin/bats-test-runner.js
@@ -4,4 +4,4 @@ const os = require('os')
 const {spawn} = require('child_process')
 
 if (os.platform() === 'win32' || os.platform() === 'windows') console.log('skipping on windows')
-else spawn('npx bats test/integration/*.bats', {stdio: 'inherit', shell: true})
+else spawn('yarn bats test/integration/*.bats', {stdio: 'inherit', shell: true})


### PR DESCRIPTION
`bats` is already installed via npm (this was introduced in [#1252][1]),
so we don't need to install it in the CircleCI build file. The CircleCI
build file was also installing the original bats, while the [`local`][2] and
[`run`][3] packages install a [fork from npm][4].

In addition, I switched the command inside the bats runners from `npx
bats` (which will download/install the latest binary if `yarn install`
was not already run), to `yarn bats`, which will always use the version
specified in the lockfile. This is more consistent with how we run other
commands anyway.

[1]: https://github.com/heroku/cli/pull/1252
[2]: https://github.com/heroku/cli/blob/62085d32f8fa3574bbe03bba707f1f576a9858bf/packages/local/bin/bats-test-runner.js
[3]: https://github.com/heroku/cli/blob/62085d32f8fa3574bbe03bba707f1f576a9858bf/packages/run/bin/bats-test-runner.js
[4]: https://www.npmjs.com/package/bats

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
