### PR TITLE
feat(redis-v5): add new command to enable keyspace notifications

### DIFF
--- a/packages/redis-v5/commands/keyspace-notifications.js
+++ b/packages/redis-v5/commands/keyspace-notifications.js
@@ -29,13 +29,13 @@ module.exports = {
   `,
   run: cli.command(async (context, heroku) => {
     let api = require('../lib/shared')(context, heroku)
-    if (!context.flags.config) {
+    if (context.flags.config !== '' && !context.flags.config) {
       cli.exit(1, 'Please specify a valid keyspace notification configuration.')
     }
 
     let addon = await api.getRedisAddon()
 
     let config = await api.request(`/redis/v0/databases/${addon.name}/config`, 'PATCH', { notify_keyspace_events: context.flags.config })
-    cli.log(`Keyspace notifcations for ${addon.name} (${addon.config_vars.join(', ')}) set to ${config.notify_keyspace_events.value}.`)
+    cli.log(`Keyspace notifications for ${addon.name} (${addon.config_vars.join(', ')}) set to '${config.notify_keyspace_events.value}'.`)
   })
 }

--- a/packages/redis-v5/commands/keyspace-notifications.js
+++ b/packages/redis-v5/commands/keyspace-notifications.js
@@ -1,0 +1,41 @@
+'use strict'
+
+let cli = require('heroku-cli-util')
+
+module.exports = {
+  topic: 'redis',
+  command: 'keyspace-notifications',
+  needsApp: true,
+  needsAuth: true,
+  args: [{ name: 'database', optional: true }],
+  flags: [{ name: 'config', char: 'c', description: 'set keyspace notifications configuration', hasValue: true, optional: false }],
+  description: 'set the keyspace notifications configuration',
+  help: `Set the configuration to enable keyspace notification events:
+    K     Keyspace events, published with __keyspace@<db>__ prefix.
+    E     Keyevent events, published with __keyevent@<db>__ prefix.
+    g     Generic commands (non-type specific) like DEL, EXPIRE, RENAME, ...
+    $     String commands
+    l     List commands
+    s     Set commands
+    h     Hash commands
+    z     Sorted set commands
+    t     Stream commands
+    x     Expired events (events generated every time a key expires)
+    e     Evicted events (events generated when a key is evicted for maxmemory)
+    m     Key miss events (events generated when a key that doesn't exist is accessed)
+    A     Alias for "g$lshztxe", so that the "AKE" string means all the events except "m".
+
+    pass an empty string ('') to disable keyspace notifications
+  `,
+  run: cli.command(async (context, heroku) => {
+    let api = require('../lib/shared')(context, heroku)
+    if (!context.flags.config) {
+      cli.exit(1, 'Please specify a valid keyspace notification configuration.')
+    }
+
+    let addon = await api.getRedisAddon()
+
+    let config = await api.request(`/redis/v0/databases/${addon.name}/config`, 'PATCH', { notify_keyspace_events: context.flags.config })
+    cli.log(`Keyspace notifcations for ${addon.name} (${addon.config_vars.join(', ')}) set to ${config.notify_keyspace_events.value}.`)
+  })
+}

--- a/packages/redis-v5/index.js
+++ b/packages/redis-v5/index.js
@@ -7,7 +7,8 @@ exports.commands = [
   require('./commands/promote'),
   require('./commands/timeout'),
   require('./commands/maxmemory'),
-  require('./commands/maintenance')
+  require('./commands/maintenance'),
+  require('./commands/keyspace-notifications')
 ]
 
 exports.topic = {

--- a/packages/redis-v5/test/commands/keyspace-notifications.js
+++ b/packages/redis-v5/test/commands/keyspace-notifications.js
@@ -1,0 +1,47 @@
+'use strict'
+/* globals describe it beforeEach cli */
+
+let expect = require('chai').expect
+let nock = require('nock')
+let exit = require('heroku-cli-util').exit
+
+let command = require('../../commands/keyspace-notifications')
+const unwrap = require('../unwrap')
+
+describe('heroku redis:keyspace-notifications', function () {
+  require('../lib/shared').shouldHandleArgs(command, { config: 'AKE' })
+})
+
+describe('heroku redis:keyspace-notifications', function () {
+  beforeEach(function () {
+    cli.mockConsole()
+    nock.cleanAll()
+    exit.mock()
+  })
+
+  it('# sets the keyspace notify events', function () {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
+      ])
+
+    let redis = nock('https://redis-api.heroku.com:443')
+      .patch('/redis/v0/databases/redis-haiku/config', { notify_keyspace_events: 'AKE' }).reply(200, {
+        notify_keyspace_events: { value: 'AKE', values: { 'AKE': '' } }
+      })
+
+    return command.run({ app: 'example', flags: { config: 'AKE' }, args: {}, auth: { username: 'foobar', password: 'password' } })
+      .then(() => app.done())
+      .then(() => redis.done())
+      .then(() => expect(cli.stdout).to.equal(
+        `Keyspace notifications for redis-haiku (REDIS_FOO, REDIS_BAR) set to 'AKE'.\n`
+      ))
+      .then(() => expect(cli.stderr).to.equal(''))
+  })
+
+  it('# errors on missing eviction policy', function () {
+    return expect(command.run({ app: 'example', flags: {}, args: {} })).to.be.rejectedWith(exit.ErrorExit)
+      .then(() => expect(cli.stdout).to.equal(''))
+      .then(() => expect(unwrap(cli.stderr)).to.equal('Please specify a valid keyspace notification configuration.\n'))
+  })
+})


### PR DESCRIPTION
Creates a new command for Redis.

```
heroku redis:keyspace-notifications HEROKU_REDIS_CPURCELL_GREEN_URL -c 'AKE' -a cp-testing
```

Adds another field to the info command

```
heroku redis:info -a cp-testing
=== redis-cpurcell-aerodynamic-53841 (HEROKU_REDIS_CPURCELL_GREEN_URL)
Plan:                   Premium 0
Status:                 available
Created:                2020-09-10 18:39
Version:                6.0.6
Timeout:                300
Maxmemory:              noeviction
Maintenance:            not required
Maintenance window:     Wednesdays 18:00 to 22:00 UTC
Persistence:            AOF
HA Status:              Available
Requires TLS:           Yes
Keyspace Notifications: AKE
=== redis-cpurcell-spherical-17414 (HEROKU_REDIS_CPURCELL_PUCE_URL)
Plan:                   Premium 0
Status:                 available
Created:                2020-09-10 18:20
Version:                6.0.6
Timeout:                300
Maxmemory:              noeviction
Maintenance:            not required
Maintenance window:     Wednesdays 18:00 to 22:00 UTC
Persistence:            AOF
HA Status:              Available
Requires TLS:           Yes
Keyspace Notifications: Disabled
```

Help output
```
set the keyspace notifications configuration

USAGE
  $ heroku redis:keyspace-notifications [DATABASE]

OPTIONS
  -a, --app=app        (required) app to run command against
  -c, --config=config  (required) set keyspace notifications configuration
  -r, --remote=remote  git remote of app to use

DESCRIPTION
  Set the configuration to enable keyspace notification events:
       K     Keyspace events, published with __keyspace@<db>__ prefix.
       E     Keyevent events, published with __keyevent@<db>__ prefix.
       g     Generic commands (non-type specific) like DEL, EXPIRE, RENAME, ...
       $     String commands
       l     List commands
       s     Set commands
       h     Hash commands
       z     Sorted set commands
       t     Stream commands
       x     Expired events (events generated every time a key expires)
       e     Evicted events (events generated when a key is evicted for maxmemory)
       m     Key miss events (events generated when a key that doesn't exist is accessed)
       A     Alias for "g$lshztxe", so that the "AKE" string means all the events except "m".

       pass an empty string ('') to disable keyspace notifications
```

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
