### PR TITLE
fix(certs-v5): fix logic for requesting all cert resources

### DIFF
--- a/packages/certs-v5/commands/certs/add.js
+++ b/packages/certs-v5/commands/certs/add.js
@@ -14,7 +14,7 @@ let isWildcard = require('../../lib/is_wildcard.js')
 let isWildcardMatch = require('../../lib/is_wildcard_match.js')
 let getCertAndKey = require('../../lib/get_cert_and_key.js')
 let matchDomains = require('../../lib/match_domains.js')
-let checkMultiSniFeature = require('../../lib/features.js')
+let { checkMultiSniFeature } = require('../../lib/features.js')
 let { waitForDomains, printDomains } = require('../../lib/domains')
 
 function Domains (domains) {

--- a/packages/certs-v5/lib/endpoints.js
+++ b/packages/certs-v5/lib/endpoints.js
@@ -1,6 +1,6 @@
 'use strict'
 
-let checkMultiSniFeature = require('./features.js')
+const { checkPrivateSniFeature } = require('./features.js')
 
 function sslCertsPromise (app, heroku) {
   return heroku.request({
@@ -58,12 +58,11 @@ function tagAndSort (app, allCerts) {
 
 function * all (appName, heroku) {
   const featureList = yield heroku.get(`/apps/${appName}/features`)
-  const multipleSniEndpointFeatureEnabled = checkMultiSniFeature(featureList)
-  const isSpaceApp = yield hasSpace(appName, heroku)
+  const privateSniFeatureEnabled = checkPrivateSniFeature(featureList)
 
   let allCerts;
 
-  if (multipleSniEndpointFeatureEnabled && isSpaceApp) {
+  if (privateSniFeatureEnabled) {
     // use SNI endpoints only
     allCerts = yield {
       ssl_certs: [],

--- a/packages/certs-v5/lib/features.js
+++ b/packages/certs-v5/lib/features.js
@@ -1,7 +1,15 @@
 const MULTIPLE_SNI_ENDPOINT_FLAG = 'allow-multiple-sni-endpoints'
+const PRIVATE_SNI_ENDPOINT_FLAG = 'private-spaces-sni'
 
 function checkMultiSniFeature(featureList) {
   return featureList.some(feature => feature.name === MULTIPLE_SNI_ENDPOINT_FLAG && feature.enabled === true)
 }
 
-module.exports = checkMultiSniFeature
+function checkPrivateSniFeature(featureList) {
+  return featureList.some(feature => feature.name === PRIVATE_SNI_ENDPOINT_FLAG && feature.enabled === true)
+}
+
+module.exports = {
+  checkMultiSniFeature,
+  checkPrivateSniFeature
+}


### PR DESCRIPTION
This PR addresses an issue in the logic for requesting cert resources that was discovered in https://heroku.support/928500.

tl;dr: This PR updates the certs `endpoints` util function to use the new `private-spaces-sni` feature flag rather than using a bunch of roundabout logic that ended up not even really working.

The issue essentially boils down to the fact that we have both `sni-endpoints` and `ssl-endpoints`, each of which are used (or not) depending on various other circumstances (feature flags, private space apps, presence of the legacy SSL addon on the app, etc.).

The CLI originally accounted for this by *always* making requests to both endpoints no matter what and simply combining and filtering the results into a single list. This works in many cases, but breaks in the case where we have a private spaces app that has been migrated to use sni-endpoints (this is a very recent development). In this scenario, requesting both the ssl and sni endpoints causes a warning about having received duplicate resources and also breaks downstream logic about which endpoint to use when *updating* a cert. Now that we have an explicit "this app has been migrated to use sni endpoints for private spaces" feature flag, we can simplify this logic a great deal.

