### PR TITLE
chore(cli): remove git tag for snapcraft builds

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,7 +27,6 @@ parts:
 
       if test "$COMMIT_MSG" = "v$CLI_VERSION"; then
         echo "Setting snapcraft version to $COMMIT_MSG"
-        git tag "$COMMIT_MSG" -m "$COMMIT_MSG"
         snapcraftctl set-version $COMMIT_MSG
       fi
     override-build: |


### PR DESCRIPTION
Using `snapcraftctl set-version` should work without needing to set the git tag per the [snapcraft examples](https://snapcraft.io/docs/using-external-metadata#heading--scriptlet). Also, setting the git tag when it's already been set upstream before snapcraft pulls the latest changes causes an error.