### PR TITLE
fix(apps-v5, certs-v5) remove use of sunset variant: allow_multiple_sni_endpoints

### DIFF
--- a/packages/apps/src/commands/domains/add.ts
+++ b/packages/apps/src/commands/domains/add.ts
@@ -90,7 +90,7 @@ export default class DomainsAdd extends Command {
         domainCreatePayload.sni_endpoint = flags.cert
       } else {
         const {body} = await this.heroku.get<Array<Heroku.SniEndpoint>>(`/apps/${flags.app}/sni-endpoints`, {
-          headers: {Accept: 'application/vnd.heroku+json; version=3.allow_multiple_sni_endpoints'},
+          headers: {Accept: 'application/vnd.heroku+json; version=3'},
         })
 
         certs = [...body]
@@ -110,7 +110,7 @@ export default class DomainsAdd extends Command {
 
     try {
       const {body: domain} = await this.heroku.post<Heroku.Domain>(`/apps/${flags.app}/domains`, {
-        headers: {Accept: 'application/vnd.heroku+json; version=3.allow_multiple_sni_endpoints'},
+        headers: {Accept: 'application/vnd.heroku+json; version=3'},
         body: domainCreatePayload,
       })
 

--- a/packages/apps/src/commands/domains/update.ts
+++ b/packages/apps/src/commands/domains/update.ts
@@ -25,7 +25,7 @@ export default class DomainsUpdate extends Command {
       cli.action.start(`Updating ${color.cyan(hostname)} to use ${color.cyan(flags['cert-id'])} certificate`)
       await this.heroku.patch<string>(`/apps/${flags.app}/domains/${hostname}`, {
         headers: {
-          Accept: 'application/vnd.heroku+json; version=3.allow_multiple_sni_endpoints',
+          Accept: 'application/vnd.heroku+json; version=3',
         },
         body: {sni_endpoint: flags['cert-id']},
       })

--- a/packages/certs-v5/commands/certs/add.js
+++ b/packages/certs-v5/commands/certs/add.js
@@ -221,7 +221,7 @@ function * configureDomains (context, heroku, meta, cert) {
         return heroku.request({
           method: 'PATCH',
           path: `/apps/${context.app}/domains/${domain}`,
-          headers: { Accept: 'application/vnd.heroku+json; version=3.allow_multiple_sni_endpoints' },
+          headers: { Accept: 'application/vnd.heroku+json; version=3' },
           body: { sni_endpoint: cert.name }
         })
       }))


### PR DESCRIPTION
Now that https://github.com/heroku/api/pull/11860 has shipped api no longer expects the variant: `allow_multiple_sni_endpoints`. Remove our usage of it.