### PR TITLE
fix: Check for connection pool attachment name conflicts

### DIFF
--- a/packages/pg-v5/commands/connection_pooling.js
+++ b/packages/pg-v5/commands/connection_pooling.js
@@ -19,7 +19,6 @@ function * run (context, heroku) {
     let attachments = yield heroku.get(`/apps/${addon.app.name}/addon-attachments`)
     let existing = attachments.find(a => a.name === flags.as.toUpperCase())
     if (existing) {
-      console.log('EXISTING')
       throw new Error(`Attachment named ${cli.color.attachment(flags.as.toUpperCase())} already exists`)
     }
   }

--- a/packages/pg-v5/commands/connection_pooling.js
+++ b/packages/pg-v5/commands/connection_pooling.js
@@ -15,6 +15,15 @@ function * run (context, heroku) {
 
   if (util.starterPlan(db)) throw new Error('This operation is not supported by Hobby tier databases.')
 
+  if (flags.as) {
+    let attachments = yield heroku.get(`/apps/${addon.app.name}/addon-attachments`)
+    let existing = attachments.find(a => a.name === flags.as.toUpperCase())
+    if (existing) {
+      console.log('EXISTING')
+      throw new Error(`Attachment named ${cli.color.attachment(flags.as.toUpperCase())} already exists`)
+    }
+  }
+
   let attachment = yield cli.action(
     `Enabling Connection Pooling${credential === 'default' ? '' : ' for credential ' + cli.color.addon(credential)} on ${cli.color.addon(addon.name)} to ${cli.color.app(app)}`,
     heroku.post(`/client/v11/databases/${encodeURIComponent(db.name)}/connection-pooling`, {


### PR DESCRIPTION
This PR adds a check for name conflicts when creating a postgres connection pool attachment.

Bug Report: https://salesforce.quip.com/TyKHALZhXe42
GUS: https://gus.lightning.force.com/a07B0000008j5lpIAA

Testing:

1. create 2 postgres add-ons on a single app
1. enable connection pooling on the first add-on with the default name: `DATABASE_CONNECTION_POOL`
1. attempt to create a connection pool attachment on the second add-on with the same name (displays an error message)
1. attempt to create a connection pool attachment on the second add-on with the same name, but lowercase (displays an error message)
1. create a connection pool attachment on the second add-on with no name specified (succeeds)
1. create a connection pool attachment on the second add-on with a custom, unique name specified (succeeds)
