### PR TITLE
chore(cli): bump @heroku-cli/command to 8.3.1

### DIFF
--- a/packages/apps-v5/package.json
+++ b/packages/apps-v5/package.json
@@ -15,7 +15,7 @@
     "repositoryPrefix": "<%- repo %>/blob/v<%- version %>/packages/apps-v5/<%- commandPath %>"
   },
   "dependencies": {
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "co": "^4.6.0",
     "filesize": "^4.0.0",
     "fs-extra": "^7.0.1",

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/heroku/heroku-cli-plugin-apps/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "@heroku-cli/schema": "^1.0.25",
     "@oclif/command": "^1",
     "@oclif/config": "^1",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "@oclif/command": "^1.5.11",
     "@oclif/config": "^1.12.10",
     "cli-ux": "^4.9.3",

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -4,7 +4,7 @@
   "author": "Philipe Navarro @RasPhilCo",
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "@oclif/command": "^1.5.11",
     "@oclif/config": "^1.12.10",
     "chalk": "^2.4.2",

--- a/packages/buildpacks/package.json
+++ b/packages/buildpacks/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "@heroku/buildpack-registry": "^1.0.1",
     "@oclif/config": "^1.12.10",
     "@oclif/plugin-legacy": "^1.1.4",

--- a/packages/certs/package.json
+++ b/packages/certs/package.json
@@ -4,7 +4,7 @@
   "author": "Jeff Dickey @jdxcode",
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "@oclif/command": "^1.5.11",
     "@oclif/config": "^1.12.10",
     "tslib": "^1.9.3"

--- a/packages/ci-v5/package.json
+++ b/packages/ci-v5/package.json
@@ -13,7 +13,7 @@
     "repositoryPrefix": "<%- repo %>/blob/v<%- version %>/packages/ci-v5/<%- commandPath %>"
   },
   "dependencies": {
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "@heroku-cli/plugin-run-v5": "^7.41.0",
     "ansi-escapes": "3.2.0",
     "bluebird": "^3.5.3",

--- a/packages/ci/package.json
+++ b/packages/ci/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "@oclif/command": "^1.5.11",
     "@oclif/config": "^1.12.10",
     "ansi-escapes": "3.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "1.1.14",
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "@heroku-cli/plugin-addons-v5": "^7.42.2",
     "@heroku-cli/plugin-apps": "^7.42.0",
     "@heroku-cli/plugin-apps-v5": "^7.42.5",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "@oclif/command": "^1.5.11",
     "@oclif/config": "^1.12.10",
     "cli-ux": "^4.9.3",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "@oclif/command": "^1.5.11",
     "@oclif/config": "^1.12.10",
     "cli-ux": "^4.9.3",

--- a/packages/local/package.json
+++ b/packages/local/package.json
@@ -5,7 +5,7 @@
   "author": "Chad Carbert @chadian",
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "foreman": "^3.0.1",

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -9,7 +9,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "@heroku-cli/schema": "^1.0.25",
     "@oclif/command": "^1",
     "@oclif/config": "^1",

--- a/packages/orgs-v5/package.json
+++ b/packages/orgs-v5/package.json
@@ -38,7 +38,7 @@
     "repositoryPrefix": "<%- repo %>/blob/v<%- version %>/packages/orgs-v5/<%- commandPath %>"
   },
   "dependencies": {
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "co": "^4.6.0",
     "heroku-cli-util": "^8.0.11",
     "inquirer": "^6.2.2",

--- a/packages/pipelines/package.json
+++ b/packages/pipelines/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "@heroku-cli/schema": "^1.0.25",
     "@oclif/command": "^1",
     "@oclif/config": "^1",

--- a/packages/ps/package.json
+++ b/packages/ps/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "@oclif/command": "^1.5.11",
     "@oclif/config": "^1.12.10",
     "cli-ux": "^4.9.3",

--- a/packages/run-v5/package.json
+++ b/packages/run-v5/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "@heroku-cli/notifications": "^1.2.2",
     "@heroku/eventsource": "^1.0.7",
     "co": "4.6.0",

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "@heroku-cli/notifications": "^1.2.2",
     "@heroku/eventsource": "^1.0.7",
     "@oclif/command": "^1",

--- a/packages/spaces/package.json
+++ b/packages/spaces/package.json
@@ -17,7 +17,7 @@
     "repositoryPrefix": "<%- repo %>/blob/v<%- version %>/packages/spaces/<%- commandPath %>"
   },
   "dependencies": {
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "@heroku-cli/notifications": "^1.2.2",
     "co": "4.6.0",
     "heroku-cli-util": "^8.0.11",

--- a/packages/status/package.json
+++ b/packages/status/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "@oclif/command": "^1.5.11",
     "@oclif/config": "^1.12.10",
     "@oclif/errors": "^1.2.2",

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.3.0",
+    "@heroku-cli/command": "^8.3.1",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "cli-ux": "^5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -291,10 +291,10 @@
     netrc-parser "^3.1.6"
     opn "^5.4.0"
 
-"@heroku-cli/command@^8.3.0":
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/@heroku-cli/command/-/command-8.3.0.tgz#bc3920454fcce7e1cc94a78614f2fa1379e977ce"
-  integrity sha512-gQoe6KnIr8q+JCYvO/6STRBsJXHw+UwwtNs5me5Zx/020u2S1I4oqi3KamcTeRTC7ZVORH3DfE30aA3HNgYXsA==
+"@heroku-cli/command@^8.3.1":
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/@heroku-cli/command/-/command-8.3.1.tgz#62dd00ecdb041ea088c820f75c3218baea19b65e"
+  integrity sha512-I6ZQkj4FG9C3DVUITE8WOSuHTtOQjyMRXDbrXoudu2xLK6zQBDV4MpDrmZbn+UKD0+TssgsIusfXOL6cWpYqQw==
   dependencies:
     "@heroku-cli/color" "^1.1.14"
     "@oclif/errors" "^1.2.2"


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

Bump `@heroku-cli/command` to 8.3.1