### PR TITLE
feat(container-registry-v5): add --target option to container:push

### DIFF
--- a/docs/container.md
+++ b/docs/container.md
@@ -83,6 +83,7 @@ OPTIONS
   -r, --remote=remote          git remote of app to use
   -v, --verbose
   --arg=arg                    set build-time variables
+  --target=production          target build stage in Dockerfile
   --context-path=context-path  path to use as build context (defaults to Dockerfile dir)
 
 EXAMPLES
@@ -91,6 +92,7 @@ EXAMPLES
   heroku container:push web worker --recursive       # Pushes Dockerfile.web and Dockerfile.worker
   heroku container:push --recursive                  # Pushes Dockerfile.*
   heroku container:push web --arg ENV=live,HTTPS=on  # Build-time variables
+  heroku container:push web --target production      # Target build stage in Dockerfile
   heroku container:push --recursive --context-path . # Pushes Dockerfile.* using current dir as build context
 ```
 

--- a/packages/container-registry-v5/commands/push.js
+++ b/packages/container-registry-v5/commands/push.js
@@ -16,6 +16,7 @@ module.exports = function (topic) {
       `${cli.color.cmd('heroku container:push web worker --recursive')}       # Pushes Dockerfile.web and Dockerfile.worker`,
       `${cli.color.cmd('heroku container:push --recursive')}                  # Pushes Dockerfile.*`,
       `${cli.color.cmd('heroku container:push web --arg ENV=live,HTTPS=on')}  # Build-time variables`,
+      `${cli.color.cmd('heroku container:push web --target production')}      # Target build stage in Dockerfile`,
       `${cli.color.cmd('heroku container:push --recursive --context-path .')} # Pushes Dockerfile.* using current dir as build context`
     ],
     flags: [
@@ -34,6 +35,11 @@ module.exports = function (topic) {
         name: 'arg',
         hasValue: true,
         description: 'set build-time variables'
+      },
+      {
+        name: 'target',
+        hasValue: true,
+        description: 'set the target build stage to build'
       },
       {
         name: 'context-path',
@@ -88,7 +94,7 @@ let push = async function (context, heroku) {
       } else {
         cli.styledHeader(`Building ${job.name} (${job.dockerfile})`)
       }
-      await Sanbashi.buildImage(job.dockerfile, job.resource, buildArg, context.flags['context-path'])
+      await Sanbashi.buildImage(job.dockerfile, job.resource, buildArg, context.flags['target'], context.flags['context-path'])
     }
   } catch (err) {
     cli.exit(1, `Error: docker build exited with ${err}`)

--- a/packages/container-registry-v5/lib/sanbashi.js
+++ b/packages/container-registry-v5/lib/sanbashi.js
@@ -80,7 +80,7 @@ Sanbashi.filterByProcessType = function (jobs, procs) {
   return filteredJobs
 }
 
-Sanbashi.buildImage = function (dockerfile, resource, buildArg, path) {
+Sanbashi.buildImage = function (dockerfile, resource, buildArg, target, path) {
   let cwd = path || Path.dirname(dockerfile)
   let args = ['build', '-f', dockerfile, '-t', resource]
 
@@ -91,7 +91,13 @@ Sanbashi.buildImage = function (dockerfile, resource, buildArg, path) {
     }
   }
 
+  if (target !== undefined) {
+    args.push('--target')
+    args.push(target)
+  }
+
   args.push(cwd)
+
   return Sanbashi.cmd('docker', args)
 }
 

--- a/packages/container-registry-v5/test/sanbashi.test.js
+++ b/packages/container-registry-v5/test/sanbashi.test.js
@@ -110,6 +110,24 @@ describe('Sanbashi', () => {
       Sinon.assert.calledWith(cmd, 'docker', dockerArg)
     })
 
+    it('set the build target', () => {
+      let buildArg = ['']
+      let targetArg = 'production'
+      let cmd = Sinon.stub(Sanbashi, 'cmd')
+      Sanbashi.buildImage(dockerfile, resource, buildArg, targetArg)
+      let dockerArg = ['build', '-f', dockerfile, '-t', 'web', '--target', 'production', path]
+      Sinon.assert.calledWith(cmd, 'docker', dockerArg)
+    })
+
+    it('skip the build target if empty', () => {
+      let buildArg = ['ENV=live', 'HTTPS=on']
+      let targetArg = ''
+      let cmd = Sinon.stub(Sanbashi, 'cmd')
+      Sanbashi.buildImage(dockerfile, resource, buildArg, targetArg)
+      let dockerArg = ['build', '-f', dockerfile, '-t', 'web', '--build-arg', 'ENV=live', '--build-arg', 'HTTPS=on', path]
+      Sinon.assert.calledWith(cmd, 'docker', dockerArg)
+    })
+
     it('set build path', () => {
       let buildArg = ['']
       let buildPath = 'build/context'


### PR DESCRIPTION
This pass-through the --target stage build parameter to Docker, via Sanbashi.

The use case is to be able to use one Dockerfile, with multi-stage builds, one for development and one for production for instance, which share common layers. Right now this isn't supported and I have to push all the stages to heroku, which results in an enormous image and longer build time.

Potentially, in the future, this would also allow using targets for defining procs, instead of having a different Dockerfile per proc at the moment.

 Ref: https://docs.docker.com/develop/develop-images/multistage-build/#stop-at-a-specific-build-stage
