### PR TITLE
feat(pg-v5): add burst checks, json output to diagnose

### DIFF
--- a/packages/pg-v5/test/commands/diagnose.js
+++ b/packages/pg-v5/test/commands/diagnose.js
@@ -8,7 +8,6 @@ const proxyquire = require('proxyquire')
 const uuid = require('uuid')
 
 describe('pg:diagnose', () => {
-
   let api, pg, diagnose, db, dbName
   let app, addon, plan, attachment
   let reportID
@@ -22,25 +21,27 @@ describe('pg:diagnose', () => {
           addon,
           app,
         }
-      }
+      },
     }
   }
 
   const cmd = proxyquire('../../commands/diagnose', {
-    '../lib/fetcher': fetcher
+    '../lib/fetcher': fetcher,
   })
 
   beforeEach(() => {
     plan = {
       name: 'heroku-postgresql:standard-0',
-      id: uuid.v4()
+      id: uuid.v4(),
     }
     db = {
       id: uuid.v4(),
       name: dbName || 'DATABASE',
-      get plan() { return plan },
+      get plan() {
+        return plan
+      },
       config_vars: ['DATABASE_ENDPOINT_042EExxx_URL', 'DATABASE_URL', 'HEROKU_POSTGRESQL_SILVER_URL'],
-      app: { name: 'myapp' }
+      app: { name: 'myapp' },
     }
     attachment = {
       id: 1,
@@ -50,17 +51,19 @@ describe('pg:diagnose', () => {
       get config_vars() {
         return db.config_vars
       },
-      namespace: null
+      namespace: null,
     }
     app = {
       name: 'myapp',
-      id: uuid.v4()
+      id: uuid.v4(),
     }
     addon = {
       name: 'postgres-1',
-      get id() { return db.id },
+      get id() {
+        return db.id
+      },
       plan,
-      app
+      app,
     }
     reportID = uuid.v4()
 
@@ -85,6 +88,7 @@ describe('pg:diagnose', () => {
         HEROKU_POSTGRESQL_SILVER_URL: dbURL,
       })
       pg.get(`/client/v11/databases/${db.id}/metrics`).reply(200, [])
+      pg.get(`/client/v11/databases/${db.id}/burst_status`).reply(200, {})
       const report = {
         id: reportID,
         app: app.name,
@@ -94,24 +98,26 @@ describe('pg:diagnose', () => {
           {
             name: 'Connection count',
             status: 'red',
-            results: [{ count: 1 }]
+            results: [{ count: 1 }],
           },
           {
             name: 'Load',
             status: 'red',
-            results: { load: 100 }
-          }
-        ]
+            results: { load: 100 },
+          },
+        ],
       }
-      diagnose.post('/reports', {
-        url: dbURL,
-        plan: 'standard-0',
-        app: app.name,
-        database: 'DATABASE_URL',
-        metrics: []
-      }).reply(200, report)
-      return cmd.run({ app: app.name, args: {} })
-        .then(() => expect(cli.stdout).to.equal(`Report ${reportID} for ${app.name}::${report.database}
+      diagnose
+        .post('/reports', {
+          url: dbURL,
+          plan: 'standard-0',
+          app: app.name,
+          database: 'DATABASE_URL',
+          metrics: [],
+        })
+        .reply(200, report)
+      return cmd.run({ app: app.name, args: {}, flags: {} }).then(() =>
+        expect(cli.stdout).to.equal(`Report ${reportID} for ${app.name}::${report.database}
 available for one month after creation on 101
 
 RED: Connection count
@@ -120,7 +126,8 @@ Count
 1
 RED: Load
 Load 100
-`))
+`),
+      )
     })
   })
 
@@ -138,18 +145,18 @@ Load 100
             {
               name: 'Connection count',
               status: 'red',
-              results: [{ count: 1 }]
+              results: [{ count: 1 }],
             },
             {
               name: 'Load',
               status: 'red',
-              results: { load: 100 }
-            }
-          ]
+              results: { load: 100 },
+            },
+          ],
         }
         diagnose.get(`/reports/${reportID}`).reply(200, report)
-        return cmd.run({ app: app.name, args: { 'DATABASE|REPORT_ID': reportID } })
-          .then(() => expect(cli.stdout).to.equal(`Report ${reportID} for ${app.name}::${report.database}
+        return cmd.run({ app: app.name, args: { 'DATABASE|REPORT_ID': reportID }, flags: {} }).then(() =>
+          expect(cli.stdout).to.equal(`Report ${reportID} for ${app.name}::${report.database}
 available for one month after creation on 101
 
 RED: Connection count
@@ -158,8 +165,9 @@ Count
 1
 RED: Load
 Load 100
-`))
-        // This is to ensure that each test sets up its own db name when that's their interest. 
+`),
+        )
+        // This is to ensure that each test sets up its own db name when that's their interest.
         // Otherwise, it'll default to `DATABASE`
         dbName = undefined
       })
@@ -171,9 +179,10 @@ Load 100
         api.get(`/apps/${app.name}/config-vars`).reply(200, {
           DATABASE_ENDPOINT_042EExxx_URL: dbURL,
           DATABASE_URL: dbURL,
-          HEROKU_POSTGRESQL_SILVER_URL: dbURL
+          HEROKU_POSTGRESQL_SILVER_URL: dbURL,
         })
         pg.get(`/client/v11/databases/${db.id}/metrics`).reply(200, [])
+        pg.get(`/client/v11/databases/${db.id}/burst_status`).reply(200, {})
         const report = {
           id: reportID,
           app: app.name,
@@ -183,24 +192,28 @@ Load 100
             {
               name: 'Connection count',
               status: 'red',
-              results: [{ count: 1 }]
+              results: [{ count: 1 }],
             },
             {
               name: 'Load',
               status: 'red',
-              results: { load: 100 }
-            }
-          ]
+              results: { load: 100 },
+            },
+          ],
         }
-        diagnose.post('/reports', {
-          url: dbURL,
-          plan: 'standard-0',
-          app: app.name,
-          database: 'HEROKU_POSTGRESQL_SILVER_URL',
-          metrics: []
-        }).reply(200, report)
-        return cmd.run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': 'HEROKU_POSTGRESQL_SILVER_URL' } })
-          .then(() => expect(cli.stdout).to.equal(`Report ${reportID} for ${app.name}::${report.database}
+        diagnose
+          .post('/reports', {
+            url: dbURL,
+            plan: 'standard-0',
+            app: app.name,
+            database: 'HEROKU_POSTGRESQL_SILVER_URL',
+            metrics: [],
+          })
+          .reply(200, report)
+        return cmd
+          .run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': 'HEROKU_POSTGRESQL_SILVER_URL' }, flags: {} })
+          .then(() =>
+            expect(cli.stdout).to.equal(`Report ${reportID} for ${app.name}::${report.database}
 available for one month after creation on 101
 
 RED: Connection count
@@ -209,7 +222,55 @@ Count
 1
 RED: Load
 Load 100
-`))
+`),
+          )
+      })
+
+      context('with the --json flag set', () => {
+        it('outputs in styled JSON', () => {
+          api.get(`/addons/${addon.name}`).reply(200, db)
+          api.get(`/apps/${app.name}/config-vars`).reply(200, {
+            DATABASE_URL: dbURL,
+          })
+          pg.get(`/client/v11/databases/${db.id}/metrics`).reply(200, [])
+          pg.get(`/client/v11/databases/${db.id}/burst_status`).reply(200, {})
+          const report = {
+            id: reportID,
+            app: app.name,
+            database: 'DATABASE_URL',
+            created_at: '101',
+            checks: [
+              {
+                name: 'Connection count',
+                status: 'red',
+                results: [{ count: 1 }],
+              },
+              {
+                name: 'Load',
+                status: 'red',
+                results: { load: 100 },
+              },
+            ],
+          }
+
+          diagnose
+            .post('/reports', {
+              url: dbURL,
+              plan: 'standard-0',
+              app: app.name,
+              database: 'DATABASE_URL',
+              metrics: [],
+            })
+            .reply(200, report)
+
+          return cmd
+            .run({
+              app: 'myapp',
+              args: { 'DATABASE|REPORT_ID': 'DATABASE_URL' },
+              flags: { json: true },
+            })
+            .then(() => expect(cli.stdout).to.equal(JSON.stringify(report, null, 2)+'\n'))
+        })
       })
     })
 
@@ -223,52 +284,54 @@ Load 100
           {
             name: 'Connection count',
             status: 'red',
-            results: []
+            results: [],
           },
           {
             name: 'Load',
             status: 'red',
-            results: {}
-          }
-        ]
+            results: {},
+          },
+        ],
       })
-      return cmd.run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c' } })
-        .then(() => expect(cli.stdout).to.equal(`Report 697c8bd7-dbba-4f2d-83b6-789c58cc3a9c for myapp::postgres-1
+      return cmd
+        .run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c' }, flags: {} })
+        .then(() =>
+          expect(cli.stdout).to.equal(`Report 697c8bd7-dbba-4f2d-83b6-789c58cc3a9c for myapp::postgres-1
 available for one month after creation on 101
 
 RED: Connection count
 RED: Load
-`))
+`),
+        )
     })
 
     it('roughly conforms with Ruby output', () => {
       diagnose.get('/reports/697c8bd7-dbba-4f2d-83b6-789c58cc3a9c').reply(200, {
-        'id': 'abc123',
-        'app': 'appname',
-        'created_at': '2014-06-24 01:26:11.941197+00',
-        'database': 'dbcolor',
-        'checks': [
-          { 'name': 'Hit Rate', 'status': 'green', 'results': null },
-          { 'name': 'Connection Count', 'status': 'red', 'results': [{ 'count': 150 }] },
+        id: 'abc123',
+        app: 'appname',
+        created_at: '2014-06-24 01:26:11.941197+00',
+        database: 'dbcolor',
+        checks: [
+          { name: 'Hit Rate', status: 'green', results: null },
+          { name: 'Connection Count', status: 'red', results: [{ count: 150 }] },
           {
-            'name': 'list',
-            'status': 'yellow',
-            'results': [
-              { 'thing': 'one' },
-              { 'thing': 'two' }
-            ]
+            name: 'list',
+            status: 'yellow',
+            results: [{ thing: 'one' }, { thing: 'two' }],
           },
           {
-            'name': 'Load',
-            'status': 'skipped',
-            'results': {
-              'error': 'Load check not supported on this plan'
-            }
-          }
-        ]
+            name: 'Load',
+            status: 'skipped',
+            results: {
+              error: 'Load check not supported on this plan',
+            },
+          },
+        ],
       })
-      return cmd.run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c' } })
-        .then(() => expect(cli.stdout).to.equal(`Report abc123 for appname::dbcolor
+      return cmd
+        .run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c' }, flags: {} })
+        .then(() =>
+          expect(cli.stdout).to.equal(`Report abc123 for appname::dbcolor
 available for one month after creation on 2014-06-24 01:26:11.941197+00
 
 RED: Connection Count
@@ -283,32 +346,36 @@ two
 GREEN: Hit Rate
 SKIPPED: Load
 Error Load check not supported on this plan
-`))
+`),
+        )
     })
 
     it('converts underscores to spaces', () => {
       diagnose.get('/reports/697c8bd7-dbba-4f2d-83b6-789c58cc3a9c').reply(200, {
-        'id': 'abc123',
-        'app': 'appname',
-        'created_at': '2014-06-24 01:26:11.941197+00',
-        'database': 'dbcolor',
-        'checks': [
+        id: 'abc123',
+        app: 'appname',
+        created_at: '2014-06-24 01:26:11.941197+00',
+        database: 'dbcolor',
+        checks: [
           {
-            'name': 'Load',
-            'status': 'skipped',
-            'results': {
-              'error_thing': 'Load check not supported on this plan'
-            }
-          }
-        ]
+            name: 'Load',
+            status: 'skipped',
+            results: {
+              error_thing: 'Load check not supported on this plan',
+            },
+          },
+        ],
       })
-      return cmd.run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c' } })
-        .then(() => expect(cli.stdout).to.equal(`Report abc123 for appname::dbcolor
+      return cmd
+        .run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c' }, flags: {} })
+        .then(() =>
+          expect(cli.stdout).to.equal(`Report abc123 for appname::dbcolor
 available for one month after creation on 2014-06-24 01:26:11.941197+00
 
 SKIPPED: Load
 Error Thing Load check not supported on this plan
-`))
+`),
+        )
     })
-  });
+  })
 })


### PR DESCRIPTION
Heroku Postgres has some plans that have burstable performance
characteristics
(https://devcenter.heroku.com/articles/heroku-postgres-production-tier-technical-characterization#performance-characteristics).

Whether or not a given resource is bursting, or at risk at throttling,
has previously not been available to end users. This commit changes
this, by providing burst data to the `pg:diagnose` backend for relevant
resources, and returning it in the report.

This commit also adds JSON output support, for when the table output is
not appropriate and to provide some interop with tools like `jq`.

Ref: GUS-W-8906686