### PR TITLE
fix(ci-v5) pass token on socket connect instead of channel join for ci --watch

### DIFF
--- a/packages/ci/src/utils/test-run.ts
+++ b/packages/ci/src/utils/test-run.ts
@@ -158,11 +158,14 @@ export async function renderList(command: Command, testRuns: Heroku.TestRun[], p
 
   const socket = new Socket(HEROKU_CI_WEBSOCKET_URL, {
     transport: WebSocket,
+    params: {
+      token: command.heroku.auth,
+    },
     logger: (kind: any, msg: any, data: any) => debug(`${kind}: ${msg}\n${inspect(data)}`),
   })
   socket.connect()
 
-  const channel = socket.channel(`events:pipelines/${pipeline.id}/test-runs`, {token: command.heroku.auth})
+  const channel = socket.channel(`events:pipelines/${pipeline.id}/test-runs`, {})
 
   channel.on('create', ({data}: any) => {
     testRuns = handleTestRunEvent(data, testRuns)


### PR DESCRIPTION
https://github.com/heroku/particleboard/pull/329

## How to test?

* Pull down branch
+ run `cd packages/ci-v5 && heroku plugins:link`
+ Start watching an app with Heroku CI with `heroku ci --app APP_NAME --watch` (e.g. dashboard)
+ Push a new branch
+ Watch it show up in the list and get updates for created/building/pending/succeeded/failed/etc
* **unlink the plugin with `heroku plugins:unlink`**