### PR TITLE
fix(apps domains): No variant needed for domains:update now

### DIFF
--- a/packages/apps/src/commands/domains/add.ts
+++ b/packages/apps/src/commands/domains/add.ts
@@ -89,9 +89,7 @@ export default class DomainsAdd extends Command {
       if (flags.cert) {
         domainCreatePayload.sni_endpoint = flags.cert
       } else {
-        const {body} = await this.heroku.get<Array<Heroku.SniEndpoint>>(`/apps/${flags.app}/sni-endpoints`, {
-          headers: {Accept: 'application/vnd.heroku+json; version=3.allow_multiple_sni_endpoints'},
-        })
+        const {body} = await this.heroku.get<Array<Heroku.SniEndpoint>>(`/apps/${flags.app}/sni-endpoints`)
 
         certs = [...body]
       }
@@ -110,7 +108,6 @@ export default class DomainsAdd extends Command {
 
     try {
       const {body: domain} = await this.heroku.post<Heroku.Domain>(`/apps/${flags.app}/domains`, {
-        headers: {Accept: 'application/vnd.heroku+json; version=3.allow_multiple_sni_endpoints'},
         body: domainCreatePayload,
       })
 

--- a/packages/apps/src/commands/domains/update.ts
+++ b/packages/apps/src/commands/domains/update.ts
@@ -25,9 +25,6 @@ export default class DomainsUpdate extends Command {
     try {
       cli.action.start(`Updating ${color.cyan(hostname)} to use ${color.cyan(flags.cert)} certificate`)
       await this.heroku.patch<string>(`/apps/${flags.app}/domains/${hostname}`, {
-        headers: {
-          Accept: 'application/vnd.heroku+json; version=3.allow_multiple_sni_endpoints',
-        },
         body: {sni_endpoint: flags.cert},
       })
     } catch (error) {

--- a/packages/certs-v5/commands/certs/add.js
+++ b/packages/certs-v5/commands/certs/add.js
@@ -221,7 +221,6 @@ function * configureDomains (context, heroku, meta, cert) {
         return heroku.request({
           method: 'PATCH',
           path: `/apps/${context.app}/domains/${domain}`,
-          headers: { Accept: 'application/vnd.heroku+json; version=3.allow_multiple_sni_endpoints' },
           body: { sni_endpoint: cert.name }
         })
       }))

--- a/packages/certs-v5/commands/certs/info.js
+++ b/packages/certs-v5/commands/certs/info.js
@@ -17,8 +17,7 @@ function * run (context, heroku) {
   if (context.flags['show-domains']) {
     let domains = yield Promise.all(endpoint.domains.map(domain => {
       return heroku.request({
-        path: `/apps/${context.flags.app}/domains/${domain}`,
-        headers: { 'Accept': `application/vnd.heroku+json; version=3.allow_multiple_sni_endpoints` }
+        path: `/apps/${context.flags.app}/domains/${domain}`
       }).then(response => response.hostname)
     }))
     cert.domains = domains


### PR DESCRIPTION
There is no variant needed for the `heroku domains:update` command any more.

Internal ref: https://github.com/heroku/api/pull/11773