### PR TITLE
fix(pg-v5): exclude the internal _heroku schema from pg dump

### DIFF
--- a/packages/pg-v5/commands/pull.js
+++ b/packages/pg-v5/commands/pull.js
@@ -114,7 +114,7 @@ const run = co.wrap(function * (sourceIn, targetIn, exclusions) {
   const target = yield maybeTunnel(targetIn)
   const exclude = exclusions.map(function (e) { return '--exclude-table-data=' + e }).join(' ')
 
-  let dumpFlags = ['--verbose', '-F', 'c', '-Z', '0', ...connArgs(source, true)]
+  let dumpFlags = ['--verbose', '-F', 'c', '-Z', '0', '-N', '_heroku', ...connArgs(source, true)]
   if (exclude !== '') dumpFlags.push(exclude)
 
   const dumpOptions = {

--- a/packages/pg-v5/test/commands/pull.js
+++ b/packages/pg-v5/test/commands/pull.js
@@ -108,7 +108,7 @@ describe('pg', () => {
     })
 
     it('pushes out a db', () => {
-      const dumpFlags = ['--verbose', '-F', 'c', '-Z', '0', 'localdb']
+      const dumpFlags = ['--verbose', '-F', 'c', '-Z', '0', '-N', '_heroku', 'localdb']
       const restoreFlags = ['--verbose', '-F', 'c', '--no-acl', '--no-owner', '-U', 'jeff', '-h', 'herokai.com', '-p', '5432', '-d', 'mydb']
 
       spawnStub.withArgs('pg_dump', dumpFlags, dumpOpts).returns({
@@ -131,7 +131,7 @@ describe('pg', () => {
     })
 
     it('pushes out a db using url port', () => {
-      const dumpFlags = ['--verbose', '-F', 'c', '-Z', '0', '-h', 'localhost', '-p', '5433', 'localdb']
+      const dumpFlags = ['--verbose', '-F', 'c', '-Z', '0', '-N', '_heroku', '-h', 'localhost', '-p', '5433', 'localdb']
       const restoreFlags = ['--verbose', '-F', 'c', '--no-acl', '--no-owner', '-U', 'jeff', '-h', 'herokai.com', '-p', '5432', '-d', 'mydb']
 
       spawnStub.withArgs('pg_dump', dumpFlags, dumpOpts).returns({
@@ -157,7 +157,7 @@ describe('pg', () => {
       env.PGPORT = dumpOpts.env.PGPORT = '5433'
       restoreOpts.env.PGPORT = '5433'
 
-      const dumpFlags = ['--verbose', '-F', 'c', '-Z', '0', '-p', '5433', 'localdb']
+      const dumpFlags = ['--verbose', '-F', 'c', '-Z', '0', '-N', '_heroku', '-p', '5433', 'localdb']
       const restoreFlags = ['--verbose', '-F', 'c', '--no-acl', '--no-owner', '-U', 'jeff', '-h', 'herokai.com', '-p', '5432', '-d', 'mydb']
 
       spawnStub.withArgs('pg_dump', dumpFlags, dumpOpts).returns({
@@ -193,7 +193,7 @@ describe('pg', () => {
         localPort: 49152
       }
 
-      const dumpFlags = ['--verbose', '-F', 'c', '-Z', '0', 'localdb']
+      const dumpFlags = ['--verbose', '-F', 'c', '-Z', '0', '-N', '_heroku', 'localdb']
       const restoreFlags = ['--verbose', '-F', 'c', '--no-acl', '--no-owner', '-U', 'jeff', '-h', 'herokai.com', '-p', '5432', '-d', 'mydb']
 
       spawnStub.withArgs('pg_dump', dumpFlags, dumpOpts).returns({
@@ -217,7 +217,7 @@ describe('pg', () => {
     })
 
     it('exits non-zero when there is an error', () => {
-      const dumpFlags = ['--verbose', '-F', 'c', '-Z', '0', 'localdb']
+      const dumpFlags = ['--verbose', '-F', 'c', '-Z', '0', '-N', '_heroku', 'localdb']
       const restoreFlags = ['--verbose', '-F', 'c', '--no-acl', '--no-owner', '-U', 'jeff', '-h', 'herokai.com', '-p', '5432', '-d', 'mydb']
 
       spawnStub.withArgs('pg_dump', dumpFlags, dumpOpts).returns({
@@ -245,7 +245,7 @@ describe('pg', () => {
   })
 
   describe('pull', () => {
-    const dumpFlags = ['--verbose', '-F', 'c', '-Z', '0', '-U', 'jeff', '-h', 'herokai.com', '-p', '5432', 'mydb']
+    const dumpFlags = ['--verbose', '-F', 'c', '-Z', '0', '-N', '_heroku', '-U', 'jeff', '-h', 'herokai.com', '-p', '5432', 'mydb']
     const dumpOpts = {
       env: {
         PGPASSWORD: 'pass',


### PR DESCRIPTION
Data recently added an internal-only schema called `_heroku` to Postgres databases that have enabled Data Connectors. The schema privileges are restricted, which results in an error when trying to use `pg:pull`. This PR updates the pull command to always exclude the `_heroku` schema.

https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B00000089frJIAQ/view