### PR TITLE
fix(pipelines): Make sure apps from filter returned doesn't get cut off

### DIFF
--- a/packages/pipelines/src/api.ts
+++ b/packages/pipelines/src/api.ts
@@ -83,7 +83,7 @@ export function getTeam(heroku: APIClient, teamId: any) {
 function getAppFilter(heroku: APIClient, appIds: Array<string>) {
   return heroku.request<Array<Heroku.App>>('/filters/apps', {
     method: 'POST',
-    headers: {Accept: FILTERS_HEADER},
+    headers: {Accept: FILTERS_HEADER, Range: 'max=1000'},
     body: {in: {id: appIds}},
   })
 }


### PR DESCRIPTION
This fixes an issue where pipeline promotion fails due to the number of apps returned by the filter API gets cut off at the default (200). This raises that max to 1000.
