### PR TITLE
feat(auth): Update generate-recovery-codes deprecation message

### DIFF
--- a/packages/auth/src/commands/auth/2fa/generate-recovery-codes.ts
+++ b/packages/auth/src/commands/auth/2fa/generate-recovery-codes.ts
@@ -13,27 +13,7 @@ Running this command will replace existing codes.`
     'auth:2fa:generate',
   ]
 
-  static example = `$ heroku auth:2fa:generate
-Password: ********************
-Recovery codes:
-02799c92ab3ba7c7
-09aea052a72b6a22
-361e00bb82c7cbd4
-588ac05dec23952c
-6020ef9ec364066b
-6cfd923315875e78
-7c576b935eafc452
-8c00eeb258ee565e
-a37c5c6985f56e66
-f82e7c2a50737494`
-
   async run() {
-    cli.warn('DEPRECATION WARNING: this command will be removed soon, in favor of generating recovery codes in your Account Settings in a browser.')
-    const password = await cli.prompt('Password', {type: 'hide'})
-    const headers = {'Heroku-Password': password}
-    const {body: codes} = await this.heroku.post<string[]>('/account/recovery-codes', {headers})
-    for (const code of codes) {
-      cli.log(code)
-    }
+    cli.warn('DEPRECATION WARNING: this command has been removed, in favor of generating recovery codes in your Account Settings in a browser.')
   }
 }


### PR DESCRIPTION
* Must be deployed after 11/22
* Removes functionality and returns error message only
* Month 2 of https://salesforce.quip.com/r2DjA7QLgHsu ("don’t let the
  command run & provide a response that points users to new command"
* Next step will be to remove entirely
* https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07B0000008gvwKIAQ