### PR TITLE
feat(certs-v5): add domain info in certs list and info

### DIFF
--- a/packages/certs-v5/commands/certs/info.js
+++ b/packages/certs-v5/commands/certs/info.js
@@ -14,10 +14,8 @@ function * run (context, heroku) {
     headers: { 'Accept': `application/vnd.heroku+json; version=3.${endpoint._meta.variant}` }
   }))
 
-  let domains;
-
   if (context.flags['show-domains']) {
-    domains = yield Promise.all(endpoint.domains.map(domain => {
+    let domains = yield Promise.all(endpoint.domains.map(domain => {
       return heroku.request({
         path: `/apps/${context.flags.app}/domains/${domain}`,
         headers: { 'Accept': `application/vnd.heroku+json; version=3.allow_multiple_sni_endpoints` }
@@ -37,7 +35,7 @@ module.exports = {
   flags: [
     { name: 'name', hasValue: true, description: 'name to check info on' },
     { name: 'endpoint', hasValue: true, description: 'endpoint to check info on' },
-    { name: 'show-domains', hasValue: false, description: 'show associated domains'}
+    { name: 'show-domains', hasValue: false, description: 'show associated domains' }
   ],
   description: 'show certificate information for an SSL certificate',
   needsApp: true,

--- a/packages/certs-v5/lib/certificate_details.js
+++ b/packages/certs-v5/lib/certificate_details.js
@@ -14,13 +14,19 @@ module.exports = function (cert, message) {
 
   let logMessage = message || 'Certificate details:'
   cli.log(logMessage)
-  cli.styledObject({
+  let tableObject = {
     'Common Name(s)': cert.ssl_cert.cert_domains,
     'Expires At': formatDate(cert.ssl_cert.expires_at),
     'Issuer': cert.ssl_cert.issuer,
     'Starts At': formatDate(cert.ssl_cert.starts_at),
-    'Subject': cert.ssl_cert.subject
-  })
+    'Subject': cert.ssl_cert.subject,
+  }
+
+  if (cert.domains && cert.domains.length) {
+    tableObject['Domain(s)'] = cert.domains
+  }
+
+  cli.styledObject(tableObject)
 
   if (cert.ssl_cert['ca_signed?']) {
     cli.log('SSL certificate is verified by a root authority.')

--- a/packages/certs-v5/lib/display_table.js
+++ b/packages/certs-v5/lib/display_table.js
@@ -56,8 +56,11 @@ module.exports = function (certs) {
     {label: 'Expires', key: 'expires_at', format: function (f) { return f ? formatDate(f) : '' }},
     {label: 'Trusted', key: 'ca_signed', format: function (f) { return f === undefined ? '' : (f ? 'True' : 'False') }},
     {label: 'Type', key: 'type'},
-    {label: 'Domains', key: 'associated_domains'}
   ])
+
+  if (certs.some(cert => !cert.ssl_cert || !cert.ssl_cert.acm)) {
+    columns.push({label: 'Domains', key: 'associated_domains'})
+  }
 
   cli.table(mapped, { columns })
 }

--- a/packages/certs-v5/lib/display_table.js
+++ b/packages/certs-v5/lib/display_table.js
@@ -25,15 +25,17 @@ function type (f) {
 
 module.exports = function (certs) {
   let mapped = certs.filter(function (f) { return f.ssl_cert }).map(function (f) {
-    return {
+    let tableContents = {
       name: f.name,
       cname: f.cname,
       expires_at: f.ssl_cert.expires_at,
       ca_signed: f.ssl_cert['ca_signed?'],
       type: type(f),
       common_names: f.ssl_cert.cert_domains.join(', '),
-      associated_domains: String(f.domains.length)
+      associated_domains: (f.domains && f.domains.length) ? f.domains.length : '0'
     }
+
+    return tableContents
   })
 
   let columns = [

--- a/packages/certs-v5/lib/display_table.js
+++ b/packages/certs-v5/lib/display_table.js
@@ -32,7 +32,12 @@ module.exports = function (certs) {
       ca_signed: f.ssl_cert['ca_signed?'],
       type: type(f),
       common_names: f.ssl_cert.cert_domains.join(', '),
-      associated_domains: (f.domains && f.domains.length) ? f.domains.length : '0'
+    }
+
+    // If they're using ACM it's not really worth showing the number of associated domains since
+    // it'll always be 1 and is entirely outside the user's control
+    if (!f.ssl_cert.acm) {
+      tableContents.associated_domains = (f.domains && f.domains.length) ? f.domains.length : '0'
     }
 
     return tableContents

--- a/packages/certs-v5/lib/display_table.js
+++ b/packages/certs-v5/lib/display_table.js
@@ -31,7 +31,8 @@ module.exports = function (certs) {
       expires_at: f.ssl_cert.expires_at,
       ca_signed: f.ssl_cert['ca_signed?'],
       type: type(f),
-      common_names: f.ssl_cert.cert_domains.join(', ')
+      common_names: f.ssl_cert.cert_domains.join(', '),
+      associated_domains: String(f.domains.length)
     }
   })
 
@@ -47,7 +48,8 @@ module.exports = function (certs) {
     {label: 'Common Name(s)', key: 'common_names'},
     {label: 'Expires', key: 'expires_at', format: function (f) { return f ? formatDate(f) : '' }},
     {label: 'Trusted', key: 'ca_signed', format: function (f) { return f === undefined ? '' : (f ? 'True' : 'False') }},
-    {label: 'Type', key: 'type'}
+    {label: 'Type', key: 'type'},
+    {label: 'Domains', key: 'associated_domains'}
   ])
 
   cli.table(mapped, { columns })

--- a/packages/certs-v5/test/commands/certs/index.js
+++ b/packages/certs-v5/test/commands/certs/index.js
@@ -36,10 +36,10 @@ describe('heroku certs', function () {
         expect(cli.stderr).to.equal('')
         /* eslint-disable no-trailing-spaces */
         expect(cli.stdout).to.equal(
-          `Name        Endpoint                  Common Name(s)  Expires               Trusted  Type
-──────────  ────────────────────────  ──────────────  ────────────────────  ───────  ────────
-akita-7777  akita-7777.herokussl.com  heroku.com      2013-08-01 21:34 UTC  True     Endpoint
-tokyo-1050  tokyo-1050.herokussl.com  example.org     2013-08-01 21:34 UTC  False    Endpoint
+          `Name        Endpoint                  Common Name(s)  Expires               Trusted  Type      Domains
+──────────  ────────────────────────  ──────────────  ────────────────────  ───────  ────────  ───────
+akita-7777  akita-7777.herokussl.com  heroku.com      2013-08-01 21:34 UTC  True     Endpoint  0
+tokyo-1050  tokyo-1050.herokussl.com  example.org     2013-08-01 21:34 UTC  False    Endpoint  0
 `)
         /* eslint-enable no-trailing-spaces */
       })
@@ -82,10 +82,10 @@ tokyo-1050  tokyo-1050.herokussl.com  example.org     2013-08-01 21:34 UTC  Fals
       expect(cli.stderr).to.equal('')
       /* eslint-disable no-trailing-spaces */
       expect(cli.stdout).to.equal(
-        `Name        Endpoint                  Common Name(s)                                     Expires               Trusted  Type
-──────────  ────────────────────────  ─────────────────────────────────────────────────  ────────────────────  ───────  ────────
-akita-7777  akita-7777.herokussl.com  heroku.com                                         2013-08-01 21:34 UTC  True     Endpoint
-tokyo-1050  (Not applicable for SNI)  foo.example.org, bar.example.org, biz.example.com  2013-08-01 21:34 UTC  False    SNI
+        `Name        Endpoint                  Common Name(s)                                     Expires               Trusted  Type      Domains
+──────────  ────────────────────────  ─────────────────────────────────────────────────  ────────────────────  ───────  ────────  ───────
+akita-7777  akita-7777.herokussl.com  heroku.com                                         2013-08-01 21:34 UTC  True     Endpoint  0
+tokyo-1050  (Not applicable for SNI)  foo.example.org, bar.example.org, biz.example.com  2013-08-01 21:34 UTC  False    SNI       0
 `)
       /* eslint-enable no-trailing-spaces */
     })
@@ -111,9 +111,9 @@ tokyo-1050  (Not applicable for SNI)  foo.example.org, bar.example.org, biz.exam
       expect(cli.stderr).to.equal('')
       /* eslint-disable no-trailing-spaces */
       expect(cli.stdout).to.equal(
-        `Name        Endpoint                               Common Name(s)  Expires               Trusted  Type
-──────────  ─────────────────────────────────────  ──────────────  ────────────────────  ───────  ─────────────────
-tokyo-1050  tokyo-1050.japan-4321.herokuspace.com  heroku.com      2013-08-01 21:34 UTC  True     Private Space App
+        `Name        Endpoint                               Common Name(s)  Expires               Trusted  Type               Domains
+──────────  ─────────────────────────────────────  ──────────────  ────────────────────  ───────  ─────────────────  ───────
+tokyo-1050  tokyo-1050.japan-4321.herokuspace.com  heroku.com      2013-08-01 21:34 UTC  True     Private Space App  0
 `)
       /* eslint-enable no-trailing-spaces */
     })
@@ -138,9 +138,9 @@ tokyo-1050  tokyo-1050.japan-4321.herokuspace.com  heroku.com      2013-08-01 21
       expect(cli.stderr).to.equal('')
       /* eslint-disable no-trailing-spaces */
       expect(cli.stdout).to.equal(
-        `Name        Common Name(s)  Expires               Trusted  Type
-──────────  ──────────────  ────────────────────  ───────  ────
-tokyo-1050  heroku.com      2013-08-01 21:34 UTC  True     ACM
+        `Name        Common Name(s)  Expires               Trusted  Type  Domains
+──────────  ──────────────  ────────────────────  ───────  ────  ───────
+tokyo-1050  heroku.com      2013-08-01 21:34 UTC  True     ACM   0
 `)
       /* eslint-enable no-trailing-spaces */
     })
@@ -165,9 +165,9 @@ tokyo-1050  heroku.com      2013-08-01 21:34 UTC  True     ACM
       expect(cli.stderr).to.equal('')
       /* eslint-disable no-trailing-spaces */
       expect(cli.stdout).to.equal(
-        `Name        Common Name(s)                                     Expires               Trusted  Type
-──────────  ─────────────────────────────────────────────────  ────────────────────  ───────  ────
-tokyo-1050  foo.example.org, bar.example.org, biz.example.com  2013-08-01 21:34 UTC  False    SNI
+        `Name        Common Name(s)                                     Expires               Trusted  Type  Domains
+──────────  ─────────────────────────────────────────────────  ────────────────────  ───────  ────  ───────
+tokyo-1050  foo.example.org, bar.example.org, biz.example.com  2013-08-01 21:34 UTC  False    SNI   0
 `)
       /* eslint-enable no-trailing-spaces */
     })
@@ -192,9 +192,9 @@ tokyo-1050  foo.example.org, bar.example.org, biz.example.com  2013-08-01 21:34 
       expect(cli.stderr).to.equal('')
       /* eslint-disable no-trailing-spaces */
       expect(cli.stdout).to.equal(
-        `Name        Common Name(s)  Expires               Trusted  Type
-──────────  ──────────────  ────────────────────  ───────  ────
-tokyo-1050  fooexample.org  2013-08-01 21:34 UTC  False    SNI
+        `Name        Common Name(s)  Expires               Trusted  Type  Domains
+──────────  ──────────────  ────────────────────  ───────  ────  ───────
+tokyo-1050  fooexample.org  2013-08-01 21:34 UTC  False    SNI   0
 `)
       /* eslint-enable no-trailing-spaces */
     })
@@ -219,9 +219,9 @@ tokyo-1050  fooexample.org  2013-08-01 21:34 UTC  False    SNI
       expect(cli.stderr).to.equal('')
       /* eslint-disable no-trailing-spaces */
       expect(cli.stdout).to.equal(
-        `Name        Common Name(s)  Expires               Trusted  Type
-──────────  ──────────────  ────────────────────  ───────  ────
-tokyo-1050  *.example.org   2013-08-01 21:34 UTC  False    SNI
+        `Name        Common Name(s)  Expires               Trusted  Type  Domains
+──────────  ──────────────  ────────────────────  ───────  ────  ───────
+tokyo-1050  *.example.org   2013-08-01 21:34 UTC  False    SNI   0
 `)
       /* eslint-enable no-trailing-spaces */
     })
@@ -246,9 +246,9 @@ tokyo-1050  *.example.org   2013-08-01 21:34 UTC  False    SNI
       expect(cli.stderr).to.equal('')
       /* eslint-disable no-trailing-spaces */
       expect(cli.stdout).to.equal(
-        `Name        Common Name(s)                                     Expires               Trusted  Type
-──────────  ─────────────────────────────────────────────────  ────────────────────  ───────  ────
-tokyo-1050  foo.example.org, bar.example.org, biz.example.com  2013-08-01 21:34 UTC  False    SNI
+        `Name        Common Name(s)                                     Expires               Trusted  Type  Domains
+──────────  ─────────────────────────────────────────────────  ────────────────────  ───────  ────  ───────
+tokyo-1050  foo.example.org, bar.example.org, biz.example.com  2013-08-01 21:34 UTC  False    SNI   0
 `)
       /* eslint-enable no-trailing-spaces */
     })

--- a/packages/certs-v5/test/commands/certs/index.js
+++ b/packages/certs-v5/test/commands/certs/index.js
@@ -138,9 +138,9 @@ tokyo-1050  tokyo-1050.japan-4321.herokuspace.com  heroku.com      2013-08-01 21
       expect(cli.stderr).to.equal('')
       /* eslint-disable no-trailing-spaces */
       expect(cli.stdout).to.equal(
-        `Name        Common Name(s)  Expires               Trusted  Type  Domains
-──────────  ──────────────  ────────────────────  ───────  ────  ───────
-tokyo-1050  heroku.com      2013-08-01 21:34 UTC  True     ACM   0
+        `Name        Common Name(s)  Expires               Trusted  Type
+──────────  ──────────────  ────────────────────  ───────  ────
+tokyo-1050  heroku.com      2013-08-01 21:34 UTC  True     ACM
 `)
       /* eslint-enable no-trailing-spaces */
     })


### PR DESCRIPTION
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008dFwjIAE/view

This PR adds two new pieces of functionality:
1. The `certs` command will now show a count of associated domains for each cert in the list
2. The `certs:info` command now has an optional `--show-domains` flag which, when used, will request and display the names of all the domains associated with the cert in question.
