### PR TITLE
Fix range header bug

### DIFF
--- a/packages/pipelines/src/api.ts
+++ b/packages/pipelines/src/api.ts
@@ -83,7 +83,7 @@ export function getTeam(heroku: APIClient, teamId: any) {
 function getAppFilter(heroku: APIClient, appIds: Array<string>) {
   return heroku.request<Array<Heroku.App>>('/filters/apps', {
     method: 'POST',
-    headers: {Accept: FILTERS_HEADER, Range: 'max=1000'},
+    headers: {Accept: FILTERS_HEADER, Range: 'id ..; max=1000;'},
     body: {in: {id: appIds}},
   })
 }


### PR DESCRIPTION
Recent PR introduced a bug when requesting a max in the range header. This fixes the bug by adding 'id..', which is required.
