### PR TITLE
chore(cli): bump @heroku-cli/command and @oclif/plugin-legacy

### DIFF
--- a/packages/addons-v5/package.json
+++ b/packages/addons-v5/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.21.3",
-    "@oclif/plugin-legacy": "^1.1.4",
+    "@oclif/plugin-legacy": "^1.2.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "lolex": "^3.1.0",

--- a/packages/apps-v5/package.json
+++ b/packages/apps-v5/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.21.3",
-    "@oclif/plugin-legacy": "^1.1.4",
+    "@oclif/plugin-legacy": "^1.2.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "lolex": "^3.1.0",

--- a/packages/apps-v5/package.json
+++ b/packages/apps-v5/package.json
@@ -15,7 +15,7 @@
     "repositoryPrefix": "<%- repo %>/blob/v<%- version %>/packages/apps-v5/<%- commandPath %>"
   },
   "dependencies": {
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "co": "^4.6.0",
     "filesize": "^4.0.0",
     "fs-extra": "^7.0.1",

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/heroku/heroku-cli-plugin-apps/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "@heroku-cli/schema": "^1.0.25",
     "@oclif/command": "^1",
     "@oclif/config": "^1",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "@oclif/command": "^1.5.11",
     "@oclif/config": "^1.12.10",
     "cli-ux": "^4.9.3",

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -4,7 +4,7 @@
   "author": "Philipe Navarro @RasPhilCo",
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "@oclif/command": "^1.5.11",
     "@oclif/config": "^1.12.10",
     "chalk": "^2.4.2",

--- a/packages/buildpacks/package.json
+++ b/packages/buildpacks/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "@heroku/buildpack-registry": "^1.0.1",
     "@oclif/config": "^1.12.10",
     "@oclif/plugin-legacy": "^1.1.4",

--- a/packages/buildpacks/package.json
+++ b/packages/buildpacks/package.json
@@ -8,7 +8,7 @@
     "@heroku-cli/command": "^8.4.1",
     "@heroku/buildpack-registry": "^1.0.1",
     "@oclif/config": "^1.12.10",
-    "@oclif/plugin-legacy": "^1.1.4",
+    "@oclif/plugin-legacy": "^1.2.0",
     "cli-ux": "^4.9.3",
     "heroku-cli-util": "^8.0.11",
     "http-call": "^5.2.3",

--- a/packages/certs-v5/package.json
+++ b/packages/certs-v5/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.21.3",
-    "@oclif/plugin-legacy": "^1.1.4",
+    "@oclif/plugin-legacy": "^1.2.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "lolex": "^3.1.0",

--- a/packages/certs/package.json
+++ b/packages/certs/package.json
@@ -4,7 +4,7 @@
   "author": "Jeff Dickey @jdxcode",
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "@oclif/command": "^1.5.11",
     "@oclif/config": "^1.12.10",
     "tslib": "^1.9.3"

--- a/packages/ci-v5/package.json
+++ b/packages/ci-v5/package.json
@@ -13,7 +13,7 @@
     "repositoryPrefix": "<%- repo %>/blob/v<%- version %>/packages/ci-v5/<%- commandPath %>"
   },
   "dependencies": {
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "@heroku-cli/plugin-run-v5": "^7.47.10",
     "ansi-escapes": "3.2.0",
     "bluebird": "^3.5.3",

--- a/packages/ci-v5/package.json
+++ b/packages/ci-v5/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.21.3",
-    "@oclif/plugin-legacy": "^1.1.4",
+    "@oclif/plugin-legacy": "^1.2.0",
     "chai": "^4.2.0",
     "estraverse": "^4.2.0",
     "mocha": "^5.1.1",

--- a/packages/ci/package.json
+++ b/packages/ci/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "@oclif/command": "^1.5.11",
     "@oclif/config": "^1.12.10",
     "ansi-escapes": "3.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,7 +40,7 @@
     "@oclif/errors": "1.2.2",
     "@oclif/plugin-commands": "^1.2.2",
     "@oclif/plugin-help": "2.2.0",
-    "@oclif/plugin-legacy": "1.1.4",
+    "@oclif/plugin-legacy": "1.2.0",
     "@oclif/plugin-not-found": "1.2.2",
     "@oclif/plugin-plugins": "1.7.9",
     "@oclif/plugin-update": "1.3.9",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "1.1.14",
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "@heroku-cli/plugin-addons-v5": "^7.47.10",
     "@heroku-cli/plugin-apps": "^7.47.10",
     "@heroku-cli/plugin-apps-v5": "^7.47.11",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "@oclif/command": "^1.5.11",
     "@oclif/config": "^1.12.10",
     "cli-ux": "^4.9.3",

--- a/packages/container-registry-v5/package.json
+++ b/packages/container-registry-v5/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.21.3",
-    "@oclif/plugin-legacy": "^1.1.4",
+    "@oclif/plugin-legacy": "^1.2.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cross-env": "^7.0.2",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "@oclif/command": "^1.5.11",
     "@oclif/config": "^1.12.10",
     "cli-ux": "^4.9.3",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -16,7 +16,7 @@
     "@heroku-cli/schema": "^1.0.25",
     "@oclif/dev-cli": "^1.21.3",
     "@oclif/plugin-help": "^2.1.6",
-    "@oclif/plugin-legacy": "^1.1.4",
+    "@oclif/plugin-legacy": "^1.2.0",
     "@oclif/test": "^1.2.4",
     "@types/chai": "^4.1.7",
     "@types/fs-extra": "^5.0.5",

--- a/packages/local/package.json
+++ b/packages/local/package.json
@@ -5,7 +5,7 @@
   "author": "Chad Carbert @chadian",
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "foreman": "^3.0.1",

--- a/packages/oauth-v5/package.json
+++ b/packages/oauth-v5/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.21.3",
-    "@oclif/plugin-legacy": "^1.1.4",
+    "@oclif/plugin-legacy": "^1.2.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cross-env": "^7.0.2",

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -9,7 +9,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "@heroku-cli/schema": "^1.0.25",
     "@oclif/command": "^1",
     "@oclif/config": "^1",

--- a/packages/orgs-v5/package.json
+++ b/packages/orgs-v5/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.21.3",
-    "@oclif/plugin-legacy": "^1.1.4",
+    "@oclif/plugin-legacy": "^1.2.0",
     "chai": "^4.2.0",
     "mocha": "^5.2.0",
     "nock": "^10.0.6",

--- a/packages/orgs-v5/package.json
+++ b/packages/orgs-v5/package.json
@@ -38,7 +38,7 @@
     "repositoryPrefix": "<%- repo %>/blob/v<%- version %>/packages/orgs-v5/<%- commandPath %>"
   },
   "dependencies": {
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "co": "^4.6.0",
     "heroku-cli-util": "^8.0.11",
     "inquirer": "^6.2.2",

--- a/packages/pg-v5/package.json
+++ b/packages/pg-v5/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.21.3",
-    "@oclif/plugin-legacy": "^1.1.4",
+    "@oclif/plugin-legacy": "^1.2.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cross-env": "^7.0.2",

--- a/packages/pipelines/package.json
+++ b/packages/pipelines/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "@heroku-cli/schema": "^1.0.25",
     "@oclif/command": "^1",
     "@oclif/config": "^1",

--- a/packages/ps/package.json
+++ b/packages/ps/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "@oclif/command": "^1.5.11",
     "@oclif/config": "^1.12.10",
     "cli-ux": "^4.9.3",

--- a/packages/redis-v5/package.json
+++ b/packages/redis-v5/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.21.3",
-    "@oclif/plugin-legacy": "^1.1.4",
+    "@oclif/plugin-legacy": "^1.2.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "lolex": "^3.1.0",

--- a/packages/run-v5/package.json
+++ b/packages/run-v5/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "@heroku-cli/notifications": "^1.2.2",
     "@heroku/eventsource": "^1.0.7",
     "co": "4.6.0",

--- a/packages/run-v5/package.json
+++ b/packages/run-v5/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.21.3",
-    "@oclif/plugin-legacy": "^1.1.4",
+    "@oclif/plugin-legacy": "^1.2.0",
     "chai": "^4.2.0",
     "fixture-stdout": "0.2.1",
     "mocha": "^5.2.0",

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -5,7 +5,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "@heroku-cli/notifications": "^1.2.2",
     "@heroku/eventsource": "^1.0.7",
     "@oclif/command": "^1",

--- a/packages/spaces/package.json
+++ b/packages/spaces/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.21.3",
-    "@oclif/plugin-legacy": "^1.1.4",
+    "@oclif/plugin-legacy": "^1.2.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "mocha": "^5.2.0",

--- a/packages/spaces/package.json
+++ b/packages/spaces/package.json
@@ -17,7 +17,7 @@
     "repositoryPrefix": "<%- repo %>/blob/v<%- version %>/packages/spaces/<%- commandPath %>"
   },
   "dependencies": {
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "@heroku-cli/notifications": "^1.2.2",
     "co": "4.6.0",
     "heroku-cli-util": "^8.0.11",

--- a/packages/status/package.json
+++ b/packages/status/package.json
@@ -31,7 +31,7 @@
     "@heroku-cli/tslint": "1.1.4",
     "@oclif/dev-cli": "^1.21.3",
     "@oclif/plugin-help": "^2.1.6",
-    "@oclif/plugin-legacy": "^1.1.4",
+    "@oclif/plugin-legacy": "^1.2.0",
     "@oclif/test": "^1.2.4",
     "@types/ansi-styles": "^3.2.1",
     "@types/chai": "^4.1.7",

--- a/packages/status/package.json
+++ b/packages/status/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "@oclif/command": "^1.5.11",
     "@oclif/config": "^1.12.10",
     "@oclif/errors": "^1.2.2",

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.4.0",
+    "@heroku-cli/command": "^8.4.1",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
     "cli-ux": "^5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -276,21 +276,6 @@
     supports-color "^5.5.0"
     tslib "^1.9.3"
 
-"@heroku-cli/command@^8.2.0":
-  version "8.2.8"
-  resolved "https://registry.yarnpkg.com/@heroku-cli/command/-/command-8.2.8.tgz#8668ce49a5ec791eb0bbd5a862badafcd33fcec4"
-  integrity sha512-2gcuKouQsOPv8DSQiNg3eTaNzCX5kIQNWf1f/7Hj6rV8sDRUdvlV4CanJRcyPox6aZfGQDaWIqxnjTgAn9GJ/w==
-  dependencies:
-    "@heroku-cli/color" "^1.1.14"
-    "@oclif/errors" "^1.2.2"
-    cli-ux "^4.9.3"
-    debug "^4.1.1"
-    fs-extra "^7.0.1"
-    heroku-client "^3.0.7"
-    http-call "^5.2.3"
-    netrc-parser "^3.1.6"
-    opn "^5.4.0"
-
 "@heroku-cli/command@^8.4.1":
   version "8.4.1"
   resolved "https://registry.yarnpkg.com/@heroku-cli/command/-/command-8.4.1.tgz#7efe7f7f2a368369108f12540760fe67405a517c"
@@ -1315,18 +1300,18 @@
     widest-line "^3.1.0"
     wrap-ansi "^4.0.0"
 
-"@oclif/plugin-legacy@1.1.4", "@oclif/plugin-legacy@^1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@oclif/plugin-legacy/-/plugin-legacy-1.1.4.tgz#d0933d13f610af529b557a2f3671b7cd0073172d"
-  integrity sha512-/oJGRcM7VaSGJ9Eodi/kl0avAKDlJvdYA8jmh4bhBHrCsaPqM61P7LUH2w2PUIccnM82mPPCp3PoUEM85PAIdw==
+"@oclif/plugin-legacy@1.2.0", "@oclif/plugin-legacy@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@oclif/plugin-legacy/-/plugin-legacy-1.2.0.tgz#67ef471b5ad0e39b7821112c8b622754e9b78cb9"
+  integrity sha512-rxKDIqDgEvEvSEyXZS5kyzZb+yd/hAYwTzKHKjFrmTIrUok/kRC5xMtg1uvIGk7Xt9hWmsqaNhIrvSqvEYYk/w==
   dependencies:
-    "@heroku-cli/command" "^8.2.0"
+    "@heroku-cli/command" "^8.4.1"
     "@oclif/color" "^0.0.0"
     "@oclif/command" "^1.5.4"
-    ansi-escapes "^3.1.0"
+    ansi-escapes "^4.3.1"
     debug "^4.1.0"
-    semver "^5.6.0"
-    tslib "^1.9.3"
+    semver "^7.3.2"
+    tslib "^2.0.0"
 
 "@oclif/plugin-not-found@1.2.2":
   version "1.2.2"
@@ -1954,7 +1939,7 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.5.2"
 
-ansi-escapes@^4.3.0:
+ansi-escapes@^4.3.0, ansi-escapes@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.1.tgz#a5c47cc43181f1f38ffd7076837700d395522a61"
   integrity sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
@@ -7434,13 +7419,6 @@ opn@^3.0.3:
   integrity sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=
   dependencies:
     object-assign "^4.0.1"
-
-opn@^5.4.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
-  integrity sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==
-  dependencies:
-    is-wsl "^1.1.0"
 
 optionator@^0.8.2:
   version "0.8.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -291,10 +291,10 @@
     netrc-parser "^3.1.6"
     opn "^5.4.0"
 
-"@heroku-cli/command@^8.4.0":
-  version "8.4.0"
-  resolved "https://registry.yarnpkg.com/@heroku-cli/command/-/command-8.4.0.tgz#3f977eeadfb3aacbe79172644f1fee8040893cae"
-  integrity sha512-TN4v5VYIJeLizhNBwP3bDKrUQLdriGVSDRT55/Il2Dyg9i8hkoUQURckcGv0H/MS2oissqCGXfNzNZu2VRbC2Q==
+"@heroku-cli/command@^8.4.1":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@heroku-cli/command/-/command-8.4.1.tgz#7efe7f7f2a368369108f12540760fe67405a517c"
+  integrity sha512-B8Jg0FtlxNnkRYepzMcAsq17uTxQlg8NubiQKKtlertJmvBUJ2QoBczhsHCc4wuXSlraVhTgRnfT77fZ8bqROw==
   dependencies:
     "@heroku-cli/color" "^1.1.14"
     "@oclif/errors" "^1.2.2"


### PR DESCRIPTION
Bump `@heroku-cli/command` and `@oclif/plugin-legacy` to include the changes to `@heroku-cli/command` made in https://github.com/heroku/heroku-cli-command/pull/79