### PR TITLE
chore: pin lerna in root package's package.json

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,5 @@
 {
   "version": "7.42.8",
-  "lerna": "2.11.0",
   "useWorkspaces": true,
   "npmClient": "yarn",
   "command": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
+    "lerna": "^3.22.1",
     "promise-request-retry": "^1.0.2",
     "standard": "12.0.1"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -77,7 +77,6 @@
     "eslint-config-oclif": "^3.1.0",
     "eslint-config-oclif-typescript": "^0.1.0",
     "globby": "^10.0.1",
-    "lerna": "^3.18.0",
     "lodash": "^4.17.11",
     "mocha": "^5.2.0",
     "nock": "^10.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6072,7 +6072,7 @@ lcov-parse@^1.0.0:
   resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-1.0.0.tgz#eb0d46b54111ebc561acb4c408ef9363bdc8f7e0"
   integrity sha1-6w1GtUER68VhrLTECO+TY73I9+A=
 
-lerna@^3.18.0:
+lerna@^3.22.1:
   version "3.22.1"
   resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.22.1.tgz#82027ac3da9c627fd8bf02ccfeff806a98e65b62"
   integrity sha512-vk1lfVRFm+UuEFA7wkLKeSF7Iz13W+N/vFd48aW2yuS7Kv0RbNm2/qcDPV863056LMfkRlsEe+QYOw3palj5Lg==


### PR DESCRIPTION
- The project was inheriting `lerna@^3.18.0` from [packages/cli/package.json][1] due to [yarn hoisting packages from dependencies from workspaces into the root package](https://classic.yarnpkg.com/blog/2018/02/15/nohoist/). Since `packages/cli` doesn't use `lerna` directly, I moved the `devDependency` for yarn into the root workspace package to be more explicit that we depend on lerna.
- The `lerna` field was removed from `lerna.json` as [`lerna` is no longer required and support was removed in Lerna 3][2].
- The [Release Notes Quip Document][3] was updated to use `yarn lerna` instead of just `lerna`. This technically isn't necessary since [lerna will now use the local version of lerna if available][4], but it's probably better to use the exact version of the CLI whenever possible to reduce possibilities for those releasing to drift lerna CLI versions.

[1]: https://github.com/heroku/cli/blob/b6757d432b3f051b32769e3d02f0fb5c3efa9499/packages/cli/package.json#L80
[2]: https://github.com/lerna/lerna/blob/f6e7a13e60fefc523d701efddfcf0ed41a77749b/README.md#legacy-fields
[3]: https://salesforce.quip.com/aPLDA1ZwjNlW
[4]: https://github.com/lerna/lerna/pull/1122
