### PR TITLE
fix(pipelines): Change how kolkrabbi gets the auth token.

### DIFF
--- a/packages/pipelines/src/commands/pipelines/connect.ts
+++ b/packages/pipelines/src/commands/pipelines/connect.ts
@@ -46,7 +46,7 @@ export default class Connect extends Command {
       return
     }
 
-    const kolkrabbi = new KolkrabbiAPI(this.config.userAgent, this.heroku.auth)
+    const kolkrabbi = new KolkrabbiAPI(this.config.userAgent, () => this.heroku.auth)
     const github = new GitHubAPI(this.config.userAgent, await getGitHubToken(kolkrabbi))
 
     const {

--- a/packages/pipelines/src/commands/pipelines/diff.ts
+++ b/packages/pipelines/src/commands/pipelines/diff.ts
@@ -83,7 +83,7 @@ export default class PipelinesDiff extends Command {
     remote: flags.remote(),
   }
 
-  kolkrabbi = new KolkrabbiAPI(this.config.userAgent, this.heroku.auth)
+  kolkrabbi: KolkrabbiAPI = new KolkrabbiAPI(this.config.userAgent, () => this.heroku.auth)
 
   getAppInfo = async (appName: string, appId: string): Promise<AppInfo> => {
     // Find GitHub connection for the app

--- a/packages/pipelines/src/commands/pipelines/setup.ts
+++ b/packages/pipelines/src/commands/pipelines/setup.ts
@@ -60,7 +60,7 @@ export default class Setup extends Command {
       return
     }
 
-    const kolkrabbi = new KolkrabbiAPI(this.config.userAgent, this.heroku.auth)
+    const kolkrabbi = new KolkrabbiAPI(this.config.userAgent, () => this.heroku.auth)
     const github = new GitHubAPI(this.config.userAgent, await getGitHubToken(kolkrabbi))
 
     const team = flags.team

--- a/packages/pipelines/src/commands/reviewapps/disable.ts
+++ b/packages/pipelines/src/commands/reviewapps/disable.ts
@@ -82,7 +82,7 @@ export default class ReviewappsDisable extends Command {
       settings.wait_for_ci = false
     }
 
-    const kolkrabbi = new KolkrabbiAPI(this.config.userAgent, this.heroku.auth)
+    const kolkrabbi = new KolkrabbiAPI(this.config.userAgent, () => this.heroku.auth)
 
     cli.action.start('Configuring pipeline')
 

--- a/packages/pipelines/src/commands/reviewapps/enable.ts
+++ b/packages/pipelines/src/commands/reviewapps/enable.ts
@@ -69,7 +69,7 @@ export default class ReviewappsEnable extends Command {
       settings.wait_for_ci = true
     }
 
-    const kolkrabbi = new KolkrabbiAPI(this.config.userAgent, this.heroku.auth)
+    const kolkrabbi = new KolkrabbiAPI(this.config.userAgent, () => this.heroku.auth)
 
     cli.action.start('Configuring pipeline')
 

--- a/packages/pipelines/src/kolkrabbi-api.ts
+++ b/packages/pipelines/src/kolkrabbi-api.ts
@@ -5,16 +5,16 @@ const KOLKRABBI_BASE_URL = 'https://kolkrabbi.heroku.com'
 export default class {
   version: any
 
-  token: any
+  getToken: () => any
 
-  constructor(version: any, token: any) {
+  constructor(version: any, getToken: () => any) {
     this.version = version
-    this.token = token
+    this.getToken = getToken
   }
 
   request(url: string, options: any = {}) {
     options.headers = {
-      Authorization: `Bearer ${this.token}`,
+      Authorization: `Bearer ${this.getToken()}`,
       'User-Agent': this.version,
     }
 


### PR DESCRIPTION
Currently the KolkrabbiAPI class only reads the auth token on creation of the class. For most instances this is fine, however, if the auth token is stale, and the cli re auths during the command, Kolkrabbi doesn't get the new auth token. for example, if you run `pipelines:diff` while not authenticated, it will first ask you to login, and then run the command, but fail. The next run, it'll pass. This was brought to light through this support ticket. https://heroku.support/903944

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
