### PR TITLE
feat(apps-v5): Update create/stack:set examples to use Heroku-20

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -71,7 +71,7 @@ OPTIONS
 
 EXAMPLES
   $ heroku apps:create
-  Creating app... done, stack is heroku-18
+  Creating app... done, stack is heroku-20
   https://floating-dragon-42.heroku.com/ | https://git.heroku.com/floating-dragon-42.git
 
   # or just
@@ -299,8 +299,8 @@ OPTIONS
   -r, --remote=remote  git remote of app to use
 
 EXAMPLES
-  $ heroku stack:set heroku-18 -a myapp
-  Stack set. Next release on myapp will use heroku-18.
+  $ heroku stack:set heroku-20 -a myapp
+  Stack set. Next release on myapp will use heroku-20.
   Run git push heroku main to create a new release on myapp.
 ```
 

--- a/packages/apps-v5/README.md
+++ b/packages/apps-v5/README.md
@@ -121,7 +121,7 @@ OPTIONS
 
 EXAMPLES
   $ heroku apps:create
-  Creating app... done, stack is heroku-18
+  Creating app... done, stack is heroku-20
   https://floating-dragon-42.heroku.com/ | https://git.heroku.com/floating-dragon-42.git
 
   # or just
@@ -310,8 +310,8 @@ OPTIONS
   -r, --remote=remote  git remote of app to use
 
 EXAMPLES
-  $ heroku stack:set heroku-18 -a myapp
-  Stack set. Next release on myapp will use heroku-18.
+  $ heroku stack:set heroku-20 -a myapp
+  Stack set. Next release on myapp will use heroku-20.
   Run git push heroku main to create a new release on myapp.
 ```
 

--- a/packages/apps-v5/src/commands/apps/create.js
+++ b/packages/apps-v5/src/commands/apps/create.js
@@ -151,7 +151,7 @@ function run (context, heroku) {
 let cmd = {
   description: 'creates a new app',
   examples: `$ heroku apps:create
-Creating app... done, stack is heroku-18
+Creating app... done, stack is heroku-20
 https://floating-dragon-42.heroku.com/ | https://git.heroku.com/floating-dragon-42.git
 
 # or just

--- a/packages/apps-v5/src/commands/apps/stacks/set.js
+++ b/packages/apps-v5/src/commands/apps/stacks/set.js
@@ -28,8 +28,8 @@ let cmd = {
   needsApp: true,
   needsAuth: true,
   description: 'set the stack of an app',
-  examples: `$ heroku stack:set heroku-18 -a myapp
-Stack set. Next release on myapp will use heroku-18.
+  examples: `$ heroku stack:set heroku-20 -a myapp
+Stack set. Next release on myapp will use heroku-20.
 Run git push heroku main to create a new release on myapp.`,
   args: [{ name: 'stack' }],
   run: cli.command(co.wrap(run))

--- a/packages/apps-v5/test/commands/apps/info.js
+++ b/packages/apps-v5/test/commands/apps/info.js
@@ -24,7 +24,7 @@ let app = {
 }
 
 let appStackChange = Object.assign({}, app, {
-  build_stack: { name: 'heroku-18' }
+  build_stack: { name: 'heroku-20' }
 })
 
 let appExtended = Object.assign({}, app, {
@@ -290,7 +290,7 @@ Region:           eu
 Repo Size:        1000 B
 Slug Size:        1000 B
 Space:            myspace
-Stack:            cedar-14 (next build will use heroku-18)
+Stack:            cedar-14 (next build will use heroku-20)
 Web URL:          https://myapp.herokuapp.com
 `))
       .then(() => appApi.done())

--- a/packages/apps-v5/test/commands/apps/stack/set.js
+++ b/packages/apps-v5/test/commands/apps/stack/set.js
@@ -12,17 +12,17 @@ const pendingUpgradeApp = {
     name: 'heroku-16'
   },
   build_stack: {
-    name: 'heroku-18'
+    name: 'heroku-20'
   }
 }
 
 const completedUpgradeApp = {
   name: 'myapp',
   stack: {
-    name: 'heroku-18'
+    name: 'heroku-20'
   },
   build_stack: {
-    name: 'heroku-18'
+    name: 'heroku-20'
   }
 }
 
@@ -31,11 +31,11 @@ describe('stack:set', function () {
 
   it('sets the stack', function () {
     let api = nock('https://api.heroku.com:443')
-      .patch('/apps/myapp', { build_stack: 'heroku-18' })
+      .patch('/apps/myapp', { build_stack: 'heroku-20' })
       .reply(200, pendingUpgradeApp)
 
-    return cmd.run({ app: 'myapp', args: { stack: 'heroku-18' }, flags: {} })
-      .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-18... done\n'))
+    return cmd.run({ app: 'myapp', args: { stack: 'heroku-20' }, flags: {} })
+      .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-20... done\n'))
       .then(() => expect(cli.stdout).to.equal(`You will need to redeploy myapp for the change to take effect.
 Run git push heroku main to create a new release on myapp.
 `))
@@ -44,11 +44,11 @@ Run git push heroku main to create a new release on myapp.
 
   it('sets the stack on a different remote', function () {
     let api = nock('https://api.heroku.com:443')
-      .patch('/apps/myapp', { build_stack: 'heroku-18' })
+      .patch('/apps/myapp', { build_stack: 'heroku-20' })
       .reply(200, pendingUpgradeApp)
 
-    return cmd.run({ app: 'myapp', args: { stack: 'heroku-18' }, flags: { remote: 'staging' } })
-      .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-18... done\n'))
+    return cmd.run({ app: 'myapp', args: { stack: 'heroku-20' }, flags: { remote: 'staging' } })
+      .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-20... done\n'))
       .then(() => expect(cli.stdout).to.equal(`You will need to redeploy myapp for the change to take effect.
 Run git push staging main to create a new release on myapp.
 `))
@@ -57,11 +57,11 @@ Run git push staging main to create a new release on myapp.
 
   it('does not show the redeploy message if the stack was immediately updated by API', function () {
     let api = nock('https://api.heroku.com:443')
-      .patch('/apps/myapp', { build_stack: 'heroku-18' })
+      .patch('/apps/myapp', { build_stack: 'heroku-20' })
       .reply(200, completedUpgradeApp)
 
-    return cmd.run({ app: 'myapp', args: { stack: 'heroku-18' }, flags: {} })
-      .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-18... done\n'))
+    return cmd.run({ app: 'myapp', args: { stack: 'heroku-20' }, flags: {} })
+      .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-20... done\n'))
       .then(() => expect(cli.stdout).to.equal(''))
       .then(() => api.done())
   })


### PR DESCRIPTION
Since we're about to make Heroku-20 the default stack, which updates the response from API and so the docs examples here.

Closes [W-8505333](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008kEPtIAM/view).