### PR TITLE
fix(pg-v5): reuse config var resolution when resolving diagnose param…

### DIFF
--- a/packages/pg-v5/commands/diagnose.js
+++ b/packages/pg-v5/commands/diagnose.js
@@ -10,6 +10,7 @@ function * run (context, heroku) {
   const host = require('../lib/host')
   const util = require('../lib/util')
   const URL = require('url')
+  const uuid = require('uuid')
 
   const { app, args } = context
 
@@ -71,7 +72,7 @@ available for one month after creation on ${report.created_at}
 
   let report
   let id = args['DATABASE|REPORT_ID']
-  if (id && id.match(/^[a-z0-9-]{36}$/)) {
+  if (id && uuid.validate(id)) {
     report = yield heroku.get(`/reports/${encodeURIComponent(id)}`, { host: PGDIAGNOSE_HOST })
   } else {
     report = yield generateReport(id)

--- a/packages/pg-v5/lib/util.js
+++ b/packages/pg-v5/lib/util.js
@@ -15,6 +15,23 @@ function getConfigVarName (configVars) {
 
 exports.getConfigVarName = getConfigVarName
 
+function getConfigVarNameFromAttachment (attachment, config) {
+  const configVars = attachment.config_vars.filter((cv) => {
+    return config[cv] && config[cv].startsWith('postgres://')
+  })
+  if (configVars.length === 0) {
+    throw new Error(`No config vars found for ${attachment.name}; perhaps they were removed as a side effect of ${cli.color.cmd('heroku rollback')}? Use ${cli.color.cmd('heroku addons:attach')} to create a new attachment and then ${cli.color.cmd('heroku addons:detach')} to remove the current attachment.`)
+  }
+
+  let configVarName = `${attachment.name}_URL`
+  if (configVars.includes(configVarName) && configVarName in config) {
+    return configVarName
+  }
+  return getConfigVarName(configVars)
+}
+
+exports.getConfigVarNameFromAttachment  = getConfigVarNameFromAttachment;
+
 function formatAttachment (attachment) {
   let attName = cli.color.addon(attachment.name)
 
@@ -77,30 +94,25 @@ exports.presentCredentialAttachments = presentCredentialAttachments
 exports.getConnectionDetails = function (attachment, config) {
   const {getBastion} = require('./bastion')
   const url = require('url')
-  const configVars = attachment.config_vars.filter((cv) => {
-    return config[cv] && config[cv].startsWith('postgres://')
-  })
-  if (configVars.length === 0) {
-    throw new Error(`No config vars found for ${attachment.name}; perhaps they were removed as a side effect of ${cli.color.cmd('heroku rollback')}? Use ${cli.color.cmd('heroku addons:attach')} to create a new attachment and then ${cli.color.cmd('heroku addons:detach')} to remove the current attachment.`)
-  }
-  const connstringVar = getConfigVarName(configVars)
+
+  const connstringVar = getConfigVarNameFromAttachment(attachment, config)
 
   // remove _URL from the end of the config var name
   const baseName = connstringVar.slice(0, -4)
 
   // build the default payload for non-bastion dbs
   debug(`Using "${connstringVar}" to connect to your database…`)
-  const target = url.parse(config[connstringVar])
-  let [user, password] = target.auth.split(':')
+  const target = new url.URL(config[connstringVar])
+  let {username: user, password} = target
 
   let payload = {
     user,
     password,
-    database: target.path.split('/', 2)[1],
+    database: target.pathname.split('/', 2)[1],
     host: target.hostname,
-    port: target.port,
+    port: target.port || null,
     attachment,
-    url: target
+    url: url.parse(target.toString())
   }
 
   // If bastion creds exist, graft it into the payload

--- a/packages/pg-v5/lib/util.js
+++ b/packages/pg-v5/lib/util.js
@@ -102,17 +102,17 @@ exports.getConnectionDetails = function (attachment, config) {
 
   // build the default payload for non-bastion dbs
   debug(`Using "${connstringVar}" to connect to your database…`)
-  const target = new url.URL(config[connstringVar])
-  let {username: user, password} = target
+  const target = url.parse(config[connstringVar])
+  let [user, password] = target.auth.split(':')
 
   let payload = {
     user,
     password,
-    database: target.pathname.split('/', 2)[1],
+    database: target.path.split('/', 2)[1],
     host: target.hostname,
-    port: target.port || null,
+    port: target.port,
     attachment,
-    url: url.parse(target.toString())
+    url: target
   }
 
   // If bastion creds exist, graft it into the payload

--- a/packages/pg-v5/package.json
+++ b/packages/pg-v5/package.json
@@ -25,7 +25,8 @@
     "node-notifier": "^5.4.0",
     "smooth-progress": "^1.1.0",
     "strip-eof": "^1.0.0",
-    "tunnel-ssh": "^4.1.4"
+    "tunnel-ssh": "^4.1.4",
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.21.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10252,6 +10252,11 @@ uuid@^8.3.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
   integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
 
+uuid@^8.3.1:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
+  integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
+
 v8-compile-cache@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"


### PR DESCRIPTION
This is a pull request to [PR #1680](https://github.com/heroku/cli/pull/1680). Instead of trying to figure out the config var name ourselves, this commit exposes and reuses the functionality from `packages/pg-v5/lib/util.js` to resolve config var names and values. This commit exposes the `getConfigVarNameFromAttachment(attachment, config)` function, which limits the search for config vars down to what the attachment has specified, rather than using _all_ of the app's config vars, which might include user-specified config vars we don't want to try to send to the `diagnose` service.

I also made the tests added in #1680 a bit more dynamic; this revealed a bug with the UUID detection for report IDs as well which i fixed by bringing in the `uuid` npm library and using its `validate` function instead of the incorrect regex that was there.