### PR TITLE
chore (docs): Remove heroku run:inside Section from Docs

### DIFF
--- a/docs/run.md
+++ b/docs/run.md
@@ -56,23 +56,3 @@ EXAMPLE
 ```
 
 _See code: [@heroku-cli/plugin-run](https://github.com/heroku/cli/blob/v7.42.5/src/commands/run/detached.ts)_
-
-## `heroku run:inside`
-
-run a one-off process inside an existing heroku dyno
-
-```
-USAGE
-  $ heroku run:inside
-
-OPTIONS
-  -a, --app=app        (required) app to run command against
-  -e, --env=env        environment variables to set (use ';' to split multiple vars)
-  -r, --remote=remote  git remote of app to use
-  -x, --exit-code      passthrough the exit code of the remote command
-
-EXAMPLE
-  $ heroku run:inside web.1 bash
-```
-
-_See code: [@heroku-cli/plugin-run](https://github.com/heroku/cli/blob/v7.42.5/src/commands/run/inside.ts)_


### PR DESCRIPTION
I recently noticed - from a customer who opened a ticket - that we have [`heroku run:inside`](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-run-inside) as a public command in our CLI docs. 

These docs are a bit misleading for a few reasons:

* The feature is hidden behind a feature flag that's non-public. So, most users will be presented with a `Error: Access to the dyno-run-inside feature is not enabled.` when they try to run the command.
* Heroku Support historically has suggested using `heroku ps:exec` for cases where users need to directly access their dyno instances via the CLI.
* The feature is still in the `alpha` stage.

Because of this, I believe we should eliminate the section entirely from the docs in favor of having folks use [`heroku ps:exec`](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-ps-exec).