### PR TITLE
feat(config): add +/- context to config:edit output

### DIFF
--- a/packages/config/src/commands/config/edit.ts
+++ b/packages/config/src/commands/config/edit.ts
@@ -55,10 +55,10 @@ function showDiff(from: Config, to: Config) {
   for (const k of allKeys(from, to)) {
     if (from[k] === to[k]) continue
     if (k in from) {
-      cli.log(color.red(`${k}=${quote(from[k])}`))
+      cli.log(color.red(`- ${k}=${quote(from[k])}`))
     }
     if (k in to) {
-      cli.log(color.green(`${k}=${quote(to[k])}`))
+      cli.log(color.green(`+ ${k}=${quote(to[k])}`))
     }
   }
 }


### PR DESCRIPTION
When sharing the output from `config:diff` that does not preserve the CLI coloring, it is difficult to determine _what_ was changed:

```
Config Diff:
IMPORTANT_SETTING=true
IMPORTANT_SETTING=false
```

This PR adds additional context showing the +/- of the diff:

```
Config Diff:
- IMPORTANT_SETTING=true
+ IMPORTANT_SETTING=false
```