### PR TITLE
feat(domains): make `domains:update` public

### DIFF
--- a/packages/apps/src/commands/domains/update.ts
+++ b/packages/apps/src/commands/domains/update.ts
@@ -5,15 +5,16 @@ import cli from 'cli-ux'
 export default class DomainsUpdate extends Command {
   static description = 'update a domain to use a different SSL certificate on an app'
 
-  static examples = ['heroku domains:update www.example.com --cert-id mycert']
-
-  static hidden = true
+  static examples = ['heroku domains:update www.example.com --cert mycert']
 
   static flags = {
     help: flags.help({char: 'h'}),
     app: flags.app({required: true}),
     remote: flags.remote(),
-    'cert-id': flags.string({required: true}),
+    cert: flags.string({
+      required: true,
+      description: 'the name or id of the certificate you want to use for this domain',
+    }),
   }
 
   static args = [{name: 'hostname'}]
@@ -22,12 +23,12 @@ export default class DomainsUpdate extends Command {
     const {args, flags} = this.parse(DomainsUpdate)
     const {hostname} = args
     try {
-      cli.action.start(`Updating ${color.cyan(hostname)} to use ${color.cyan(flags['cert-id'])} certificate`)
+      cli.action.start(`Updating ${color.cyan(hostname)} to use ${color.cyan(flags.cert)} certificate`)
       await this.heroku.patch<string>(`/apps/${flags.app}/domains/${hostname}`, {
         headers: {
           Accept: 'application/vnd.heroku+json; version=3.allow_multiple_sni_endpoints',
         },
-        body: {sni_endpoint: flags['cert-id']},
+        body: {sni_endpoint: flags.cert},
       })
     } catch (error) {
       cli.error(error)

--- a/packages/apps/test/commands/domains/update.test.ts
+++ b/packages/apps/test/commands/domains/update.test.ts
@@ -22,7 +22,7 @@ describe('domains:update', () => {
   .patch('/apps/myapp/domains/example.com', {sni_endpoint: 'sniendpoint-id'})
   .reply(200, responseBody),
   )
-  .command(['domains:update', 'example.com', '--cert-id', 'sniendpoint-id', '--app', 'myapp'])
+  .command(['domains:update', 'example.com', '--cert', 'sniendpoint-id', '--app', 'myapp'])
   .it('updates the domain to use a different certificate', ctx => {
     expect(ctx.stderr).to.contain('Updating example.com to use sniendpoint-id certificate... done')
   })


### PR DESCRIPTION
Closes https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008hTd9IAE/view

This PR un-hides the `domains:update` command and changes the certificate flag name from `cert-id` to `cert` now that we've got the `domains` endpoint accepts both name and ID when associating a cert.

This actual command has been in CLI for a while and has actually been used (successfully) by Herokai, this PR is simply making it more widely available rather than adding any new functionality.
