### PR TITLE
fix(pg-v5): return child process stdout

### DIFF
--- a/packages/pg-v5/commands/psql.js
+++ b/packages/pg-v5/commands/psql.js
@@ -9,27 +9,29 @@ function * run (context, heroku) {
 
   const { app, args, flags } = context
 
-  let namespace = flags.credential ? `credential:${flags.credential}` : null
+  const namespace = flags.credential ? `credential:${flags.credential}` : null
   let db
   try {
     db = yield fetcher.database(app, args.database, namespace)
   } catch (err) {
-    if (namespace && err.message === `Couldn't find that addon.`) {
-      throw new Error(`Credential doesn't match, make sure credential is attached`)
+    if (namespace && err.message === 'Couldn\'t find that addon.') {
+      throw new Error('Credential doesn\'t match, make sure credential is attached')
     }
     throw err
   }
   cli.console.error(`--> Connecting to ${cli.color.addon(db.attachment.addon.name)}`)
   if (flags.command) {
-    yield psql.exec(db, flags.command)
+    const output = yield psql.exec(db, flags.command)
+    process.stdout.write(output)
   } else if (flags.file) {
-    yield psql.execFile(db, flags.file)
+    const output = yield psql.execFile(db, flags.file)
+    process.stdout.write(output)
   } else {
     yield psql.interactive(db)
   }
 }
 
-let cmd = {
+const cmd = {
   description: 'open a psql shell to the database',
   needsApp: true,
   needsAuth: true,

--- a/packages/pg-v5/test/commands/ps.js
+++ b/packages/pg-v5/test/commands/ps.js
@@ -5,6 +5,7 @@ const cli = require('heroku-cli-util')
 const expect = require('unexpected')
 const nock = require('nock')
 const proxyquire = require('proxyquire')
+const { stdout } = require('stdout-stderr')
 
 const db = {}
 const fetcher = () => {
@@ -13,10 +14,18 @@ const fetcher = () => {
   }
 }
 
+const FAKE_OUTPUT_TEXT = `
+pid  | state  | source  | username | running_for | transaction_start | waiting | query
+-------+--------+---------+----------+-------------+-------------------+---------+-------
+ 17496 | active | standby | postgres |             |                   | t       |
+(1 row)
+
+`
+
 const psql = {
   exec: function (db, query) {
     this._query = query
-    return Promise.resolve('')
+    return Promise.resolve(FAKE_OUTPUT_TEXT)
   }
 }
 
@@ -29,18 +38,20 @@ describe('pg:ps', () => {
   let api
 
   beforeEach(() => {
+    stdout.start()
     api = nock('https://api.heroku.com:443')
     cli.mockConsole()
   })
 
   afterEach(() => {
+    stdout.stop()
     nock.cleanAll()
     api.done()
   })
 
-  it('runs query', () => {
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(psql._query.trim(), 'to equal', `SELECT
+  it('runs query', async () => {
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+    expect(removeEmptyLines(psql._query.trim()), 'to equal', removeEmptyLines(`SELECT
  pid,
  state,
  application_name AS source,
@@ -55,11 +66,13 @@ WHERE
  AND state <> 'idle'
  AND pid <> pg_backend_pid()
  ORDER BY query_start DESC`))
+
+    expect(stdout.output, 'to equal', FAKE_OUTPUT_TEXT)
   })
 
-  it('runs verbose query', () => {
-    return cmd.run({ app: 'myapp', args: {}, flags: { verbose: true } })
-      .then(() => expect(psql._query.trim(), 'to equal', `SELECT
+  it('runs verbose query', async () => {
+    await cmd.run({ app: 'myapp', args: {}, flags: { verbose: true } })
+    expect(removeEmptyLines(psql._query.trim()), 'to equal', removeEmptyLines(`SELECT
  pid,
  state,
  application_name AS source,
@@ -71,8 +84,13 @@ WHERE
 FROM pg_stat_activity
 WHERE
  query <> '<insufficient privilege>'
- 
  AND pid <> pg_backend_pid()
  ORDER BY query_start DESC`))
+
+    expect(stdout.output, 'to equal', FAKE_OUTPUT_TEXT)
   })
 })
+
+function removeEmptyLines (string) {
+  return string.split('\n').filter(str => str.trim().length > 0).join('\n')
+}


### PR DESCRIPTION
https://heroku.support/945120

In [PR #1691][1], some refactoring was done to make the way psql is executed more consistent. Unfortunately, this ended up in a regression for commands that were expecting the result of `PSQL.exec` to return a promise that resolved with the result of the psql child_process's stdout stream. Previously `PSQL.exec`'s resolved value would be a string. While the output is displayed, some commands, [like `ps` were looking at the return result of `psql.exec`][2]. Because #1691 made this return `undefined`, rather than a `string`, downstream commands like `ps` or others now error.

This changes the behavior in `packages/pg-v5/lib/psql.js` back to what it was doing before:

- Resolve the promise returned from `psql.exec` with the value of the psql child_process's `stdout` stream
- lib/psql.js no longer pipes to stdout. This is once again the responsibility of the caller.

Ideally, long term, we would return the child process (or a wrapper) and let callers decide to do with output themselves. Node has a lot of great utilities to make this easier. I tried going down this route but it ended up being a larger change than intended due to tests. In the interest of fixing this issue quickly, let's go with this approach until we can revisit the return value of `PSQL.exec` in the future.

[1]: https://github.com/heroku/cli/pull/1691
[2]: https://github.com/heroku/cli/blob/729acd6382b424649c51bff7f4afb02df99d46ac/packages/pg-v5/commands/ps.js#L27

## How to verify?

* Clone this branch
* Run `cd packages/pg-v5`
* Run `heroku plugins:link`
* Run `heroku pg:ps -a someappwithpostgres`
* It should finish successfully
* **Make sure to run `heroku plugins:unlink` to uninstall this local branch **