### PR TITLE
chore(cli): tweak snapcraft script

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,7 @@ parts:
       echo "CLI_VERSION"
       echo $CLI_VERSION
 
-      if [ "$COMMIT_MSG" == "v$CLI_VERSION" ]; then
+      if test "$COMMIT_MSG" = "v$CLI_VERSION"; then
         git tag "$COMMIT_MSG" -m "$COMMIT_MSG"
       fi
     override-build: |


### PR DESCRIPTION
Currently, in the snapcraft CI it is failing to do the comparison, and failing with a syntax error. Testing locally in a snapcraft
container simulating the snapcraftctl pull step, this should fix it.