### PR TITLE
docs(git): Fix a mistake in git:remote examples

### DIFF
--- a/docs/git.md
+++ b/docs/git.md
@@ -51,7 +51,7 @@ EXAMPLES
   # set git remote heroku to https://git.heroku.com/example.git
        $ heroku git:remote -a example
 
-       # set git remote heroku-staging to https://git.heroku.com/example-staging.git
+       # set git remote heroku-staging to https://git.heroku.com/example.git
        $ heroku git:remote --remote heroku-staging -a example
 ```
 

--- a/packages/git/src/commands/git/remote.ts
+++ b/packages/git/src/commands/git/remote.ts
@@ -12,7 +12,7 @@ extra arguments will be passed to git remote add
   static example = `# set git remote heroku to https://git.heroku.com/example.git
     $ heroku git:remote -a example
 
-    # set git remote heroku-staging to https://git.heroku.com/example-staging.git
+    # set git remote heroku-staging to https://git.heroku.com/example.git
     $ heroku git:remote --remote heroku-staging -a example`
 
   static flags = {


### PR DESCRIPTION
The example of adding a new remote with a custom alias stated that the remote URL was `https://git.heroku.com/example-staging.git`, but the command was pointing to `https://git.heroku.com/example.git`.

I've updated the example to use the same remote URL as the previous example, so that the only difference is the addition of the `--remote` argument.