### PR TITLE
fix(certs-v5): check if an app is a private space app when using SNI endpoints

### DIFF
--- a/packages/certs-v5/lib/endpoints.js
+++ b/packages/certs-v5/lib/endpoints.js
@@ -58,12 +58,12 @@ function tagAndSort (app, allCerts) {
 
 function * all (appName, heroku) {
   const featureList = yield heroku.get(`/apps/${appName}/features`)
-  const app = yield heroku.get(`/apps/${appName}`)
   const multipleSniEndpointFeatureEnabled = checkMultiSniFeature(featureList)
+  const isSpaceApp = yield hasSpace(appName, heroku)
 
   let allCerts;
 
-  if (multipleSniEndpointFeatureEnabled && !!app.space) {
+  if (multipleSniEndpointFeatureEnabled && isSpaceApp) {
     // use SNI endpoints only
     allCerts = yield {
       ssl_certs: [],

--- a/packages/certs-v5/lib/endpoints.js
+++ b/packages/certs-v5/lib/endpoints.js
@@ -67,16 +67,16 @@ function * all (appName, heroku) {
     // use SNI endpoints only
     allCerts = yield {
       ssl_certs: [],
-      sni_certs: sniCertsPromise(app, heroku),
+      sni_certs: sniCertsPromise(appName, heroku),
     }
   } else {
     allCerts = yield {
-      ssl_certs: sslCertsPromise(app, heroku),
-      sni_certs: sniCertsPromise(app, heroku)
+      ssl_certs: sslCertsPromise(appName, heroku),
+      sni_certs: sniCertsPromise(appName, heroku)
     }
   }
 
-  return tagAndSort(app, allCerts)
+  return tagAndSort(appName, allCerts)
 }
 
 function * hasAddon (app, heroku) {

--- a/packages/certs-v5/lib/endpoints.js
+++ b/packages/certs-v5/lib/endpoints.js
@@ -56,13 +56,14 @@ function tagAndSort (app, allCerts) {
   })
 }
 
-function * all (app, heroku) {
-  const featureList = yield heroku.get(`/apps/${app}/features`)
+function * all (appName, heroku) {
+  const featureList = yield heroku.get(`/apps/${appName}/features`)
+  const app = yield heroku.get(`/apps/${appName}`)
   const multipleSniEndpointFeatureEnabled = checkMultiSniFeature(featureList)
 
   let allCerts;
 
-  if (multipleSniEndpointFeatureEnabled) {
+  if (multipleSniEndpointFeatureEnabled && !!app.space) {
     // use SNI endpoints only
     allCerts = yield {
       ssl_certs: [],

--- a/packages/certs-v5/test/lib/mock_sni_feature.js
+++ b/packages/certs-v5/test/lib/mock_sni_feature.js
@@ -1,12 +1,16 @@
-function mockSniFeatureFlag (nock, appName, enabled = false) {
+function mockSniFeatureFlag (nock, appName, multiSniEnabled = false, isPrivateSpaceApp = false) {
   return nock('https://api.heroku.com')
     .get(`/apps/${appName}/features`)
     .reply(200, [
       {
         name: 'allow-multiple-sni-endpoints',
-        enabled
+        enabled: multiSniEnabled
       }
     ])
+    .get(`/apps/${appName}`)
+    .reply(200, {
+      space: isPrivateSpaceApp ? {} : null
+    })
 }
 
 module.exports = mockSniFeatureFlag


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

https://gus.lightning.force.com/lightning/_classic/%2Fa07B0000008dSIoIAM

Update the endpoint lookup logic to only use SNI endpoints when the multi SNI flag is enabled AND the app is a private space app. This helps to address an API issue with the ssl endpoints addon.
