### PR TITLE
fix(pg-v5): Running diagnose on not default DBs

### DIFF
--- a/packages/pg-v5/commands/diagnose.js
+++ b/packages/pg-v5/commands/diagnose.js
@@ -10,6 +10,7 @@ function * run (context, heroku) {
   const host = require('../lib/host')
   const util = require('../lib/util')
   const URL = require('url')
+  const uuid = require('uuid')
 
   const { app, args } = context
 
@@ -71,7 +72,7 @@ available for one month after creation on ${report.created_at}
 
   let report
   let id = args['DATABASE|REPORT_ID']
-  if (id && id.match(/^[a-z0-9-]{36}$/)) {
+  if (id && uuid.validate(id)) {
     report = yield heroku.get(`/reports/${encodeURIComponent(id)}`, { host: PGDIAGNOSE_HOST })
   } else {
     report = yield generateReport(id)

--- a/packages/pg-v5/lib/util.js
+++ b/packages/pg-v5/lib/util.js
@@ -15,6 +15,23 @@ function getConfigVarName (configVars) {
 
 exports.getConfigVarName = getConfigVarName
 
+function getConfigVarNameFromAttachment (attachment, config) {
+  const configVars = attachment.config_vars.filter((cv) => {
+    return config[cv] && config[cv].startsWith('postgres://')
+  })
+  if (configVars.length === 0) {
+    throw new Error(`No config vars found for ${attachment.name}; perhaps they were removed as a side effect of ${cli.color.cmd('heroku rollback')}? Use ${cli.color.cmd('heroku addons:attach')} to create a new attachment and then ${cli.color.cmd('heroku addons:detach')} to remove the current attachment.`)
+  }
+
+  let configVarName = `${attachment.name}_URL`
+  if (configVars.includes(configVarName) && configVarName in config) {
+    return configVarName
+  }
+  return getConfigVarName(configVars)
+}
+
+exports.getConfigVarNameFromAttachment  = getConfigVarNameFromAttachment;
+
 function formatAttachment (attachment) {
   let attName = cli.color.addon(attachment.name)
 
@@ -77,30 +94,25 @@ exports.presentCredentialAttachments = presentCredentialAttachments
 exports.getConnectionDetails = function (attachment, config) {
   const {getBastion} = require('./bastion')
   const url = require('url')
-  const configVars = attachment.config_vars.filter((cv) => {
-    return config[cv] && config[cv].startsWith('postgres://')
-  })
-  if (configVars.length === 0) {
-    throw new Error(`No config vars found for ${attachment.name}; perhaps they were removed as a side effect of ${cli.color.cmd('heroku rollback')}? Use ${cli.color.cmd('heroku addons:attach')} to create a new attachment and then ${cli.color.cmd('heroku addons:detach')} to remove the current attachment.`)
-  }
-  const connstringVar = getConfigVarName(configVars)
+
+  const connstringVar = getConfigVarNameFromAttachment(attachment, config)
 
   // remove _URL from the end of the config var name
   const baseName = connstringVar.slice(0, -4)
 
   // build the default payload for non-bastion dbs
   debug(`Using "${connstringVar}" to connect to your database…`)
-  const target = url.parse(config[connstringVar])
-  let [user, password] = target.auth.split(':')
+  const target = new url.URL(config[connstringVar])
+  let {username: user, password} = target
 
   let payload = {
     user,
     password,
-    database: target.path.split('/', 2)[1],
+    database: target.pathname.split('/', 2)[1],
     host: target.hostname,
-    port: target.port,
+    port: target.port || null,
     attachment,
-    url: target
+    url: url.parse(target.toString())
   }
 
   // If bastion creds exist, graft it into the payload

--- a/packages/pg-v5/lib/util.js
+++ b/packages/pg-v5/lib/util.js
@@ -102,17 +102,17 @@ exports.getConnectionDetails = function (attachment, config) {
 
   // build the default payload for non-bastion dbs
   debug(`Using "${connstringVar}" to connect to your database…`)
-  const target = new url.URL(config[connstringVar])
-  let {username: user, password} = target
+  const target = url.parse(config[connstringVar])
+  let [user, password] = target.auth.split(':')
 
   let payload = {
     user,
     password,
-    database: target.pathname.split('/', 2)[1],
+    database: target.path.split('/', 2)[1],
     host: target.hostname,
-    port: target.port || null,
+    port: target.port,
     attachment,
-    url: url.parse(target.toString())
+    url: target
   }
 
   // If bastion creds exist, graft it into the payload

--- a/packages/pg-v5/package.json
+++ b/packages/pg-v5/package.json
@@ -25,7 +25,8 @@
     "node-notifier": "^5.4.0",
     "smooth-progress": "^1.1.0",
     "strip-eof": "^1.0.0",
-    "tunnel-ssh": "^4.1.4"
+    "tunnel-ssh": "^4.1.4",
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.21.3",

--- a/packages/pg-v5/test/commands/diagnose.js
+++ b/packages/pg-v5/test/commands/diagnose.js
@@ -10,7 +10,7 @@ const db = {
   id: 1,
   name: 'postgres-1',
   plan: { name: 'heroku-postgresql:standard-0' },
-  config_vars: ['DATABASE_URL'],
+  config_vars: ['DATABASE_ENDPOINT_042EExxx_URL', 'DATABASE_URL', 'HEROKU_POSTGRESQL_SILVER_URL'],
   app: { name: 'myapp' }
 }
 
@@ -40,135 +40,187 @@ describe('pg:diagnose', () => {
     pg.done()
   })
 
-  it('generates a report', () => {
-    api.get('/addons/postgres-1').reply(200, db)
-    api.get('/apps/myapp/config-vars').reply(200, { DATABASE_URL: 'postgres://db' })
-    pg.get('/client/v11/databases/1/metrics').reply(200, [])
-    diagnose.post('/reports', {
-      url: 'postgres://db',
-      plan: 'standard-0',
-      app: 'myapp',
-      database: 'DATABASE_URL',
-      metrics: []
-    }).reply(200, {
-      id: '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c',
-      app: 'myapp',
-      database: 'postgres-1',
-      created_at: '101',
-      checks: [
-        {
-          name: 'Connection count',
-          status: 'red',
-          results: [{ count: 1 }]
-        },
-        {
-          name: 'Load',
-          status: 'red',
-          results: { load: 100 }
-        }
-      ]
-    })
-    return cmd.run({ app: 'myapp', args: {} })
-      .then(() => expect(cli.stdout, 'to equal', `Report 697c8bd7-dbba-4f2d-83b6-789c58cc3a9c for myapp::postgres-1
-available for one month after creation on 101
-
-RED: Connection count
-Count
-─────
-1
-RED: Load
-Load 100
-`))
-  })
-
-  it('displays an existing report', () => {
-    diagnose.get('/reports/697c8bd7-dbba-4f2d-83b6-789c58cc3a9c').reply(200, {
-      id: '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c',
-      app: 'myapp',
-      database: 'postgres-1',
-      created_at: '101',
-      checks: [
-        {
-          name: 'Connection count',
-          status: 'red',
-          results: [{ count: 1 }]
-        },
-        {
-          name: 'Load',
-          status: 'red',
-          results: { load: 100 }
-        }
-      ]
-    })
-    return cmd.run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c' } })
-      .then(() => expect(cli.stdout, 'to equal', `Report 697c8bd7-dbba-4f2d-83b6-789c58cc3a9c for myapp::postgres-1
-available for one month after creation on 101
-
-RED: Connection count
-Count
-─────
-1
-RED: Load
-Load 100
-`))
-  })
-
-  it('displays an existing report with empty results', () => {
-    diagnose.get('/reports/697c8bd7-dbba-4f2d-83b6-789c58cc3a9c').reply(200, {
-      id: '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c',
-      app: 'myapp',
-      database: 'postgres-1',
-      created_at: '101',
-      checks: [
-        {
-          name: 'Connection count',
-          status: 'red',
-          results: []
-        },
-        {
-          name: 'Load',
-          status: 'red',
-          results: {}
-        }
-      ]
-    })
-    return cmd.run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c' } })
-      .then(() => expect(cli.stdout, 'to equal', `Report 697c8bd7-dbba-4f2d-83b6-789c58cc3a9c for myapp::postgres-1
-available for one month after creation on 101
-
-RED: Connection count
-RED: Load
-`))
-  })
-
-  it('roughly conforms with Ruby output', () => {
-    diagnose.get('/reports/697c8bd7-dbba-4f2d-83b6-789c58cc3a9c').reply(200, {
-      'id': 'abc123',
-      'app': 'appname',
-      'created_at': '2014-06-24 01:26:11.941197+00',
-      'database': 'dbcolor',
-      'checks': [
-        { 'name': 'Hit Rate', 'status': 'green', 'results': null },
-        { 'name': 'Connection Count', 'status': 'red', 'results': [{ 'count': 150 }] },
-        {
-          'name': 'list',
-          'status': 'yellow',
-          'results': [
-            { 'thing': 'one' },
-            { 'thing': 'two' }
-          ]
-        },
-        {
-          'name': 'Load',
-          'status': 'skipped',
-          'results': {
-            'error': 'Load check not supported on this plan'
+  describe('when not passing arguments', () => {
+    it('generates a report', () => {
+      api.get('/addons/postgres-1').reply(200, db)
+      api.get('/apps/myapp/config-vars').reply(200, {
+        DATABASE_ENDPOINT_042EExxx_URL: 'postgres://db',
+        DATABASE_URL: 'postgres://db',
+        HEROKU_POSTGRESQL_SILVER_URL: 'postgres://db'
+      })
+      pg.get('/client/v11/databases/1/metrics').reply(200, [])
+      diagnose.post('/reports', {
+        url: 'postgres://db',
+        plan: 'standard-0',
+        app: 'myapp',
+        database: 'DATABASE_URL',
+        metrics: []
+      }).reply(200, {
+        id: '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c',
+        app: 'myapp',
+        database: 'postgres-1',
+        created_at: '101',
+        checks: [
+          {
+            name: 'Connection count',
+            status: 'red',
+            results: [{ count: 1 }]
+          },
+          {
+            name: 'Load',
+            status: 'red',
+            results: { load: 100 }
           }
-        }
-      ]
+        ]
+      })
+      return cmd.run({ app: 'myapp', args: {} })
+        .then(() => expect(cli.stdout, 'to equal', `Report 697c8bd7-dbba-4f2d-83b6-789c58cc3a9c for myapp::postgres-1
+available for one month after creation on 101
+
+RED: Connection count
+Count
+─────
+1
+RED: Load
+Load 100
+`))
     })
-    return cmd.run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c' } })
-      .then(() => expect(cli.stdout, 'to equal', `Report abc123 for appname::dbcolor
+  })
+
+  describe('when passing arguments', () => {
+    context('and this argument is a report ID', () => {
+      it('displays an existing report', () => {
+        diagnose.get('/reports/697c8bd7-dbba-4f2d-83b6-789c58cc3a9c').reply(200, {
+          id: '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c',
+          app: 'myapp',
+          database: 'postgres-1',
+          created_at: '101',
+          checks: [
+            {
+              name: 'Connection count',
+              status: 'red',
+              results: [{ count: 1 }]
+            },
+            {
+              name: 'Load',
+              status: 'red',
+              results: { load: 100 }
+            }
+          ]
+        })
+        return cmd.run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c' } })
+          .then(() => expect(cli.stdout, 'to equal', `Report 697c8bd7-dbba-4f2d-83b6-789c58cc3a9c for myapp::postgres-1
+available for one month after creation on 101
+
+RED: Connection count
+Count
+─────
+1
+RED: Load
+Load 100
+`))
+      })
+    })
+
+    context('and this argument is a HEROKU_POSTGRESQL_SILVER_URL', () => {
+      it('generates a report for that DB', () => {
+        api.get('/addons/postgres-1').reply(200, db)
+        api.get('/apps/myapp/config-vars').reply(200, { HEROKU_POSTGRESQL_SILVER_URL: 'postgres://db' })
+        pg.get('/client/v11/databases/1/metrics').reply(200, [])
+        diagnose.post('/reports', {
+          url: 'postgres://db',
+          plan: 'standard-0',
+          app: 'myapp',
+          database: 'HEROKU_POSTGRESQL_SILVER_URL',
+          metrics: []
+        }).reply(200, {
+          id: '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c',
+          app: 'myapp',
+          database: 'postgres-1',
+          created_at: '101',
+          checks: [
+            {
+              name: 'Connection count',
+              status: 'red',
+              results: [{ count: 1 }]
+            },
+            {
+              name: 'Load',
+              status: 'red',
+              results: { load: 100 }
+            }
+          ]
+        })
+        return cmd.run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': 'HEROKU_POSTGRESQL_SILVER_URL' } })
+          .then(() => expect(cli.stdout, 'to equal', `Report 697c8bd7-dbba-4f2d-83b6-789c58cc3a9c for myapp::postgres-1
+available for one month after creation on 101
+
+RED: Connection count
+Count
+─────
+1
+RED: Load
+Load 100
+`))
+      })
+    })
+
+    it('displays an existing report with empty results', () => {
+      diagnose.get('/reports/697c8bd7-dbba-4f2d-83b6-789c58cc3a9c').reply(200, {
+        id: '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c',
+        app: 'myapp',
+        database: 'postgres-1',
+        created_at: '101',
+        checks: [
+          {
+            name: 'Connection count',
+            status: 'red',
+            results: []
+          },
+          {
+            name: 'Load',
+            status: 'red',
+            results: {}
+          }
+        ]
+      })
+      return cmd.run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c' } })
+        .then(() => expect(cli.stdout, 'to equal', `Report 697c8bd7-dbba-4f2d-83b6-789c58cc3a9c for myapp::postgres-1
+available for one month after creation on 101
+
+RED: Connection count
+RED: Load
+`))
+    })
+
+    it('roughly conforms with Ruby output', () => {
+      diagnose.get('/reports/697c8bd7-dbba-4f2d-83b6-789c58cc3a9c').reply(200, {
+        'id': 'abc123',
+        'app': 'appname',
+        'created_at': '2014-06-24 01:26:11.941197+00',
+        'database': 'dbcolor',
+        'checks': [
+          { 'name': 'Hit Rate', 'status': 'green', 'results': null },
+          { 'name': 'Connection Count', 'status': 'red', 'results': [{ 'count': 150 }] },
+          {
+            'name': 'list',
+            'status': 'yellow',
+            'results': [
+              { 'thing': 'one' },
+              { 'thing': 'two' }
+            ]
+          },
+          {
+            'name': 'Load',
+            'status': 'skipped',
+            'results': {
+              'error': 'Load check not supported on this plan'
+            }
+          }
+        ]
+      })
+      return cmd.run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c' } })
+        .then(() => expect(cli.stdout, 'to equal', `Report abc123 for appname::dbcolor
 available for one month after creation on 2014-06-24 01:26:11.941197+00
 
 RED: Connection Count
@@ -184,30 +236,31 @@ GREEN: Hit Rate
 SKIPPED: Load
 Error Load check not supported on this plan
 `))
-  })
-
-  it('converts underscores to spaces', () => {
-    diagnose.get('/reports/697c8bd7-dbba-4f2d-83b6-789c58cc3a9c').reply(200, {
-      'id': 'abc123',
-      'app': 'appname',
-      'created_at': '2014-06-24 01:26:11.941197+00',
-      'database': 'dbcolor',
-      'checks': [
-        {
-          'name': 'Load',
-          'status': 'skipped',
-          'results': {
-            'error_thing': 'Load check not supported on this plan'
-          }
-        }
-      ]
     })
-    return cmd.run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c' } })
-      .then(() => expect(cli.stdout, 'to equal', `Report abc123 for appname::dbcolor
+  
+    it('converts underscores to spaces', () => {
+      diagnose.get('/reports/697c8bd7-dbba-4f2d-83b6-789c58cc3a9c').reply(200, {
+        'id': 'abc123',
+        'app': 'appname',
+        'created_at': '2014-06-24 01:26:11.941197+00',
+        'database': 'dbcolor',
+        'checks': [
+          {
+            'name': 'Load',
+            'status': 'skipped',
+            'results': {
+              'error_thing': 'Load check not supported on this plan'
+            }
+          }
+        ]
+      })
+      return cmd.run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c' } })
+        .then(() => expect(cli.stdout, 'to equal', `Report abc123 for appname::dbcolor
 available for one month after creation on 2014-06-24 01:26:11.941197+00
 
 SKIPPED: Load
 Error Thing Load check not supported on this plan
 `))
-  })
+    })
+  });
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -10252,6 +10252,11 @@ uuid@^8.3.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
   integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
 
+uuid@^8.3.1:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
+  integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
+
 v8-compile-cache@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"


### PR DESCRIPTION
Fixes https://heroku.support/934830.

Better explained by @iriberri:

> The problem is that we’ll always get the connection string that’s in the first *_URL config var, ordered alphabetically, instead of explicitly looking for `DATABASE_URL` or any other attachment name (`HEROKU_POSTGRES_ROSE_URL`).
> 
> In [this ticket](https://heroku.support/934830), this conflicted with the config vars we create for PrivateLink setups, which happen to be the first alphabetically. Another ticket we had in the past was the case where a customer had a `DATABASE_S3_URL` manually set up, which was pointing to something unrelated and external, and that config var was picked up before DATABASE_URL because of us getting the first result in the array,
