### PR TITLE
chore: add windows job requirement to releasing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,6 +267,9 @@ workflows:
           filters:
             tags: &version_tags
               only: /^v.*/
+            branches:
+              ignore:
+                - master
       - node12-test: *windows_test
       - node10-test: *windows_test
   heroku_cli_release:
@@ -279,10 +282,12 @@ workflows:
             tags: &version_tags
               only: /^v.*/
       - node10-test: *node12_test
+      - windows-test: *node12_test
       - release_tarballs: &release_tarballs
           requires:
             - node12-test
             - node10-test
+            - windows-test
           filters: &master_dev_and_version_tags
             tags:
               <<: *version_tags
@@ -304,12 +309,14 @@ workflows:
 #           requires:
 #             - node12-test
 #             - node10-test
+#             - windows-test
 #           filters:
 #             <<: *only_version_tags
       - release_snap:
           requires:
             - node12-test
             - node10-test
+            - windows-test
           filters:
             <<: *only_version_tags
       - invalidate_cdn_cache:


### PR DESCRIPTION
Previously, windows CI was failing intermittently holding up releases. Now that we have a decent* working solution, require windows CI to pass before releasing.

*but not perfect