### PR TITLE
feat(auth): add a deprecation warning to generate-recovery-codes

### DIFF
--- a/packages/auth/src/commands/auth/2fa/generate-recovery-codes.ts
+++ b/packages/auth/src/commands/auth/2fa/generate-recovery-codes.ts
@@ -1,4 +1,5 @@
 import {Command} from '@heroku-cli/command'
+import cli from 'cli-ux'
 import ux from 'cli-ux'
 
 export default class Auth2faGenerate extends Command {
@@ -28,6 +29,7 @@ a37c5c6985f56e66
 f82e7c2a50737494`
 
   async run() {
+    cli.warn('DEPRECATION WARNING: this command will be removed soon, in favor of generating recovery codes in your Account Settings in a browser.')
     const password = await ux.prompt('Password', {type: 'hide'})
     const headers = {'Heroku-Password': password}
     const {body: codes} = await this.heroku.post<string[]>('/account/recovery-codes', {headers})

--- a/packages/auth/src/commands/auth/2fa/generate-recovery-codes.ts
+++ b/packages/auth/src/commands/auth/2fa/generate-recovery-codes.ts
@@ -1,6 +1,5 @@
 import {Command} from '@heroku-cli/command'
 import cli from 'cli-ux'
-import ux from 'cli-ux'
 
 export default class Auth2faGenerate extends Command {
   static description = `generates 2fa recovery codes
@@ -30,11 +29,11 @@ f82e7c2a50737494`
 
   async run() {
     cli.warn('DEPRECATION WARNING: this command will be removed soon, in favor of generating recovery codes in your Account Settings in a browser.')
-    const password = await ux.prompt('Password', {type: 'hide'})
+    const password = await cli.prompt('Password', {type: 'hide'})
     const headers = {'Heroku-Password': password}
     const {body: codes} = await this.heroku.post<string[]>('/account/recovery-codes', {headers})
     for (const code of codes) {
-      ux.log(code)
+      cli.log(code)
     }
   }
 }


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

GUS: https://gus.my.salesforce.com/a07B0000008TzhqIAC

We are moving away from Heroku 2FA to integrating with VaaS (Verification-as-a-Service). Generating recovery codes will happen in VaaS' interface, so we plan to remove the cli command `heroku auth:2fa:generate-recovery-codes`. Our research indicates this is rarely used, so we are not replacing it (see https://gus.lightning.force.com/lightning/r/0D5B000001Bmu1yKAB/view => we concluded it is currently used perhaps once/day).