### PR TITLE
feat(cli): add warning to accept new terms of service

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -225,7 +225,8 @@
     },
     "hooks": {
       "init": [
-        "./lib/hooks/init/version"
+        "./lib/hooks/init/version",
+        "./lib/hooks/init/terms-of-service"
       ],
       "prerun": [
         "./lib/hooks/prerun/analytics"

--- a/packages/cli/src/hooks/init/terms-of-service.ts
+++ b/packages/cli/src/hooks/init/terms-of-service.ts
@@ -1,0 +1,21 @@
+import {Hook} from '@oclif/config'
+import * as path from 'path'
+import * as fs from 'fs-extra'
+import cli from 'cli-ux'
+
+export function checkTos(options: any) {
+  const tosPath: string = path.join(options.config.cacheDir, 'terms-of-service')
+  const viewedBanner = fs.pathExistsSync(tosPath)
+  const message = 'Our terms of service have changed: https://dashboard.heroku.com/terms-of-service'
+
+  if (!viewedBanner) {
+    cli.warn(message)
+    fs.createFile(tosPath)
+  }
+}
+
+const hook: Hook.Init = async function (options) {
+  checkTos(options)
+}
+
+export default hook

--- a/packages/cli/test/hooks/terms-of-service.test.ts
+++ b/packages/cli/test/hooks/terms-of-service.test.ts
@@ -1,0 +1,41 @@
+import {expect, test} from '@oclif/test'
+import {afterEach, beforeEach} from 'mocha'
+import {checkTos} from '../../src/hooks/init/terms-of-service'
+import * as fs from 'fs-extra'
+import {join} from 'path'
+
+const options = {
+  config: {
+    cacheDir: '/tmp/',
+  },
+}
+
+const tosPath: string = join(options.config.cacheDir, 'terms-of-service')
+
+describe('terms-of-service hook', () => {
+  afterEach(() => {
+    fs.removeSync(tosPath)
+  })
+
+  describe('has never run before', () => {
+    test
+    .stderr()
+    .do(() => checkTos(options))
+    .it('warns of new terms of service', context => {
+      expect(context.stderr).to.contain('Our terms of service have changed')
+    })
+  })
+
+  describe('has run once before', () => {
+    beforeEach(() => {
+      fs.createFileSync(tosPath)
+    })
+
+    test
+    .stderr()
+    .do(() => checkTos(options))
+    .it('does not give a warning', context => {
+      expect(context.stderr).to.not.contain('Our terms of service have changed')
+    })
+  })
+})


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## DO NOT MERGE/RELEASE before 10/1/2020

This should not be released until
 10/1/2020

Heroku's terms of service are being covered by Salesforce's  Master Subscription Agreement. This legal change is requiring all users to accept these new terms of service in Dashboard.

This change adds a `std error` message before any command to let users know they should update their terms of service.
<img width="860" alt="Screen Shot 2020-09-09 at 4 29 51 PM" src="https://user-images.githubusercontent.com/698595/92649892-b81cfb00-f2b9-11ea-841d-4512ef3e7f0f.png">

Users will only ever see this warning the first time they run a command after updating to this version.

### To Test:
- Clone the Repo
- Check out this branch `git checkout mc/lp/tos-banner`
- run `./bin/run apps`
- See warning banner display before the "apps" output
- Run `./bin/run apps` again
- You should not see the banner

https://gus.my.salesforce.com/a07B0000008XUeBIAW