### PR TITLE
fix(pg-v5) only support default credential for connection pooling

### DIFF
--- a/packages/pg-v5/commands/connection_pooling.js
+++ b/packages/pg-v5/commands/connection_pooling.js
@@ -11,14 +11,13 @@ function * run (context, heroku) {
 
   let db = yield fetcher.addon(app, args.database)
   let addon = yield heroku.get(`/addons/${encodeURIComponent(db.name)}`)
-  let credential = flags.credential || 'default'
 
   if (util.starterPlan(db)) throw new Error('This operation is not supported by Hobby tier databases.')
 
   let attachment = yield cli.action(
-    `Enabling Connection Pooling${credential === 'default' ? '' : ' for credential ' + cli.color.addon(credential)} on ${cli.color.addon(addon.name)} to ${cli.color.app(app)}`,
+    `Enabling Connection Pooling on ${cli.color.addon(addon.name)} to ${cli.color.app(app)}`,
     heroku.post(`/client/v11/databases/${encodeURIComponent(db.name)}/connection-pooling`, {
-      body: { name: flags.as, credential: credential, app: app },
+      body: { name: flags.as, credential: 'default', app: app },
       host: host(db)
     })
   )
@@ -44,12 +43,11 @@ module.exports = {
   needsAuth: true,
   help: `Example:
 
-  heroku pg:connection-pooling:attach postgresql-something-12345 --credential cred-name
+  heroku pg:connection-pooling:attach postgresql-something-12345
 `,
   args: [{ name: 'database', optional: true }],
   flags: [
-    { name: 'as', description: 'name for add-on attachment', hasValue: true },
-    { name: 'credential', char: 'n', hasValue: true, required: false, description: 'name of the credential within the database' }
+    { name: 'as', description: 'name for add-on attachment', hasValue: true }
   ],
   run: cli.command({ preauth: true }, co.wrap(run))
 }

--- a/packages/pg-v5/test/commands/connection_pooling.js
+++ b/packages/pg-v5/test/commands/connection_pooling.js
@@ -52,22 +52,6 @@ describe('pg:connection-polling:attach', () => {
     api.done()
   })
 
-  context('includes a credential', () => {
-    beforeEach(() => {
-      pg.post(`/client/v11/databases/${addon.name}/connection-pooling`, {
-        credential: readonlyCredential,
-        app: 'myapp'
-      }).reply(201, { name: 'HEROKU_COLOR' })
-    })
-
-    it('attaches pgbouncer with readonly credential', () => {
-      return cmd.run({ app: 'myapp', args: { database: 'postgres-1' }, flags: { credential: readonlyCredential } })
-        .then(() => expect(cli.stdout, 'to equal', ``))
-        .then(() => expect(cli.stderr, 'to contain', 'Enabling Connection Pooling for credential ' + readonlyCredential))
-        .then(() => expect(cli.stderr, 'to contain', 'Setting HEROKU_COLOR config vars and restarting myapp... done, v0\n'))
-    })
-  })
-
   context('includes an attachment name', () => {
     beforeEach(() => {
       pg.post(`/client/v11/databases/${addon.name}/connection-pooling`, {


### PR DESCRIPTION
We only support default credential for connection pooling atm. Disallow non-default credentials

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
