### PR TITLE
build: add release scripts

### DIFF
--- a/scripts/create-release-pr
+++ b/scripts/create-release-pr
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+CURRENT_BRANCH=`git branch --show-current`
+MAIN_BRANCH="master"
+
+if [[ "${CURRENT_BRANCH}" != "${MAIN_BRANCH}" ]]; then
+  echo "scripts/publish-release must be run on the ${MAIN_BRANCH}."
+  echo "Please checkout the ${MAIN_BRANCH} branch with:"
+  echo "git checkout ${MAIN_BRANCH}"
+  exit 1
+fi
+
+if !(command -v gh > /dev/null); then
+  echo "GitHub CLI is required for this release script."
+  echo "Please install GitHub CLI and try again:"
+  echo "https://github.com/cli/cli#installation"
+  exit 1
+fi
+
+# hostname is necessary just in case you are logged into the CLI
+# GitHub enterprise instance
+if !(gh auth status --hostname "github.com" > /dev/null 2>&1); then
+  echo "Not logged into GitHub".
+  echo "Please run: gh auth login"
+  exit 1
+fi
+
+git pull --rebase origin "${MAIN_BRANCH}"
+
+# Create a branch with the unix timestamp of the current second
+BRANCH_NAME="release-$(date +%s)"
+
+echo "Creating git branch ${BRANCH_NAME}"
+git checkout -b "${BRANCH_NAME}"
+
+echo "Installing dependencies with yarn..."
+yarn
+echo "Done installing dependencies with yarn"
+
+echo "Creating new CLI package(s) versions with yarn lerna version..."
+yarn lerna version \
+  --allow-branch ${BRANCH_NAME} \
+  --no-push \
+  --no-git-tag-version \
+  --yes
+git add . -u
+PACKAGE_VERSION=`node -e "console.log(require('./lerna.json').version)"`
+echo "Done creating new CLI package(s) versions"
+
+echo "Creating git commit and pushing to GitHub..."
+git commit -m "v${PACKAGE_VERSION}"
+git push origin "${BRANCH_NAME}"
+gh pr create --title="release v${PACKAGE_VERSION}" --body "release v${PACKAGE_VERSION}"

--- a/scripts/publish-release
+++ b/scripts/publish-release
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+CURRENT_BRANCH=`git branch --show-current`
+MAIN_BRANCH="master"
+
+if [[ "${CURRENT_BRANCH}" != "${MAIN_BRANCH}" ]]; then
+  echo "scripts/publish-release must be run on the ${MAIN_BRANCH}."
+  echo "Please checkout the ${MAIN_BRANCH} branch with:"
+  echo "git checkout ${MAIN_BRANCH}"
+  exit 1
+fi
+
+if !(command -v gh > /dev/null); then
+  echo "GitHub CLI is required for this release script."
+  echo "Please install GitHub CLI and try again:"
+  echo "https://github.com/cli/cli#installation"
+  exit 1
+fi
+
+# hostname is necessary just in case you are logged into the CLI
+# GitHub enterprise instance
+if !(gh auth status --hostname "github.com" > /dev/null 2>&1); then
+  echo "Not logged into github".
+  echo "Please run: gh auth login"
+  exit 1
+fi
+
+git pull --rebase origin "${MAIN_BRANCH}"
+git fetch origin --tags
+
+PACKAGE_VERSION=`node -e "console.log(require('./lerna.json').version)"`
+TAG_NAME="v${PACKAGE_VERSION}"
+EXISTING_REMOTE_TAG=$(git ls-remote origin "refs/tags/${TAG_NAME}")
+
+if [ -n "${EXISTING_REMOTE_TAG}" ]; then
+  echo "The tag ${TAG_NAME} already exists on github.com"
+  echo "This likely means this version has already been published."
+  echo "Please examine the tag ${TAG_NAME} on github.com/heroku/cli to see the contents of the ${TAG_NAME} release"
+  echo "You may need to run scripts/create-release-pr to create a new release before running this script"
+  exit 1
+fi
+
+echo "Installing dependencies with yarn..."
+yarn
+echo "Done installing dependencies with yarn"
+
+echo "publishing packages to npm..."
+yarn lerna publish --yes from-package
+
+
+LAST_PUBLISHED_TAG=$(git tag --sort="-version:refname" --list --format="%(refname:strip=2)" | head -n1)
+
+git tag "${TAG_NAME}" -m "${TAG_NAME}"
+git push origin "${TAG_NAME}"
+
+RELEASE_NOTES=$(git log --graph --format="%h %s" "${LAST_PUBLISHED_TAG}...${TAG_NAME}~1")
+
+gh release create "${TAG_NAME}" --title="${TAG_NAME}" --notes="${RELEASE_NOTES}"


### PR DESCRIPTION
Takes the steps outlined in https://salesforce.quip.com/aPLDA1ZwjNlW and creates some scripts that automate some of the steps so we don't have to figure this out manually every time.

Added two scripts:

- `scripts/create-release-pr`
  - Creates a new branch (so a pull request can be opened)
  - Bumps the version and generates new changelogs using `yarn lerna version`
  - Opens a pull request
- `scripts/publish-release`
  - Checks that the script is only run on the main branch (`master` at the time of this writing)
  - Pulls down the latest Git branches/tags from GitHub
  - Creates a new tag based off of the version in `lerna.json`
  - Pushes tag to GitHub
  - Publishes packages to NPM
  - Creates a GitHub release with the correct release notes of things that changed based off of Git commit history

Here's what the new steps in the Release document will look like now:

* Make sure you have the latest [GithubCLI][1] installed.
* Run `scripts/create-release-pr`
* Get approval from someone in @heroku/front-end 
* Merge the PR
* Run `git checkout master`
* Run `scripts/publish-release`
* Publish snap script by logging into snapcraft.io....

The scripts require installation of the GitHub CLI, and will error/message appropriately if the [GitHub CLI][1] is not installed or the person running the script is not logged into GitHub.

These scripts were used/tested to create the v7.47.7 release.

[1]: https://cli.github.com/
