### PR TITLE
(fix: domains) fix logic for SNI endpoint selection

### DIFF
--- a/packages/apps/src/commands/domains/add.ts
+++ b/packages/apps/src/commands/domains/add.ts
@@ -104,6 +104,8 @@ export default class DomainsAdd extends Command {
       if (certSelection) {
         domainCreatePayload.sni_endpoint = certSelection
       }
+
+      cli.action.start(`Adding ${color.green(domainCreatePayload.hostname)} to ${color.app(flags.app)}`)
     }
 
     try {

--- a/packages/apps/test/commands/domains/add.test.ts
+++ b/packages/apps/test/commands/domains/add.test.ts
@@ -123,13 +123,6 @@ describe('domains:add', () => {
       ])
       .post('/apps/myapp/domains', {
         hostname: 'example.com',
-      })
-      .reply(422, {
-        id: 'invalid_params',
-        message: '\'sni_endpoint\' param is required when adding a domain to an app with multiple SSL certs.',
-      })
-      .post('/apps/myapp/domains', {
-        hostname: 'example.com',
         sni_endpoint: 'my-cert',
       })
       .reply(200, domainsResponseWithEndpoint)

--- a/packages/apps/test/helpers/init.js
+++ b/packages/apps/test/helpers/init.js
@@ -1,5 +1,5 @@
-const chalk = require('chalk')
-chalk.enabled = false
+const {color} = require('@heroku-cli/color')
+color.enabled = false
 
 process.stdout.columns = 80
 process.stderr.columns = 80


### PR DESCRIPTION
This PR updates the logic involved in deciding when to show an SNI endpoint interactive prompt for `domains:add`.

Previously, the API would return an error response indicating that a cert was required, which we'd catch and then use as the trigger for the prompt. However, now that API is no longer performing this check, we now show the cert picker whenever a cert has not been passed AND the app has more than 1 cert on it.

https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008d2nCIAQ/view