### PR TITLE
fix(pg-v5): Properly close ssh connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "eslint-plugin-standard": "^4.0.0",
     "lerna": "^3.22.1",
     "promise-request-retry": "^1.0.2",
-    "standard": "12.0.1"
+    "standard": "12.0.1",
+    "tmp": "^0.2.1"
   },
   "standard": {
     "env": "mocha",

--- a/packages/pg-v5/commands/psql.js
+++ b/packages/pg-v5/commands/psql.js
@@ -21,9 +21,9 @@ function * run (context, heroku) {
   }
   cli.console.error(`--> Connecting to ${cli.color.addon(db.attachment.addon.name)}`)
   if (flags.command) {
-    process.stdout.write(yield psql.exec(db, flags.command))
+    yield psql.exec(db, flags.command)
   } else if (flags.file) {
-    process.stdout.write(yield psql.execFile(db, flags.file))
+    yield psql.execFile(db, flags.file)
   } else {
     yield psql.interactive(db)
   }

--- a/packages/pg-v5/lib/bastion.js
+++ b/packages/pg-v5/lib/bastion.js
@@ -129,8 +129,8 @@ async function sshTunnel (db, dbTunnelConfig, timeout = 10000) {
 
 exports.sshTunnel = sshTunnel
 
-function * fetchConfig (heroku, db) {
-  return yield heroku.get(
+async function fetchConfig (heroku, db) {
+  return heroku.get(
     `/client/v11/databases/${encodeURIComponent(db.id)}/bastion`,
     {
       host: host(db)

--- a/packages/pg-v5/lib/bastion.js
+++ b/packages/pg-v5/lib/bastion.js
@@ -1,9 +1,11 @@
 'use strict'
 
 const debug = require('./debug')
-const tunnel = require('tunnel-ssh')
-const cli = require('heroku-cli-util')
+const tunnelSSH = require('tunnel-ssh')
 const host = require('./host')
+const util = require('util')
+const { once, EventEmitter } = require('events')
+const createSSHTunnel = util.promisify(tunnelSSH)
 
 const getBastion = function (config, baseName) {
   const { sample } = require('lodash')
@@ -81,31 +83,48 @@ function getConfigs (db) {
 
 exports.getConfigs = getConfigs
 
-function sshTunnel (db, dbTunnelConfig, timeout) {
-  return new Promise((resolve, reject) => {
-    // if necessary to tunnel, setup a tunnel
-    // see also https://github.com/heroku/heroku/blob/master/lib/heroku/helpers/heroku_postgresql.rb#L53-L80
-    let timer = setTimeout(() => reject(new Error('Establishing a secure tunnel timed out')), timeout)
-    if (db.bastionKey) {
-      let tun = tunnel(dbTunnelConfig, (err, tnl) => {
-        if (err) {
-          debug(err)
-          reject(new Error('Unable to establish a secure tunnel to your database.'))
-        }
-        debug('Tunnel created')
-        clearTimeout(timer)
-        resolve(tnl)
-      })
-      tun.on('error', (err) => {
-        // we can't reject the promise here because we may already have resolved it
-        debug(err)
-        cli.exit(1, 'Secure tunnel to your database failed')
-      })
-    } else {
-      clearTimeout(timer)
-      resolve()
+class Timeout {
+  constructor (timeout, message) {
+    this.timeout = timeout
+    this.message = message;
+    this.events = new EventEmitter()
+  }
+
+  async promise () {
+    this.timer = setTimeout(() => {
+      this.events.emit('error', new Error(this.message))
+    }, this.timeout)
+
+    try {
+      await once(this.events, 'cancelled')
+    } finally {
+      clearTimeout(this.timer)
     }
-  })
+  }
+
+  cancel () {
+    this.events.emit('cancelled')
+  }
+}
+
+async function sshTunnel (db, dbTunnelConfig, timeout = 10000) {
+  if (!db.bastionKey) {
+    return null
+  }
+
+  const timeoutInstance = new Timeout(timeout, 'Establishing a secure tunnel timed out');
+  try {
+    const tunnelInstance = await Promise.race([
+      timeoutInstance.promise(),
+      createSSHTunnel(dbTunnelConfig)
+    ])
+    return tunnelInstance
+  } catch (err) {
+    debug(err)
+    throw new Error('Unable to establish a secure tunnel to your database.')
+  } finally {
+    timeoutInstance.cancel()
+  }
 }
 
 exports.sshTunnel = sshTunnel

--- a/packages/pg-v5/lib/psql.js
+++ b/packages/pg-v5/lib/psql.js
@@ -94,6 +94,7 @@ function execPSQL ({ dbEnv, psqlArgs, childProcessOptions, pipeToStdout }) {
 async function waitForPSQLExit (psql) {
   try {
     const exitCode = await once(psql, 'close')
+    debug(`psql exited with code ${exitCode}`)
     if (exitCode > 0) {
       throw new Error(`psql exited with code ${exitCode}`)
     }
@@ -115,7 +116,7 @@ async function waitForPSQLExit (psql) {
 // To be on the safe side, check if the process was already killed before sending the signal
 function kill (childProcess, signal) {
   if (!childProcess.killed) {
-    psql('killing psql child process')
+    debug('killing psql child process')
     childProcess.kill(signal)
   }
 }

--- a/packages/pg-v5/lib/psql.js
+++ b/packages/pg-v5/lib/psql.js
@@ -3,91 +3,209 @@
 const co = require('co')
 const bastion = require('./bastion')
 const debug = require('./debug')
+const { once, EventEmitter } = require('events')
 
-function handlePsqlError (reject, psql) {
-  psql.on('error', (err) => {
-    if (err.code === 'ENOENT') {
-      reject(`The local psql command could not be located. For help installing psql, see https://devcenter.heroku.com/articles/heroku-postgresql#local-setup`)
+function psqlQueryOptions (query, dbEnv) {
+  debug('Running query: %s', query.trim())
+
+  const psqlArgs = ['-c', query, '--set', 'sslmode=require']
+
+  const childProcessOptions = {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'inherit']
+  }
+
+  return {
+    dbEnv,
+    psqlArgs,
+    childProcessOptions,
+    pipeToStdout: true
+  }
+}
+
+function psqlFileOptions (file, dbEnv) {
+  debug('Running sql file: %s', file.trim())
+
+  const childProcessOptions = {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'inherit']
+  }
+
+  const psqlArgs = ['-f', file, '--set', 'sslmode=require']
+
+  return {
+    dbEnv,
+    psqlArgs,
+    childProcessOptions,
+    pipeToStdout: true
+  }
+}
+
+function psqlInteractiveOptions (prompt, dbEnv) {
+  let psqlArgs = ['--set', `PROMPT1=${prompt}`, '--set', `PROMPT2=${prompt}`]
+  let psqlHistoryPath = process.env.HEROKU_PSQL_HISTORY
+  if (psqlHistoryPath) {
+    const fs = require('fs')
+    const path = require('path')
+    if (fs.existsSync(psqlHistoryPath) && fs.statSync(psqlHistoryPath).isDirectory()) {
+      let appLogFile = `${psqlHistoryPath}/${prompt.split(':')[0]}`
+      debug('Logging psql history to %s', appLogFile)
+      psqlArgs = psqlArgs.concat(['--set', `HISTFILE=${appLogFile}`])
+    } else if (fs.existsSync(path.dirname(psqlHistoryPath))) {
+      debug('Logging psql history to %s', psqlHistoryPath)
+      psqlArgs = psqlArgs.concat(['--set', `HISTFILE=${psqlHistoryPath}`])
     } else {
-      reject(err)
+      const cli = require('heroku-cli-util')
+      cli.warn(`HEROKU_PSQL_HISTORY is set but is not a valid path (${psqlHistoryPath})`)
     }
-  })
+  }
+  psqlArgs = psqlArgs.concat(['--set', 'sslmode=require'])
+
+  const childProcessOptions = {
+    stdio: 'inherit'
+  }
+
+  return {
+    dbEnv,
+    psqlArgs,
+    childProcessOptions
+  }
 }
 
-function execPsql (query, dbEnv) {
+function execPSQL ({ dbEnv, psqlArgs, childProcessOptions, pipeToStdout }) {
   const { spawn } = require('child_process')
-  return new Promise((resolve, reject) => {
-    let result = ''
-    debug('Running query: %s', query.trim())
-    let psql = spawn('psql', ['-c', query, '--set', 'sslmode=require'], { env: dbEnv, encoding: 'utf8', stdio: [ 'ignore', 'pipe', 'inherit' ] })
-    psql.stdout.on('data', function (data) {
-      result += data.toString()
-    })
-    psql.on('close', function (code) {
-      resolve(result)
-    })
-    handlePsqlError(reject, psql)
-  })
+
+  const options = {
+    env: dbEnv,
+    ...childProcessOptions
+  }
+
+  const psql = spawn('psql', psqlArgs, options)
+
+  if (pipeToStdout) {
+    psql.stdout.pipe(process.stdout)
+  }
+
+  return psql
 }
 
-function execPsqlWithFile (file, dbEnv) {
-  const { spawn } = require('child_process')
-  return new Promise((resolve, reject) => {
-    let result = ''
-    debug('Running sql file: %s', file.trim())
-    let psql = spawn('psql', ['-f', file, '--set', 'sslmode=require'], { env: dbEnv, encoding: 'utf8', stdio: [ 'ignore', 'pipe', 'inherit' ] })
-    psql.stdout.on('data', function (data) {
-      result += data.toString()
-    })
-    psql.on('close', function (code) {
-      resolve(result)
-    })
-    handlePsqlError(reject, psql)
-  })
+async function waitForPSQLExit (psql) {
+  try {
+    const exitCode = await once(psql, 'close')
+    debug(`psql exited with code ${exitCode}`)
+    if (exitCode > 0) {
+      throw new Error(`psql exited with code ${exitCode}`)
+    }
+  } catch (err) {
+    debug('psql error', err)
+    let error = err
+
+    if (error.code === 'ENOENT') {
+      error = new Error(`The local psql command could not be located. For help installing psql, see https://devcenter.heroku.com/articles/heroku-postgresql#local-setup`)
+    }
+
+    throw error
+  }
 }
 
-function psqlInteractive (dbEnv, prompt) {
-  const { spawn } = require('child_process')
-  return new Promise((resolve, reject) => {
-    let psqlArgs = ['--set', `PROMPT1=${prompt}`, '--set', `PROMPT2=${prompt}`]
-    let psqlHistoryPath = process.env.HEROKU_PSQL_HISTORY
-    if (psqlHistoryPath) {
-      const fs = require('fs')
-      const path = require('path')
-      if (fs.existsSync(psqlHistoryPath) && fs.statSync(psqlHistoryPath).isDirectory()) {
-        let appLogFile = `${psqlHistoryPath}/${prompt.split(':')[0]}`
-        debug('Logging psql history to %s', appLogFile)
-        psqlArgs = psqlArgs.concat(['--set', `HISTFILE=${appLogFile}`])
-      } else if (fs.existsSync(path.dirname(psqlHistoryPath))) {
-        debug('Logging psql history to %s', psqlHistoryPath)
-        psqlArgs = psqlArgs.concat(['--set', `HISTFILE=${psqlHistoryPath}`])
-      } else {
-        const cli = require('heroku-cli-util')
-        cli.warn(`HEROKU_PSQL_HISTORY is set but is not a valid path (${psqlHistoryPath})`)
+// According to node.js docs, sending a kill to a process won't cause an error
+// but could have unintended consequences if the PID gets reassigned:
+// https://nodejs.org/docs/latest-v14.x/api/child_process.html#child_process_subprocess_kill_signal
+// To be on the safe side, check if the process was already killed before sending the signal
+function killUnlessDead (childProcess, signal) {
+  if (!childProcess.killed) {
+    childProcess.kill(signal)
+  }
+}
+
+// trap SIGINT so that ctrl+c can be used by psql without killing the
+// parent node process.
+// you can use ctrl+c in psql to kill running queries
+// while keeping the psql process open.
+// This code is to stop the parent node process (heroku CLI)
+// from exiting. If the parent Heroku CLI node process exits, then psql will exit as it
+// is a child process of the Heroku CLI node process.
+const trapAndForwardSignalsToChildProcess = (childProcess) => {
+  const signalsToTrap = ['SIGINT']
+  const signalTraps = signalsToTrap.map((signal) => {
+    process.removeAllListeners(signal);
+    const listener = () => killUnlessDead(childProcess, signal)
+    process.on(signal, listener)
+    return [signal, listener]
+  });
+
+  const cleanup = () => {
+    signalTraps.forEach(([signal, listener]) => {
+      process.removeListener(signal, listener)
+    })
+  }
+
+  return cleanup
+}
+
+async function runWithTunnel (db, tunnelConfig, options) {
+  const tunnel = await Tunnel.connect(db, tunnelConfig)
+
+  const psql = execPSQL(options)
+  const cleanupSignalTraps = trapAndForwardSignalsToChildProcess(psql)
+
+  try {
+    await Promise.race([
+      waitForPSQLExit(psql),
+      tunnel.waitForClose()
+    ])
+  } finally {
+    cleanupSignalTraps()
+    tunnel.close()
+    killUnlessDead(psql, 'SIGKILL')
+  }
+}
+
+class Tunnel {
+  constructor (tunnel) {
+    this.tunnel = tunnel
+    this.events = new EventEmitter()
+  }
+
+  async waitForClose () {
+    if (this.tunnel) {
+      try {
+        await once(this.tunnel, 'close')
+      } catch (err) {
+        debug(err)
+        throw new Error('Secure tunnel to your database failed')
       }
+    } else {
+      await once(this.events, 'close')
     }
-    psqlArgs = psqlArgs.concat(['--set', 'sslmode=require'])
+  }
 
-    let psql = spawn('psql', psqlArgs, { env: dbEnv, stdio: 'inherit' })
-    handlePsqlError(reject, psql)
-    psql.on('close', (data) => {
-      resolve()
-    })
-  })
+  close () {
+    if (this.tunnel) {
+      this.tunnel.close()
+    } else {
+      this.events.emit('close', 0)
+    }
+  }
+
+  static async connect (db, tunnelConfig) {
+    const tunnel = await bastion.sshTunnel(db, tunnelConfig)
+    return new Tunnel(tunnel)
+  }
 }
 
 function * exec (db, query) {
   let configs = bastion.getConfigs(db)
+  const options = psqlQueryOptions(query, configs.dbEnv)
 
-  yield bastion.sshTunnel(db, configs.dbTunnelConfig)
-  return yield execPsql(query, configs.dbEnv)
+  return runWithTunnel(db, configs.dbTunnelConfig, options)
 }
 
 async function execFile (db, file) {
-  let configs = bastion.getConfigs(db)
+  const configs = bastion.getConfigs(db)
+  const options = psqlFileOptions(file, configs.dbEnv)
 
-  await bastion.sshTunnel(db, configs.dbTunnelConfig)
-  return execPsqlWithFile(file, configs.dbEnv)
+  return runWithTunnel(db, configs.dbTunnelConfig, options)
 }
 
 function * interactive (db) {
@@ -95,9 +213,9 @@ function * interactive (db) {
   let prompt = `${db.attachment.app.name}::${name}%R%# `
   let configs = bastion.getConfigs(db)
   configs.dbEnv.PGAPPNAME = 'psql interactive' // default was 'psql non-interactive`
+  const options = psqlInteractiveOptions(prompt, configs.dbEnv)
 
-  yield bastion.sshTunnel(db, configs.dbTunnelConfig)
-  return yield psqlInteractive(configs.dbEnv, prompt)
+  return runWithTunnel(db, configs.dbTunnelConfig, options)
 }
 
 module.exports = {

--- a/packages/pg-v5/lib/psql.js
+++ b/packages/pg-v5/lib/psql.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const co = require('co')
 const bastion = require('./bastion')
 const debug = require('./debug')
 const { once, EventEmitter } = require('events')
@@ -194,7 +193,7 @@ class Tunnel {
   }
 }
 
-function * exec (db, query) {
+async function exec (db, query) {
   let configs = bastion.getConfigs(db)
   const options = psqlQueryOptions(query, configs.dbEnv)
 
@@ -208,7 +207,7 @@ async function execFile (db, file) {
   return runWithTunnel(db, configs.dbTunnelConfig, options)
 }
 
-function * interactive (db) {
+async function interactive (db) {
   let name = db.attachment.name
   let prompt = `${db.attachment.app.name}::${name}%R%# `
   let configs = bastion.getConfigs(db)
@@ -219,7 +218,7 @@ function * interactive (db) {
 }
 
 module.exports = {
-  exec: co.wrap(exec),
-  execFile: execFile,
-  interactive: co.wrap(interactive)
+  exec,
+  execFile,
+  interactive,
 }

--- a/packages/pg-v5/lib/psql.js
+++ b/packages/pg-v5/lib/psql.js
@@ -93,7 +93,8 @@ function execPSQL ({ dbEnv, psqlArgs, childProcessOptions, pipeToStdout }) {
 
 async function waitForPSQLExit (psql) {
   try {
-    const exitCode = await once(psql, 'close')
+    const [exitCode] = await once(psql, 'close')
+
     debug(`psql exited with code ${exitCode}`)
     if (exitCode > 0) {
       throw new Error(`psql exited with code ${exitCode}`)

--- a/packages/pg-v5/test/lib/psql.js
+++ b/packages/pg-v5/test/lib/psql.js
@@ -282,29 +282,17 @@ describe('psql', () => {
 
     context('when HEROKU_PSQL_HISTORY is set', () => {
       let historyPath
-      let envStub
 
       function mockHerokuPSQLHistory (path) {
-        envStub = sandbox.stub()
-        const envProxy = new Proxy(process.env, {
-          get (target, prop, receiver) {
-            if (prop === 'HEROKU_PSQL_HISTORY') {
-              envStub()
-              return path
-            }
-            return target[prop]
-          }
-        })
-        sandbox.stub(process, 'env').value(envProxy)
-        return envStub
+        process.env.HEROKU_PSQL_HISTORY = path
       }
 
-      afterEach(() => {
-        if (envStub) {
-          expect(envStub.callCount, 'to be greater than or equal to', 1)
-          envStub = undefined
-        }
+      before(function () {
         tmp.setGracefulCleanup()
+      })
+
+      afterEach(() => {
+        delete process.env.HEROKU_PSQL_HISTORY
       })
 
       context('when HEROKU_PSQL_HISTORY is a valid directory path', () => {

--- a/packages/pg-v5/test/lib/psql.js
+++ b/packages/pg-v5/test/lib/psql.js
@@ -16,47 +16,6 @@ const expect = require('unexpected')
 
 const unwrap = require('../unwrap')
 
-class FakeChildProcess extends EventEmitter {
-  constructor (...args) {
-    super(...args)
-    this.ready = false
-    this._exited = false
-    this.killed = false
-    this.stdout = new PassThrough()
-  }
-  async waitForStart () {
-    if (!this.ready) {
-      await once(this, 'ready')
-    }
-  }
-  start () {
-    this.ready = true
-    this.emit('ready')
-  }
-  async simulateExit (code) {
-    if (!this._exited) {
-      this._exited = true
-      this.stdout.end()
-      const waitForClose = once(this, 'close')
-      this.emit('close', code)
-      await waitForClose
-    }
-  }
-  kill (signal) {
-    this.killed = true
-    this._killedWithSignal = signal
-    const killedWithCode = signals[signal]
-    this.simulateExit(killedWithCode)
-  }
-  get killedWithSignal () {
-    return this._killedWithSignal
-  }
-  async teardown () {
-    await this.simulateExit(0)
-    this.removeAllListeners()
-  }
-}
-
 const db = {
   user: 'jeff',
   password: 'pass',
@@ -77,97 +36,48 @@ const bastionDb = {
   hostname: 'localhost'
 }
 
-async function ensureFinished (promise, callback) {
-  await callback()
-  await promise
-}
-
-function isSinonMatcher (value) {
-  return typeof value === 'object' &&
-    value !== null &&
-    typeof value.test === 'function'
-}
-
-function matchEnv (expectedEnv) {
-  const matcher = (actualEnv) => {
-    const reducedActualEnv = Object.entries(expectedEnv).reduce((memo, [key, value]) => {
-      if (key in actualEnv) {
-        memo[key] = value
-      }
-      return memo
-    }, {})
-    sinon.match(expectedEnv).test(reducedActualEnv)
-
-    return true
-  }
-
-  return sinon.match(matcher, 'env contains expected keys and values')
-}
-
-function createSpawnMocker (sandbox) {
-  return function mockSpawn (commandName, expectedArgs, expectedOptions) {
-    const spawnMock = sandbox.mock(ChildProcess)
-    const { env: expectedEnv } = expectedOptions
-
-    let optionsMatchers
-    if (isSinonMatcher(expectedOptions)) {
-      optionsMatchers = expectedOptions
-    } else {
-      optionsMatchers = Object.entries(expectedOptions).reduce((memo, [key, value]) => {
-        let matcher
-        if (key === 'env') {
-          matcher = matchEnv(expectedEnv)
-        } else {
-          matcher = value
-        }
-
-        memo[key] = matcher
-        return memo
-      }, {})
-    }
-
-    return spawnMock
-      .expects('spawn')
-      .withArgs(
-        commandName,
-        sinon.match.array.deepEquals(expectedArgs),
-        sinon.match(optionsMatchers)
-      )
-  }
-}
-
 describe('psql', () => {
-  let fakeChildProcess
+  let fakePsqlProcess, fakeTunnel, tunnelStub
   let sandbox
   let mockSpawn
+  let psql, bastion
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
+    tunnelStub = sandbox.stub().callsFake((_config, callback) => {
+      fakeTunnel = new TunnelStub()
+      callback(null, fakeTunnel)
+    })
     mockSpawn = createSpawnMocker(sandbox)
-    fakeChildProcess = new FakeChildProcess()
+    bastion = proxyquire('../../lib/bastion', {
+      'tunnel-ssh': tunnelStub
+    })
+    psql = proxyquire('../../lib/psql', {
+      './bastion': bastion
+    })
+    fakePsqlProcess = new FakeChildProcess()
     sandbox.stub(Math, 'random').callsFake(() => 0)
   })
 
   afterEach(async () => {
+    await fakePsqlProcess.teardown()
+    fakeTunnel = fakePsqlProcess = undefined
     sandbox.restore()
-    await fakeChildProcess.teardown()
   })
 
+  async function ensureFinished (promise) {
+    await promise
+    if (fakeTunnel) {
+      if (!fakeTunnel.exited) {
+        throw new Error('tunnel was not closed')
+      }
+    }
+    if (!fakePsqlProcess.exited) {
+      throw new Error('psql process did not close')
+    }
+  }
+
   describe('exec', () => {
-    let tunnelStub
-    let bastion
-    let psql
-
-    beforeEach(() => {
-      tunnelStub = sandbox.stub().callsArg(1)
-      bastion = proxyquire('../../lib/bastion', {
-        'tunnel-ssh': tunnelStub
-      })
-      psql = proxyquire('../../lib/psql', {
-        './bastion': bastion
-      })
-    })
-
     it('runs psql', async () => {
       const expectedEnv = Object.freeze({
         PGAPPNAME: 'psql non-interactive',
@@ -179,7 +89,6 @@ describe('psql', () => {
         PGHOST: 'localhost'
       })
 
-      const fakeChildProcess = new FakeChildProcess()
       const mock = mockSpawn(
         'psql',
         ['-c', 'SELECT NOW();', '--set', 'sslmode=require'],
@@ -191,66 +100,111 @@ describe('psql', () => {
       )
 
       mock.callsFake(() => {
-        fakeChildProcess.start()
-        return fakeChildProcess
+        fakePsqlProcess.start()
+        return fakePsqlProcess
       })
 
-      await ensureFinished(psql.exec(db, 'SELECT NOW();'), async () => {
-        await fakeChildProcess.waitForStart()
-        mock.verify()
-        await fakeChildProcess.simulateExit(0)
-      })
+      const promise = psql.exec(db, 'SELECT NOW();')
+      await fakePsqlProcess.waitForStart()
+      mock.verify()
+      await fakePsqlProcess.simulateExit(0)
+      await ensureFinished(promise)
     })
-    it('opens an SSH tunnel and runs psql for bastion databases', async () => {
-      let tunnelConf = {
-        username: 'bastion',
-        host: 'bastion-host',
-        privateKey: 'super-private-key',
-        dstHost: 'localhost',
-        dstPort: 5432,
-        localHost: '127.0.0.1',
-        localPort: 49152
-      }
-      const mock = mockSpawn(
-        'psql',
-        ['-c', 'SELECT NOW();', '--set', 'sslmode=require'],
-        sinon.match.any
-      )
 
-      mock.callsFake(() => {
-        fakeChildProcess.start()
-        return fakeChildProcess
-      })
-      await ensureFinished(psql.exec(bastionDb, 'SELECT NOW();', 1000), async () => {
-        await fakeChildProcess.waitForStart()
+    describe('private databases (not shield)', () => {
+      it('opens an SSH tunnel and runs psql for bastion databases', async () => {
+        let tunnelConf = {
+          username: 'bastion',
+          host: 'bastion-host',
+          privateKey: 'super-private-key',
+          dstHost: 'localhost',
+          dstPort: 5432,
+          localHost: '127.0.0.1',
+          localPort: 49152
+        }
+        const mock = mockSpawn(
+          'psql',
+          ['-c', 'SELECT NOW();', '--set', 'sslmode=require'],
+          sinon.match.any
+        )
+
+        mock.callsFake(() => {
+          fakePsqlProcess.start()
+          return fakePsqlProcess
+        })
+        const promise = psql.exec(bastionDb, 'SELECT NOW();', 1000)
+        await fakePsqlProcess.waitForStart()
         mock.verify()
         expect(tunnelStub.withArgs(tunnelConf).calledOnce, 'to equal', true)
-        await fakeChildProcess.simulateExit(0)
+        await fakePsqlProcess.simulateExit(0)
+        await ensureFinished(promise)
+      })
+
+      it('closes the tunnel manually if psql exits and the tunnel does not close on its own', async () => {
+        let tunnelConf = {
+          username: 'bastion',
+          host: 'bastion-host',
+          privateKey: 'super-private-key',
+          dstHost: 'localhost',
+          dstPort: 5432,
+          localHost: '127.0.0.1',
+          localPort: 49152
+        }
+        const mock = mockSpawn(
+          'psql',
+          ['-c', 'SELECT NOW();', '--set', 'sslmode=require'],
+          sinon.match.any
+        )
+
+        mock.callsFake(() => {
+          fakePsqlProcess.start()
+          return fakePsqlProcess
+        })
+
+        const promise = psql.exec(bastionDb, 'SELECT NOW();', 1000)
+        await fakePsqlProcess.waitForStart()
+        mock.verify()
+        expect(tunnelStub.withArgs(tunnelConf).calledOnce, 'to equal', true)
+        expect(fakeTunnel.exited, 'to equal', false)
+        await fakePsqlProcess.simulateExit(0)
+        await ensureFinished(promise)
+        expect(fakeTunnel.exited, 'to equal', true)
+      })
+
+      it('closes psql manually if the tunnel exits and psql does not close on its own', async () => {
+        let tunnelConf = {
+          username: 'bastion',
+          host: 'bastion-host',
+          privateKey: 'super-private-key',
+          dstHost: 'localhost',
+          dstPort: 5432,
+          localHost: '127.0.0.1',
+          localPort: 49152
+        }
+        const mock = mockSpawn(
+          'psql',
+          ['-c', 'SELECT NOW();', '--set', 'sslmode=require'],
+          sinon.match.any
+        )
+
+        mock.callsFake(() => {
+          fakePsqlProcess.start()
+          return fakePsqlProcess
+        })
+
+        const execPromise = psql.exec(bastionDb, 'SELECT NOW();', 1000)
+        await fakePsqlProcess.waitForStart()
+        mock.verify()
+        expect(tunnelStub.withArgs(tunnelConf).calledOnce, 'to equal', true)
+        expect(fakePsqlProcess.exited, 'to equal', false)
+        fakeTunnel.close()
+        await ensureFinished(execPromise)
+        expect(fakePsqlProcess.exited, 'to equal', true)
       })
     })
   })
 
   describe('execFile', () => {
-    let sandbox
-    let tunnelStub
-    let bastion
-    let psql
-
-    beforeEach(() => {
-      sandbox = sinon.createSandbox()
-      tunnelStub = sandbox.stub().callsArg(1)
-      bastion = proxyquire('../../lib/bastion', {
-        'tunnel-ssh': tunnelStub
-      })
-      psql = proxyquire('../../lib/psql', {
-        './bastion': bastion
-      })
-    })
-
-    afterEach(() => {
-      sandbox.restore()
-    })
-
     it('runs psql', async () => {
       const expectedEnv = Object.freeze({
         PGAPPNAME: 'psql non-interactive',
@@ -272,15 +226,15 @@ describe('psql', () => {
         }
       )
       mock.callsFake(() => {
-        fakeChildProcess.start()
-        return fakeChildProcess
+        fakePsqlProcess.start()
+        return fakePsqlProcess
       })
 
-      await ensureFinished(psql.execFile(db, 'test.sql'), async () => {
-        await fakeChildProcess.waitForStart()
-        mock.verify()
-        await fakeChildProcess.simulateExit(0)
-      })
+      const promise = psql.execFile(db, 'test.sql')
+      await fakePsqlProcess.waitForStart()
+      mock.verify()
+      await fakePsqlProcess.simulateExit(0)
+      await ensureFinished(promise)
     })
     it('opens an SSH tunnel and runs psql for bastion databases', async () => {
       let tunnelConf = {
@@ -303,21 +257,20 @@ describe('psql', () => {
         }
       )
       mock.callsFake(() => {
-        fakeChildProcess.start()
-        return fakeChildProcess
+        fakePsqlProcess.start()
+        return fakePsqlProcess
       })
 
-      await ensureFinished(psql.execFile(bastionDb, 'test.sql', 1000), async () => {
-        await fakeChildProcess.waitForStart()
-        mock.verify()
-        expect(tunnelStub.withArgs(tunnelConf).calledOnce, 'to equal', true)
-        await fakeChildProcess.simulateExit(0)
-      })
+      const promise = psql.execFile(bastionDb, 'test.sql', 1000)
+      await fakePsqlProcess.waitForStart()
+      mock.verify()
+      expect(tunnelStub.withArgs(tunnelConf).calledOnce, 'to equal', true)
+      await fakePsqlProcess.simulateExit(0)
+      await ensureFinished(promise)
     })
   })
 
   describe('psqlInteractive', () => {
-    const psql = proxyquire('../../lib/psql', {})
     const db = {
       attachment: {
         app: {
@@ -331,10 +284,10 @@ describe('psql', () => {
       let historyPath
       let envStub
 
-      function mockHerokuPSQLHistory(path) {
+      function mockHerokuPSQLHistory (path) {
         envStub = sandbox.stub()
         const envProxy = new Proxy(process.env, {
-          get(target, prop, receiver) {
+          get (target, prop, receiver) {
             if (prop === 'HEROKU_PSQL_HISTORY') {
               envStub()
               return path
@@ -343,7 +296,7 @@ describe('psql', () => {
           }
         })
         sandbox.stub(process, 'env').value(envProxy)
-        return envStub;
+        return envStub
       }
 
       afterEach(() => {
@@ -391,20 +344,20 @@ describe('psql', () => {
           )
 
           mock.callsFake(() => {
-            fakeChildProcess.start()
-            return fakeChildProcess
+            fakePsqlProcess.start()
+            return fakePsqlProcess
           })
 
-          await ensureFinished(psql.interactive(db), async () => {
-            await fakeChildProcess.waitForStart()
-            await fakeChildProcess.simulateExit(0)
-            mock.verify()
-          })
+          const promise = psql.interactive(db)
+          await fakePsqlProcess.waitForStart()
+          await fakePsqlProcess.simulateExit(0)
+          mock.verify()
+          await ensureFinished(promise)
         })
       })
 
       context('when HEROKU_PSQL_HISTORY is a valid file path', () => {
-        beforeEach(function() {
+        beforeEach(function () {
           historyPath = tmp.fileSync().name
           mockHerokuPSQLHistory(historyPath)
         })
@@ -440,15 +393,15 @@ describe('psql', () => {
           )
 
           mock.callsFake(() => {
-            fakeChildProcess.start()
-            return fakeChildProcess
+            fakePsqlProcess.start()
+            return fakePsqlProcess
           })
 
-          await ensureFinished(psql.interactive(db), async () => {
-            await fakeChildProcess.waitForStart()
-            await fakeChildProcess.simulateExit(0)
-            mock.verify()
-          })
+          const promise = psql.interactive(db)
+          await fakePsqlProcess.waitForStart()
+          await fakePsqlProcess.simulateExit(0)
+          mock.verify()
+          await ensureFinished(promise)
         })
       })
 
@@ -484,20 +437,132 @@ describe('psql', () => {
           )
 
           mock.callsFake(() => {
-            fakeChildProcess.start()
-            return fakeChildProcess
+            fakePsqlProcess.start()
+            return fakePsqlProcess
           })
 
-          await ensureFinished(psql.interactive(db), async () => {
-            await fakeChildProcess.waitForStart()
-            await fakeChildProcess.simulateExit(0)
-            mock.verify()
-            const expectedMessage = `HEROKU_PSQL_HISTORY is set but is not a valid path (${invalidPath})\n`
+          const promise = psql.interactive(db)
+          await fakePsqlProcess.waitForStart()
+          await fakePsqlProcess.simulateExit(0)
+          mock.verify()
+          const expectedMessage = `HEROKU_PSQL_HISTORY is set but is not a valid path (${invalidPath})\n`
 
-            expect(unwrap(cli.stderr), 'to equal', expectedMessage)
-          })
+          await ensureFinished(promise)
+          expect(unwrap(cli.stderr), 'to equal', expectedMessage)
         })
       })
     })
   })
 })
+
+function isSinonMatcher (value) {
+  return typeof value === 'object' &&
+    value !== null &&
+    typeof value.test === 'function'
+}
+
+// create a sinon matcher that only asserts on ENV values we expect.
+// we don't want to leak other ENV variables to the console in CI.
+// it also makes the test output easier by not listing all the environment variables available in process.env
+function matchEnv (expectedEnv) {
+  const matcher = (actualEnv) => {
+    const reducedActualEnv = Object.entries(expectedEnv).reduce((memo, [key, value]) => {
+      if (key in actualEnv) {
+        memo[key] = value
+      }
+      return memo
+    }, {})
+    sinon.match(expectedEnv).test(reducedActualEnv)
+
+    return true
+  }
+
+  return sinon.match(matcher, 'env contains expected keys and values')
+}
+
+class FakeChildProcess extends EventEmitter {
+  constructor (...args) {
+    super(...args)
+    this.ready = false
+    this.exited = false
+    this.killed = false
+    this.stdout = new PassThrough()
+  }
+  async waitForStart () {
+    if (!this.ready) {
+      await once(this, 'ready')
+    }
+  }
+  start () {
+    this.ready = true
+    this.emit('ready')
+  }
+  simulateExit (code) {
+    if (!this.exited) {
+      return new Promise((resolve) => {
+        this.exited = true
+        this.stdout.end()
+        this.emit('close', code)
+        resolve()
+      })
+    }
+  }
+  kill (signal) {
+    this.killed = true
+    this._killedWithSignal = signal
+    const killedWithCode = signals[signal]
+    this.simulateExit(killedWithCode)
+  }
+  get killedWithSignal () {
+    return this._killedWithSignal
+  }
+  async teardown () {
+    await this.simulateExit(0)
+    this.removeAllListeners()
+  }
+}
+
+class TunnelStub extends EventEmitter {
+  constructor (...args) {
+    super(...args)
+    this.exited = false
+  }
+  close () {
+    this.exited = true
+    process.nextTick(() => {
+      this.emit('close')
+    })
+  }
+}
+
+function createSpawnMocker (sandbox) {
+  return function mockSpawn (commandName, expectedArgs, expectedOptions) {
+    const spawnMock = sandbox.mock(ChildProcess)
+    const { env: expectedEnv } = expectedOptions
+
+    let optionsMatchers
+    if (isSinonMatcher(expectedOptions)) {
+      optionsMatchers = expectedOptions
+    } else {
+      optionsMatchers = Object.entries(expectedOptions).reduce((memo, [key, value]) => {
+        let matcher
+        if (key === 'env') {
+          matcher = matchEnv(expectedEnv)
+        } else {
+          matcher = value
+        }
+
+        memo[key] = matcher
+        return memo
+      }, {})
+    }
+
+    return spawnMock
+      .expects('spawn')
+      .withArgs(
+        commandName,
+        sinon.match.array.deepEquals(expectedArgs),
+        sinon.match(optionsMatchers)
+      )
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8718,6 +8718,13 @@ rimraf@2.6.3, rimraf@^2.5.2, rimraf@^2.6.3, rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
@@ -9799,6 +9806,13 @@ tmp@^0.1.0:
   integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
   dependencies:
     rimraf "^2.6.3"
+
+tmp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+  dependencies:
+    rimraf "^3.0.0"
 
 to-buffer@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
https://heroku.support/939668
[W-8530613](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008kgP4IAI/view)

In the case that the following events happen:

* `heroku pg:psql` is run on a **private-tier** (not shield) postgres plan  in a **private space** 
* Connection to postgres server times out (leave terminal open for 10-15 minutes to reproduce this)
* When psql reconnects due to timeout
* And user exits program (ctrl+D or types `exit` or `\q` into psql terminal)
* psql exits successfully

Then the heroku CLI process should exit. Before this commit, the process would hang because the tunnel created by the `tunnel-ssh` package does not seem to close itself in this scenario of reconnection. This PR does a bit of refactoring so we can retain a reference to the `tunnel-ssh` server instance, and always call `.close` ourselves when psql exits. Or kill psql ourselves when the server is closed for whatever reason.


## Other stuff included

### ctrl-c handler

I also brought back the Ctrl-C handler removed in https://github.com/heroku/cli/pull/1687; turns out that psql swallows ctrl+c (you have to use ctrl+d to kill psql). This is useful and important to have so that you can kill a long-running query while running psql. I've restored it with a comment that hopefully makes it a bit more clear why the code was necessary. We need to swallow the ctrl-c from Node so that the node process isn't killed (if the parent node process is killed it will take the child psql process, and the SSH tunnel, with it)

### test refactoring

The tests contained a lot of duplication, so I created a new `mockSpawn` helper to help with that. I also created some fake child process stubs and `ssh-tunnel` stubs so we could better test the failure cases this PR was trying to address.


## How to test?

* Pull down this branch
* Run `cd packages/pg-v5 && heroku plugins:link`
* Run `heroku psql -a chad-test-space-app HEROKU_POSTGRESQL_ORANGE`
* psql should connect. You should be able to run queries.
* Leave the terminal psql console open for 15 minutes
* type a query like `select now();` into the psql console and hit enter
* You should see a message about disconnecting and reconnecting over SSL from psql
* quit psql with ctrl+d or by typing `exit` or `\q` into psql and hitting enter
* the CLI process should quit
* **Be sure to run `heroku plugins:unlink` after testing**
