### PR TITLE
build: Release script fixes

### DIFF
--- a/scripts/create-release-pr
+++ b/scripts/create-release-pr
@@ -2,7 +2,7 @@
 
 set -e -o pipefail
 
-CURRENT_BRANCH=`git branch --show-current`
+CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 MAIN_BRANCH="master"
 
 if [[ "${CURRENT_BRANCH}" != "${MAIN_BRANCH}" ]]; then

--- a/scripts/publish-release
+++ b/scripts/publish-release
@@ -2,7 +2,7 @@
 
 set -e -o pipefail
 
-CURRENT_BRANCH=`git branch --show-current`
+CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 MAIN_BRANCH="master"
 
 if [[ "${CURRENT_BRANCH}" != "${MAIN_BRANCH}" ]]; then

--- a/scripts/publish-release
+++ b/scripts/publish-release
@@ -28,7 +28,10 @@ if !(gh auth status --hostname "github.com" > /dev/null 2>&1); then
 fi
 
 git pull --rebase origin "${MAIN_BRANCH}"
-git fetch origin --tags
+# The --force overrides local tags.
+# This is needed if you've published the CLI previously,
+# otherwise git will exit with an error unnecessarily.
+git fetch origin  --force --tags
 
 PACKAGE_VERSION=`node -e "console.log(require('./lerna.json').version)"`
 TAG_NAME="v${PACKAGE_VERSION}"


### PR DESCRIPTION
# Fix pulling tags in `scripts/publish-release`

If someone has released the CLI locally, they'll have a tag name for the release that gets pulled from origin. Using `--force` is the only way to override the local tag with the tag from GitHub, which should be the canonical source of truth anyway and not cause conflicts since it should be the same tag.

# Use more compatible `git rev-parse --abref HEAD` instead of `git branch --show-current`.

`git branch --show-current` is only available in Git >= 2.22. Changing this to `git rev-parse --abbrev-ref HEAD` works in all versions and reduces friction when running the release script.
