### PR TITLE
Add helpful error message for VaaS MFA users

### DIFF
--- a/packages/auth/src/commands/auth/2fa/disable.ts
+++ b/packages/auth/src/commands/auth/2fa/disable.ts
@@ -15,7 +15,7 @@ Disabling 2fa on me@example.com... done`
 
   async run() {
     cli.action.start('Disabling 2fa')
-    const headers = { 'Accept': 'application/vnd.heroku+json; version=3.with_vaas_info' }
+    const headers = {Accept: 'application/vnd.heroku+json; version=3.with_vaas_info'}
     const {body: account} = await this.heroku.get<Heroku.Account>('/account', {headers})
     cli.action.start(`Disabling 2fa on ${account.email}`)
     if (account.vaas_enrolled) this.error('Cannot disable 2fa via CLI\nPlease visit your Account page on the Heroku Dashboad to manage 2fa')

--- a/packages/auth/src/commands/auth/2fa/disable.ts
+++ b/packages/auth/src/commands/auth/2fa/disable.ts
@@ -15,8 +15,13 @@ Disabling 2fa on me@example.com... done`
 
   async run() {
     ux.action.start('Disabling 2fa')
-    const {body: account} = await this.heroku.get<Heroku.Account>('/account')
+    const {body: account} = await this.heroku.get<Heroku.Account>('/account'), {
+        headers: {
+          Accept: 'application/vnd.heroku+json; version=3.with_vaas_info',
+        }
+    }
     ux.action.start(`Disabling 2fa on ${account.email}`)
+    if (account.vaas_enrolled) this.error('Cannot disable 2fa via CLI\nPlease visit your Account page on the Heroku Dashboad to manage 2fa')
     if (!account.two_factor_authentication) this.error('2fa is already disabled')
     const password = await ux.prompt('Password', {type: 'hide'})
     await this.heroku.patch('/account', {body: {password, two_factor_authentication: false}})

--- a/packages/auth/src/commands/auth/2fa/disable.ts
+++ b/packages/auth/src/commands/auth/2fa/disable.ts
@@ -18,7 +18,7 @@ Disabling 2fa on me@example.com... done`
     const headers = {Accept: 'application/vnd.heroku+json; version=3.with_vaas_info'}
     const {body: account} = await this.heroku.get<Heroku.Account>('/account', {headers})
     cli.action.start(`Disabling 2fa on ${account.email}`)
-    if (account.vaas_enrolled) this.error('Cannot disable 2fa via CLI\nPlease visit your Account page on the Heroku Dashboad to manage 2fa')
+    if (account.vaas_enrolled) this.error('Cannot disable 2fa via CLI\nPlease visit your Account page on the Heroku Dashboard to manage 2fa: https://dashboard.heroku.com/account')
     if (!account.two_factor_authentication) this.error('2fa is already disabled')
     const password = await cli.prompt('Password', {type: 'hide'})
     await this.heroku.patch('/account', {body: {password, two_factor_authentication: false}})

--- a/packages/auth/src/commands/auth/2fa/disable.ts
+++ b/packages/auth/src/commands/auth/2fa/disable.ts
@@ -15,11 +15,9 @@ Disabling 2fa on me@example.com... done`
 
   async run() {
     ux.action.start('Disabling 2fa')
-    const {body: account} = await this.heroku.get<Heroku.Account>('/account'), {
-        headers: {
-          Accept: 'application/vnd.heroku+json; version=3.with_vaas_info',
-        }
-    }
+    const {body: account} = await this.heroku.get<Heroku.Account>('/account', {
+        headers: {Accept: 'application/vnd.heroku+json; version=3.with_vaas_info'},
+    })
     ux.action.start(`Disabling 2fa on ${account.email}`)
     if (account.vaas_enrolled) this.error('Cannot disable 2fa via CLI\nPlease visit your Account page on the Heroku Dashboad to manage 2fa')
     if (!account.two_factor_authentication) this.error('2fa is already disabled')

--- a/packages/auth/src/commands/auth/2fa/disable.ts
+++ b/packages/auth/src/commands/auth/2fa/disable.ts
@@ -1,6 +1,6 @@
 import {Command} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
-import ux from 'cli-ux'
+import cli from 'cli-ux'
 
 export default class Auth2faGenerate extends Command {
   static description = 'disables 2fa on account'
@@ -14,14 +14,13 @@ export default class Auth2faGenerate extends Command {
 Disabling 2fa on me@example.com... done`
 
   async run() {
-    ux.action.start('Disabling 2fa')
-    const {body: account} = await this.heroku.get<Heroku.Account>('/account', {
-      headers: {Accept: 'application/vnd.heroku+json; version=3.with_vaas_info'},
-    })
-    ux.action.start(`Disabling 2fa on ${account.email}`)
+    cli.action.start('Disabling 2fa')
+    const headers = { 'Accept': 'application/vnd.heroku+json; version=3.with_vaas_info' }
+    const {body: account} = await this.heroku.get<Heroku.Account>('/account', {headers})
+    cli.action.start(`Disabling 2fa on ${account.email}`)
     if (account.vaas_enrolled) this.error('Cannot disable 2fa via CLI\nPlease visit your Account page on the Heroku Dashboad to manage 2fa')
     if (!account.two_factor_authentication) this.error('2fa is already disabled')
-    const password = await ux.prompt('Password', {type: 'hide'})
+    const password = await cli.prompt('Password', {type: 'hide'})
     await this.heroku.patch('/account', {body: {password, two_factor_authentication: false}})
   }
 }

--- a/packages/auth/src/commands/auth/2fa/disable.ts
+++ b/packages/auth/src/commands/auth/2fa/disable.ts
@@ -16,7 +16,7 @@ Disabling 2fa on me@example.com... done`
   async run() {
     ux.action.start('Disabling 2fa')
     const {body: account} = await this.heroku.get<Heroku.Account>('/account', {
-        headers: {Accept: 'application/vnd.heroku+json; version=3.with_vaas_info'},
+      headers: {Accept: 'application/vnd.heroku+json; version=3.with_vaas_info'},
     })
     ux.action.start(`Disabling 2fa on ${account.email}`)
     if (account.vaas_enrolled) this.error('Cannot disable 2fa via CLI\nPlease visit your Account page on the Heroku Dashboad to manage 2fa')


### PR DESCRIPTION
* Soon, we will roll out a beta where users can have MFA/2FA for their
  Heroku Accounts using VaaS (verification as a service), a Salesforce
  platform that all clouds are adopting.
* In the next few months, we will migrate all existing Heroku 2FA users
  over to VaaS. The login experience will still be very similar for
these users, but they will be verifying themselves via the VaaS redirect
interface rather than on the Heroku home-grown 2FA flow.
* Users who are migrated over may not even know it, so they may attempt
  to disable MFA via CLI. While technically we could do some trickery
with the VaaS Admin API to make this possible, the intent of VaaS is
that users go into the VaaS manage page, which is accessible via the
Heroku Dashboard, to do all verifier management.
* This CLI command is used very rarely but we figure it doesn't hurt to
  add a helpful error message here rather than confusingly telling users
with VaaS MFA enabled that they do not have 2FA enabled (because they
do...it's just a *different* 2FA).
* https://gus.my.salesforce.com/a07B0000008TzijIAC

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
