### PR TITLE
fix(redis-v5) Use TLS_URL for hobby dev if version supports TLS

### DIFF
--- a/packages/redis-v5/commands/cli.js
+++ b/packages/redis-v5/commands/cli.js
@@ -142,6 +142,10 @@ function maybeTunnel (redis, config) {
   let uri = url.parse(redis.resource_url)
   let prefer_native_tls = redis.prefer_native_tls
 
+  if (prefer_native_tls && hobby) {
+    uri = url.parse(match(config, /_TLS_URL/))
+  }
+
   if (bastions != null) {
     return bastionConnect({ uri, bastions, config, prefer_native_tls })
   } else {


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

For hobby, the TLS url is exposed in a separate config _TLS_URL. This PR fixes the bug where we are trying to connect over TLS with the plaintext URL for versions supporting TLS.