### PR TITLE
feat(domains): show SNI endpoints in domains list

### DIFF
--- a/packages/apps/src/commands/domains/index.ts
+++ b/packages/apps/src/commands/domains/index.ts
@@ -48,7 +48,6 @@ www.example.com  CNAME            www.example.herokudns.com
       cname: {header: 'DNS Target'},
       acm_status: {header: 'ACM Status', extended: true},
       acm_status_reason: {header: 'ACM Status', extended: true},
-
     }
 
     const sniConfig = {

--- a/packages/apps/src/lib/multiple-sni-feature.ts
+++ b/packages/apps/src/lib/multiple-sni-feature.ts
@@ -1,0 +1,12 @@
+import * as Heroku from '@heroku-cli/schema'
+import {APIClient} from '@heroku-cli/command'
+
+const MULTIPLE_SNI_ENDPOINT_FLAG = 'allow-multiple-sni-endpoints'
+
+export default async function multipleSniEndpointsEnabled(heroku: APIClient, appName: string) {
+  const {body: featureList} = await heroku.get<Array<Heroku.AppFeature>>(`/apps/${appName}/features`)
+
+  const multipleSniEndpointFeature = featureList.find(feature => feature.name === MULTIPLE_SNI_ENDPOINT_FLAG)
+
+  return Boolean(multipleSniEndpointFeature && multipleSniEndpointFeature.enabled)
+}


### PR DESCRIPTION
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008d2mEIAQ/view

This PR adds a column to the `domains:list` table that show the domain's associated SNI endpoint if the the Multiple SNI endpoints flag is enabled.

![image](https://user-images.githubusercontent.com/7971393/92970216-8895fc00-f43b-11ea-8dd9-7691501335a3.png)
