### PR TITLE
feat(webhooks): show 20 deliveries by default, add --num flag

### DIFF
--- a/packages/webhooks/src/commands/webhooks/deliveries/index.ts
+++ b/packages/webhooks/src/commands/webhooks/deliveries/index.ts
@@ -15,6 +15,7 @@ export default class Deliveries extends BaseCommand {
     remote: flags.remote(),
     status: flags.string({char: 's', description: 'filter deliveries by status'}),
     pipeline: flags.pipeline({char: 'p', description: 'pipeline on which to list', hidden: true}),
+    num: flags.integer({char: 'n', description: 'number of deliveries to show (default: 20)'}),
   }
 
   async run() {
@@ -22,16 +23,18 @@ export default class Deliveries extends BaseCommand {
     const webhookType = this.webhookType(flags)
     let {path} = webhookType
     const {display} = webhookType
-    const max = 1000
 
     path = `${path}/webhook-deliveries`
     if (flags.status) {
       path += `?eq[status]=${encodeURIComponent(flags.status)}`
     }
 
-    const {body: deliveries} = await this.webhooksClient.get(path, {
+    if (!flags.num) {
+      flags.num = 20
+    }
+    const {body: deliveries, statusCode: status} = await this.webhooksClient.get(path, {
       headers: {
-        Range: `seq ..; order=desc,max=${max}`,
+        Range: `seq ..; order=desc,max=${flags.num}`,
       },
       partial: true,
     })
@@ -45,8 +48,8 @@ export default class Deliveries extends BaseCommand {
 
       deliveries.reverse()
 
-      if (deliveries.length === max) {
-        this.warn(`Only showing the ${max} most recent deliveries`)
+      if (status === 206) {
+        this.warn(`Only showing the ${flags.num} most recent deliveries`)
         this.warn('It is possible to filter deliveries by using the --status flag')
       }
 

--- a/packages/webhooks/test/commands/webhooks/deliveries/index.test.ts
+++ b/packages/webhooks/test/commands/webhooks/deliveries/index.test.ts
@@ -6,10 +6,10 @@ describe('webhooks:deliveries', () => {
     .stdout()
     .stderr()
     .nock('https://api.heroku.com', {
-      reqheaders: {range: 'seq ..; order=desc,max=1000'},
+      reqheaders: {range: 'seq ..; order=desc,max=20'},
     }, api => api
     .get('/apps/example-app/webhook-deliveries')
-    .reply(206, [
+    .reply(200, [
       {
         id: '66666666-6666-6666-6666-666666666666',
         event: {
@@ -48,9 +48,9 @@ describe('webhooks:deliveries', () => {
     .command(['webhooks:deliveries', '--app', 'example-app'])
     .it('lists webhooks deliveries for app webhooks', ctx => {
       expect(ctx.stderr).to.equal('')
-      expect(ctx.stdout.trim()).to.equal(
-        `Delivery ID                          Created              Status   Include   Level  Attempts Code Error  Next Attempt         
-99999999-9999-9999-9999-999999999999 2017-08-17T20:22:37Z retrying api:build notify 4        401  Foobar 2017-08-17T20:22:39Z 
+      expect(ctx.stdout.trim().split('\n').map(l => l.trim()).join('\n')).to.equal(
+        `Delivery ID                          Created              Status   Include   Level  Attempts Code Error  Next Attempt
+99999999-9999-9999-9999-999999999999 2017-08-17T20:22:37Z retrying api:build notify 4        401  Foobar 2017-08-17T20:22:39Z
 66666666-6666-6666-6666-666666666666 2017-08-17T20:22:38Z pending  api:build notify 4`)
     })
 
@@ -58,10 +58,10 @@ describe('webhooks:deliveries', () => {
     .stdout()
     .stderr()
     .nock('https://api.heroku.com', {
-      reqheaders: {range: 'seq ..; order=desc,max=1000'},
+      reqheaders: {range: 'seq ..; order=desc,max=20'},
     }, api => api
     .get('/apps/example-app/webhook-deliveries?eq[status]=pending')
-    .reply(206, [
+    .reply(200, [
       {
         id: '66666666-6666-6666-6666-666666666666',
         event: {
@@ -81,8 +81,8 @@ describe('webhooks:deliveries', () => {
     .command(['webhooks:deliveries', '--app', 'example-app', '--status', 'pending'])
     .it('lists webhook deliveries for app webhooks filtered by status', ctx => {
       expect(ctx.stderr).to.equal('')
-      expect(ctx.stdout.trim()).to.equal(
-        `Delivery ID                          Created              Status  Include   Level  Attempts Code Error Next Attempt 
+      expect(ctx.stdout.trim().split('\n').map(l => l.trim()).join('\n')).to.equal(
+        `Delivery ID                          Created              Status  Include   Level  Attempts Code Error Next Attempt
 66666666-6666-6666-6666-666666666666 2017-08-17T20:22:38Z pending api:build notify 4`)
     })
 
@@ -90,7 +90,7 @@ describe('webhooks:deliveries', () => {
     .stderr()
     .stdout()
     .nock('https://api.heroku.com', {
-      reqheaders: {range: 'seq ..; order=desc,max=1000'},
+      reqheaders: {range: 'seq ..; order=desc,max=20'},
     }, api => api
     .get('/apps/example-app/webhook-deliveries')
     .reply(206, () => {
@@ -109,32 +109,76 @@ describe('webhooks:deliveries', () => {
         created_at: '2017-08-17T20:22:38Z',
       }
 
-      return new Array(1000).fill(delivery)
+      return new Array(20).fill(delivery)
     }),
     )
     .command(['webhooks:deliveries', '--app', 'example-app'])
-    .it('only shows 1000 webhook deliveries', ctx => {
+    .it('only shows 20 webhook deliveries', ctx => {
       const expectedHeader = 'Delivery ID                          Created              Status  Include   Level  Attempts Code Error Next Attempt'
       const expectedRow = '66666666-6666-6666-6666-666666666666 2017-08-17T20:22:38Z pending api:build notify 4'
       const angleBrackets = process.platform === 'win32' ? '»' : '›'
       const rows = ctx.stdout.split('\n')
 
       const headerRowCount = 1
-      const dataRowsCount = 1000
+      const dataRowsCount = 20
       const finalTrailingRowCount = 1
       expect(rows.length).to.equal(headerRowCount + dataRowsCount + finalTrailingRowCount)
 
       expect(rows[0].trim()).to.equal(expectedHeader)
       expect(rows[1].trim()).to.equal(expectedRow)
 
-      expect(ctx.stderr).to.include(` ${angleBrackets}   Warning: Only showing the 1000 most recent deliveries\n ${angleBrackets}   Warning: It is possible to filter deliveries by using the --status flag\n`)
+      expect(ctx.stderr).to.include(` ${angleBrackets}   Warning: Only showing the 20 most recent deliveries\n ${angleBrackets}   Warning: It is possible to filter deliveries by using the --status flag\n`)
+    })
+
+    test
+    .stderr()
+    .stdout()
+    .nock('https://api.heroku.com', {
+      reqheaders: {range: 'seq ..; order=desc,max=5'},
+    }, api => api
+    .get('/apps/example-app/webhook-deliveries')
+    .reply(206, () => {
+      const delivery = {
+        id: '66666666-6666-6666-6666-666666666666',
+        event: {
+          id: '55555555-5555-5555-5555-555555555555',
+          include: 'api:build',
+        },
+        webhook: {
+          id: '44444444-4444-4444-4444-444444444444',
+          level: 'notify',
+        },
+        status: 'pending',
+        num_attempts: 4,
+        created_at: '2017-08-17T20:22:38Z',
+      }
+
+      return new Array(5).fill(delivery)
+    }),
+    )
+    .command(['webhooks:deliveries', '--app', 'example-app', '--num', '5'])
+    .it('shows a specified number of deliveries', ctx => {
+      const expectedHeader = 'Delivery ID                          Created              Status  Include   Level  Attempts Code Error Next Attempt'
+      const expectedRow = '66666666-6666-6666-6666-666666666666 2017-08-17T20:22:38Z pending api:build notify 4'
+      const angleBrackets = process.platform === 'win32' ? '»' : '›'
+      const rows = ctx.stdout.split('\n')
+
+      const headerRowCount = 1
+      const dataRowsCount = 5
+      const finalTrailingRowCount = 1
+      expect(rows.length).to.equal(headerRowCount + dataRowsCount + finalTrailingRowCount)
+
+      expect(rows[0].trim()).to.equal(expectedHeader)
+      expect(rows[1].trim()).to.equal(expectedRow)
+
+      expect(ctx.stderr).to.include(` ${angleBrackets}   Warning: Only showing the 5 most recent deliveries\n ${angleBrackets}   Warning: It is possible to filter deliveries by using the --status flag\n`)
     })
 
     test
     .stdout()
     .stderr()
     .nock('https://api.heroku.com', {
-      reqheaders: {range: 'seq ..; order=desc,max=1000'},
+      reqheaders: {range: 'seq ..; order=desc,max=20'},
     }, api => api
     .get('/apps/example-app/webhook-deliveries')
     .reply(200, []),
@@ -151,10 +195,10 @@ describe('webhooks:deliveries', () => {
     .stdout()
     .stderr()
     .nock('https://api.heroku.com', {
-      reqheaders: {range: 'seq ..; order=desc,max=1000'},
+      reqheaders: {range: 'seq ..; order=desc,max=20'},
     }, api => api
     .get('/pipelines/example-pipeline/webhook-deliveries')
-    .reply(206, [
+    .reply(200, [
       {
         id: '66666666-6666-6666-6666-666666666666',
         event: {
@@ -193,9 +237,9 @@ describe('webhooks:deliveries', () => {
     .command(['webhooks:deliveries', '--pipeline', 'example-pipeline'])
     .it('lists webhooks deliveries for pipeline webhooks', ctx => {
       expect(ctx.stderr).to.equal('')
-      expect(ctx.stdout.trim()).to.equal(
-        `Delivery ID                          Created              Status   Include   Level  Attempts Code Error  Next Attempt         
-99999999-9999-9999-9999-999999999999 2017-08-17T20:22:37Z retrying api:build notify 4        401  Foobar 2017-08-17T20:22:39Z 
+      expect(ctx.stdout.trim().split('\n').map(l => l.trim()).join('\n')).to.equal(
+        `Delivery ID                          Created              Status   Include   Level  Attempts Code Error  Next Attempt
+99999999-9999-9999-9999-999999999999 2017-08-17T20:22:37Z retrying api:build notify 4        401  Foobar 2017-08-17T20:22:39Z
 66666666-6666-6666-6666-666666666666 2017-08-17T20:22:38Z pending  api:build notify 4`)
     })
 
@@ -203,7 +247,7 @@ describe('webhooks:deliveries', () => {
     .stdout()
     .stderr()
     .nock('https://api.heroku.com', {
-      reqheaders: {range: 'seq ..; order=desc,max=1000'},
+      reqheaders: {range: 'seq ..; order=desc,max=20'},
     }, api => api
     .get('/pipelines/example-pipeline/webhook-deliveries')
     .reply(200, []),


### PR DESCRIPTION
The previously hard-coded number of 1000 puts strain on the webhooks
API subsystem and can cause requests to fail. While that's not ideal,
there's also no way to use a different number to work around the
issue.

1000 is probably a bit much for normal use, too, since it can easily
scroll most results off the screen. 20 is used as the default,
matching `heroku releases`.

The new --num flag, also matching `heroku releases`, can be used to
specify a different number.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
