### PR TITLE
Remove co

### DIFF
--- a/packages/addons-v5/commands/addons/attach.js
+++ b/packages/addons-v5/commands/addons/attach.js
@@ -1,13 +1,12 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const util = require('../../lib/util')
 
   let app = context.app
-  let addon = yield heroku.get(`/addons/${encodeURIComponent(context.args.addon_name)}`)
+  let addon = await heroku.get(`/addons/${encodeURIComponent(context.args.addon_name)}`)
 
   function createAttachment (app, as, confirm, credential) {
     let body = {
@@ -30,24 +29,24 @@ function * run (context, heroku) {
   }
 
   if (context.flags.credential && context.flags.credential !== 'default') {
-    let credentialConfig = yield heroku.get(`/addons/${addon.name}/config/credential:${encodeURIComponent(context.flags.credential)}`)
+    let credentialConfig = await heroku.get(`/addons/${addon.name}/config/credential:${encodeURIComponent(context.flags.credential)}`)
     if (credentialConfig.length === 0) {
       throw new Error(`Could not find credential ${context.flags.credential} for database ${addon.name}`)
     }
   }
 
-  let attachment = yield util.trapConfirmationRequired(context.app, context.flags.confirm, (confirm) => createAttachment(app, context.flags.as, confirm, context.flags.credential))
+  let attachment = await util.trapConfirmationRequired(context.app, context.flags.confirm, (confirm) => createAttachment(app, context.flags.as, confirm, context.flags.credential))
 
-  yield cli.action(
+  await cli.action(
     `Setting ${cli.color.attachment(attachment.name)} config vars and restarting ${cli.color.app(app)}`,
     { success: false },
-    co(function * () {
-      let releases = yield heroku.get(`/apps/${app}/releases`, {
+    async function () {
+      let releases = await heroku.get(`/apps/${app}/releases`, {
         partial: true,
         headers: { 'Range': 'version ..; max=1, order=desc' }
       })
       cli.action.done(`done, v${releases[0].version}`)
-    })
+    }()
   )
 }
 
@@ -63,5 +62,5 @@ module.exports = {
     { name: 'confirm', description: 'overwrite existing add-on attachment with same name', hasValue: true }
   ],
   args: [{ name: 'addon_name' }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/addons-v5/commands/addons/create.js
+++ b/packages/addons-v5/commands/addons/create.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 const { notify } = require('../../lib/notify')
 
 function parseConfig (args) {
@@ -31,7 +30,7 @@ function parseConfig (args) {
   return config
 }
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let createAddon = require('../../lib/create_addon')
 
   let { app, flags, args } = context
@@ -44,7 +43,7 @@ function * run (context, heroku) {
   let addon
 
   try {
-    addon = yield createAddon(heroku, app, args[0], context.flags.confirm, context.flags.wait, { config, name, as })
+    addon = await createAddon(heroku, app, args[0], context.flags.confirm, context.flags.wait, { config, name, as })
     if (context.flags.wait) {
       notify(`heroku addons:create ${addon.name}`, 'Add-on successfully provisioned')
     }
@@ -55,7 +54,7 @@ function * run (context, heroku) {
     throw error
   }
 
-  yield context.config.runHook('recache', { type: 'addon', app, addon })
+  await context.config.runHook('recache', { type: 'addon', app, addon })
   cli.log(`Use ${cli.color.cmd('heroku addons:docs ' + addon.addon_service.name)} to view documentation`)
 }
 
@@ -72,7 +71,7 @@ const cmd = {
     { name: 'confirm', description: 'overwrite existing config vars or existing add-on attachments', hasValue: true },
     { name: 'wait', description: 'watch add-on creation status and exit when complete' }
   ],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }
 
 module.exports = [

--- a/packages/addons-v5/commands/addons/detach.js
+++ b/packages/addons-v5/commands/addons/detach.js
@@ -1,13 +1,12 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let app = context.app
-  let attachment = yield heroku.get(`/apps/${app}/addon-attachments/${context.args.attachment_name}`)
+  let attachment = await heroku.get(`/apps/${app}/addon-attachments/${context.args.attachment_name}`)
 
-  yield cli.action(
+  await cli.action(
     `Detaching ${cli.color.attachment(attachment.name)} to ${cli.color.addon(attachment.addon.name)} from ${cli.color.app(app)}`,
     heroku.request({
       path: `/addon-attachments/${attachment.id}`,
@@ -15,17 +14,17 @@ function * run (context, heroku) {
     })
   )
 
-  yield cli.action(
+  await cli.action(
     `Unsetting ${cli.color.attachment(attachment.name)} config vars and restarting ${cli.color.app(app)}`,
     { success: false },
-    co(function * () {
-      let releases = yield heroku.request({
+    async function () {
+      let releases = await heroku.request({
         path: `/apps/${app}/releases`,
         partial: true,
         headers: { 'Range': 'version ..; max=1, order=desc' }
       })
       cli.action.done(`done, v${releases[0].version}`)
-    })
+    }()
   )
 }
 
@@ -36,5 +35,5 @@ module.exports = {
   needsAuth: true,
   needsApp: true,
   args: [{ name: 'attachment_name' }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/addons-v5/commands/addons/docs.js
+++ b/packages/addons-v5/commands/addons/docs.js
@@ -1,21 +1,20 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const resolve = require('../../lib/resolve')
 
   let id = context.args.addon.split(':')[0]
-  let addon = yield heroku.get(`/addon-services/${encodeURIComponent(id)}`).catch(() => null)
-  if (!addon) addon = (yield resolve.addon(heroku, context.app, id)).addon_service
+  let addon = await heroku.get(`/addon-services/${encodeURIComponent(id)}`).catch(() => null)
+  if (!addon) addon = ((await resolve.addon(heroku, context.app, id))).addon_service
   let url = `https://devcenter.heroku.com/articles/${addon.name}`
 
   if (context.flags['show-url']) {
     cli.log(url)
   } else {
     cli.log(`Opening ${cli.color.cyan(url)}...`)
-    yield cli.open(url)
+    await cli.open(url)
   }
 }
 
@@ -26,6 +25,6 @@ module.exports = {
   needsAuth: true,
   args: [{ name: 'addon' }],
   flags: [{ name: 'show-url', description: 'show URL, do not open browser' }],
-  run: cli.command({ preauth: true }, co.wrap(run)),
+  run: cli.command({ preauth: true }, run),
   description: "open an add-on's Dev Center documentation in your browser"
 }

--- a/packages/addons-v5/commands/addons/info.js
+++ b/packages/addons-v5/commands/addons/info.js
@@ -1,7 +1,6 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
 let grandfatheredPrice = require('../../lib/util').grandfatheredPrice
 let formatPrice = require('../../lib/util').formatPrice
@@ -10,14 +9,12 @@ let style = require('../../lib/util').style
 
 let run = cli.command({ preauth: true }, function (ctx, api) {
   const resolve = require('../../lib/resolve')
-  return co(function * () {
-    let addon = yield resolve.addon(api, ctx.app, ctx.args.addon)
-    let [attachments] = yield [
-      api.request({
-        method: 'GET',
-        path: `/addons/${addon.id}/addon-attachments`
-      })
-    ]
+  return async function () {
+    let addon = await resolve.addon(api, ctx.app, ctx.args.addon)
+    let attachments = await api.request({
+      method: 'GET',
+      path: `/addons/${addon.id}/addon-attachments`
+    })
 
     addon.plan.price = grandfatheredPrice(addon)
     addon.attachments = attachments
@@ -36,7 +33,7 @@ let run = cli.command({ preauth: true }, function (ctx, api) {
       'Installed at': (new Date(addon.created_at)).toString(),
       'State': formatState(addon.state)
     })
-  })
+  }();
 })
 
 let topic = 'addons'

--- a/packages/addons-v5/commands/addons/open.js
+++ b/packages/addons-v5/commands/addons/open.js
@@ -1,7 +1,6 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 let fs = require('fs')
 let os = require('os')
 let path = require('path')
@@ -48,8 +47,8 @@ function writeSudoTemplate (ctx, sso, path) {
   })
 }
 
-let sudo = co.wrap(function * (ctx, api) {
-  let sso = yield api.request({
+let sudo = async function (ctx, api) {
+  let sso = await api.request({
     method: 'GET',
     path: `/apps/${ctx.app}/addons/${ctx.args.addon}/sso`,
     headers: {
@@ -57,19 +56,19 @@ let sudo = co.wrap(function * (ctx, api) {
     }
   })
   if (sso.method === 'get') {
-    yield open(sso.action)
+    await open(sso.action)
   } else {
-    yield writeSudoTemplate(ctx, sso, ssoPath)
-    yield open(`file://${ssoPath}`)
+    await writeSudoTemplate(ctx, sso, ssoPath)
+    await open(`file://${ssoPath}`)
   }
-})
+}
 
-function * run (ctx, api) {
+async function run(ctx, api) {
   const resolve = require('../../lib/resolve')
 
   if (process.env.HEROKU_SUDO) return sudo(ctx, api)
 
-  let attachment = yield resolve.attachment(api, ctx.app, ctx.args.addon)
+  let attachment = await resolve.attachment(api, ctx.app, ctx.args.addon)
     .catch(function (err) {
       if (err.statusCode !== 404) throw err
     })
@@ -78,14 +77,14 @@ function * run (ctx, api) {
   if (attachment) {
     webUrl = attachment.web_url
   } else {
-    let addon = yield resolve.addon(api, ctx.app, ctx.args.addon)
+    let addon = await resolve.addon(api, ctx.app, ctx.args.addon)
     webUrl = addon.web_url
   }
 
   if (ctx.flags['show-url']) {
     cli.log(webUrl)
   } else {
-    yield open(webUrl)
+    await open(webUrl)
   }
 }
 
@@ -96,6 +95,6 @@ module.exports = {
   needsAuth: true,
   args: [{ name: 'addon' }],
   flags: [{ name: 'show-url', description: 'show URL, do not open browser' }],
-  run: cli.command({ preauth: true }, co.wrap(run)),
+  run: cli.command({ preauth: true }, run),
   description: "open an add-on's dashboard in your browser"
 }

--- a/packages/addons-v5/commands/addons/plans.js
+++ b/packages/addons-v5/commands/addons/plans.js
@@ -1,13 +1,12 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const util = require('../../lib/util')
   const _ = require('lodash')
 
-  let plans = yield heroku.get(`/addon-services/${context.args.service}/plans`)
+  let plans = await heroku.get(`/addon-services/${context.args.service}/plans`)
   plans = _.sortBy(plans, ['price.contract', 'price.cents'])
 
   if (context.flags.json) {
@@ -32,5 +31,5 @@ module.exports = {
   flags: [
     { name: 'json', description: 'output in json format' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/addons-v5/commands/addons/rename.js
+++ b/packages/addons-v5/commands/addons/rename.js
@@ -1,20 +1,19 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
 let run = cli.command({ preauth: true }, function (ctx, api) {
-  return co(function * () {
-    let addon = yield api.get(`/addons/${ctx.args.addon}`)
+  return async function () {
+    let addon = await api.get(`/addons/${ctx.args.addon}`)
     let addonUrl = `/apps/${addon.app.id}/addons/${addon.id}`
 
-    yield api.patch(addonUrl, { body: { name: ctx.args.name } })
+    await api.patch(addonUrl, { body: { name: ctx.args.name } })
 
     let oldName = ctx.args.addon
     let newName = cli.color.magenta(ctx.args.name)
 
     cli.log(`${oldName} successfully renamed to ${newName}.`)
-  })
+  }();
 })
 
 let topic = 'addons'

--- a/packages/addons-v5/commands/addons/services.js
+++ b/packages/addons-v5/commands/addons/services.js
@@ -1,10 +1,9 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
-  let services = yield heroku.get('/addon-services')
+async function run(context, heroku) {
+  let services = await heroku.get('/addon-services')
 
   if (context.flags.json) {
     cli.styledJSON(services)
@@ -28,5 +27,5 @@ module.exports = {
   flags: [
     { name: 'json', description: 'output in json format' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/addons-v5/lib/addons_wait.js
+++ b/packages/addons-v5/lib/addons_wait.js
@@ -1,18 +1,17 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-module.exports = function * (api, addon, interval) {
+module.exports = async function (api, addon, interval) {
   const wait = require('co-wait')
   const app = addon.app.name
   const addonName = addon.name
 
-  yield cli.action(`Creating ${cli.color.addon(addon.name)}`, co(function * () {
+  await cli.action(`Creating ${cli.color.addon(addon.name)}`, async function () {
     while (addon.state === 'provisioning') {
-      yield wait(interval * 1000)
+      await wait(interval * 1000)
 
-      addon = yield api.request({
+      addon = await api.request({
         method: 'GET',
         path: `/apps/${app}/addons/${addonName}`,
         headers: {'Accept-Expansion': 'addon_service,plan'}
@@ -21,7 +20,7 @@ module.exports = function * (api, addon, interval) {
     if (addon.state === 'deprovisioned') {
       throw new Error(`The add-on was unable to be created, with status ${addon.state}`)
     }
-  }))
+  }())
 
   return addon
 }

--- a/packages/addons-v5/lib/create_addon.js
+++ b/packages/addons-v5/lib/create_addon.js
@@ -13,7 +13,7 @@ function formatConfigVarsMessage (addon) {
   }
 }
 
-module.exports = function * (heroku, app, plan, confirm, wait, options) {
+module.exports = async function (heroku, app, plan, confirm, wait, options) {
   const util = require('./util')
   const waitForAddonProvisioning = require('./addons_wait')
 
@@ -40,14 +40,14 @@ module.exports = function * (heroku, app, plan, confirm, wait, options) {
     )
   }
 
-  let addon = yield util.trapConfirmationRequired(app, confirm, (confirm) => (createAddonRequest(confirm)))
+  let addon = await util.trapConfirmationRequired(app, confirm, (confirm) => (createAddonRequest(confirm)))
 
   if (addon.provision_message) { cli.log(addon.provision_message) }
 
   if (addon.state === 'provisioning') {
     if (wait) {
       cli.log(`Waiting for ${cli.color.addon(addon.name)}...`)
-      addon = yield waitForAddonProvisioning(heroku, addon, 5)
+      addon = await waitForAddonProvisioning(heroku, addon, 5)
       cli.log(formatConfigVarsMessage(addon))
     } else {
       cli.log(`${cli.color.addon(addon.name)} is being created in the background. The app will restart when complete...`)

--- a/packages/addons-v5/lib/util.js
+++ b/packages/addons-v5/lib/util.js
@@ -41,13 +41,13 @@ module.exports = {
     return printf(fmt, price.cents / 100, price.unit)
   },
 
-  trapConfirmationRequired: function * (app, confirm, fn) {
-    return yield fn(confirm)
+  trapConfirmationRequired: async function (app, confirm, fn) {
+    return await fn(confirm)
       .catch((err) => {
         if (!err.body || err.body.id !== 'confirmation_required') throw err
         return cli.confirmApp(app, confirm, err.body.message)
           .then(() => fn(app))
-      })
+      });
   },
 
   formatState: function (state) {

--- a/packages/addons-v5/package.json
+++ b/packages/addons-v5/package.json
@@ -14,7 +14,6 @@
     "repositoryPrefix": "<%- repo %>/blob/v<%- version %>/packages/addons-v5/<%- commandPath %>"
   },
   "dependencies": {
-    "co": "4.6.0",
     "co-wait": "0.0.0",
     "heroku-cli-util": "^8.0.11",
     "lodash": "^4.17.11",

--- a/packages/apps-v5/package.json
+++ b/packages/apps-v5/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "@heroku-cli/command": "^8.4.1",
-    "co": "^4.6.0",
     "filesize": "^4.0.0",
     "fs-extra": "^7.0.1",
     "heroku-cli-util": "^8.0.11",

--- a/packages/apps-v5/src/commands/apps/destroy.js
+++ b/packages/apps-v5/src/commands/apps/destroy.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const _ = require('lodash')
   const git = require('../../git')(context)
 
@@ -12,17 +11,17 @@ function * run (context, heroku) {
 
   context.app = app // make sure context.app is always set for herkou-cli-util
 
-  yield heroku.get(`/apps/${app}`)
-  yield cli.confirmApp(app, context.flags.confirm, `WARNING: This will delete ${cli.color.app(app)} including all add-ons.`)
+  await heroku.get(`/apps/${app}`)
+  await cli.confirmApp(app, context.flags.confirm, `WARNING: This will delete ${cli.color.app(app)} including all add-ons.`)
   let request = heroku.request({
     method: 'DELETE',
     path: `/apps/${app}`
   })
-  yield cli.action(`Destroying ${cli.color.app(app)} (including all add-ons)`, request)
+  await cli.action(`Destroying ${cli.color.app(app)} (including all add-ons)`, request)
 
   if (git.inGitRepo()) {
     // delete git remotes pointing to this app
-    _(yield git.listRemotes())
+    _(await git.listRemotes())
       .filter((r) => git.gitUrl(app) === r[1] || git.sshGitUrl(app) === r[1])
       .map((r) => r[0])
       .uniq()
@@ -39,7 +38,7 @@ let cmd = {
   flags: [
     { name: 'confirm', char: 'c', hasValue: true }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }
 
 module.exports = [

--- a/packages/apps-v5/src/commands/apps/favorites/add.js
+++ b/packages/apps-v5/src/commands/apps/favorites/add.js
@@ -1,21 +1,20 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let app = context.app
 
-  yield cli.action(`Adding ${cli.color.app(app)} to favorites`, co(function * () {
-    let favorites = yield heroku.request({ host: 'particleboard.heroku.com', path: '/favorites?type=app', headers: { Range: '' } })
+  await cli.action(`Adding ${cli.color.app(app)} to favorites`, async function () {
+    let favorites = await heroku.request({ host: 'particleboard.heroku.com', path: '/favorites?type=app', headers: { Range: '' } })
     if (favorites.find((f) => f.resource_name === app)) throw new Error(`${cli.color.app(app)} is already a favorite app.`)
-    yield heroku.request({
+    await heroku.request({
       host: 'particleboard.heroku.com',
       path: '/favorites',
       method: 'POST',
       body: { type: 'app', resource_id: app }
     })
-  }))
+  }())
 }
 
 module.exports = {
@@ -24,5 +23,5 @@ module.exports = {
   description: 'favorites an app',
   needsAuth: true,
   needsApp: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/apps/favorites/index.js
+++ b/packages/apps-v5/src/commands/apps/favorites/index.js
@@ -1,10 +1,9 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
-  let favorites = yield heroku.request({ host: 'particleboard.heroku.com', path: '/favorites?type=app', headers: { Range: '' } })
+async function run(context, heroku) {
+  let favorites = await heroku.request({ host: 'particleboard.heroku.com', path: '/favorites?type=app', headers: { Range: '' } })
 
   if (context.flags.json) {
     cli.styledJSON(favorites)
@@ -22,5 +21,5 @@ module.exports = {
   flags: [
     { name: 'json', description: 'output in json format' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/apps/favorites/remove.js
+++ b/packages/apps-v5/src/commands/apps/favorites/remove.js
@@ -1,21 +1,20 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let app = context.app
 
-  yield cli.action(`Removing ${cli.color.app(app)} from favorites`, co(function * () {
-    let favorites = yield heroku.request({ host: 'particleboard.heroku.com', path: '/favorites?type=app', headers: { Range: '' } })
+  await cli.action(`Removing ${cli.color.app(app)} from favorites`, async function () {
+    let favorites = await heroku.request({ host: 'particleboard.heroku.com', path: '/favorites?type=app', headers: { Range: '' } })
     let favorite = favorites.find((f) => f.resource_name === app)
     if (!favorite) throw new Error(`${cli.color.app(app)} is not already a favorite app.`)
-    yield heroku.request({
+    await heroku.request({
       host: 'particleboard.heroku.com',
       path: `/favorites/${favorite.id}`,
       method: 'DELETE'
     })
-  }))
+  }())
 }
 
 module.exports = {
@@ -24,5 +23,5 @@ module.exports = {
   description: 'unfavorites an app',
   needsAuth: true,
   needsApp: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/apps/info.js
+++ b/packages/apps-v5/src/commands/apps/info.js
@@ -1,32 +1,48 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const filesize = require('filesize')
   const util = require('util')
   const { countBy, snakeCase } = require('lodash')
 
-  function * getInfo (app) {
-    const pipelineCouplings = heroku.get(`/apps/${app}/pipeline-couplings`).catch(() => null)
-
-    let promises = {
-      addons: heroku.get(`/apps/${app}/addons`),
-      app: heroku.request({
+  async function getInfo(app) {
+    let promises = [
+      heroku.get(`/apps/${app}/addons`),
+      heroku.request({
         path: `/apps/${app}`,
         headers: { 'Accept': 'application/vnd.heroku+json; version=3.cedar-acm' }
       }),
-      dynos: heroku.get(`/apps/${app}/dynos`).catch(() => []),
-      collaborators: heroku.get(`/apps/${app}/collaborators`).catch(() => []),
-      pipeline_coupling: pipelineCouplings
-    }
+      heroku.get(`/apps/${app}/dynos`).catch(() => []),
+      heroku.get(`/apps/${app}/collaborators`).catch(() => []),
+      heroku.get(`/apps/${app}/pipeline-couplings`).catch(() => null)
+    ]
 
     if (context.flags.extended) {
-      promises.appExtended = heroku.get(`/apps/${app}?extended=true`)
+      promises.push(heroku.get(`/apps/${app}?extended=true`))
     }
 
-    let data = yield promises
+    let [
+      addons,
+      appWithMoreInfo,
+      dynos,
+      collaborators,
+      pipelineCouplings,
+      appExtended
+    ] = await Promise.all(promises)
+
+    let data = {
+      addons,
+      app: appWithMoreInfo,
+      dynos,
+      collaborators,
+      pipeline_coupling: pipelineCouplings,
+    }
+
+    if (appExtended) {
+      data.appExtended = appExtended
+    }
 
     if (context.flags.extended) {
       data.appExtended.acm = data.app.acm
@@ -42,7 +58,7 @@ function * run (context, heroku) {
 
   context.app = app // make sure context.app is always set for herkou-cli-util
 
-  let info = yield getInfo(app)
+  let info = await getInfo(app)
   let addons = info.addons.map(a => a.plan.name).sort()
   let collaborators = info.collaborators.map(c => c.user.email).filter(c => c !== info.app.owner.email).sort()
 
@@ -141,7 +157,7 @@ repo_size=5000000
     { name: 'extended', char: 'x', hidden: true },
     { name: 'json', char: 'j' }
   ],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }
 
 module.exports = [

--- a/packages/apps-v5/src/commands/apps/open.js
+++ b/packages/apps-v5/src/commands/apps/open.js
@@ -1,12 +1,11 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 let url = require('url')
 
-function * run (context, heroku) {
-  let app = yield heroku.get(`/apps/${context.app}`)
-  yield cli.open(url.resolve(app.web_url, context.args.path || ''))
+async function run(context, heroku) {
+  let app = await heroku.get(`/apps/${context.app}`)
+  await cli.open(url.resolve(app.web_url, context.args.path || ''))
 }
 
 let cmd = {
@@ -19,7 +18,7 @@ $ heroku open -a myapp /foo
   needsApp: true,
   needsAuth: true,
   args: [{ name: 'path', optional: true }],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }
 
 module.exports = [

--- a/packages/apps-v5/src/commands/apps/rename.js
+++ b/packages/apps-v5/src/commands/apps/rename.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const _ = require('lodash')
 
   let git = require('../../git')(context)
@@ -16,13 +15,13 @@ function * run (context, heroku) {
     path: `/apps/${oldApp}`,
     body: { name: newApp }
   })
-  let app = yield cli.action(`Renaming ${cli.color.cyan(oldApp)} to ${cli.color.green(newApp)}`, request)
+  let app = await cli.action(`Renaming ${cli.color.cyan(oldApp)} to ${cli.color.green(newApp)}`, request)
   let gitUrl = context.flags['ssh-git'] ? git.sshGitHurl(app.name) : git.gitUrl(app.name)
   cli.log(`${app.web_url} | ${gitUrl}`)
 
   if (git.inGitRepo()) {
     // delete git remotes pointing to this app
-    yield _(yield git.listRemotes())
+    await _(await git.listRemotes())
       .filter((r) => git.gitUrl(oldApp) === r[1] || git.sshGitUrl(oldApp) === r[1])
       .map((r) => r[0])
       .uniq()
@@ -48,7 +47,7 @@ Git remote heroku updated`,
   flags: [
     { name: 'ssh-git', description: 'use ssh git protocol instead of https' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }
 
 module.exports = [

--- a/packages/apps-v5/src/commands/apps/stacks/set.js
+++ b/packages/apps-v5/src/commands/apps/stacks/set.js
@@ -1,21 +1,20 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 const push = require('../../../push')
 
 function map (stack) {
   return stack === 'cedar-10' ? 'cedar' : stack
 }
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let stack = map(context.args.stack)
   const request = heroku.request({
     method: 'PATCH',
     path: `/apps/${context.app}`,
     body: { build_stack: stack }
   })
-  const app = yield cli.action(`Setting stack to ${cli.color.green(stack)}`, request)
+  const app = await cli.action(`Setting stack to ${cli.color.green(stack)}`, request)
   // A redeploy is not required for apps that have never been deployed, since
   // API updates the app's `stack` to match `build_stack` immediately.
   if (app.stack.name !== app.build_stack.name) {
@@ -32,7 +31,7 @@ let cmd = {
 Stack set. Next release on myapp will use heroku-20.
 Run git push heroku main to create a new release on myapp.`,
   args: [{ name: 'stack' }],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }
 
 module.exports = [

--- a/packages/apps-v5/src/commands/dashboard.js
+++ b/packages/apps-v5/src/commands/dashboard.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 const { round, flatten, mean, groupBy, map, sum, sumBy, toPairs, sortBy, zip } = require('lodash')
 
@@ -86,7 +85,7 @@ function displayApps (apps, appsMetrics) {
   }
 }
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const img = require('term-img')
   const path = require('path')
 
@@ -109,13 +108,21 @@ function * run (context, heroku) {
     const NOW = new Date().toISOString()
     const YESTERDAY = new Date(new Date().getTime() - (24 * 60 * 60 * 1000)).toISOString()
     let date = `start_time=${YESTERDAY}&end_time=${NOW}&step=1h`
-    return apps.map((app) => {
+    return apps.map(async (app) => {
       let types = app.formation.map((p) => p.type)
+
+      let [dynoErrors, routerLatency, routerErrors, routerStatus] = await Promise.all([
+        Promise.all(types.map((type) => heroku.request({ host: 'api.metrics.herokai.com', path: `/apps/${app.app.name}/formation/${type}/metrics/errors?${date}`, headers: { Range: '' } }).catch(() => null))),
+        heroku.request({ host: 'api.metrics.herokai.com', path: `/apps/${app.app.name}/router-metrics/latency?${date}&process_type=${types[0]}`, headers: { Range: '' } }).catch(() => null),
+        heroku.request({ host: 'api.metrics.herokai.com', path: `/apps/${app.app.name}/router-metrics/errors?${date}&process_type=${types[0]}`, headers: { Range: '' } }).catch(() => null),
+        heroku.request({ host: 'api.metrics.herokai.com', path: `/apps/${app.app.name}/router-metrics/status?${date}&process_type=${types[0]}`, headers: { Range: '' } }).catch(() => null)
+      ])
+
       return {
-        dynoErrors: types.map((type) => heroku.request({ host: 'api.metrics.herokai.com', path: `/apps/${app.app.name}/formation/${type}/metrics/errors?${date}`, headers: { Range: '' } }).catch(() => null)),
-        routerLatency: heroku.request({ host: 'api.metrics.herokai.com', path: `/apps/${app.app.name}/router-metrics/latency?${date}&process_type=${types[0]}`, headers: { Range: '' } }).catch(() => null),
-        routerErrors: heroku.request({ host: 'api.metrics.herokai.com', path: `/apps/${app.app.name}/router-metrics/errors?${date}&process_type=${types[0]}`, headers: { Range: '' } }).catch(() => null),
-        routerStatus: heroku.request({ host: 'api.metrics.herokai.com', path: `/apps/${app.app.name}/router-metrics/status?${date}&process_type=${types[0]}`, headers: { Range: '' } }).catch(() => null)
+        dynoErrors,
+        routerLatency,
+        routerErrors,
+        routerStatus
       }
     })
   }
@@ -126,20 +133,34 @@ function * run (context, heroku) {
     img(path.join(__dirname, '..', '..', 'assets', 'heroku.png'), { fallback: () => {} })
   } catch (err) { }
 
-  yield cli.action('Loading', { clear: true }, co(function * () {
-    apps = yield favoriteApps()
+  await cli.action('Loading', { clear: true }, async function () {
+    apps = await favoriteApps()
 
-    data = yield {
-      teams: heroku.request({ path: '/teams' }),
-      notifications: heroku.request({ host: 'telex.heroku.com', path: '/user/notifications' }).catch(() => null),
-      apps: apps.map((app) => ({
-        app: heroku.get(`/apps/${app}`),
-        formation: heroku.get(`/apps/${app}/formation`),
-        pipeline: heroku.get(`/apps/${app}/pipeline-couplings`).catch(() => null)
+    let [ teams, notifications, appsWithMoreInfo ] = await Promise.all([
+      heroku.request({ path: '/teams' }),
+      heroku.request({ host: 'telex.heroku.com', path: '/user/notifications' }).catch(() => null),
+      Promise.all(apps.map(async (appID) => {
+        let [app, formation, pipeline] = await Promise.all([
+          heroku.get(`/apps/${appID}`),
+          heroku.get(`/apps/${appID}/formation`),
+          heroku.get(`/apps/${appID}/pipeline-couplings`).catch(() => null)
+        ])
+        return {
+          app,
+          formation,
+          pipeline
+        }
       }))
+    ])
+
+    data = {
+      teams,
+      notifications,
+      apps: appsWithMoreInfo
     }
-    metrics = yield fetchMetrics(data.apps)
-  }))
+
+    metrics = await fetchMetrics(data.apps)
+  }())
 
   if (apps.length > 0) displayApps(data.apps, metrics)
   else cli.warn(`Add apps to this dashboard by favoriting them with ${cli.color.cmd('heroku apps:favorites:add')}`)
@@ -159,5 +180,5 @@ module.exports = {
   description: 'display information about favorite apps',
   hidden: true,
   needsAuth: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/drains/add.js
+++ b/packages/apps-v5/src/commands/drains/add.js
@@ -1,10 +1,9 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
-  let drain = yield heroku.request({
+async function run(context, heroku) {
+  let drain = await heroku.request({
     method: 'post',
     path: `/apps/${context.app}/log-drains`,
     body: { url: context.args.url }
@@ -19,5 +18,5 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   args: [{ name: 'url' }],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/drains/index.js
+++ b/packages/apps-v5/src/commands/drains/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
 function styledDrain (id, name, drain) {
   let output = `${id} (${name})`
@@ -9,12 +8,12 @@ function styledDrain (id, name, drain) {
   cli.log(output)
 }
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const { partition } = require('lodash')
 
   let path = `/apps/${context.app}/log-drains`
   if (context.flags.extended) path = path + '?extended=true'
-  let drains = yield heroku.request({ path })
+  let drains = await heroku.request({ path })
   if (context.flags.json) {
     cli.styledJSON(drains)
   } else {
@@ -26,7 +25,9 @@ function * run (context, heroku) {
       })
     }
     if (drains[0].length > 0) {
-      let addons = yield drains[0].map((d) => heroku.get(`/apps/${context.app}/addons/${d.addon.name}`))
+      let addons = await Promise.all(
+        drains[0].map((d) => heroku.get(`/apps/${context.app}/addons/${d.addon.name}`))
+      )
       cli.styledHeader('Add-on Drains')
       addons.forEach((addon, i) => {
         styledDrain(cli.color.yellow(addon.plan.name), cli.color.green(addon.name), drains[0][i])
@@ -44,5 +45,5 @@ module.exports = {
     { name: 'json', description: 'output in json format' },
     { name: 'extended', char: 'x', hidden: true }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/drains/remove.js
+++ b/packages/apps-v5/src/commands/drains/remove.js
@@ -1,10 +1,9 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
-  let drain = yield heroku.request({
+async function run(context, heroku) {
+  let drain = await heroku.request({
     method: 'delete',
     path: `/apps/${context.app}/log-drains/${encodeURIComponent(context.args.url)}`
   })
@@ -19,5 +18,5 @@ module.exports = {
   needsAuth: true,
   args: [{ name: 'url' }],
   usage: 'drains:remove [URL|TOKEN]',
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/features/disable.js
+++ b/packages/apps-v5/src/commands/features/disable.js
@@ -1,22 +1,21 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let app = context.app
   let feature = context.args.feature
 
-  yield cli.action(`Disabling ${cli.color.green(feature)} for ${cli.color.app(app)}`, co(function * () {
-    let f = yield heroku.get(`/apps/${app}/features/${feature}`)
+  await cli.action(`Disabling ${cli.color.green(feature)} for ${cli.color.app(app)}`, async function () {
+    let f = await heroku.get(`/apps/${app}/features/${feature}`)
     if (!f.enabled) throw new Error(`${cli.color.red(feature)} is already disabled.`)
 
-    yield heroku.request({
+    await heroku.request({
       path: `/apps/${app}/features/${feature}`,
       method: 'PATCH',
       body: { enabled: false }
     })
-  }))
+  }())
 }
 
 module.exports = {
@@ -26,5 +25,5 @@ module.exports = {
   args: [{ name: 'feature' }],
   needsAuth: true,
   needsApp: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/features/enable.js
+++ b/packages/apps-v5/src/commands/features/enable.js
@@ -1,22 +1,21 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let app = context.app
   let feature = context.args.feature
 
-  yield cli.action(`Enabling ${cli.color.green(feature)} for ${cli.color.app(app)}`, co(function * () {
-    let f = yield heroku.get(`/apps/${app}/features/${feature}`)
+  await cli.action(`Enabling ${cli.color.green(feature)} for ${cli.color.app(app)}`, async function () {
+    let f = await heroku.get(`/apps/${app}/features/${feature}`)
     if (f.enabled) throw new Error(`${cli.color.red(feature)} is already enabled.`)
 
-    yield heroku.request({
+    await heroku.request({
       path: `/apps/${app}/features/${feature}`,
       method: 'PATCH',
       body: { enabled: true }
     })
-  }))
+  }())
 }
 
 module.exports = {
@@ -26,5 +25,5 @@ module.exports = {
   args: [{ name: 'feature' }],
   needsAuth: true,
   needsApp: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/features/info.js
+++ b/packages/apps-v5/src/commands/features/info.js
@@ -1,10 +1,9 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
-  let feature = yield heroku.get(`/apps/${context.app}/features/${context.args.feature}`)
+async function run(context, heroku) {
+  let feature = await heroku.get(`/apps/${context.app}/features/${context.args.feature}`)
 
   if (context.flags.json) {
     cli.styledJSON(feature)
@@ -26,5 +25,5 @@ module.exports = {
   flags: [{ name: 'json', description: 'output in json format' }],
   needsAuth: true,
   needsApp: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/keys/clear.js
+++ b/packages/apps-v5/src/commands/keys/clear.js
@@ -1,18 +1,17 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
-  yield cli.action('Removing all SSH keys', co(function * () {
-    let keys = yield heroku.get('/account/keys')
+async function run(context, heroku) {
+  await cli.action('Removing all SSH keys', async function () {
+    let keys = await heroku.get('/account/keys')
     for (let key of keys) {
-      yield heroku.request({
+      await heroku.request({
         method: 'DELETE',
         path: `/account/keys/${key.id}`
       })
     }
-  }))
+  }())
 }
 
 module.exports = {
@@ -20,5 +19,5 @@ module.exports = {
   command: 'clear',
   description: 'remove all SSH keys for current user',
   needsAuth: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/keys/index.js
+++ b/packages/apps-v5/src/commands/keys/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 
 function formatKey (key) {
@@ -8,8 +7,8 @@ function formatKey (key) {
   return `${key[0]} ${key[1].substr(0, 10)}...${key[1].substr(-10, 10)} ${cli.color.green(key[2])}`
 }
 
-function * run (context, heroku) {
-  let keys = yield heroku.get('/account/keys')
+async function run(context, heroku) {
+  let keys = await heroku.get('/account/keys')
   if (context.flags.json) {
     cli.styledJSON(keys)
   } else if (keys.length === 0) {
@@ -28,7 +27,7 @@ module.exports = {
   topic: 'keys',
   description: 'display your SSH keys',
   needsAuth: true,
-  run: cli.command(co.wrap(run)),
+  run: cli.command(run),
   flags: [
     { name: 'long', char: 'l', description: 'display full SSH keys' },
     { name: 'json', description: 'output in json format' }

--- a/packages/apps-v5/src/commands/keys/remove.js
+++ b/packages/apps-v5/src/commands/keys/remove.js
@@ -1,19 +1,18 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
-  yield cli.action(`Removing ${cli.color.cyan(context.args.key)} SSH key`, co(function * () {
-    let keys = yield heroku.get('/account/keys')
+async function run(context, heroku) {
+  await cli.action(`Removing ${cli.color.cyan(context.args.key)} SSH key`, async function () {
+    let keys = await heroku.get('/account/keys')
     if (keys.length === 0) throw new Error('No SSH keys on account')
     let toRemove = keys.filter((k) => k.comment === context.args.key)
     if (toRemove.length === 0) {
       throw new Error(`SSH Key ${cli.color.red(context.args.key)} not found.
 Found keys: ${cli.color.yellow(keys.map((k) => k.comment).join(', '))}.`)
     }
-    yield Promise.all(toRemove.map((key) => heroku.request({ method: 'DELETE', path: `/account/keys/${key.id}` })))
-  }))
+    await Promise.all(toRemove.map((key) => heroku.request({ method: 'DELETE', path: `/account/keys/${key.id}` })))
+  }())
 }
 
 module.exports = {
@@ -24,5 +23,5 @@ module.exports = {
 Removing email@example.com SSH key... done`,
   needsAuth: true,
   args: [{ name: 'key' }],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/labs/enable.js
+++ b/packages/apps-v5/src/commands/labs/enable.js
@@ -1,9 +1,8 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   function enableFeature (feature, app) {
     return heroku.request({
       path: app ? `/apps/${app}/features/${feature}` : `/account/features/${feature}`,
@@ -16,19 +15,19 @@ function * run (context, heroku) {
   let request
   let target
   try {
-    yield heroku.get(`/account/features/${feature}`)
+    await heroku.get(`/account/features/${feature}`)
     request = enableFeature(feature)
-    target = (yield heroku.get('/account')).email
+    target = ((await heroku.get('/account'))).email
   } catch (err) {
     if (err.statusCode !== 404) throw err
     // might be an app feature
     if (!context.app) throw err
-    yield heroku.get(`/apps/${context.app}/features/${feature}`)
+    await heroku.get(`/apps/${context.app}/features/${feature}`)
     request = enableFeature(feature, context.app)
     target = context.app
   }
 
-  yield cli.action(`Enabling ${cli.color.green(feature)} for ${cli.color.cyan(target)}`, request)
+  await cli.action(`Enabling ${cli.color.green(feature)} for ${cli.color.cyan(target)}`, request)
 }
 
 module.exports = {
@@ -38,5 +37,5 @@ module.exports = {
   args: [{ name: 'feature' }],
   needsAuth: true,
   wantsApp: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/labs/info.js
+++ b/packages/apps-v5/src/commands/labs/info.js
@@ -1,7 +1,6 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
 function print (feature) {
   cli.styledHeader(feature.name)
@@ -12,15 +11,15 @@ function print (feature) {
   })
 }
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let feature
   try {
-    feature = yield heroku.get(`/account/features/${context.args.feature}`)
+    feature = await heroku.get(`/account/features/${context.args.feature}`)
   } catch (err) {
     if (err.statusCode !== 404) throw err
     // might be an app feature
     if (!context.app) throw err
-    feature = yield heroku.get(`/apps/${context.app}/features/${context.args.feature}`)
+    feature = await heroku.get(`/apps/${context.app}/features/${context.args.feature}`)
   }
   if (context.flags.json) {
     cli.styledJSON(feature)
@@ -39,5 +38,5 @@ module.exports = {
   ],
   needsAuth: true,
   wantsApp: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/maintenance/index.js
+++ b/packages/apps-v5/src/commands/maintenance/index.js
@@ -1,10 +1,9 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
-  let app = yield heroku.get(`/apps/${context.app}`)
+async function run(context, heroku) {
+  let app = await heroku.get(`/apps/${context.app}`)
   cli.log(app.maintenance ? 'on' : 'off')
 }
 
@@ -13,5 +12,5 @@ module.exports = {
   description: 'display the current maintenance status of app',
   needsApp: true,
   needsAuth: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/maintenance/off.js
+++ b/packages/apps-v5/src/commands/maintenance/off.js
@@ -1,12 +1,11 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let app = context.app
   let p = heroku.patch(`/apps/${app}`, { body: { maintenance: false } })
-  yield cli.action(`Disabling maintenance mode for ${cli.color.app(app)}`, p)
+  await cli.action(`Disabling maintenance mode for ${cli.color.app(app)}`, p)
 }
 
 module.exports = {
@@ -15,5 +14,5 @@ module.exports = {
   description: 'take the app out of maintenance mode',
   needsApp: true,
   needsAuth: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/maintenance/on.js
+++ b/packages/apps-v5/src/commands/maintenance/on.js
@@ -1,12 +1,11 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let app = context.app
   let p = heroku.patch(`/apps/${app}`, { body: { maintenance: true } })
-  yield cli.action(`Enabling maintenance mode for ${cli.color.app(app)}`, p)
+  await cli.action(`Enabling maintenance mode for ${cli.color.app(app)}`, p)
 }
 
 module.exports = {
@@ -15,5 +14,5 @@ module.exports = {
   description: 'put the app into maintenance mode',
   needsApp: true,
   needsAuth: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/notifications/index.js
+++ b/packages/apps-v5/src/commands/notifications/index.js
@@ -1,16 +1,15 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 let time = require('../../time')
 
-function * run (context, heroku) {
-  let app = context.app && !context.flags.all ? yield heroku.get(`/apps/${context.app}`) : null
-  let notifications = yield heroku.request({ host: 'telex.heroku.com', path: '/user/notifications' })
+async function run(context, heroku) {
+  let app = context.app && !context.flags.all ? await heroku.get(`/apps/${context.app}`) : null
+  let notifications = await heroku.request({ host: 'telex.heroku.com', path: '/user/notifications' })
   if (app) notifications = notifications.filter((n) => n.target.id === app.id)
   if (!context.flags.read) {
     notifications = notifications.filter((n) => !n.read)
-    yield Promise.all(notifications.map((n) => heroku.request({ host: 'telex.heroku.com', path: `/user/notifications/${n.id}`, method: 'PATCH', body: { read: true } })))
+    await Promise.all(notifications.map((n) => heroku.request({ host: 'telex.heroku.com', path: `/user/notifications/${n.id}`, method: 'PATCH', body: { read: true } })))
   }
 
   function displayNotifications (notifications) {
@@ -49,5 +48,5 @@ module.exports = {
     { name: 'json', description: 'output in json format' },
     { name: 'read', description: 'show notifications already read' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/ps/index.js
+++ b/packages/apps-v5/src/commands/ps/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 let time = require('../../time')
 const { truncate, sortBy, reduce, forEach } = require('lodash')
 
@@ -30,7 +29,7 @@ function printExtended (dynos) {
   })
 }
 
-function * printAccountQuota (context, heroku, app, account) {
+async function printAccountQuota(context, heroku, app, account) {
   if (app.process_tier !== 'free') {
     return
   }
@@ -39,7 +38,7 @@ function * printAccountQuota (context, heroku, app, account) {
     return
   }
 
-  let quota = yield heroku.request({
+  let quota = await heroku.request({
     path: `/accounts/${account.id}/actions/get-quota`,
     headers: { Accept: 'application/vnd.heroku+json; version=3.account-quotas' }
   })
@@ -101,7 +100,7 @@ function printDynos (dynos) {
   })
 }
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const { app, flags, args } = context
   const types = args
   const { json, extended } = flags
@@ -117,7 +116,11 @@ function * run (context, heroku) {
   })
   promises.accountInfo = heroku.request({ path: '/account' })
 
-  let { dynos, appInfo, accountInfo } = yield promises
+  let [ dynos, appInfo, accountInfo ] = await Promise.all([
+    promises.dynos,
+    promises.appInfo,
+    promises.accountInfo
+  ])
   const shielded = appInfo.space && appInfo.space.shield
 
   if (shielded) {
@@ -149,7 +152,7 @@ function * run (context, heroku) {
   if (json) cli.styledJSON(dynos)
   else if (extended) printExtended(dynos)
   else {
-    yield printAccountQuota(context, heroku, appInfo, accountInfo)
+    await printAccountQuota(context, heroku, appInfo, accountInfo)
     if (dynos.length === 0) cli.log(`No dynos on ${cli.color.app(app)}`)
     else printDynos(dynos)
   }
@@ -176,5 +179,5 @@ $ heroku ps run # specifying types
 run.1: up for 5m: bash`,
   needsAuth: true,
   needsApp: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/ps/restart.js
+++ b/packages/apps-v5/src/commands/ps/restart.js
@@ -1,9 +1,8 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let app = context.app
   let dyno = context.args.dyno
 
@@ -12,9 +11,9 @@ function * run (context, heroku) {
   msg += (dyno && dyno.indexOf('.') !== -1) ? ' dyno' : ' dynos'
   msg += ` on ${cli.color.app(app)}`
 
-  yield cli.action(msg, co(function * () {
-    yield heroku.delete(dyno ? `/apps/${app}/dynos/${encodeURIComponent(dyno)}` : `/apps/${app}/dynos`)
-  }))
+  await cli.action(msg, async function () {
+    await heroku.delete(dyno ? `/apps/${app}/dynos/${encodeURIComponent(dyno)}` : `/apps/${app}/dynos`)
+  }())
 }
 
 let cmd = {
@@ -31,7 +30,7 @@ Restarting dynos... done`,
   needsAuth: true,
   needsApp: true,
   args: [{ name: 'dyno', optional: true }],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }
 
 module.exports = [

--- a/packages/apps-v5/src/commands/ps/stop.js
+++ b/packages/apps-v5/src/commands/ps/stop.js
@@ -1,14 +1,13 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let app = context.app
   let dyno = context.args.dyno
   let type = dyno.indexOf('.') !== -1 ? 'ps' : 'type'
 
-  yield cli.action(`Stopping ${cli.color.cyan(dyno)} ${type === 'ps' ? 'dyno' : 'dynos'} on ${cli.color.app(app)}`,
+  await cli.action(`Stopping ${cli.color.cyan(dyno)} ${type === 'ps' ? 'dyno' : 'dynos'} on ${cli.color.app(app)}`,
     heroku.post(`/apps/${app}/dynos/${dyno}/actions/stop`))
 }
 
@@ -24,7 +23,7 @@ Stopping run dynos... done`,
   needsAuth: true,
   needsApp: true,
   args: [{ name: 'dyno' }],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }
 
 module.exports = [

--- a/packages/apps-v5/src/commands/releases/index.js
+++ b/packages/apps-v5/src/commands/releases/index.js
@@ -1,10 +1,9 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 const stripAnsi = require('strip-ansi')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const statusHelper = require('../../status_helper')
   const time = require('../../time')
   const { truncate } = require('lodash')
@@ -29,7 +28,7 @@ function * run (context, heroku) {
 
   let url = `/apps/${context.app}/releases`
   if (context.flags.extended) url = url + '?extended=true'
-  let releases = yield heroku.request({
+  let releases = await heroku.request({
     path: url,
     partial: true,
     headers: {
@@ -45,7 +44,7 @@ function * run (context, heroku) {
   let runningRelease = releases.filter((r) => r.status === 'pending').slice(-1)[0]
   let runningSlug
   if (runningRelease && runningRelease.slug) {
-    runningSlug = yield heroku.get(`/apps/${context.app}/slugs/${runningRelease.slug.id}`)
+    runningSlug = await heroku.get(`/apps/${context.app}/slugs/${runningRelease.slug.id}`)
   }
 
   let optimizeWidth = function (releases, columns, optimizeKey) {
@@ -163,5 +162,5 @@ v3 Config add BAZ_QUX email@example.com 2015/11/17 17:37:41 (~ 1h ago)`,
     { name: 'json', description: 'output releases in json format' },
     { name: 'extended', char: 'x', hidden: true }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/releases/info.js
+++ b/packages/apps-v5/src/commands/releases/info.js
@@ -1,17 +1,16 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 let releases = require('../../releases')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const shellescape = require('shell-escape')
   const statusHelper = require('../../status_helper')
   const { forEach } = require('lodash')
 
-  let release = yield releases.FindByLatestOrId(heroku, context.app, context.args.release)
+  let release = await releases.FindByLatestOrId(heroku, context.app, context.args.release)
 
-  let config = yield heroku.get(`/apps/${context.app}/releases/${release.version}/config-vars`)
+  let config = await heroku.get(`/apps/${context.app}/releases/${release.version}/config-vars`)
 
   if (context.flags.json) {
     cli.styledJSON(release)
@@ -52,5 +51,5 @@ module.exports = {
     { name: 'json', description: 'output in json format' },
     { name: 'shell', char: 's', description: 'output in shell format' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/apps-v5/src/commands/releases/output.js
+++ b/packages/apps-v5/src/commands/releases/output.js
@@ -1,12 +1,11 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 let releases = require('../../releases')
 let output = require('../../output')
 
-function * run (context, heroku) {
-  let release = yield releases.FindByLatestOrId(heroku, context.app, context.args.release)
+async function run(context, heroku) {
+  let release = await releases.FindByLatestOrId(heroku, context.app, context.args.release)
 
   let streamUrl = release.output_stream_url
 
@@ -15,7 +14,7 @@ function * run (context, heroku) {
     return
   }
 
-  yield output.Stream(streamUrl)
+  await output.Stream(streamUrl)
     .catch(err => {
       if (err.statusCode === 404) {
         cli.warn('Release command not started yet. Please try again in a few seconds.')
@@ -32,5 +31,5 @@ module.exports = {
   needsAuth: true,
   needsApp: true,
   args: [{ name: 'release', optional: true }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/apps-v5/src/commands/releases/rollback.js
+++ b/packages/apps-v5/src/commands/releases/rollback.js
@@ -1,32 +1,31 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 let releases = require('../../releases')
 let output = require('../../output')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let release
   if (context.args.release) {
     let id = context.args.release.toLowerCase()
     id = id.startsWith('v') ? id.slice(1) : id
-    release = yield heroku.get(`/apps/${context.app}/releases/${id}`)
+    release = await heroku.get(`/apps/${context.app}/releases/${id}`)
   } else {
-    release = yield releases.FindRelease(heroku, context.app, (releases) => releases.filter((r) => r.status === 'succeeded')[1])
+    release = await releases.FindRelease(heroku, context.app, (releases) => releases.filter((r) => r.status === 'succeeded')[1])
   }
 
   let latest
-  yield cli.action(`Rolling back ${cli.color.app(context.app)} to ${cli.color.green('v' + release.version)}`, { success: false }, co(function * () {
-    latest = yield heroku.post(`/apps/${context.app}/releases`, { body: { release: release.id } })
+  await cli.action(`Rolling back ${cli.color.app(context.app)} to ${cli.color.green('v' + release.version)}`, { success: false }, async function () {
+    latest = await heroku.post(`/apps/${context.app}/releases`, { body: { release: release.id } })
 
     cli.action.done(`done, ${cli.color.green('v' + latest.version)}`)
     cli.warn(`Rollback affects code and config vars; it doesn't add or remove addons.
 To undo, run: ${cli.color.cmd('heroku rollback v' + (latest.version - 1))}`)
-  }))
+  }())
 
   if (latest.output_stream_url) {
     cli.log('Running release command...')
-    yield output.Stream(latest.output_stream_url)
+    await output.Stream(latest.output_stream_url)
       .catch(err => {
         if (err.statusCode === 404) {
           cli.warn('Release command starting. Use `heroku releases:output` to view the log.')
@@ -43,7 +42,7 @@ let cmd = {
   needsApp: true,
   needsAuth: true,
   args: [{ name: 'release', optional: true }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }
 
 module.exports = [

--- a/packages/apps-v5/src/domains_wait.js
+++ b/packages/apps-v5/src/domains_wait.js
@@ -3,8 +3,8 @@
 const cli = require('heroku-cli-util')
 const wait = ms => new Promise(resolve => setTimeout(resolve, ms))
 
-module.exports = function * (context, heroku, domain) {
-  yield cli.action(`Waiting for ${cli.color.green(domain.hostname)}`, (async () => {
+module.exports = async function (context, heroku, domain) {
+  await cli.action(`Waiting for ${cli.color.green(domain.hostname)}`, (async () => {
     while (domain.status === 'pending') {
       await wait(5000)
       domain = await heroku.get(`/apps/${context.app}/domains/${domain.id}`)

--- a/packages/certs-v5/commands/certs/auto/disable.js
+++ b/packages/certs-v5/commands/certs/auto/disable.js
@@ -1,9 +1,8 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let app = cli.color.app(context.app)
   let warning = `This command will disable Automatic Certificate Management from ${app}.
 This will cause the certificate to be removed from ${app} causing SSL
@@ -14,9 +13,9 @@ are preferred which will also disable Automatic Certificate Management.
 2) heroku certs:update CRT KEY
 `
 
-  yield cli.confirmApp(context.app, context.flags.confirm, warning)
+  await cli.confirmApp(context.app, context.flags.confirm, warning)
 
-  yield cli.action('Disabling Automatic Certificate Management', heroku.request({
+  await cli.action('Disabling Automatic Certificate Management', heroku.request({
     method: 'DELETE',
     path: `/apps/${context.app}/acm`,
     headers: { 'Accept': 'application/vnd.heroku+json; version=3.cedar-acm' }
@@ -32,5 +31,5 @@ module.exports = {
   ],
   needsApp: true,
   needsAuth: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/certs-v5/commands/certs/auto/index.js
+++ b/packages/certs-v5/commands/certs/auto/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 let certificateDetails = require('../../../lib/certificate_details.js')
 let _ = require('lodash')
@@ -28,8 +27,8 @@ function humanize (value) {
   return value.split('-').map((word) => _.capitalize(word)).join(' ')
 }
 
-function * run (context, heroku) {
-  let [app, certs, domains] = yield [
+async function run(context, heroku) {
+  let [app, certs, domains] = await Promise.all([
     heroku.request({
       path: `/apps/${context.app}`,
       headers: { 'Accept': 'application/vnd.heroku+json; version=3.cedar-acm' }
@@ -42,7 +41,7 @@ function * run (context, heroku) {
       path: `/apps/${context.app}/domains`,
       headers: { 'Accept': 'application/vnd.heroku+json; version=3.cedar-acm' }
     })
-  ]
+  ])
 
   let message
   if (app.acm) {
@@ -104,5 +103,5 @@ module.exports = {
   description: 'show ACM status for an app',
   needsApp: true,
   needsAuth: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/certs-v5/commands/certs/auto/refresh.js
+++ b/packages/certs-v5/commands/certs/auto/refresh.js
@@ -1,10 +1,9 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
-  yield cli.action('Refreshing Automatic Certificate Management', heroku.request({
+async function run(context, heroku) {
+  await cli.action('Refreshing Automatic Certificate Management', heroku.request({
     method: 'PATCH',
     path: `/apps/${context.app}/acm`,
     headers: { 'Accept': 'application/vnd.heroku+json; version=3.cedar-acm' },
@@ -18,5 +17,5 @@ module.exports = {
   description: 'refresh ACM for an app',
   needsApp: true,
   needsAuth: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/certs-v5/commands/certs/chain.js
+++ b/packages/certs-v5/commands/certs/chain.js
@@ -1,20 +1,19 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 
 let error = require('../../lib/error.js')
 let readFile = require('../../lib/read_file.js')
 let sslDoctor = require('../../lib/ssl_doctor.js')
 
-function * run (context) {
+async function run(context) {
   if (context.args.length === 0) {
     error.exit(1, 'Usage: heroku certs:chain CRT [CRT ...]\nMust specify at least one certificate file.')
   }
 
-  let res = yield context.args.map(function (arg) { return readFile(arg) })
+  let res = await Promise.all(context.args.map(function (arg) { return readFile(arg) }))
 
-  let body = yield sslDoctor('resolve-chain', res)
+  let body = await sslDoctor('resolve-chain', res)
   cli.console.writeLog(body)
 }
 
@@ -25,5 +24,5 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   variableArgs: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/certs-v5/commands/certs/index.js
+++ b/packages/certs-v5/commands/certs/index.js
@@ -1,14 +1,13 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 let _ = require('lodash')
 
 let endpoints = require('../../lib/endpoints.js').all
 let displayTable = require('../../lib/display_table.js')
 
-function * run (context, heroku) {
-  let certs = yield endpoints(context.app, heroku)
+async function run(context, heroku) {
+  let certs = await endpoints(context.app, heroku)
 
   if (certs.length === 0) {
     cli.log(`${cli.color.app(context.app)} has no SSL certificates.\nUse ${cli.color.cmd('heroku certs:add CRT KEY')} to add one.`)
@@ -22,5 +21,5 @@ module.exports = {
   description: 'list SSL certificates for an app',
   needsApp: true,
   needsAuth: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/certs-v5/commands/certs/info.js
+++ b/packages/certs-v5/commands/certs/info.js
@@ -1,21 +1,20 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 
 let flags = require('../../lib/flags.js')
 let certificateDetails = require('../../lib/certificate_details.js')
 
-function * run (context, heroku) {
-  let endpoint = yield flags(context, heroku)
+async function run(context, heroku) {
+  let endpoint = await flags(context, heroku)
 
-  let cert = yield cli.action(`Fetching SSL certificate ${endpoint.name} info for ${cli.color.app(context.app)}`, {}, heroku.request({
+  let cert = await cli.action(`Fetching SSL certificate ${endpoint.name} info for ${cli.color.app(context.app)}`, {}, heroku.request({
     path: endpoint._meta.path,
     headers: { 'Accept': `application/vnd.heroku+json; version=3.${endpoint._meta.variant}` }
   }))
 
   if (context.flags['show-domains']) {
-    let domains = yield Promise.all(endpoint.domains.map(domain => {
+    let domains = await Promise.all(endpoint.domains.map(domain => {
       return heroku.request({
         path: `/apps/${context.flags.app}/domains/${domain}`
       }).then(response => response.hostname)
@@ -39,5 +38,5 @@ module.exports = {
   description: 'show certificate information for an SSL certificate',
   needsApp: true,
   needsAuth: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/certs-v5/commands/certs/key.js
+++ b/packages/certs-v5/commands/certs/key.js
@@ -1,20 +1,19 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 
 let error = require('../../lib/error.js')
 let readFile = require('../../lib/read_file.js')
 let sslDoctor = require('../../lib/ssl_doctor.js')
 
-function * run (context) {
+async function run(context) {
   if (context.args.length < 2) {
     error.exit(1, 'Usage: heroku certs:key CRT KEY [KEY ...]\nMust specify one certificate file and at least one key file.')
   }
 
-  let res = yield context.args.map(function (arg) { return readFile(arg) })
+  let res = await Promise.all(context.args.map(function (arg) { return readFile(arg) }))
 
-  let body = JSON.parse(yield sslDoctor('resolve-chain-and-key', res, 'Testing for signing key'))
+  let body = JSON.parse(await sslDoctor('resolve-chain-and-key', res, 'Testing for signing key'))
   cli.console.writeLog(body.key)
 }
 
@@ -27,5 +26,5 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   variableArgs: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/certs-v5/commands/certs/remove.js
+++ b/packages/certs-v5/commands/certs/remove.js
@@ -1,29 +1,28 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 
 let flags = require('../../lib/flags.js')
 let endpoints = require('../../lib/endpoints.js')
 let formatEndpoint = require('../../lib/format_endpoint.js')
 
-function * run (context, heroku) {
-  let endpoint = yield flags(context, heroku)
+async function run(context, heroku) {
+  let endpoint = await flags(context, heroku)
 
   let formattedEndpoint = formatEndpoint(endpoint)
 
-  yield cli.confirmApp(context.app, context.flags.confirm, `WARNING: Destructive Action - you cannot rollback this change\nThis command will remove the endpoint ${formattedEndpoint} from ${cli.color.app(context.app)}.`)
+  await cli.confirmApp(context.app, context.flags.confirm, `WARNING: Destructive Action - you cannot rollback this change\nThis command will remove the endpoint ${formattedEndpoint} from ${cli.color.app(context.app)}.`)
 
-  let actions = yield {
-    action: cli.action(`Removing SSL certificate ${formattedEndpoint} from ${cli.color.app(context.app)}`, {}, heroku.request({
+  let [, hasAddon] = await Promise.all([
+    cli.action(`Removing SSL certificate ${formattedEndpoint} from ${cli.color.app(context.app)}`, {}, heroku.request({
       path: endpoint._meta.path,
       method: 'DELETE',
       headers: { 'Accept': `application/vnd.heroku+json; version=3.${endpoint._meta.variant}` }
     })),
-    hasAddon: endpoints.hasAddon(context.app, heroku)
-  }
+    endpoints.hasAddon(context.app, heroku)
+  ])
 
-  if (actions.hasAddon) {
+  if (hasAddon) {
     cli.log('NOTE: Billing is still active. Remove SSL Endpoint add-on to stop billing.')
   }
 }
@@ -39,5 +38,5 @@ module.exports = {
   description: 'remove an SSL certificate from an app',
   needsApp: true,
   needsAuth: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/certs-v5/commands/certs/update.js
+++ b/packages/certs-v5/commands/certs/update.js
@@ -1,6 +1,5 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 
 let flags = require('../../lib/flags.js')
@@ -9,16 +8,16 @@ let formatEndpoint = require('../../lib/format_endpoint.js')
 let certificateDetails = require('../../lib/certificate_details.js')
 let getCertAndKey = require('../../lib/get_cert_and_key.js')
 
-function * run (context, heroku) {
-  let endpoint = yield flags(context, heroku)
+async function run(context, heroku) {
+  let endpoint = await flags(context, heroku)
 
-  let files = yield getCertAndKey(context)
+  let files = await getCertAndKey(context)
 
   let formattedEndpoint = formatEndpoint(endpoint)
 
-  yield cli.confirmApp(context.app, context.flags.confirm, `Potentially Destructive Action\nThis command will change the certificate of endpoint ${formattedEndpoint} from ${cli.color.app(context.app)}.`)
+  await cli.confirmApp(context.app, context.flags.confirm, `Potentially Destructive Action\nThis command will change the certificate of endpoint ${formattedEndpoint} from ${cli.color.app(context.app)}.`)
 
-  let cert = yield cli.action(`Updating SSL certificate ${formattedEndpoint} for ${cli.color.app(context.app)}`, {}, heroku.request({
+  let cert = await cli.action(`Updating SSL certificate ${formattedEndpoint} for ${cli.color.app(context.app)}`, {}, heroku.request({
     path: endpoint._meta.path,
     method: 'PATCH',
     headers: { 'Accept': `application/vnd.heroku+json; version=3.${endpoint._meta.variant}` },
@@ -51,5 +50,5 @@ Certificate Intermediary:
 $ heroku certs:update intermediary.crt example.com.crt example.com.key`,
   needsApp: true,
   needsAuth: true,
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/certs-v5/lib/flags.js
+++ b/packages/certs-v5/lib/flags.js
@@ -3,12 +3,12 @@
 let allEndpoints = require('./endpoints.js').all
 let error = require('./error.js')
 
-module.exports = function * (context, heroku) {
+module.exports = async function (context, heroku) {
   if (context.flags.endpoint && context.flags.name) {
     error.exit(1, 'Specified both --name and --endpoint, please use just one')
   }
 
-  var endpoints = yield allEndpoints(context.app, heroku)
+  var endpoints = await allEndpoints(context.app, heroku)
 
   if (endpoints.length === 0) {
     error.exit(1, `${context.app} has no SSL certificates`)

--- a/packages/certs-v5/lib/get_cert_and_key.js
+++ b/packages/certs-v5/lib/get_cert_and_key.js
@@ -8,27 +8,29 @@ function usageError () {
   error.exit(1, 'Usage: heroku certs:add CRT KEY')
 }
 
-function * getFiles (context) {
-  return yield context.args.map((arg) => readFile(arg, 'utf-8'))
+async function getFiles(context) {
+  return await Promise.all(
+    context.args.map((arg) => readFile(arg, 'utf-8'))
+  );
 }
 
-function * getFilesBypass (context) {
+async function getFilesBypass(context) {
   if (context.args.length > 2) usageError()
-  let files = yield getFiles(context)
+  let files = await getFiles(context)
   return {crt: files[0], key: files[1]}
 }
 
-function * getFilesDoctor (context) {
-  let files = yield getFiles(context)
-  let res = JSON.parse(yield sslDoctor('resolve-chain-and-key', files))
+async function getFilesDoctor(context) {
+  let files = await getFiles(context)
+  let res = JSON.parse(await sslDoctor('resolve-chain-and-key', files))
   return {crt: res.pem, key: res.key}
 }
 
-module.exports = function * (context) {
+module.exports = async function (context) {
   if (context.args.length < 2) usageError()
   if (context.flags.bypass) {
-    return yield getFilesBypass(context)
+    return await getFilesBypass(context);
   } else {
-    return yield getFilesDoctor(context)
+    return await getFilesDoctor(context);
   }
 }

--- a/packages/certs-v5/package.json
+++ b/packages/certs-v5/package.json
@@ -15,7 +15,6 @@
     "repositoryPrefix": "<%- repo %>/blob/v<%- version %>/packages/certs-v5/<%- commandPath %>"
   },
   "dependencies": {
-    "co": "4.6.0",
     "co-wait": "0.0.0",
     "date-fns": "^1.29.0",
     "heroku-cli-util": "^8.0.11",

--- a/packages/ci-v5/commands/ci/config-get.js
+++ b/packages/ci-v5/commands/ci/config-get.js
@@ -1,13 +1,12 @@
 const cli = require('heroku-cli-util')
-const co = require('co')
 const shellescape = require('shell-escape')
 const api = require('../../lib/heroku-api')
 const Utils = require('../../lib/utils')
 const PipelineCompletion = require('../../lib/completions')
 
-function * run (context, heroku) {
-  const pipeline = yield Utils.getPipeline(context, heroku)
-  const config = yield api.configVars(heroku, pipeline.id)
+async function run(context, heroku) {
+  const pipeline = await Utils.getPipeline(context, heroku)
+  const config = await api.configVars(heroku, pipeline.id)
   const value = config[context.args.key]
 
   if (context.flags.shell) {
@@ -45,5 +44,5 @@ module.exports = {
       completion: PipelineCompletion
     }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/ci-v5/commands/ci/config-index.js
+++ b/packages/ci-v5/commands/ci/config-index.js
@@ -1,13 +1,12 @@
 const cli = require('heroku-cli-util')
-const co = require('co')
 const shellescape = require('shell-escape')
 const api = require('../../lib/heroku-api')
 const Utils = require('../../lib/utils')
 const PipelineCompletion = require('../../lib/completions')
 
-function * run (context, heroku) {
-  const pipeline = yield Utils.getPipeline(context, heroku)
-  const config = yield api.configVars(heroku, pipeline.id)
+async function run(context, heroku) {
+  const pipeline = await Utils.getPipeline(context, heroku)
+  const config = await api.configVars(heroku, pipeline.id)
 
   if (context.flags.shell) {
     Object.keys(config).forEach((key) => {
@@ -48,7 +47,7 @@ module.exports = {
       completion: PipelineCompletion
     }
   ],
-  run: cli.command(co.wrap(run)),
+  run: cli.command(run),
   help: `Example:
 
     $ heroku ci:config --app murmuring-headland-14719 --json`

--- a/packages/ci-v5/commands/ci/config-set.js
+++ b/packages/ci-v5/commands/ci/config-set.js
@@ -1,5 +1,4 @@
 const cli = require('heroku-cli-util')
-const co = require('co')
 const api = require('../../lib/heroku-api')
 const Utils = require('../../lib/utils')
 const PipelineCompletion = require('../../lib/completions')
@@ -18,7 +17,7 @@ function validateInput (str) {
   return true
 }
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   validateArgs(context.args)
 
   const vars = context.args.reduce((memo, str) => {
@@ -28,9 +27,9 @@ function * run (context, heroku) {
     return memo
   }, {})
 
-  const pipeline = yield Utils.getPipeline(context, heroku)
+  const pipeline = await Utils.getPipeline(context, heroku)
 
-  yield cli.action(
+  await cli.action(
     `Setting ${Object.keys(vars).join(', ')}`,
     api.setConfigVars(heroku, pipeline.id, vars)
   )
@@ -64,5 +63,5 @@ module.exports = {
 
     RAILS_ENV: test
 `,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/ci-v5/commands/ci/config-unset.js
+++ b/packages/ci-v5/commands/ci/config-unset.js
@@ -1,5 +1,4 @@
 const cli = require('heroku-cli-util')
-const co = require('co')
 const api = require('../../lib/heroku-api')
 const Utils = require('../../lib/utils')
 const PipelineCompletion = require('../../lib/completions')
@@ -10,7 +9,7 @@ function validateArgs (args) {
   }
 }
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   validateArgs(context.args)
 
   const vars = context.args.reduce((memo, key) => {
@@ -18,9 +17,9 @@ function * run (context, heroku) {
     return memo
   }, {})
 
-  const pipeline = yield Utils.getPipeline(context, heroku)
+  const pipeline = await Utils.getPipeline(context, heroku)
 
-  yield cli.action(
+  await cli.action(
     `Unsetting ${Object.keys(vars).join(', ')}`,
     api.setConfigVars(heroku, pipeline.id, vars)
   )
@@ -47,5 +46,5 @@ module.exports = {
     $ heroku ci:config:uset RAILS_ENV
     Unsetting RAILS_ENV... done
 `,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/ci-v5/commands/ci/migrate-manifest.js
+++ b/packages/ci-v5/commands/ci/migrate-manifest.js
@@ -1,11 +1,10 @@
 const fs = require('fs')
 const cli = require('heroku-cli-util')
-const co = require('co')
 const BB = require('bluebird')
 const writeFile = BB.promisify(fs.writeFile)
 const unlinkFile = BB.promisify(fs.unlink)
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const appJSONPath = `${process.cwd()}/app.json`
   const appCiJSONPath = `${process.cwd()}/app-ci.json`
   let action
@@ -14,8 +13,8 @@ function * run (context, heroku) {
     cli.log(cli.color.green('Please check the contents of your app.json before committing to your repo.'))
   }
 
-  function * updateAppJson () {
-    yield cli.action(
+  async function updateAppJson() {
+    await cli.action(
       // Updating / Creating
       `${action.charAt(0).toUpperCase() + action.slice(1)} app.json file`,
       writeFile(appJSONPath, `${JSON.stringify(appJSON, null, '  ')}\n`)
@@ -40,7 +39,7 @@ function * run (context, heroku) {
       msg += `, but we're ${action} ${action === 'updating' ? 'your' : 'a new'} app.json manifest for you.`
       appJSON.environments = {}
       cli.log(msg)
-      yield updateAppJson()
+      await updateAppJson()
       showWarning()
     } else {
       msg += `, and your app.json already has the environments key.`
@@ -58,8 +57,8 @@ function * run (context, heroku) {
     }
 
     appJSON.environments.test = appCiJSON
-    yield updateAppJson()
-    yield cli.action(
+    await updateAppJson()
+    await cli.action(
       'Deleting app-ci.json file',
       unlinkFile(appCiJSONPath)
     )
@@ -82,5 +81,5 @@ module.exports = {
     Deleting app-ci.json file... done
     Please check the contents of your app.json before committing to your repo
     You're all set! 🎉.`,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/ci-v5/commands/ci/open.js
+++ b/packages/ci-v5/commands/ci/open.js
@@ -1,11 +1,10 @@
 const cli = require('heroku-cli-util')
-const co = require('co')
 const Utils = require('../../lib/utils')
 const PipelineCompletion = require('../../lib/completions')
 
-function * run (context, heroku) {
-  const pipeline = yield Utils.getPipeline(context, heroku)
-  yield cli.open(`https://dashboard.heroku.com/pipelines/${pipeline.id}/tests`)
+async function run(context, heroku) {
+  const pipeline = await Utils.getPipeline(context, heroku)
+  await cli.open(`https://dashboard.heroku.com/pipelines/${pipeline.id}/tests`)
 }
 
 module.exports = {
@@ -28,5 +27,5 @@ module.exports = {
     Example:
 
     $ heroku ci:open --app murmuring-headland-14719`,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/ci-v5/lib/disambiguate.js
+++ b/packages/ci-v5/lib/disambiguate.js
@@ -3,12 +3,12 @@ let validator = require('validator')
 let inquirer = require('inquirer')
 let api = require('./api')
 
-function* disambiguate (heroku, pipelineIDOrName) {
+async function disambiguate(heroku, pipelineIDOrName) {
   var pipeline
   if (validator.isUUID(pipelineIDOrName)) {
-    pipeline = yield api.getPipeline(heroku, pipelineIDOrName)
+    pipeline = await api.getPipeline(heroku, pipelineIDOrName)
   } else {
-    let pipelines = yield api.findPipelineByName(heroku, pipelineIDOrName)
+    let pipelines = await api.findPipelineByName(heroku, pipelineIDOrName)
     if (pipelines.length === 0) {
       throw new Error('Pipeline not found')
     } else if (pipelines.length === 1) {
@@ -22,7 +22,7 @@ function* disambiguate (heroku, pipelineIDOrName) {
         message: `Which ${pipelineIDOrName} pipeline?`,
         choices: choices
       }]
-      pipeline = yield new Promise(function (resolve, reject) {
+      pipeline = await new Promise(function (resolve, reject) {
         inquirer.prompt(questions, function (answers) {
           if (answers.pipeline) resolve(answers.pipeline)
           else reject('Must pick a pipeline')

--- a/packages/ci-v5/lib/git.js
+++ b/packages/ci-v5/lib/git.js
@@ -35,21 +35,21 @@ function runGit (...args) {
   })
 }
 
-function * getRef (branch) {
+async function getRef(branch) {
   return runGit('rev-parse', branch || 'HEAD')
 }
 
-function * getBranch (symbolicRef) {
+async function getBranch(symbolicRef) {
   return runGit('symbolic-ref', '--short', symbolicRef)
 }
 
-function * getCommitTitle (ref) {
+async function getCommitTitle(ref) {
   return runGit('log', ref || '', '-1', '--pretty=format:%s')
 }
 
-function * createArchive (ref) {
+async function createArchive(ref) {
   const tar = spawn('git', ['archive', '--format', 'tar.gz', ref])
-  const file = yield tmp.openAsync({ suffix: '.tar.gz' })
+  const file = await tmp.openAsync({ suffix: '.tar.gz' })
   const write = tar.stdout.pipe(fs.createWriteStream(file.path))
 
   return new Promise((resolve, reject) => {
@@ -58,8 +58,8 @@ function * createArchive (ref) {
   })
 }
 
-function * githubRepository () {
-  const remote = yield runGit('remote', 'get-url', 'origin')
+async function githubRepository() {
+  const remote = await runGit('remote', 'get-url', 'origin')
   const repository = gh(remote)
 
   if (repository === null) {
@@ -69,10 +69,10 @@ function * githubRepository () {
   return repository
 }
 
-function * readCommit (commit) {
-  const branch = yield getBranch('HEAD')
-  const ref = yield getRef(commit)
-  const message = yield getCommitTitle(ref)
+async function readCommit(commit) {
+  const branch = await getBranch('HEAD')
+  const ref = await getRef(commit)
+  const message = await getCommitTitle(ref)
 
   return Promise.resolve({
     branch: branch,

--- a/packages/ci-v5/lib/heroku-api.js
+++ b/packages/ci-v5/lib/heroku-api.js
@@ -4,11 +4,11 @@ const V3_HEADER = 'application/vnd.heroku+json; version=3'
 const VERSION_HEADER = `${V3_HEADER}.ci`
 const PIPELINE_HEADER = `${V3_HEADER}.pipelines`
 
-function * pipelineCoupling (client, app) {
+async function pipelineCoupling(client, app) {
   return client.get(`/apps/${app}/pipeline-couplings`)
 }
 
-function * pipelineRepository (client, pipelineID) {
+async function pipelineRepository(client, pipelineID) {
   return client.request({
     host: KOLKRABBI,
     path: `/pipelines/${pipelineID}/repository`,
@@ -18,7 +18,7 @@ function * pipelineRepository (client, pipelineID) {
   })
 }
 
-function * getDyno (client, appID, dynoID) {
+async function getDyno(client, appID, dynoID) {
   return client.request({
     path: `/apps/${appID}/dynos/${dynoID}`,
     headers: {
@@ -28,7 +28,7 @@ function * getDyno (client, appID, dynoID) {
   })
 }
 
-function * githubArchiveLink (client, user, repository, ref) {
+async function githubArchiveLink(client, user, repository, ref) {
   return client.request({
     host: KOLKRABBI,
     path: `/github/repos/${user}/${repository}/tarball/${ref}`,
@@ -38,7 +38,7 @@ function * githubArchiveLink (client, user, repository, ref) {
   })
 }
 
-function * testRun (client, pipelineID, number) {
+async function testRun(client, pipelineID, number) {
   return client.request({
     path: `/pipelines/${pipelineID}/test-runs/${number}`,
     headers: {
@@ -48,7 +48,7 @@ function * testRun (client, pipelineID, number) {
   })
 }
 
-function * testNodes (client, testRunIdD) {
+async function testNodes(client, testRunIdD) {
   return client.request({
     path: `/test-runs/${testRunIdD}/test-nodes`,
     headers: {
@@ -58,7 +58,7 @@ function * testNodes (client, testRunIdD) {
   })
 }
 
-function * testRuns (client, pipelineID) {
+async function testRuns(client, pipelineID) {
   return client.request({
     path: `/pipelines/${pipelineID}/test-runs`,
     headers: {
@@ -68,8 +68,8 @@ function * testRuns (client, pipelineID) {
   })
 }
 
-function * latestTestRun (client, pipelineID) {
-  const latestTestRuns = yield client.request({
+async function latestTestRun(client, pipelineID) {
+  const latestTestRuns = await client.request({
     path: `/pipelines/${pipelineID}/test-runs`,
     headers: {
       Authorization: `Bearer ${client.options.token}`,
@@ -96,11 +96,11 @@ function logStream (url, fn) {
   return https.get(url, fn)
 }
 
-function * createSource (client) {
-  return yield client.post(`/sources`)
+async function createSource(client) {
+  return await client.post(`/sources`);
 }
 
-function * createTestRun (client, body) {
+async function createTestRun(client, body) {
   const headers = {
     Accept: VERSION_HEADER
   }

--- a/packages/ci-v5/lib/test-run.js
+++ b/packages/ci-v5/lib/test-run.js
@@ -1,10 +1,10 @@
 const api = require('./heroku-api')
 const wait = require('co-wait')
 
-function * waitForStates (states, testRun, { heroku }) {
+async function waitForStates(states, testRun, { heroku }) {
   while (!states.includes(testRun.status)) {
-    testRun = yield api.testRun(heroku, testRun.pipeline.id, testRun.number)
-    yield wait(1000)
+    testRun = await api.testRun(heroku, testRun.pipeline.id, testRun.number)
+    await wait(1000)
   }
   return testRun
 }

--- a/packages/ci-v5/lib/utils.js
+++ b/packages/ci-v5/lib/utils.js
@@ -2,16 +2,16 @@ const api = require('./heroku-api')
 const cli = require('heroku-cli-util')
 const disambiguatePipeline = require('./disambiguate')
 
-function * getPipeline (context, client) {
+async function getPipeline(context, client) {
   let pipeline = context.flags.pipeline
 
   let pipelineOrApp = pipeline || context.app
   if (!pipelineOrApp) cli.exit(1, 'Required flag:  --pipeline PIPELINE or --app APP')
 
   if (pipeline) {
-    pipeline = yield disambiguatePipeline(client, pipeline)
+    pipeline = await disambiguatePipeline(client, pipeline)
   } else {
-    const coupling = yield api.pipelineCoupling(client, context.app)
+    const coupling = await api.pipelineCoupling(client, context.app)
     pipeline = coupling.pipeline
   }
 

--- a/packages/ci-v5/package.json
+++ b/packages/ci-v5/package.json
@@ -17,7 +17,6 @@
     "@heroku-cli/plugin-run-v5": "^7.47.13",
     "ansi-escapes": "3.2.0",
     "bluebird": "^3.5.3",
-    "co": "^4.6.0",
     "co-wait": "0.0.0",
     "github-url-to-object": "^4.0.4",
     "got": "^8.3.2",

--- a/packages/ci-v5/test/lib/heroku-api-test.js
+++ b/packages/ci-v5/test/lib/heroku-api-test.js
@@ -5,41 +5,40 @@ const nock = require('nock')
 const expect = require('chai').expect
 const Heroku = require('heroku-client')
 const herokuAPI = require('../../lib/heroku-api')
-const co = require('co');
 
 describe('heroku-api', function () {
   afterEach(() => nock.cleanAll())
 
   describe('#pipelineCoupling', function () {
-    it('gets the pipeline coupling given an app', co.wrap(function * () {
+    it('gets the pipeline coupling given an app', async function () {
       const app = 'sausages'
       const coupling = { pipeline: { id: '123-abc' } }
       const api = nock(`https://api.heroku.com`)
         .get(`/apps/${app}/pipeline-couplings`)
         .reply(200, coupling)
 
-      const response = yield herokuAPI.pipelineCoupling(new Heroku(), app)
+      const response = await herokuAPI.pipelineCoupling(new Heroku(), app)
       expect(response).to.deep.eq(coupling)
       api.done()
-    }))
+    })
   })
 
   describe('#pipelineRepository', function () {
-    it('gets the pipeline repository given a pipeline', co.wrap(function * () {
+    it('gets the pipeline repository given a pipeline', async function () {
       const pipeline = '123-abc'
       const repo = { repository: { name: 'heroku/heroku' } }
       const api = nock(`https://kolkrabbi.heroku.com`)
         .get(`/pipelines/${pipeline}/repository`)
         .reply(200, repo)
 
-      const response = yield herokuAPI.pipelineRepository(new Heroku(), pipeline)
+      const response = await herokuAPI.pipelineRepository(new Heroku(), pipeline)
       expect(response).to.deep.eq(repo)
       api.done()
-    }))
+    })
   })
 
   describe('#getDyno', function () {
-    it('returns dyno information', co.wrap(function * () {
+    it('returns dyno information', async function () {
       const appID = '123-456-67-89'
       const dynoID = '01234567-89ab-cdef-0123-456789abcdef'
       const dyno = {
@@ -52,14 +51,14 @@ describe('heroku-api', function () {
         .get(`/apps/${appID}/dynos/${dynoID}`)
         .reply(200, dyno)
 
-      const response = yield herokuAPI.getDyno(new Heroku(), appID, dynoID)
+      const response = await herokuAPI.getDyno(new Heroku(), appID, dynoID)
       expect(response).to.deep.eq(dyno)
       api.done()
-    }))
+    })
   })
 
   describe('#githubArchiveLink', function () {
-    it('gets a GitHub archive link', co.wrap(function * () {
+    it('gets a GitHub archive link', async function () {
       const { user, repository } = ['heroku', 'heroku-ci']
       const ref = '123-abc'
       const archiveLink = { archive_link: 'https://example.com' }
@@ -67,14 +66,14 @@ describe('heroku-api', function () {
         .get(`/github/repos/${user}/${repository}/tarball/${ref}`)
         .reply(200, archiveLink)
 
-      const response = yield herokuAPI.githubArchiveLink(new Heroku(), user, repository, ref)
+      const response = await herokuAPI.githubArchiveLink(new Heroku(), user, repository, ref)
       expect(response).to.deep.eq(archiveLink)
       api.done()
-    }))
+    })
   })
 
   describe('#testRun', function () {
-    it('gets a test run given a pipeline and number', co.wrap(function * () {
+    it('gets a test run given a pipeline and number', async function () {
       const pipeline = '123-abc'
       const number = 1
       const testRun = { number }
@@ -82,14 +81,14 @@ describe('heroku-api', function () {
         .get(`/pipelines/${pipeline}/test-runs/${number}`)
         .reply(200, testRun)
 
-      const response = yield herokuAPI.testRun(new Heroku(), pipeline, number)
+      const response = await herokuAPI.testRun(new Heroku(), pipeline, number)
       expect(response).to.deep.eq(testRun)
       api.done()
-    }))
+    })
   })
 
   describe('#testNodes', function () {
-    it('gets a test run given a pipeline and number', co.wrap(function * () {
+    it('gets a test run given a pipeline and number', async function () {
       const testRun = { id: 'uuid-999' }
       const testNode = { test_run: { id: testRun.id } }
 
@@ -97,79 +96,79 @@ describe('heroku-api', function () {
         .get(`/test-runs/${testRun.id}/test-nodes`)
         .reply(200, [testNode])
 
-      const response = yield herokuAPI.testNodes(new Heroku(), testRun.id)
+      const response = await herokuAPI.testNodes(new Heroku(), testRun.id)
       expect(response).to.deep.eq([testNode])
       api.done()
-    }))
+    })
   })
 
   describe('#testRuns', function () {
-    it('gets test runs given a pipeline', co.wrap(function * () {
+    it('gets test runs given a pipeline', async function () {
       const pipeline = '123-abc'
       const testRuns = [{ id: '123' }]
       const api = nock(`https://api.heroku.com`, { reqheaders: { Accept: 'application/vnd.heroku+json; version=3.ci' } })
         .get(`/pipelines/${pipeline}/test-runs`)
         .reply(200, testRuns)
 
-      const response = yield herokuAPI.testRuns(new Heroku(), pipeline)
+      const response = await herokuAPI.testRuns(new Heroku(), pipeline)
       expect(response).to.deep.eq(testRuns)
       api.done()
-    }))
+    })
   })
 
   describe('#latestTestRun', function () {
-    it('gets the latest test run given a pipeline', co.wrap(function * () {
+    it('gets the latest test run given a pipeline', async function () {
       const pipeline = '123-abc'
       const testRuns = [{ number: 123 }, { number: 122 }]
       const api = nock(`https://api.heroku.com`, { reqheaders: { Accept: 'application/vnd.heroku+json; version=3.ci' } })
         .get(`/pipelines/${pipeline}/test-runs`)
         .reply(200, testRuns)
 
-      const response = yield herokuAPI.latestTestRun(new Heroku(), pipeline)
+      const response = await herokuAPI.latestTestRun(new Heroku(), pipeline)
       expect(response).to.deep.eq(testRuns[0])
       api.done()
-    }))
+    })
   })
 
   describe('#createSource', function () {
-    it('creates a source', co.wrap(function * () {
+    it('creates a source', async function () {
       const source = { source_blob: { get_url: 'https://example.com/get', put_url: 'https://example.com/put' } }
       const api = nock(`https://api.heroku.com`)
         .post(`/sources`)
         .reply(201, source)
 
-      const response = yield herokuAPI.createSource(new Heroku())
+      const response = await herokuAPI.createSource(new Heroku())
       expect(response).to.deep.eq(source)
       api.done()
-    }))
+    })
   })
 
   describe('#configVars', function () {
-    it('gets config vars', co.wrap(function * () {
+    it('gets config vars', async function () {
       const id = '123'
       const config = { FOO: 'bar' }
       const api = nock(`https://api.heroku.com`)
         .get(`/pipelines/${id}/stage/test/config-vars`)
         .reply(200, config)
 
-      const response = yield herokuAPI.configVars(new Heroku(), id)
+      const response = await herokuAPI.configVars(new Heroku(), id)
       expect(response).to.deep.eq(config)
       api.done()
-    }))
+    })
   })
 
   describe('#setConfigVars', function () {
-    it('patches config vars', co.wrap(function * () {
+    it('patches config vars', async function () {
       const id = '123'
       const config = { FOO: 'bar' }
       const api = nock(`https://api.heroku.com`)
         .patch(`/pipelines/${id}/stage/test/config-vars`)
         .reply(200, config)
 
-      const response = yield herokuAPI.setConfigVars(new Heroku(), id, config)
+      const response = await herokuAPI.setConfigVars(new Heroku(), id, config)
       expect(response).to.deep.eq(config)
 
       api.done()
-    }))
+    })
   })
 })

--- a/packages/ci-v5/test/lib/utils-test.js
+++ b/packages/ci-v5/test/lib/utils-test.js
@@ -5,25 +5,24 @@ const expect = require('chai').expect
 const Heroku = require('heroku-client')
 const Utils = require('../../lib/utils')
 const Factory = require('./factory')
-const co = require('co')
 
 describe('Utils', function () {
   afterEach(() => nock.cleanAll())
 
   describe('#getPipeline', function () {
-    it('disambiguates when passing a pipeline', co.wrap(function * () {
+    it('disambiguates when passing a pipeline', async function () {
       const pipeline = Factory.pipeline
       const context = { flags: { pipeline: pipeline.id } }
       const api = nock(`https://api.heroku.com`)
         .get(`/pipelines/${pipeline.id}`)
         .reply(200, pipeline)
 
-      const response = yield Utils.getPipeline(context, new Heroku())
+      const response = await Utils.getPipeline(context, new Heroku())
       expect(response).to.deep.eq(Factory.pipeline)
       api.done()
-    }))
+    })
 
-    it('uses pipeline-couplings when passing an application', co.wrap(function * () {
+    it('uses pipeline-couplings when passing an application', async function () {
       const app = '123-app'
 
       const coupling = { pipeline: Factory.pipeline }
@@ -33,10 +32,10 @@ describe('Utils', function () {
         .get(`/apps/${app}/pipeline-couplings`)
         .reply(200, coupling)
 
-      const response = yield Utils.getPipeline(context, new Heroku())
+      const response = await Utils.getPipeline(context, new Heroku())
       expect(response).to.deep.eq(Factory.pipeline)
       api.done()
-    }))
+    })
   })
 
   describe('#dig', function () {

--- a/packages/oauth-v5/lib/commands/authorizations/create.js
+++ b/packages/oauth-v5/lib/commands/authorizations/create.js
@@ -1,10 +1,9 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 const authorizations = require('../../authorizations')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let promise = heroku.request({
     method: 'POST',
     path: '/oauth/authorizations',
@@ -19,7 +18,7 @@ function * run (context, heroku) {
     promise = cli.action('Creating OAuth Authorization', promise)
   }
 
-  let auth = yield promise
+  let auth = await promise
 
   if (context.flags.short) {
     cli.log(auth.access_token.token)
@@ -50,5 +49,5 @@ module.exports = {
     {char: 'S', name: 'short', description: 'only output token'},
     {char: 'j', name: 'json', description: 'output in json format'}
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/oauth-v5/lib/commands/authorizations/index.js
+++ b/packages/oauth-v5/lib/commands/authorizations/index.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const _ = require('lodash')
-  let authorizations = yield heroku.get('/oauth/authorizations')
+  let authorizations = await heroku.get('/oauth/authorizations')
   authorizations = _.sortBy(authorizations, 'description')
 
   if (context.flags.json) {
@@ -31,5 +30,5 @@ module.exports = {
   flags: [
     {name: 'json', char: 'j', description: 'output in json format'}
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/oauth-v5/lib/commands/authorizations/info.js
+++ b/packages/oauth-v5/lib/commands/authorizations/info.js
@@ -1,11 +1,10 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 let authorizations = require('../../authorizations')
 
-function * run (context, heroku) {
-  let auth = yield heroku.get(`/oauth/authorizations/${encodeURIComponent(context.args.id)}`)
+async function run(context, heroku) {
+  let auth = await heroku.get(`/oauth/authorizations/${encodeURIComponent(context.args.id)}`)
   if (context.flags.json) {
     cli.styledJSON(auth)
   } else {
@@ -22,5 +21,5 @@ module.exports = {
     {char: 'j', name: 'json', description: 'output in json format'}
   ],
   args: [{name: 'id'}],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/oauth-v5/lib/commands/authorizations/revoke.js
+++ b/packages/oauth-v5/lib/commands/authorizations/revoke.js
@@ -1,10 +1,9 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
-  let auth = yield cli.action('Revoking OAuth Authorization', {success: false}, heroku.request({
+async function run(context, heroku) {
+  let auth = await cli.action('Revoking OAuth Authorization', {success: false}, heroku.request({
     method: 'DELETE',
     path: `/oauth/authorizations/${encodeURIComponent(context.args.id)}`
   }))
@@ -18,5 +17,5 @@ module.exports = {
   description: 'revoke OAuth authorization',
   needsAuth: true,
   args: [{name: 'id'}],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/oauth-v5/lib/commands/authorizations/rotate.js
+++ b/packages/oauth-v5/lib/commands/authorizations/rotate.js
@@ -1,11 +1,10 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 let authorizations = require('../../authorizations')
 
-function * run (context, heroku) {
-  let auth = yield cli.action('Rotating OAuth Authorization', heroku.request({
+async function run(context, heroku) {
+  let auth = await cli.action('Rotating OAuth Authorization', heroku.request({
     method: 'POST',
     path: `/oauth/authorizations/${encodeURIComponent(context.args.id)}/actions/regenerate-tokens`
   }))
@@ -20,5 +19,5 @@ module.exports = {
   needsAuth: true,
   args: [{name: 'id'}],
   flags: [],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/oauth-v5/lib/commands/authorizations/update.js
+++ b/packages/oauth-v5/lib/commands/authorizations/update.js
@@ -1,10 +1,9 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 let authorizations = require('../../authorizations')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let client
   if (context.flags['client-id']) {
     client = {
@@ -12,7 +11,7 @@ function * run (context, heroku) {
       secret: context.flags['client-secret']
     }
   }
-  let auth = yield cli.action('Updating OAuth Authorization', heroku.request({
+  let auth = await cli.action('Updating OAuth Authorization', heroku.request({
     method: 'PATCH',
     path: `/oauth/authorizations/${encodeURIComponent(context.args.id)}`,
     body: {
@@ -35,5 +34,5 @@ module.exports = {
     {name: 'client-id', hasValue: true, description: 'identifier of OAuth client to set'},
     {name: 'client-secret', hasValue: true, description: 'secret of OAuth client to set'}
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/oauth-v5/lib/commands/clients/create.js
+++ b/packages/oauth-v5/lib/commands/clients/create.js
@@ -1,10 +1,9 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 let lib = require('../../clients')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let url = context.args['redirect_uri']
   lib.validateURL(url)
   let request = heroku.request({
@@ -17,9 +16,9 @@ function * run (context, heroku) {
   })
   let client
   if (context.flags.shell || context.flags.json) {
-    client = yield request
+    client = await request
   } else {
-    client = yield cli.action(`Creating ${context.args.name}`, request)
+    client = await cli.action(`Creating ${context.args.name}`, request)
   }
 
   if (context.flags.json) {
@@ -40,5 +39,5 @@ module.exports = {
     {name: 'shell', char: 's', description: 'output in shell format'},
     {char: 'j', name: 'json', description: 'output in json format'}
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/oauth-v5/lib/commands/clients/destroy.js
+++ b/packages/oauth-v5/lib/commands/clients/destroy.js
@@ -1,15 +1,14 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let id = context.args.id
   let request = heroku.request({
     method: 'DELETE',
     path: `/oauth/clients/${id}`
   })
-  yield cli.action(`Destroying ${cli.color.cyan(id)}`, request)
+  await cli.action(`Destroying ${cli.color.cyan(id)}`, request)
 }
 
 module.exports = {
@@ -18,5 +17,5 @@ module.exports = {
   description: 'delete client by ID',
   needsAuth: true,
   args: [{name: 'id'}],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/oauth-v5/lib/commands/clients/index.js
+++ b/packages/oauth-v5/lib/commands/clients/index.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const _ = require('lodash')
-  let clients = yield heroku.get('/oauth/clients')
+  let clients = await heroku.get('/oauth/clients')
   clients = _.sortBy(clients, 'name')
 
   if (context.flags.json) {
@@ -31,5 +30,5 @@ module.exports = {
   flags: [
     {char: 'j', name: 'json', description: 'output in json format'}
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/oauth-v5/lib/commands/clients/info.js
+++ b/packages/oauth-v5/lib/commands/clients/info.js
@@ -1,10 +1,9 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
-  let client = yield heroku.get(`/oauth/clients/${context.args.id}`)
+async function run(context, heroku) {
+  let client = await heroku.get(`/oauth/clients/${context.args.id}`)
   if (context.flags.json) {
     cli.styledJSON(client)
   } else if (context.flags.shell) {
@@ -26,5 +25,5 @@ module.exports = {
     {name: 'json', char: 'j', description: 'output in json format'},
     {name: 'shell', char: 's', description: 'output in shell format'}
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/oauth-v5/lib/commands/clients/rotate.js
+++ b/packages/oauth-v5/lib/commands/clients/rotate.js
@@ -1,14 +1,13 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let id = context.args.id
 
   cli.log(`Updating ${cli.color.cyan(id)}`)
 
-  let client = yield heroku.request({
+  let client = await heroku.request({
     method: 'POST',
     path: `/oauth/clients/${encodeURIComponent(id)}/actions/rotate-credentials`
   })
@@ -34,5 +33,5 @@ module.exports = {
     {name: 'shell', char: 's', description: 'output in shell format'}
   ],
   needsAuth: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/oauth-v5/lib/commands/clients/update.js
+++ b/packages/oauth-v5/lib/commands/clients/update.js
@@ -1,7 +1,6 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 let lib = require('../../clients')
 
 let empty = o => Object.keys(o).length === 0
@@ -16,7 +15,7 @@ function getUpdates (o) {
   return updates
 }
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let id = context.args.id
   let request = heroku.request({
     method: 'PATCH',
@@ -24,7 +23,7 @@ function * run (context, heroku) {
     body: getUpdates(context.flags)
   })
 
-  yield cli.action(`Updating ${cli.color.cyan(id)}`, request)
+  await cli.action(`Updating ${cli.color.cyan(id)}`, request)
 }
 
 module.exports = {
@@ -37,5 +36,5 @@ module.exports = {
     {name: 'url', hasValue: true, description: 'change the client redirect URL'}
   ],
   needsAuth: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/oauth-v5/lib/commands/sessions/destroy.js
+++ b/packages/oauth-v5/lib/commands/sessions/destroy.js
@@ -1,16 +1,15 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let id = context.args.id
-  yield cli.action(`Destroying ${cli.color.cyan(id)}`, co(function * () {
-    yield heroku.request({
+  await cli.action(`Destroying ${cli.color.cyan(id)}`, async function () {
+    await heroku.request({
       method: 'DELETE',
       path: `/oauth/sessions/${id}`
     })
-  }))
+  }())
 }
 
 module.exports = {
@@ -19,5 +18,5 @@ module.exports = {
   description: 'delete (logout) OAuth session by ID',
   needsAuth: true,
   args: [{name: 'id'}],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/oauth-v5/lib/commands/sessions/index.js
+++ b/packages/oauth-v5/lib/commands/sessions/index.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const _ = require('lodash')
-  let sessions = yield heroku.get('/oauth/sessions')
+  let sessions = await heroku.get('/oauth/sessions')
   sessions = _.sortBy(sessions, 'description')
 
   if (context.flags.json) {
@@ -30,5 +29,5 @@ module.exports = {
   flags: [
     {char: 'j', name: 'json', description: 'output in json format'}
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/oauth-v5/package.json
+++ b/packages/oauth-v5/package.json
@@ -21,7 +21,6 @@
     "repositoryPrefix": "<%- repo %>/blob/v<%- version %>/packages/oauth-v5/<%- commandPath %>"
   },
   "dependencies": {
-    "co": "^4.6.0",
     "date-fns": "^1.29.0",
     "heroku-cli-util": "^8.0.11",
     "lodash": "^4.17.11"

--- a/packages/orgs-v5/commands/apps/join.js
+++ b/packages/orgs-v5/commands/apps/join.js
@@ -1,9 +1,8 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let request = heroku.get('/account')
     .then(function (user) {
       return heroku.post(`/teams/apps/${context.app}/collaborators`, {
@@ -11,7 +10,7 @@ function * run (context, heroku) {
       })
     })
 
-  yield cli.action(`Joining ${cli.color.cyan(context.app)}`, request)
+  await cli.action(`Joining ${cli.color.cyan(context.app)}`, request)
 }
 
 let cmd = {
@@ -20,7 +19,7 @@ let cmd = {
   description: 'add yourself to a team app',
   needsAuth: true,
   needsApp: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }
 
 let root = Object.assign({}, cmd, { topic: 'join', command: null })

--- a/packages/orgs-v5/commands/apps/leave.js
+++ b/packages/orgs-v5/commands/apps/leave.js
@@ -1,9 +1,8 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let request = heroku.get('/account')
     .then(function (user) {
       return heroku.delete(`/apps/${context.app}/collaborators/${encodeURIComponent(user.email)}`).catch(function (err) {
@@ -11,7 +10,7 @@ function * run (context, heroku) {
         throw new Error(err.body)
       })
     })
-  yield cli.action(`Leaving ${cli.color.cyan(context.app)}`, request)
+  await cli.action(`Leaving ${cli.color.cyan(context.app)}`, request)
 }
 
 let cmd = {
@@ -20,7 +19,7 @@ let cmd = {
   description: 'remove yourself from a team app',
   needsAuth: true,
   needsApp: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }
 
 let root = Object.assign({}, cmd, { topic: 'leave', command: null })

--- a/packages/orgs-v5/commands/apps/lock.js
+++ b/packages/orgs-v5/commands/apps/lock.js
@@ -1,10 +1,9 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
-  let app = yield heroku.get(`/teams/apps/${context.app}`)
+async function run(context, heroku) {
+  let app = await heroku.get(`/teams/apps/${context.app}`)
   if (app.locked) {
     throw new Error(`Error: cannot lock ${cli.color.cyan(app.name)}
 This app is already locked.`)
@@ -14,14 +13,14 @@ This app is already locked.`)
     path: `/teams/apps/${app.name}`,
     body: { locked: true }
   })
-  yield cli.action(`Locking ${cli.color.cyan(app.name)}`, request)
+  await cli.action(`Locking ${cli.color.cyan(app.name)}`, request)
 }
 
 let cmd = {
   description: 'prevent team members from joining an app',
   needsAuth: true,
   needsApp: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }
 
 module.exports = [

--- a/packages/orgs-v5/commands/apps/unlock.js
+++ b/packages/orgs-v5/commands/apps/unlock.js
@@ -1,10 +1,9 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
-  let app = yield heroku.get(`/teams/apps/${context.app}`)
+async function run(context, heroku) {
+  let app = await heroku.get(`/teams/apps/${context.app}`)
   if (!app.locked) {
     throw new Error(`Error: cannot unlock ${cli.color.cyan(app.name)}
 This app is not locked.`)
@@ -14,7 +13,7 @@ This app is not locked.`)
     path: `/teams/apps/${app.name}`,
     body: { locked: false }
   })
-  yield cli.action(`Unlocking ${cli.color.cyan(app.name)}`, request)
+  await cli.action(`Unlocking ${cli.color.cyan(app.name)}`, request)
 }
 
 let cmd = {
@@ -23,7 +22,7 @@ let cmd = {
   description: 'unlock an app so any team member can join',
   needsAuth: true,
   needsApp: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }
 
 let root = Object.assign({}, cmd, { topic: 'unlock', command: null })

--- a/packages/orgs-v5/commands/members/index.js
+++ b/packages/orgs-v5/commands/members/index.js
@@ -2,21 +2,20 @@
 
 let _ = require('lodash')
 let cli = require('heroku-cli-util')
-let co = require('co')
 let Utils = require('../../lib/utils')
 const { flags } = require('@heroku-cli/command')
 const { RoleCompletion } = require('@heroku-cli/command/lib/completions')
 
-function * run (context, heroku) {
-  let teamInfo = yield Utils.teamInfo(context, heroku)
+async function run(context, heroku) {
+  let teamInfo = await Utils.teamInfo(context, heroku)
   let groupName = context.flags.team
   let teamInvites = []
 
   if (teamInfo.type === 'team') {
-    let orgFeatures = yield heroku.get(`/teams/${groupName}/features`)
+    let orgFeatures = await heroku.get(`/teams/${groupName}/features`)
 
     if (orgFeatures.find(feature => feature.name === 'team-invite-acceptance' && feature.enabled)) {
-      teamInvites = yield heroku.request({
+      teamInvites = await heroku.request({
         headers: {
           Accept: 'application/vnd.heroku+json; version=3.team-invitations'
         },
@@ -29,7 +28,7 @@ function * run (context, heroku) {
     }
   }
 
-  let members = yield heroku.get(`/teams/${groupName}/members`)
+  let members = await heroku.get(`/teams/${groupName}/members`)
   // Set status '' to all existing members
   _.map(members, (member) => { member.status = '' })
   members = _.sortBy(_.union(members, teamInvites), 'email')
@@ -64,5 +63,5 @@ module.exports = {
     { name: 'json', description: 'output in json format' },
     flags.team({ name: 'team', hasValue: true, hidden: true })
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/orgs-v5/commands/members/set.js
+++ b/packages/orgs-v5/commands/members/set.js
@@ -1,19 +1,18 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 let Utils = require('../../lib/utils')
 const { flags } = require('@heroku-cli/command')
 const { RoleCompletion } = require('@heroku-cli/command/lib/completions')
 
-function * run (context, heroku) {
-  let teamInfo = yield Utils.teamInfo(context, heroku)
+async function run(context, heroku) {
+  let teamInfo = await Utils.teamInfo(context, heroku)
   let groupName = context.flags.team
   let email = context.args.email
   let role = context.flags.role
 
-  yield Utils.addMemberToTeam(email, role, groupName, heroku, 'PATCH')
-  yield Utils.warnIfAtTeamMemberLimit(teamInfo, groupName, context, heroku)
+  await Utils.addMemberToTeam(email, role, groupName, heroku, 'PATCH')
+  await Utils.warnIfAtTeamMemberLimit(teamInfo, groupName, context, heroku)
 }
 
 let set = {
@@ -27,7 +26,7 @@ let set = {
     { name: 'role', char: 'r', hasValue: true, required: true, description: 'member role (admin, collaborator, member, owner)', completion: RoleCompletion },
     flags.team({ name: 'team', hasValue: true, hidden: true })
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }
 
 module.exports = set

--- a/packages/orgs-v5/commands/orgs/default.js
+++ b/packages/orgs-v5/commands/orgs/default.js
@@ -1,9 +1,8 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run () {
+async function run() {
   cli.error(`orgs:default is no longer in the CLI.
 Use the HEROKU_ORGANIZATION environment variable instead.
 See ${cli.color.cyan('https://devcenter.heroku.com/articles/develop-orgs#default-org')} for more info.`)
@@ -13,5 +12,5 @@ module.exports = {
   topic: 'orgs',
   command: 'default',
   hidden: true,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/orgs-v5/commands/orgs/index.js
+++ b/packages/orgs-v5/commands/orgs/index.js
@@ -1,11 +1,10 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 let Utils = require('../../lib/utils')
 
-function * run (context, heroku) {
-  let orgs = yield heroku.get('/teams')
+async function run(context, heroku) {
+  let orgs = await heroku.get('/teams')
 
   if (context.flags.enterprise) {
     orgs = orgs.filter(o => o.type === 'enterprise')
@@ -27,5 +26,5 @@ module.exports = {
     { name: 'enterprise', hasValue: false, description: 'filter by enterprise teams' },
     { name: 'teams', hasValue: false, description: 'filter by teams', hidden: true }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/orgs-v5/commands/orgs/open.js
+++ b/packages/orgs-v5/commands/orgs/open.js
@@ -1,14 +1,13 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 const { flags } = require('@heroku-cli/command')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let team = context.flags.team
   if (!team) throw new Error('No team specified')
-  let org = yield heroku.get(`/teams/${team}`)
-  yield cli.open(`https://dashboard.heroku.com/teams/${org.name}`)
+  let org = await heroku.get(`/teams/${team}`)
+  await cli.open(`https://dashboard.heroku.com/teams/${org.name}`)
 }
 
 module.exports = {
@@ -20,5 +19,5 @@ module.exports = {
   flags: [
     flags.team({ name: 'team', hasValue: true, hidden: true })
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/orgs-v5/commands/teams/index.js
+++ b/packages/orgs-v5/commands/teams/index.js
@@ -1,14 +1,14 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 let Utils = require('../../lib/utils')
 
-function * run (context, heroku) {
-  let teams = yield heroku.get('/teams')
+async function run(context, heroku) {
+  let teams = await heroku.get('/teams')
   if (context.flags.json) Utils.printGroupsJSON(teams)
   else Utils.printGroups(teams, { label: 'Teams' })
 }
+
 module.exports = {
   topic: 'teams',
   description: `list the teams that you are a member of
@@ -18,5 +18,5 @@ Use ${cli.color.cmd('heroku members:*')} to manage team members.`,
   flags: [
     { name: 'json', description: 'output in json format' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/orgs-v5/lib/utils.js
+++ b/packages/orgs-v5/lib/utils.js
@@ -32,19 +32,19 @@ let printGroupsJSON = function (group) {
   cli.log(JSON.stringify(group, null, 2))
 }
 
-let teamInfo = function * (context, heroku) {
+let teamInfo = async function (context, heroku) {
   let teamName = context.flags.team
   if (!teamName) error.exit(1, 'No team or org specified.\nRun this command with --team')
-  return yield heroku.get(`/teams/${teamName}`)
+  return await heroku.get(`/teams/${teamName}`);
 }
 
-let addMemberToTeam = function * (email, role, groupName, heroku, method = 'PUT') {
+let addMemberToTeam = async function (email, role, groupName, heroku, method = 'PUT') {
   let request = heroku.request({
     method: method,
     path: `/teams/${groupName}/members`,
     body: {email, role}
   })
-  yield cli.action(`Adding ${cli.color.cyan(email)} to ${cli.color.magenta(groupName)} as ${cli.color.green(role)}`, request)
+  await cli.action(`Adding ${cli.color.cyan(email)} to ${cli.color.magenta(groupName)} as ${cli.color.green(role)}`, request)
 }
 
 let warnIfAtTeamMemberLimit = async function (teamInfo, groupName, context, heroku) {

--- a/packages/orgs-v5/package.json
+++ b/packages/orgs-v5/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "@heroku-cli/command": "^8.4.1",
-    "co": "^4.6.0",
     "heroku-cli-util": "^8.0.11",
     "inquirer": "^6.2.2",
     "lodash": "^4.17.11",

--- a/packages/pg-v5/commands/backups/cancel.js
+++ b/packages/pg-v5/commands/backups/cancel.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const pgbackups = require('../../lib/pgbackups')(context, heroku)
   const host = require('../../lib/host')()
   const { sortBy } = require('lodash')
@@ -12,11 +11,11 @@ function * run (context, heroku) {
 
   let transfer
   if (args.backup_id) {
-    let num = yield pgbackups.transfer.num(args.backup_id)
+    let num = await pgbackups.transfer.num(args.backup_id)
     if (!num) throw new Error(`Invalid backup: ${args.backup_id}`)
-    transfer = yield heroku.get(`/client/v11/apps/${app}/transfers/${num}`, { host })
+    transfer = await heroku.get(`/client/v11/apps/${app}/transfers/${num}`, { host })
   } else {
-    let transfers = yield heroku.get(`/client/v11/apps/${app}/transfers`, { host })
+    let transfers = await heroku.get(`/client/v11/apps/${app}/transfers`, { host })
     transfer = sortBy(transfers, 'created_at').reverse().find(t => !t.finished_at)
     if (!transfer) throw new Error('No active backups/transfers')
   }
@@ -32,5 +31,5 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   args: [{ name: 'backup_id', optional: true }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/backups/capture.js
+++ b/packages/pg-v5/commands/backups/capture.js
@@ -1,23 +1,22 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const pgbackups = require('../../lib/pgbackups')(context, heroku)
   const fetcher = require('../../lib/fetcher')(heroku)
   const host = require('../../lib/host')
 
   const { app, args, flags } = context
   const interval = Math.max(3, parseInt(flags['wait-interval'])) || 3
-  const db = yield fetcher.addon(app, args.database)
+  const db = await fetcher.addon(app, args.database)
 
   if (flags.snapshot) {
-    yield cli.action(`Taking snapshot of ${cli.color.addon(db.name)}`, co(function * () {
-      yield heroku.post(`/postgres/v0/databases/${db.id}/snapshots`, { host: host(db) })
-    }))
+    await cli.action(`Taking snapshot of ${cli.color.addon(db.name)}`, async function () {
+      await heroku.post(`/postgres/v0/databases/${db.id}/snapshots`, { host: host(db) })
+    }())
   } else {
-    let dbInfo = yield heroku.request({
+    let dbInfo = await heroku.request({
       host: host(db),
       method: 'get',
       path: `/client/v11/databases/${db.id}`
@@ -33,9 +32,9 @@ function * run (context, heroku) {
       }
     }
     let backup
-    yield cli.action(`Starting backup of ${cli.color.addon(db.name)}`, co(function * () {
-      backup = yield heroku.post(`/client/v11/databases/${db.id}/backups`, { host: host(db) })
-    }))
+    await cli.action(`Starting backup of ${cli.color.addon(db.name)}`, async function () {
+      backup = await heroku.post(`/client/v11/databases/${db.id}/backups`, { host: host(db) })
+    }())
     cli.log(`
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue running.
 Use ${cli.color.cmd('heroku pg:backups:info')} to check progress.
@@ -46,7 +45,7 @@ Stop a running backup with ${cli.color.cmd('heroku pg:backups:cancel')}.
 Use ${cli.color.cmd('heroku pg:backups -a ' + db.app.name)} to check the list of backups.
 `)
     }
-    yield pgbackups.wait(`Backing up ${cli.color.configVar(backup.from_name)} to ${cli.color.cyan(pgbackups.transfer.name(backup))}`, backup.uuid, interval, flags.verbose, db.app.name)
+    await pgbackups.wait(`Backing up ${cli.color.configVar(backup.from_name)} to ${cli.color.cyan(pgbackups.transfer.name(backup))}`, backup.uuid, interval, flags.verbose, db.app.name)
   }
 }
 
@@ -62,5 +61,5 @@ module.exports = {
     { name: 'snapshot', hidden: true },
     { name: 'verbose', char: 'v' }
   ],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/backups/delete.js
+++ b/packages/pg-v5/commands/backups/delete.js
@@ -1,22 +1,21 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const host = require('../../lib/host')()
   const pgbackups = require('../../lib/pgbackups')(context, heroku)
 
   const { app, args, flags } = context
 
-  yield cli.confirmApp(app, flags.confirm)
+  await cli.confirmApp(app, flags.confirm)
 
-  yield cli.action(`Deleting backup ${cli.color.cyan(args.backup_id)} on ${cli.color.app(app)}`, co(function * () {
-    let num = yield pgbackups.transfer.num(args.backup_id)
+  await cli.action(`Deleting backup ${cli.color.cyan(args.backup_id)} on ${cli.color.app(app)}`, async function () {
+    let num = await pgbackups.transfer.num(args.backup_id)
     if (!num) throw new Error(`Invalid Backup: ${args.backup_id}`)
 
-    yield heroku.delete(`/client/v11/apps/${app}/transfers/${num}`, { host })
-  }))
+    await heroku.delete(`/client/v11/apps/${app}/transfers/${num}`, { host })
+  }())
 }
 
 module.exports = {
@@ -27,5 +26,5 @@ module.exports = {
   needsAuth: true,
   args: [{ name: 'backup_id' }],
   flags: [{ name: 'confirm', char: 'c', hasValue: true }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/backups/download.js
+++ b/packages/pg-v5/commands/backups/download.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
 function defaultFilename () {
@@ -13,7 +12,7 @@ function defaultFilename () {
   return f
 }
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const host = require('../../lib/host')()
   const pgbackups = require('../../lib/pgbackups')(context, heroku)
   const download = require('../../lib/download')
@@ -24,23 +23,23 @@ function * run (context, heroku) {
 
   let num, info
 
-  yield cli.action(`Getting backup from ${cli.color.app(app)}`, co(function * () {
+  await cli.action(`Getting backup from ${cli.color.app(app)}`, async function () {
     if (args.backup_id) {
-      num = yield pgbackups.transfer.num(args.backup_id)
+      num = await pgbackups.transfer.num(args.backup_id)
       if (!num) throw new Error(`Invalid Backup: ${args.backup_id}`)
     } else {
-      let transfers = yield heroku.get(`/client/v11/apps/${app}/transfers`, { host })
+      let transfers = await heroku.get(`/client/v11/apps/${app}/transfers`, { host })
       let lastBackup = sortBy(transfers.filter(t => t.succeeded && t.to_type === 'gof3r'), 'created_at').pop()
       if (!lastBackup) throw new Error(`No backups on ${cli.color.app(app)}. Capture one with ${cli.color.cmd('heroku pg:backups:capture')}`)
       num = lastBackup.num
     }
     cli.action.status(`fetching url of #${num}`)
 
-    info = yield heroku.post(`/client/v11/apps/${app}/transfers/${num}/actions/public-url`, { host })
+    info = await heroku.post(`/client/v11/apps/${app}/transfers/${num}/actions/public-url`, { host })
     cli.action.done(`done, #${num}`)
-  }))
+  }())
 
-  yield download(info.url, output, { progress: true })
+  await download(info.url, output, { progress: true })
 }
 
 module.exports = {
@@ -53,5 +52,5 @@ module.exports = {
   flags: [
     { name: 'output', char: 'o', description: 'location to download to. Defaults to latest.dump', hasValue: true }
   ],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/backups/index.js
+++ b/packages/pg-v5/commands/backups/index.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   if (context.args.length > 0) {
     // backwards compatible for executing commands like
     // `heroku pg:backups info` instead of `heroku pg:backups:info`
@@ -27,13 +26,13 @@ function * run (context, heroku) {
 
     context = Object.assign(context, { args })
 
-    yield cmd.run(context, heroku)
+    await cmd.run(context, heroku)
   } else {
-    yield list(context, heroku)
+    await list(context, heroku)
   }
 }
 
-function * list (context, heroku) {
+async function list(context, heroku) {
   const pgbackups = require('../../lib/pgbackups')(context, heroku)
   const { sortBy } = require('lodash')
   const host = require('../../lib/host')()
@@ -96,7 +95,7 @@ function * list (context, heroku) {
     cli.log()
   }
 
-  let transfers = yield heroku.get(`/client/v11/apps/${app}/transfers`, { host })
+  let transfers = await heroku.get(`/client/v11/apps/${app}/transfers`, { host })
   transfers = sortBy(transfers, 'created_at').reverse()
 
   let backups = transfers.filter(t => t.from_type === 'pg_dump' && t.to_type === 'gof3r')
@@ -124,5 +123,5 @@ module.exports = {
     { name: 'at', hasValue: true, hidden: true },
     { name: 'quiet', char: 'q', hidden: true }
   ],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/backups/restore.js
+++ b/packages/pg-v5/commands/backups/restore.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
 function dropboxURL (url) {
@@ -14,7 +13,7 @@ function dropboxURL (url) {
   return url
 }
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const pgbackups = require('../../lib/pgbackups')(context, heroku)
   const fetcher = require('../../lib/fetcher')(heroku)
   const host = require('../../lib/host')
@@ -22,7 +21,7 @@ function * run (context, heroku) {
 
   const { app, args, flags } = context
   const interval = Math.max(3, parseInt(flags['wait-interval'])) || 3
-  const db = yield fetcher.addon(app, args.database)
+  const db = await fetcher.addon(app, args.database)
 
   let backupURL
   let backupName = args.backup
@@ -36,7 +35,7 @@ function * run (context, heroku) {
     } else {
       backupApp = app
     }
-    let transfers = yield heroku.get(`/client/v11/apps/${backupApp}/transfers`, { host: host() })
+    let transfers = await heroku.get(`/client/v11/apps/${backupApp}/transfers`, { host: host() })
     let backups = transfers.filter(t => t.from_type === 'pg_dump' && t.to_type === 'gof3r')
     let backup
     if (backupName) {
@@ -51,21 +50,21 @@ function * run (context, heroku) {
     backupURL = backup.to_url
   }
 
-  yield cli.confirmApp(app, flags.confirm)
+  await cli.confirmApp(app, flags.confirm)
   let restore
-  yield cli.action(`Starting restore of ${cli.color.cyan(backupName)} to ${cli.color.addon(db.name)}`, co(function * () {
-    restore = yield heroku.post(`/client/v11/databases/${db.id}/restores`, {
+  await cli.action(`Starting restore of ${cli.color.cyan(backupName)} to ${cli.color.addon(db.name)}`, async function () {
+    restore = await heroku.post(`/client/v11/databases/${db.id}/restores`, {
       body: { backup_url: backupURL },
       host: host(db)
     })
-  }))
+  }())
   cli.log(`
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue restoring.
 Use ${cli.color.cmd('heroku pg:backups')} to check progress.
 Stop a running restore with ${cli.color.cmd('heroku pg:backups:cancel')}.
 `)
 
-  yield pgbackups.wait('Restoring', restore.uuid, interval, flags.verbose, db.app.name)
+  await pgbackups.wait('Restoring', restore.uuid, interval, flags.verbose, db.app.name)
 }
 
 module.exports = {
@@ -84,5 +83,5 @@ module.exports = {
     { name: 'verbose', char: 'v' },
     { name: 'confirm', char: 'c', hasValue: true }
   ],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/backups/schedules.js
+++ b/packages/pg-v5/commands/backups/schedules.js
@@ -1,15 +1,14 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const host = require('../../lib/host')
   const fetcher = require('../../lib/fetcher')(heroku)
   const { app } = context
 
-  let db = yield fetcher.arbitraryAppDB(app)
-  let schedules = yield heroku.get(`/client/v11/databases/${db.id}/transfer-schedules`, { host: host(db) })
+  let db = await fetcher.arbitraryAppDB(app)
+  let schedules = await heroku.get(`/client/v11/databases/${db.id}/transfer-schedules`, { host: host(db) })
 
   if (!schedules.length) {
     cli.warn(`No backup schedules found on ${cli.color.app(app)}
@@ -28,5 +27,5 @@ module.exports = {
   description: 'list backup schedule',
   needsApp: true,
   needsAuth: true,
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/backups/unschedule.js
+++ b/packages/pg-v5/commands/backups/unschedule.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const host = require('../../lib/host')
   const fetcher = require('../../lib/fetcher')(heroku)
 
@@ -11,8 +10,8 @@ function * run (context, heroku) {
   let db = args.database
 
   if (!args.database) {
-    let appDB = yield fetcher.arbitraryAppDB(app)
-    let schedules = yield heroku.get(`/client/v11/databases/${appDB.id}/transfer-schedules`, { host: host(appDB) })
+    let appDB = await fetcher.arbitraryAppDB(app)
+    let schedules = await heroku.get(`/client/v11/databases/${appDB.id}/transfer-schedules`, { host: host(appDB) })
     if (!schedules.length) throw new Error(`No schedules on ${cli.color.app(app)}`)
     if (schedules.length > 1) {
       throw new Error(`Specify schedule on ${cli.color.app(app)}. Existing schedules: ${schedules.map(s => cli.color.configVar(s.name)).join(', ')}`)
@@ -20,15 +19,15 @@ function * run (context, heroku) {
     db = schedules[0].name
   }
 
-  yield cli.action(`Unscheduling ${cli.color.configVar(db)} daily backups`, co(function * () {
-    let addon = yield fetcher.addon(app, db)
-    let schedules = yield heroku.get(`/client/v11/databases/${addon.id}/transfer-schedules`, { host: host(addon) })
+  await cli.action(`Unscheduling ${cli.color.configVar(db)} daily backups`, async function () {
+    let addon = await fetcher.addon(app, db)
+    let schedules = await heroku.get(`/client/v11/databases/${addon.id}/transfer-schedules`, { host: host(addon) })
     let schedule = schedules.find(s => s.name.match(new RegExp(db, 'i')))
     if (!schedule) throw new Error(`No daily backups found for ${cli.color.addon(addon.name)}`)
-    yield heroku.delete(`/client/v11/databases/${addon.id}/transfer-schedules/${schedule.uuid}`, {
+    await heroku.delete(`/client/v11/databases/${addon.id}/transfer-schedules/${schedule.uuid}`, {
       host: host(addon)
     })
-  }))
+  }())
 }
 
 module.exports = {
@@ -40,5 +39,5 @@ module.exports = {
   args: [
     { name: 'database', optional: true }
   ],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/backups/url.js
+++ b/packages/pg-v5/commands/backups/url.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const host = require('../../lib/host')()
   const pgbackups = require('../../lib/pgbackups')(context, heroku)
   const { sortBy } = require('lodash')
@@ -13,16 +12,16 @@ function * run (context, heroku) {
   let num
 
   if (args.backup_id) {
-    num = yield pgbackups.transfer.num(args.backup_id)
+    num = await pgbackups.transfer.num(args.backup_id)
     if (!num) throw new Error(`Invalid Backup: ${args.backup_id}`)
   } else {
-    let transfers = yield heroku.get(`/client/v11/apps/${app}/transfers`, { host })
+    let transfers = await heroku.get(`/client/v11/apps/${app}/transfers`, { host })
     let lastBackup = sortBy(transfers.filter(t => t.succeeded && t.to_type === 'gof3r'), 'created_at').pop()
     if (!lastBackup) throw new Error(`No backups on ${cli.color.app(app)}. Capture one with ${cli.color.cmd('heroku pg:backups:capture')}`)
     num = lastBackup.num
   }
 
-  let info = yield heroku.post(`/client/v11/apps/${app}/transfers/${num}/actions/public-url`, { host })
+  let info = await heroku.post(`/client/v11/apps/${app}/transfers/${num}/actions/public-url`, { host })
   cli.log(info.url)
 }
 
@@ -36,7 +35,7 @@ let cmd = {
     // ignored but present for backwards compatibility
     { name: 'quiet', char: 'q', hidden: true }
   ],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }
 
 module.exports = [

--- a/packages/pg-v5/commands/bloat.js
+++ b/packages/pg-v5/commands/bloat.js
@@ -1,13 +1,12 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const fetcher = require('../lib/fetcher')(heroku)
   const psql = require('../lib/psql')
 
-  let db = yield fetcher.database(context.app, context.args.database)
+  let db = await fetcher.database(context.app, context.args.database)
 
   let query = `
 WITH constants AS (
@@ -72,7 +71,7 @@ FROM
 ORDER BY raw_waste DESC, bloat DESC
 `
 
-  let output = yield psql.exec(db, query)
+  let output = await psql.exec(db, query)
   process.stdout.write(output)
 }
 
@@ -82,7 +81,7 @@ const cmd = {
   needsApp: true,
   needsAuth: true,
   args: [{ name: 'database', optional: true }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }
 
 module.exports = [

--- a/packages/pg-v5/commands/blocking.js
+++ b/packages/pg-v5/commands/blocking.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
 const query = `
@@ -20,12 +19,12 @@ ON bl.transactionid = kl.transactionid AND bl.pid != kl.pid
 WHERE NOT bl.granted
 `
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const fetcher = require('../lib/fetcher')(heroku)
   const psql = require('../lib/psql')
 
-  let db = yield fetcher.database(context.app, context.args.database)
-  let output = yield psql.exec(db, query)
+  let db = await fetcher.database(context.app, context.args.database)
+  let output = await psql.exec(db, query)
   process.stdout.write(output)
 }
 
@@ -35,7 +34,7 @@ const cmd = {
   needsApp: true,
   needsAuth: true,
   args: [{ name: 'database', optional: true }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }
 
 module.exports = [

--- a/packages/pg-v5/commands/connection_pooling.js
+++ b/packages/pg-v5/commands/connection_pooling.js
@@ -1,20 +1,19 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 const host = require('../lib/host')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const util = require('../lib/util')
   const fetcher = require('../lib/fetcher')(heroku)
   const { app, args, flags } = context
 
-  let db = yield fetcher.addon(app, args.database)
-  let addon = yield heroku.get(`/addons/${encodeURIComponent(db.name)}`)
+  let db = await fetcher.addon(app, args.database)
+  let addon = await heroku.get(`/addons/${encodeURIComponent(db.name)}`)
 
   if (util.starterPlan(db)) throw new Error('This operation is not supported by Hobby tier databases.')
 
-  let attachment = yield cli.action(
+  let attachment = await cli.action(
     `Enabling Connection Pooling on ${cli.color.addon(addon.name)} to ${cli.color.app(app)}`,
     heroku.post(`/client/v11/databases/${encodeURIComponent(db.name)}/connection-pooling`, {
       body: { name: flags.as, credential: 'default', app: app },
@@ -22,16 +21,16 @@ function * run (context, heroku) {
     })
   )
 
-  yield cli.action(
+  await cli.action(
     `Setting ${cli.color.attachment(attachment.name)} config vars and restarting ${cli.color.app(app)}`,
     { success: false },
-    co(function * () {
-      let releases = yield heroku.get(`/apps/${app}/releases`, {
+    async function () {
+      let releases = await heroku.get(`/apps/${app}/releases`, {
         partial: true,
         headers: { 'Range': 'version ..; max=1, order=desc' }
       })
       cli.action.done(`done, v${releases[0].version}`)
-    })
+    }()
   )
 }
 
@@ -49,5 +48,5 @@ module.exports = {
   flags: [
     { name: 'as', description: 'name for add-on attachment', hasValue: true }
   ],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/copy.js
+++ b/packages/pg-v5/commands/copy.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const url = require('url')
   const host = require('../lib/host')
   const pgbackups = require('../lib/pgbackups')(context, heroku)
@@ -19,7 +18,7 @@ function * run (context, heroku) {
     return output
   }
 
-  let resolve = co.wrap(function * (db) {
+  let resolve = async function (db) {
     if (db.match(/^postgres:\/\//)) {
       // For the case an input is URL format
       let uri = url.parse(db)
@@ -32,12 +31,12 @@ function * run (context, heroku) {
       }
     } else {
       // Other case (need to resolve attachment)
-      let attachment = yield fetcher.attachment(app, db)
+      let attachment = await fetcher.attachment(app, db)
       if (!attachment) throw new Error(`${db} not found on ${cli.color.app(app)}`)
-      let [addon, config] = yield [
+      let [addon, config] = await Promise.all([
         heroku.get(`/addons/${attachment.addon.name}`),
         heroku.get(`/apps/${attachment.app.name}/config-vars`)
-      ]
+      ])
       attachment.addon = addon
       config = upperCaseConfig(config) // Upper case config var keys
       return {
@@ -47,7 +46,7 @@ function * run (context, heroku) {
         confirm: app
       }
     }
-  })
+  }
 
   // Get source and target from inputs
   // source/target format:
@@ -56,19 +55,19 @@ function * run (context, heroku) {
   //  * just color: PINK
   //  * addon name: my-heroku-addon-name
   //  * app name + color/config: myapp::ORANGE
-  let [source, target] = yield [resolve(args.source), resolve(args.target)]
+  let [source, target] = await Promise.all([resolve(args.source), resolve(args.target)])
   if (source.url === target.url) throw new Error('Cannot copy database onto itself')
 
-  yield cli.confirmApp(target.confirm, flags.confirm, `WARNING: Destructive action
+  await cli.confirmApp(target.confirm, flags.confirm, `WARNING: Destructive action
 This command will remove all data from ${cli.color.yellow(target.name)}
 Data from ${cli.color.yellow(source.name)} will then be transferred to ${cli.color.yellow(target.name)}`)
 
   let copy
   let attachment
-  yield cli.action(`Starting copy of ${cli.color.yellow(source.name)} to ${cli.color.yellow(target.name)}`, co(function * () {
+  await cli.action(`Starting copy of ${cli.color.yellow(source.name)} to ${cli.color.yellow(target.name)}`, async function () {
     attachment = target.attachment || source.attachment
     if (!attachment) throw new Error('Heroku PostgreSQL database must be source or target')
-    copy = yield heroku.post(`/client/v11/databases/${attachment.addon.id}/transfers`, {
+    copy = await heroku.post(`/client/v11/databases/${attachment.addon.id}/transfers`, {
       body: {
         from_name: source.name,
         from_url: source.url,
@@ -77,16 +76,16 @@ Data from ${cli.color.yellow(source.name)} will then be transferred to ${cli.col
       },
       host: host(attachment.addon)
     })
-  }))
+  }())
 
   if (source.attachment) {
-    let credentials = yield heroku.get(`/postgres/v0/databases/${source.attachment.addon.name}/credentials`,
+    let credentials = await heroku.get(`/postgres/v0/databases/${source.attachment.addon.name}/credentials`,
       { host: host(source.attachment.addon) })
     if (credentials.length > 1) {
       cli.action.warn(`pg:copy will only copy your default credential and the data it has access to. Any additional credentials and data that only they can access will not be copied.`)
     }
   }
-  yield pgbackups.wait('Copying', copy.uuid, interval, flags.verbose, attachment.addon.app.name)
+  await pgbackups.wait('Copying', copy.uuid, interval, flags.verbose, attachment.addon.app.name)
 }
 
 module.exports = {
@@ -105,5 +104,5 @@ module.exports = {
     { name: 'verbose' },
     { name: 'confirm', hasValue: true }
   ],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/credentials.js
+++ b/packages/pg-v5/commands/credentials.js
@@ -1,18 +1,17 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 const { sortBy } = require('lodash')
 const util = require('../lib/util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const fetcher = require('../lib/fetcher')(heroku)
 
   const { app, args, flags } = context
 
-  let showCredentials = co.wrap(function * () {
+  let showCredentials = async function () {
     const host = require('../lib/host')
-    let addon = yield fetcher.addon(app, args.database)
+    let addon = await fetcher.addon(app, args.database)
     let attachments = []
     let credentials = []
 
@@ -26,11 +25,11 @@ function * run (context, heroku) {
       return util.presentCredentialAttachments(app, credAttachments, credentials, cred)
     }
 
-    credentials = yield heroku.get(`/postgres/v0/databases/${addon.name}/credentials`,
+    credentials = await heroku.get(`/postgres/v0/databases/${addon.name}/credentials`,
       { host: host(addon) })
     let isDefaultCredential = (cred) => cred.name !== 'default'
     credentials = sortBy(credentials, isDefaultCredential, 'name')
-    attachments = yield heroku.get(`/addons/${addon.name}/addon-attachments`)
+    attachments = await heroku.get(`/addons/${addon.name}/addon-attachments`)
 
     cli.warn(`${cli.color.cmd('pg:credentials')} has recently changed. Please use ${cli.color.cmd('pg:credentials:url')} for the previous output.`)
     cli.table(credentials, {
@@ -39,12 +38,12 @@ function * run (context, heroku) {
         { key: 'state', label: 'State' }
       ]
     })
-  })
+  }
 
   if (flags.reset) {
     cli.error(`${cli.color.cmd('pg:credentials --reset')} is deprecated. Please use ${cli.color.cmd('pg:credentials:rotate')} instead.`)
   } else {
-    yield showCredentials()
+    await showCredentials()
   }
 }
 
@@ -56,5 +55,5 @@ module.exports = {
   needsAuth: true,
   flags: [{ name: 'reset', description: 'DEPRECATED' }],
   args: [{ name: 'database', optional: true }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/credentials/create.js
+++ b/packages/pg-v5/commands/credentials/create.js
@@ -1,24 +1,23 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const fetcher = require('../../lib/fetcher')(heroku)
   const host = require('../../lib/host')
   const util = require('../../lib/util')
 
   const { app, args, flags } = context
 
-  let db = yield fetcher.addon(app, args.database)
+  let db = await fetcher.addon(app, args.database)
   if (util.starterPlan(db)) throw new Error('This operation is not supported by Hobby tier databases.')
 
   let data = {
     name: flags.name
   }
-  yield cli.action(`Creating credential ${cli.color.cmd(flags.name)}`, co(function * () {
-    yield heroku.post(`/postgres/v0/databases/${db.name}/credentials`, { host: host(db), body: data })
-  }))
+  await cli.action(`Creating credential ${cli.color.cmd(flags.name)}`, async function () {
+    await heroku.post(`/postgres/v0/databases/${db.name}/credentials`, { host: host(db), body: data })
+  }())
   let attachCmd = `heroku addons:attach ${db.name} --credential ${flags.name} -a ${app}`
   let psqlCmd = `heroku pg:psql ${db.name} -a ${app}`
   cli.log(`
@@ -38,5 +37,5 @@ module.exports = {
 `,
   args: [{ name: 'database', optional: true }],
   flags: [{ name: 'name', char: 'n', hasValue: true, required: true, description: 'name of the new credential within the database' }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/credentials/destroy.js
+++ b/packages/pg-v5/commands/credentials/destroy.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const fetcher = require('../../lib/fetcher')(heroku)
   const host = require('../../lib/host')
   const util = require('../../lib/util')
@@ -15,21 +14,21 @@ function * run (context, heroku) {
     throw new Error('Default credential cannot be destroyed.')
   }
 
-  let db = yield fetcher.addon(app, args.database)
+  let db = await fetcher.addon(app, args.database)
   if (util.starterPlan(db)) {
     throw new Error(`Only one default credential is supported for Hobby tier databases.`)
   }
 
-  let attachments = yield heroku.get(`/addons/${db.name}/addon-attachments`)
+  let attachments = await heroku.get(`/addons/${db.name}/addon-attachments`)
   let credAttachments = attachments.filter(a => a.namespace === `credential:${flags.name}`)
   let credAttachmentApps = Array.from(new Set(credAttachments.map(a => a.app.name)))
   if (credAttachmentApps.length > 0) throw new Error(`Credential ${flags.name} must be detached from the app${credAttachmentApps.length > 1 ? 's' : ''} ${credAttachmentApps.map(name => cli.color.app(name)).join(', ')} before destroying.`)
 
-  yield cli.confirmApp(app, flags.confirm, `WARNING: Destructive action`)
+  await cli.confirmApp(app, flags.confirm, `WARNING: Destructive action`)
 
-  yield cli.action(`Destroying credential ${cli.color.cmd(cred)}`, co(function * () {
-    yield heroku.delete(`/postgres/v0/databases/${db.name}/credentials/${encodeURIComponent(cred)}`, { host: host(db) })
-  }))
+  await cli.action(`Destroying credential ${cli.color.cmd(cred)}`, async function () {
+    await heroku.delete(`/postgres/v0/databases/${db.name}/credentials/${encodeURIComponent(cred)}`, { host: host(db) })
+  }())
 
   cli.log(`The credential has been destroyed within ${db.name}.`)
   cli.log(`Database objects owned by ${cred} will be assigned to the default credential.`)
@@ -50,5 +49,5 @@ module.exports = {
     { name: 'name', char: 'n', hasValue: true, required: true, description: 'unique identifier for the credential' },
     { name: 'confirm', char: 'c', hasValue: true }
   ],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/credentials/repair_default.js
+++ b/packages/pg-v5/commands/credentials/repair_default.js
@@ -1,26 +1,25 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const fetcher = require('../../lib/fetcher')(heroku)
   const host = require('../../lib/host')
   const util = require('../../lib/util')
 
   const { app, args, flags } = context
 
-  let db = yield fetcher.addon(app, args.database)
+  let db = await fetcher.addon(app, args.database)
   if (util.starterPlan(db)) throw new Error('This operation is not supported by Hobby tier databases.')
 
-  yield cli.confirmApp(app, flags.confirm, `WARNING: Destructive Action
+  await cli.confirmApp(app, flags.confirm, `WARNING: Destructive Action
 Ownership of all database objects owned by additional credentials will be transferred to the default credential.
 This command will also grant the default credential admin option for all additional credentials.
 `)
 
-  yield cli.action(`Resetting permissions and object ownership for default role to factory settings`, co(function * () {
-    yield heroku.post(`/postgres/v0/databases/${db.name}/repair-default`, { host: host(db) })
-  }))
+  await cli.action(`Resetting permissions and object ownership for default role to factory settings`, async function () {
+    await heroku.post(`/postgres/v0/databases/${db.name}/repair-default`, { host: host(db) })
+  }())
 }
 
 module.exports = {
@@ -37,5 +36,5 @@ module.exports = {
   flags: [
     { name: 'confirm', char: 'c', hasValue: true }
   ],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/credentials/url.js
+++ b/packages/pg-v5/commands/credentials/url.js
@@ -1,22 +1,21 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 const url = require('url')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const host = require('../../lib/host')
   const fetcher = require('../../lib/fetcher')(heroku)
   const util = require('../../lib/util')
 
   const { app, args, flags } = context
 
-  let db = yield fetcher.addon(app, args.database)
+  let db = await fetcher.addon(app, args.database)
   let cred = flags.name || 'default'
   if (util.starterPlan(db) && cred !== 'default') {
     throw new Error(`Only one default credential is supported for Hobby tier databases.`)
   }
-  let credInfo = yield heroku.get(`/postgres/v0/databases/${db.name}/credentials/${encodeURIComponent(cred)}`,
+  let credInfo = await heroku.get(`/postgres/v0/databases/${db.name}/credentials/${encodeURIComponent(cred)}`,
     { host: host(db) })
 
   let activeCreds = credInfo.credentials.find((c) => c.state === 'active')
@@ -57,5 +56,5 @@ module.exports = {
     { name: 'name', char: 'n', description: 'which credential to show (default credentials if not specified)', hasValue: true }
   ],
   args: [{ name: 'database', optional: true }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/kill.js
+++ b/packages/pg-v5/commands/kill.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const fetcher = require('../lib/fetcher')
   const psql = require('../lib/psql')
 
@@ -11,12 +10,12 @@ function * run (context, heroku) {
   const { pid, database } = args
   const { force } = flags
 
-  let db = yield fetcher(heroku).database(app, database)
+  let db = await fetcher(heroku).database(app, database)
 
   let query = `
 SELECT ${force ? 'pg_terminate_backend' : 'pg_cancel_backend'}(${parseInt(pid)});`
 
-  let output = yield psql.exec(db, query)
+  let output = await psql.exec(db, query)
   process.stdout.write(output)
 }
 
@@ -31,5 +30,5 @@ module.exports = {
     { name: 'pid' },
     { name: 'database', optional: true }
   ],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/killall.js
+++ b/packages/pg-v5/commands/killall.js
@@ -1,16 +1,15 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const fetcher = require('../lib/fetcher')(heroku)
   const host = require('../lib/host')
 
-  yield cli.action('Terminating connections for all credentials', co(function * () {
-    const db = yield fetcher.addon(context.app, context.args.database)
-    yield heroku.post(`/client/v11/databases/${db.id}/connection_reset`, { host: host(db) })
-  }))
+  await cli.action('Terminating connections for all credentials', async function () {
+    const db = await fetcher.addon(context.app, context.args.database)
+    await heroku.post(`/client/v11/databases/${db.id}/connection_reset`, { host: host(db) })
+  }())
 }
 
 module.exports = {
@@ -20,5 +19,5 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   args: [{ name: 'database', optional: true }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/links/create.js
+++ b/packages/pg-v5/commands/links/create.js
@@ -1,27 +1,26 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const host = require('../../lib/host')
   const fetcher = require('../../lib/fetcher')(heroku)
   const addons = require('@heroku-cli/plugin-addons').resolve
   let { app, args, flags } = context
 
-  let service = co.wrap(function * (name) {
-    let addon = yield addons.addon(heroku, app, name)
+  let service = async function (name) {
+    let addon = await addons.addon(heroku, app, name)
     if (!addon.plan.name.match(/^heroku-(redis|postgresql)/)) throw new Error('Remote database must be heroku-redis or heroku-postgresql')
     return addon
-  })
+  }
 
-  const [db, target] = yield [
+  const [db, target] = await Promise.all([
     fetcher.addon(app, args.database),
     service(args.remote)
-  ]
+  ])
 
-  yield cli.action(`Adding link from ${cli.color.addon(target.name)} to ${cli.color.addon(db.name)}`, co(function * () {
-    let link = yield heroku.post(`/client/v11/databases/${db.id}/links`, {
+  await cli.action(`Adding link from ${cli.color.addon(target.name)} to ${cli.color.addon(db.name)}`, async function () {
+    let link = await heroku.post(`/client/v11/databases/${db.id}/links`, {
       body: {
         target: target.name,
         as: flags.as
@@ -30,7 +29,7 @@ function * run (context, heroku) {
     })
     if (link.message) throw new Error(link.message)
     cli.action.done(`done, ${cli.color.cyan(link.name)}`)
-  }))
+  }())
 }
 
 module.exports = {
@@ -44,5 +43,5 @@ module.exports = {
   needsAuth: true,
   args: [{ name: 'remote' }, { name: 'database' }],
   flags: [{ name: 'as', hasValue: true, description: 'name of link to create' }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/links/destroy.js
+++ b/packages/pg-v5/commands/links/destroy.js
@@ -1,23 +1,22 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const host = require('../../lib/host')
   const fetcher = require('../../lib/fetcher')(heroku)
   let { app, args, flags } = context
 
-  const db = yield fetcher.addon(app, args.database)
+  const db = await fetcher.addon(app, args.database)
 
-  yield cli.confirmApp(app, flags.confirm, `WARNING: Destructive action
+  await cli.confirmApp(app, flags.confirm, `WARNING: Destructive action
 This command will affect the database ${cli.color.addon(db.name)}
 This will delete ${cli.color.cyan(args.link)} along with the tables and views created within it.
 This may have adverse effects for software written against the ${cli.color.cyan(args.link)} schema.
 `)
-  yield cli.action(`Destroying link ${cli.color.cyan(args.link)} from ${cli.color.addon(db.name)}`, co(function * () {
-    yield heroku.delete(`/client/v11/databases/${db.id}/links/${encodeURIComponent(args.link)}`, { host: host(db) })
-  }))
+  await cli.action(`Destroying link ${cli.color.cyan(args.link)} from ${cli.color.addon(db.name)}`, async function () {
+    await heroku.delete(`/client/v11/databases/${db.id}/links/${encodeURIComponent(args.link)}`, { host: host(db) })
+  }())
 }
 
 module.exports = {
@@ -31,5 +30,5 @@ module.exports = {
   needsAuth: true,
   args: [{ name: 'database' }, { name: 'link' }],
   flags: [{ name: 'confirm', char: 'c', hasValue: true }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/locks.js
+++ b/packages/pg-v5/commands/locks.js
@@ -1,13 +1,12 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const fetcher = require('../lib/fetcher')(heroku)
   const psql = require('../lib/psql')
 
-  let db = yield fetcher.database(context.app, context.args.database)
+  let db = await fetcher.database(context.app, context.args.database)
 
   let truncatedQueryString = prefix => {
     let column = `${prefix}query`
@@ -35,7 +34,7 @@ function * run (context, heroku) {
     AND pg_stat_activity.pid <> pg_backend_pid() order by query_start;
   `
 
-  let output = yield psql.exec(db, query)
+  let output = await psql.exec(db, query)
   process.stdout.write(output)
 }
 
@@ -46,7 +45,7 @@ const cmd = {
   needsAuth: true,
   args: [{ name: 'database', optional: true }],
   flags: [{ name: 'truncate', char: 't', description: 'truncates queries to 40 charaters' }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }
 
 module.exports = [

--- a/packages/pg-v5/commands/maintenance/index.js
+++ b/packages/pg-v5/commands/maintenance/index.js
@@ -1,17 +1,16 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const fetcher = require('../../lib/fetcher')(heroku)
   const host = require('../../lib/host')
   const util = require('../../lib/util')
   const { app, args } = context
-  const db = yield fetcher.addon(app, args.database)
+  const db = await fetcher.addon(app, args.database)
 
   if (util.starterPlan(db)) throw new Error('pg:maintenance is only available for production databases')
-  let info = yield heroku.get(`/client/v11/databases/${db.id}/maintenance`, { host: host(db) })
+  let info = await heroku.get(`/client/v11/databases/${db.id}/maintenance`, { host: host(db) })
   cli.log(info.message)
 }
 
@@ -22,5 +21,5 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   args: [{ name: 'database', optional: true }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/maintenance/run.js
+++ b/packages/pg-v5/commands/maintenance/run.js
@@ -1,24 +1,23 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const fetcher = require('../../lib/fetcher')(heroku)
   const host = require('../../lib/host')
   const util = require('../../lib/util')
   const { app, args, flags } = context
-  const db = yield fetcher.addon(app, args.database)
+  const db = await fetcher.addon(app, args.database)
 
   if (util.starterPlan(db)) throw new Error('pg:maintenance is only available for production databases')
-  yield cli.action(`Starting maintenance for ${cli.color.addon(db.name)}`, co(function * () {
+  await cli.action(`Starting maintenance for ${cli.color.addon(db.name)}`, async function () {
     if (!flags.force) {
-      let appInfo = yield heroku.get(`/apps/${app}`)
+      let appInfo = await heroku.get(`/apps/${app}`)
       if (!appInfo.maintenance) throw new Error('Application must be in maintenance mode or run with --force')
     }
-    let response = yield heroku.post(`/client/v11/databases/${db.id}/maintenance`, { host: host(db) })
+    let response = await heroku.post(`/client/v11/databases/${db.id}/maintenance`, { host: host(db) })
     cli.action.done(response.message || 'done')
-  }))
+  }())
 }
 
 module.exports = {
@@ -29,5 +28,5 @@ module.exports = {
   needsAuth: true,
   args: [{ name: 'database', optional: true }],
   flags: [{ name: 'force', char: 'f' }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/maintenance/window.js
+++ b/packages/pg-v5/commands/maintenance/window.js
@@ -1,26 +1,25 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const fetcher = require('../../lib/fetcher')(heroku)
   const host = require('../../lib/host')
   const util = require('../../lib/util')
   const { app, args } = context
-  const db = yield fetcher.addon(app, args.database)
+  const db = await fetcher.addon(app, args.database)
 
   if (util.starterPlan(db)) throw new Error('pg:maintenance is only available for production databases')
 
   if (!args.window.match(/^[A-Za-z]{2,10} \d\d?:[03]0$/)) throw new Error('Window must be "Day HH:MM" where MM is 00 or 30')
 
-  yield cli.action(`Setting maintenance window for ${cli.color.addon(db.name)} to ${cli.color.cyan(args.window)}`, co(function * () {
-    let response = yield heroku.put(`/client/v11/databases/${db.id}/maintenance_window`, {
+  await cli.action(`Setting maintenance window for ${cli.color.addon(db.name)} to ${cli.color.cyan(args.window)}`, async function () {
+    let response = await heroku.put(`/client/v11/databases/${db.id}/maintenance_window`, {
       body: { description: args.window },
       host: host(db)
     })
     cli.action.done(response.message || 'done')
-  }))
+  }())
 }
 
 module.exports = {
@@ -35,5 +34,5 @@ Example:
   needsApp: true,
   needsAuth: true,
   args: [{ name: 'database' }, { name: 'window' }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/ps.js
+++ b/packages/pg-v5/commands/ps.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const fetcher = require('../lib/fetcher')(heroku)
   const psql = require('../lib/psql')
 
@@ -11,7 +10,7 @@ function * run (context, heroku) {
   const { database } = args
   const { verbose } = flags
 
-  let db = yield fetcher.database(app, database)
+  let db = await fetcher.database(app, database)
 
   const num = Math.random()
   const waitingMarker = `${num}${num}`
@@ -23,7 +22,7 @@ SELECT '${num}' || '${num}' WHERE EXISTS (
     AND column_name = 'waiting'
 )
 `
-  let waitingOutput = yield psql.exec(db, waitingQuery)
+  let waitingOutput = await psql.exec(db, waitingQuery)
   let waiting = waitingOutput.includes(waitingMarker)
     ? 'waiting'
     : 'wait_event IS NOT NULL AS waiting'
@@ -45,7 +44,7 @@ WHERE
   ORDER BY query_start DESC
   `
 
-  const output = yield psql.exec(db, query)
+  const output = await psql.exec(db, query)
   process.stdout.write(output)
 }
 
@@ -57,5 +56,5 @@ module.exports = {
   needsAuth: true,
   flags: [{ name: 'verbose', char: 'v' }],
   args: [{ name: 'database', optional: true }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/psql.js
+++ b/packages/pg-v5/commands/psql.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const fetcher = require('../lib/fetcher')(heroku)
   const psql = require('../lib/psql')
 
@@ -12,7 +11,7 @@ function * run (context, heroku) {
   const namespace = flags.credential ? `credential:${flags.credential}` : null
   let db
   try {
-    db = yield fetcher.database(app, args.database, namespace)
+    db = await fetcher.database(app, args.database, namespace)
   } catch (err) {
     if (namespace && err.message === 'Couldn\'t find that addon.') {
       throw new Error('Credential doesn\'t match, make sure credential is attached')
@@ -21,13 +20,13 @@ function * run (context, heroku) {
   }
   cli.console.error(`--> Connecting to ${cli.color.addon(db.attachment.addon.name)}`)
   if (flags.command) {
-    const output = yield psql.exec(db, flags.command)
+    const output = await psql.exec(db, flags.command)
     process.stdout.write(output)
   } else if (flags.file) {
-    const output = yield psql.execFile(db, flags.file)
+    const output = await psql.execFile(db, flags.file)
     process.stdout.write(output)
   } else {
-    yield psql.interactive(db)
+    await psql.interactive(db)
   }
 }
 
@@ -41,7 +40,7 @@ const cmd = {
     { name: 'credential', description: 'credential to use', hasValue: true }
   ],
   args: [{ name: 'database', optional: true }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }
 
 module.exports = [

--- a/packages/pg-v5/commands/reset.js
+++ b/packages/pg-v5/commands/reset.js
@@ -1,21 +1,20 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const host = require('../lib/host')
   const fetcher = require('../lib/fetcher')(heroku)
   let { app, args, flags } = context
-  let db = yield fetcher.addon(app, args.database)
+  let db = await fetcher.addon(app, args.database)
 
-  yield cli.confirmApp(app, flags.confirm, `WARNING: Destructive action
+  await cli.confirmApp(app, flags.confirm, `WARNING: Destructive action
 ${cli.color.addon(db.name)} will lose all of its data
 `)
 
-  yield cli.action(`Resetting ${cli.color.addon(db.name)}`, co(function * () {
-    yield heroku.put(`/client/v11/databases/${db.id}/reset`, { host: host(db) })
-  }))
+  await cli.action(`Resetting ${cli.color.addon(db.name)}`, async function () {
+    await heroku.put(`/client/v11/databases/${db.id}/reset`, { host: host(db) })
+  }())
 }
 
 module.exports = {
@@ -26,5 +25,5 @@ module.exports = {
   needsAuth: true,
   args: [{ name: 'database', optional: true }],
   flags: [{ name: 'confirm', char: 'c', hasValue: true }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/settings/index.js
+++ b/packages/pg-v5/commands/settings/index.js
@@ -1,20 +1,19 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const host = require('../../lib/host')
   const util = require('../../lib/util')
   const fetcher = require('../../lib/fetcher')(heroku)
   const { app, args } = context
 
-  const db = yield fetcher.addon(app, args.database)
+  const db = await fetcher.addon(app, args.database)
 
   if (util.starterPlan(db)) throw new Error('This operation is not supported by Hobby tier databases.')
   if (util.legacyPlan(db)) throw new Error('This operation is not supported by Legacy-tier databases.')
 
-  let settings = yield heroku.get(`/postgres/v0/databases/${db.id}/config`, { host: host(db) })
+  let settings = await heroku.get(`/postgres/v0/databases/${db.id}/config`, { host: host(db) })
   cli.styledHeader(db.name)
   let remapped = Object.keys(settings).reduce((s, key) => {
     s[key.replace(/_/g, '-')] = settings[key]['value']
@@ -30,5 +29,5 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   args: [{ name: 'database', optional: true }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/unfollow.js
+++ b/packages/pg-v5/commands/unfollow.js
@@ -1,27 +1,26 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const host = require('../lib/host')
   const util = require('../lib/util')
   const fetcher = require('../lib/fetcher')(heroku)
   let { app, args, flags } = context
-  let db = yield fetcher.addon(app, args.database)
+  let db = await fetcher.addon(app, args.database)
 
-  let replica = yield heroku.get(`/client/v11/databases/${db.id}`, { host: host(db) })
+  let replica = await heroku.get(`/client/v11/databases/${db.id}`, { host: host(db) })
 
   if (!replica.following) throw new Error(`${cli.color.addon(db.name)} is not a follower`)
 
-  let origin = util.databaseNameFromUrl(replica.following, yield heroku.get(`/apps/${app}/config-vars`))
-  yield cli.confirmApp(app, flags.confirm, `WARNING: Destructive action
+  let origin = util.databaseNameFromUrl(replica.following, await heroku.get(`/apps/${app}/config-vars`))
+  await cli.confirmApp(app, flags.confirm, `WARNING: Destructive action
 ${cli.color.addon(db.name)} will become writeable and no longer follow ${origin}. This cannot be undone.
 `)
 
-  yield cli.action(`${cli.color.addon(db.name)} unfollowing`, co(function * () {
-    yield heroku.put(`/client/v11/databases/${db.id}/unfollow`, { host: host(db) })
-  }))
+  await cli.action(`${cli.color.addon(db.name)} unfollowing`, async function () {
+    await heroku.put(`/client/v11/databases/${db.id}/unfollow`, { host: host(db) })
+  }())
 }
 
 module.exports = {
@@ -32,5 +31,5 @@ module.exports = {
   needsAuth: true,
   args: [{ name: 'database' }],
   flags: [{ name: 'confirm', char: 'c', hasValue: true }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/commands/vacuum_stats.js
+++ b/packages/pg-v5/commands/vacuum_stats.js
@@ -1,13 +1,12 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   const fetcher = require('../lib/fetcher')(heroku)
   const psql = require('../lib/psql')
 
-  let db = yield fetcher.database(context.app, context.args.database)
+  let db = await fetcher.database(context.app, context.args.database)
 
   let query = `
 WITH table_opts AS (
@@ -50,7 +49,7 @@ FROM
 ORDER BY 1
 `
 
-  let output = yield psql.exec(db, query)
+  let output = await psql.exec(db, query)
   process.stdout.write(output)
 }
 
@@ -60,7 +59,7 @@ const cmd = {
   needsApp: true,
   needsAuth: true,
   args: [{ name: 'database', optional: true }],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }
 
 module.exports = [

--- a/packages/pg-v5/commands/wait.js
+++ b/packages/pg-v5/commands/wait.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 const path = require('path')
 const wait = ms => new Promise(resolve => setTimeout(resolve, ms))
 
@@ -91,5 +90,5 @@ module.exports = {
     { name: 'wait-interval', description: 'how frequently to poll in seconds (to avoid rate limiting)', hasValue: true },
     { name: 'no-notify', description: 'do not show OS notification' }
   ],
-  run: cli.command({ preauth: true }, co.wrap(run))
+  run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/lib/setter.js
+++ b/packages/pg-v5/lib/setter.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 
 exports.boolean = (value) => {
   switch (value) {
@@ -27,25 +26,25 @@ exports.numeric = (value) => {
 }
 
 exports.generate = (name, convert, explain) => {
-  return co.wrap(function * run (context, heroku) {
+  return async function run(context, heroku) {
     const host = require('./host')
     const util = require('./util')
     const fetcher = require('./fetcher')(heroku)
     const { app, args } = context
     const { value, database } = args
 
-    const db = yield fetcher.addon(app, database)
+    const db = await fetcher.addon(app, database)
 
     if (util.starterPlan(db)) throw new Error('This operation is not supported by Hobby tier databases.')
     if (util.legacyPlan(db)) throw new Error('This operation is not supported by Legacy tier databases.')
 
     if (!value) {
-      let settings = yield heroku.get(`/postgres/v0/databases/${db.id}/config`, { host: host(db) })
+      let settings = await heroku.get(`/postgres/v0/databases/${db.id}/config`, { host: host(db) })
       let setting = settings[name]
       cli.log(`${name.replace(/_/g, '-')} is set to ${setting.value} for ${db.name}.`)
       cli.log(explain(setting))
     } else {
-      let settings = yield heroku.patch(`/postgres/v0/databases/${db.id}/config`, {
+      let settings = await heroku.patch(`/postgres/v0/databases/${db.id}/config`, {
         host: host(db),
         body: { [name]: convert(value) }
       })
@@ -53,5 +52,5 @@ exports.generate = (name, convert, explain) => {
       cli.log(`${name.replace(/_/g, '-')} has been set to ${setting.value} for ${db.name}.`)
       cli.log(explain(setting))
     }
-  })
+  };
 }

--- a/packages/pg-v5/package.json
+++ b/packages/pg-v5/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@heroku-cli/plugin-addons": "^1.2.29",
     "bytes": "^3.1.0",
-    "co": "^4.6.0",
     "co-wait": "^0.0.0",
     "debug": "^4.1.1",
     "filesize": "^4.0.0",

--- a/packages/pg-v5/test/commands/credentials/rotate.js
+++ b/packages/pg-v5/test/commands/credentials/rotate.js
@@ -48,7 +48,7 @@ const cmd = proxyquire('../../../commands/credentials/rotate', {
 
 let lastApp, lastConfirm, lastMsg
 
-const confirmApp = function * (app, confirm, msg) {
+const confirmApp = async function (app, confirm, msg) {
   lastApp = app
   lastConfirm = confirm
   lastMsg = msg

--- a/packages/run-v5/commands/console.js
+++ b/packages/run-v5/commands/console.js
@@ -1,11 +1,10 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 let helpers = require('../lib/helpers')
 let Dyno = require('../lib/dyno')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let opts = {
     heroku: heroku,
     app: context.app,
@@ -16,7 +15,7 @@ function * run (context, heroku) {
   }
 
   let dyno = new Dyno(opts)
-  yield dyno.start()
+  await dyno.start()
 }
 
 module.exports = {
@@ -28,5 +27,5 @@ module.exports = {
     { name: 'size', char: 's', description: 'dyno size', hasValue: true },
     { name: 'env', char: 'e', description: "environment variables to set (use ';' to split multiple vars)", hasValue: true }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/run-v5/commands/rake.js
+++ b/packages/run-v5/commands/rake.js
@@ -1,11 +1,10 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 let helpers = require('../lib/helpers')
 let Dyno = require('../lib/dyno')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   context.args.unshift('rake')
   let opts = {
     heroku: heroku,
@@ -20,7 +19,7 @@ function * run (context, heroku) {
 
   let dyno = new Dyno(opts)
   try {
-    yield dyno.start()
+    await dyno.start()
   } catch (err) {
     if (err.exitCode) {
       cli.error(err)
@@ -41,5 +40,5 @@ module.exports = {
     { name: 'env', char: 'e', description: "environment variables to set (use ';' to split multiple vars)", hasValue: true },
     { name: 'no-tty', description: 'force the command to not run in a tty', hasValue: false }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/run-v5/commands/run/detached.js
+++ b/packages/run-v5/commands/run/detached.js
@@ -1,13 +1,12 @@
 'use strict'
 
-let co = require('co')
 let cli = require('heroku-cli-util')
 let helpers = require('../../lib/helpers')
 let logDisplayer = require('../../lib/log_displayer')
 let Dyno = require('../../lib/dyno')
 const { DynoSizeCompletion, ProcessTypeCompletion } = require('@heroku-cli/command/lib/completions')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   let opts = {
     heroku: heroku,
     app: context.app,
@@ -19,10 +18,10 @@ function * run (context, heroku) {
   }
   if (!opts.command) throw new Error('Usage: heroku run COMMAND\n\nExample: heroku run bash')
   let dyno = new Dyno(opts)
-  yield dyno.start()
+  await dyno.start()
 
   if (context.flags.tail) {
-    yield logDisplayer(heroku, {
+    await logDisplayer(heroku, {
       app: context.app,
       dyno: dyno.dyno.name,
       tail: true
@@ -48,5 +47,5 @@ Run heroku logs -a app -p run.1 to view the output.`,
     { name: 'type', description: 'process type', hasValue: true, completion: ProcessTypeCompletion },
     { name: 'env', char: 'e', description: "environment variables to set (use ';' to split multiple vars)", hasValue: true }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/run-v5/commands/run/inside.js
+++ b/packages/run-v5/commands/run/inside.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const co = require('co')
 const cli = require('heroku-cli-util')
 const helpers = require('../../lib/helpers')
 const Dyno = require('../../lib/dyno')
 
-function * run (context, heroku) {
+async function run(context, heroku) {
   if (context.args.length < 2) throw new Error('Usage: heroku run:inside DYNO COMMAND\n\nExample: heroku run:inside web.1 bash')
   let opts = {
     heroku: heroku,
@@ -18,7 +17,7 @@ function * run (context, heroku) {
   }
 
   let dyno = new Dyno(opts)
-  yield dyno.start()
+  await dyno.start()
 }
 
 module.exports = {
@@ -37,5 +36,5 @@ Running bash on web.1.... up
     { name: 'env', description: "environment variables to set (use ';' to split multiple vars)", hasValue: true },
     { name: 'listen', description: 'listen on a local port', hasValue: false, hidden: true }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/run-v5/package.json
+++ b/packages/run-v5/package.json
@@ -22,7 +22,6 @@
     "@heroku-cli/command": "^8.4.1",
     "@heroku-cli/notifications": "^1.2.2",
     "@heroku/eventsource": "^1.0.7",
-    "co": "4.6.0",
     "fs-extra": "^7.0.1",
     "heroku-cli-util": "^8.0.11",
     "shellwords": "^0.1.1"

--- a/packages/spaces/commands/create.js
+++ b/packages/spaces/commands/create.js
@@ -1,13 +1,12 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 const lib = require('../lib/spaces')
 const parsers = require('../lib/parsers')()
 const { flags } = require('@heroku-cli/command')
 const { RegionCompletion } = require('@heroku-cli/command/lib/completions')
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let space = context.flags.space || context.args.space
   let dollarAmount = '$1000'
   let spaceType = 'Standard'
@@ -32,7 +31,7 @@ function * run (context, heroku) {
     }
   })
 
-  space = yield cli.action(`Creating space ${cli.color.green(space)} in team ${cli.color.cyan(team)}`, request)
+  space = await cli.action(`Creating space ${cli.color.green(space)} in team ${cli.color.cyan(team)}`, request)
   cli.warn(`${cli.color.bold('Spend Alert.')} Each Heroku ${spaceType} Private Space costs ${dollarAmount} in Add-on Credits/month (pro-rated to the second).`)
   cli.warn('Use spaces:wait to track allocation.')
   cli.styledHeader(space.name)
@@ -82,5 +81,5 @@ module.exports = {
     { name: 'data-cidr', hasValue: true, description: 'RFC-1918 CIDR used by Heroku Data resources for the space' },
     flags.team({ name: 'team', hasValue: true })
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/destroy.js
+++ b/packages/spaces/commands/destroy.js
@@ -1,17 +1,16 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 const lib = require('../lib/spaces')
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let spaceName = context.flags.space || context.args.space
   if (!spaceName) throw new Error('Space name required.\nUSAGE: heroku spaces:destroy my-space')
   let natWarning = ''
 
-  let space = yield heroku.get(`/spaces/${spaceName}`)
+  let space = await heroku.get(`/spaces/${spaceName}`)
   if (space.state === 'allocated') {
-    space.outbound_ips = yield heroku.get(`/spaces/${spaceName}/nat`)
+    space.outbound_ips = await heroku.get(`/spaces/${spaceName}/nat`)
     if (space.outbound_ips && space.outbound_ips.state === 'enabled') {
       natWarning = `
 The Outbound IPs for this space will be reused!
@@ -19,12 +18,12 @@ Ensure that external services no longer allow these Outbound IPs: ${lib.displayN
     }
   }
 
-  yield cli.confirmApp(spaceName, context.flags.confirm, `Destructive Action
+  await cli.confirmApp(spaceName, context.flags.confirm, `Destructive Action
 This command will destroy the space ${cli.color.bold.red(spaceName)}
 ${natWarning}
 `)
   let request = heroku.delete(`/spaces/${spaceName}`)
-  yield cli.action(`Destroying space ${cli.color.cyan(spaceName)}`, request)
+  await cli.action(`Destroying space ${cli.color.cyan(spaceName)}`, request)
 }
 
 module.exports = {
@@ -43,5 +42,5 @@ module.exports = {
     { name: 'space', char: 's', hasValue: true, description: 'space to destroy' },
     { name: 'confirm', hasValue: true, description: 'set to space name to bypass confirm prompt' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/drains/get.js
+++ b/packages/spaces/commands/drains/get.js
@@ -1,11 +1,10 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let lib = require('../../lib/log-drains')(heroku)
-  let drain = yield lib.getLogDrain(context.flags.space)
+  let drain = await lib.getLogDrain(context.flags.space)
   if (context.flags.json) {
     cli.log(JSON.stringify(drain, null, 2))
   } else {
@@ -25,5 +24,5 @@ module.exports = {
     { name: 'space', char: 's', hasValue: true, description: 'space for which to get log drain', required: true },
     { name: 'json', description: 'output in json format' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/drains/set.js
+++ b/packages/spaces/commands/drains/set.js
@@ -1,12 +1,11 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let lib = require('../../lib/log-drains')(heroku)
   let space = context.flags.space
-  let drain = yield lib.putLogDrain(space, context.args.url)
+  let drain = await lib.putLogDrain(space, context.args.url)
   cli.log(`Successfully set drain ${cli.color.cyan(drain.url)} for ${cli.color.cyan.bold(space)}.`)
   cli.warn('It may take a few moments for the changes to take effect.')
 }
@@ -24,5 +23,5 @@ module.exports = {
   flags: [
     { name: 'space', char: 's', hasValue: true, description: 'space for which to set log drain', required: true }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/hosts/index.js
+++ b/packages/spaces/commands/hosts/index.js
@@ -1,17 +1,16 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
 function displayJSON (hosts) {
   cli.log(JSON.stringify(hosts, null, 2))
 }
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let lib = require('../../lib/hosts')(heroku)
   let space = context.flags.space || context.args.space
   if (!space) throw new Error('Space name required.\nUSAGE: heroku spaces:hosts --space my-space')
-  let hosts = yield lib.getHosts(space)
+  let hosts = await lib.getHosts(space)
   if (context.flags.json) displayJSON(hosts)
   else lib.displayHosts(space, hosts)
 }
@@ -28,5 +27,5 @@ module.exports = {
     { name: 'space', char: 's', hasValue: true, description: 'space to get host list from' },
     { name: 'json', description: 'output in json format' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/index.js
+++ b/packages/spaces/commands/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 const { flags } = require('@heroku-cli/command')
 const _ = require('lodash')
 
@@ -21,10 +20,10 @@ function displayJSON (spaces) {
   cli.log(JSON.stringify(spaces, null, 2))
 }
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let team = context.flags.team
 
-  let spaces = yield heroku.get('/spaces')
+  let spaces = await heroku.get('/spaces')
   if (team) {
     spaces = spaces.filter((s) => s.team.name === team)
   }
@@ -47,5 +46,5 @@ module.exports = {
     { name: 'json', description: 'output in json format' },
     flags.team({ name: 'team', hasValue: true })
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/info.js
+++ b/packages/spaces/commands/info.js
@@ -1,10 +1,9 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 const lib = require('../lib/spaces')
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let spaceName = context.flags.space || context.args.space
   if (!spaceName) throw new Error('Space name required.\nUSAGE: heroku spaces:info my-space')
 
@@ -13,9 +12,9 @@ function * run (context, heroku) {
     headers = { 'Accept-Expansion': 'region' }
   }
 
-  let space = yield heroku.get(`/spaces/${spaceName}`, { headers })
+  let space = await heroku.get(`/spaces/${spaceName}`, { headers })
   if (space.state === 'allocated') {
-    space.outbound_ips = yield heroku.get(`/spaces/${spaceName}/nat`)
+    space.outbound_ips = await heroku.get(`/spaces/${spaceName}/nat`)
   }
   render(space, context.flags)
 }
@@ -50,5 +49,5 @@ module.exports = {
     { name: 'json', description: 'output in json format' }
   ],
   render: render,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/outbound-rules/add.js
+++ b/packages/spaces/commands/outbound-rules/add.js
@@ -1,7 +1,6 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 const { SpaceCompletion } = require('@heroku-cli/command/lib/completions')
 
 const ProtocolCompletion = {
@@ -11,19 +10,19 @@ const ProtocolCompletion = {
   }
 }
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let lib = require('../../lib/outbound-rules')(heroku)
   let space = context.flags.space
   if (!space) throw new Error('Space name required.')
-  let ruleset = yield lib.getOutboundRules(space)
+  let ruleset = await lib.getOutboundRules(space)
   ruleset.rules = ruleset.rules || []
-  let ports = yield lib.parsePorts(context.flags.protocol, context.flags.port)
+  let ports = await lib.parsePorts(context.flags.protocol, context.flags.port)
   ruleset.rules.push({
     target: context.flags.dest,
     from_port: ports[0],
     to_port: ports[1] || ports[0],
     protocol: context.flags.protocol })
-  ruleset = yield lib.putOutboundRules(space, ruleset)
+  ruleset = await lib.putOutboundRules(space, ruleset)
   cli.log(`Added rule to the Outbound Rules of ${cli.color.cyan.bold(space)}`)
   cli.warn('Modifying the Outbound Rules may break Add-ons for Apps in this Private Space')
 }
@@ -66,5 +65,5 @@ allow. ICMP types are numbered, 0-255.
     { name: 'protocol', hasValue: true, description: 'the protocol dynos are allowed to use when communicating with hosts in destination CIDR block. Valid protocols are "tcp", "udp", "icmp", "0-255" and "any".', completion: ProtocolCompletion },
     { name: 'port', hasValue: true, description: 'the port dynos are allowed to use when communicating with hosts in destination CIDR block. Accepts a range in `<lowest port>-<highest port>` format. 0 is the minimum. The maximum port allowed is 65535, except for ICMP with a maximum of 255.' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/outbound-rules/index.js
+++ b/packages/spaces/commands/outbound-rules/index.js
@@ -1,18 +1,17 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 const { SpaceCompletion } = require('@heroku-cli/command/lib/completions')
 
 function displayJSON (rules) {
   cli.log(JSON.stringify(rules, null, 2))
 }
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let lib = require('../../lib/outbound-rules')(heroku)
   let space = context.flags.space || context.args.space
   if (!space) throw new Error('Space name required.\nUSAGE: heroku outbound-rules --space my-space')
-  let rules = yield lib.getOutboundRules(space)
+  let rules = await lib.getOutboundRules(space)
   if (context.flags.json) displayJSON(rules)
   else lib.displayRules(space, rules)
 }
@@ -38,5 +37,5 @@ You can add specific rules that only allow your dyno to communicate with trusted
     { name: 'space', char: 's', hasValue: true, description: 'space to get outbound rules from', completion: SpaceCompletion },
     { name: 'json', description: 'output in json format' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/outbound-rules/remove.js
+++ b/packages/spaces/commands/outbound-rules/remove.js
@@ -1,25 +1,24 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let lib = require('../../lib/outbound-rules')(heroku)
   let space = context.flags.space
   if (!space) throw new Error('Space name required.')
-  let rules = yield lib.getOutboundRules(space)
+  let rules = await lib.getOutboundRules(space)
   rules.rules = rules.rules || []
 
   if (rules.rules.length === 0) throw new Error('No Outbound Rules configured. Nothing to do.')
 
   let deleted = rules.rules.splice(context.args.ruleNumber - 1, 1)[0]
 
-  yield cli.confirmApp(space, context.flags.confirm, `Destructive Action
+  await cli.confirmApp(space, context.flags.confirm, `Destructive Action
 This will remove:
 Destination: ${deleted.target}, From Port: ${deleted.from_port}, To Port: ${deleted.to_port}, Protocol ${deleted.protocol}
 from the Outbound Rules on ${cli.color.cyan.bold(space)}
 `)
-  rules = yield lib.putOutboundRules(space, rules)
+  rules = await lib.putOutboundRules(space, rules)
   cli.log(`Removed Rule ${cli.color.cyan.bold(context.args.rulenumber)} from Outbound Rules on ${cli.color.cyan.bold(space)}`)
   cli.warn('It may take a few moments for the changes to take effect.')
 }
@@ -43,5 +42,5 @@ module.exports = {
     { name: 'space', hasValue: true, optional: false, description: 'space to remove rule from' },
     { name: 'confirm', hasValue: true, description: 'set to space name to bypass confirm prompt' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/peering/accept.js
+++ b/packages/spaces/commands/peering/accept.js
@@ -1,14 +1,13 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let lib = require('../../lib/peering')(heroku)
   let space = context.flags.space || context.args.space
   if (!space) throw new Error('Space name required.\nUSAGE: heroku spaces:peerings:accept pcx-12345678 --space my-space')
   let pcxID = context.flags.pcxid || context.args.pcxid
-  yield lib.acceptPeeringRequest(space, pcxID)
+  await lib.acceptPeeringRequest(space, pcxID)
   cli.log(`Accepting and configuring peering connection ${cli.color.cyan.bold(pcxID)}`)
 }
 
@@ -28,5 +27,5 @@ module.exports = {
     { name: 'pcxid', char: 'p', hasValue: true, description: 'PCX ID of a pending peering' },
     { name: 'space', char: 's', hasValue: true, description: 'space to get peering info from' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/peering/destroy.js
+++ b/packages/spaces/commands/peering/destroy.js
@@ -1,16 +1,15 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let lib = require('../../lib/peering')(heroku)
   let space = context.flags.space || context.args.space
   if (!space) throw new Error('Space name required.\nUSAGE: heroku spaces:peerings:destroy pcx-12345678 --space my-space')
   let pcxID = context.flags.pcxid || context.args.pcxid
-  yield cli.confirmApp(pcxID, context.flags.confirm, `Destructive Action
+  await cli.confirmApp(pcxID, context.flags.confirm, `Destructive Action
 This command will attempt to destroy the peering connection ${cli.color.bold.red(pcxID)}`)
-  yield lib.destroyPeeringRequest(space, pcxID)
+  await lib.destroyPeeringRequest(space, pcxID)
   cli.log(`Tearing down peering connection ${cli.color.cyan.bold(pcxID)}`)
 }
 
@@ -31,5 +30,5 @@ module.exports = {
     { name: 'space', char: 's', hasValue: true, description: 'space to get peering info from' },
     { name: 'confirm', hasValue: true, description: 'set to PCX ID to bypass confirm prompt' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/peering/index.js
+++ b/packages/spaces/commands/peering/index.js
@@ -1,17 +1,16 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
 function displayJSON (peerings) {
   cli.log(JSON.stringify(peerings, null, 2))
 }
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let lib = require('../../lib/peering')(heroku)
   let space = context.flags.space || context.args.space
   if (!space) throw new Error('Space name required.\nUSAGE: heroku spaces:peerings --space my-space')
-  let peers = yield lib.getPeerings(space)
+  let peers = await lib.getPeerings(space)
   if (context.flags.json) displayJSON(peers)
   else lib.displayPeers(space, peers)
 }
@@ -27,5 +26,5 @@ module.exports = {
     { name: 'space', char: 's', hasValue: true, description: 'space to get peer list from' },
     { name: 'json', description: 'output in json format' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/peering/info.js
+++ b/packages/spaces/commands/peering/info.js
@@ -1,17 +1,16 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
 function displayJSON (info) {
   cli.log(JSON.stringify(info, null, 2))
 }
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let lib = require('../../lib/peering')(heroku)
   let space = context.flags.space || context.args.space
   if (!space) throw new Error('Space name required.\nUSAGE: heroku spaces:peering:info --space my-space')
-  let pInfo = yield lib.getPeeringInfo(space)
+  let pInfo = await lib.getPeeringInfo(space)
   if (context.flags.json) displayJSON(pInfo)
   else lib.displayPeeringInfo(space, pInfo)
 }
@@ -49,5 +48,5 @@ configure the peering connection for the space.
     { name: 'space', char: 's', hasValue: true, description: 'space to get peering info from' },
     { name: 'json', description: 'output in json format' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/ps.js
+++ b/packages/spaces/commands/ps.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 const strftime = require('strftime')
 const _ = require('lodash')
 
@@ -16,11 +15,11 @@ function timeAgo (since) {
   else return message
 }
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   const spaceName = context.flags.space || context.args.space
   if (!spaceName) throw new Error('Space name required.\nUSAGE: heroku spaces:ps my-space')
 
-  const [spaceDynos, space] = yield Promise.all([
+  const [spaceDynos, space] = await Promise.all([
     heroku.get(`/spaces/${spaceName}/dynos`),
     heroku.get(`/spaces/${spaceName}`)
   ])
@@ -84,5 +83,5 @@ module.exports = {
     { name: 'space', char: 's', hasValue: true, description: 'space to get dynos of' },
     { name: 'json', description: 'output in json format' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/rename.js
+++ b/packages/spaces/commands/rename.js
@@ -1,9 +1,8 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let to = context.flags.to
   let from = context.flags.from
   let request = heroku.request({
@@ -11,7 +10,7 @@ function * run (context, heroku) {
     path: `/spaces/${from}`,
     body: { name: to }
   })
-  yield cli.action(`Renaming space from ${cli.color.cyan(from)} to ${cli.color.green(to)}`, request)
+  await cli.action(`Renaming space from ${cli.color.cyan(from)} to ${cli.color.green(to)}`, request)
 }
 
 module.exports = {
@@ -29,5 +28,5 @@ module.exports = {
     { name: 'from', hasValue: true, required: true, description: 'current name of space' },
     { name: 'to', hasValue: true, required: true, description: 'desired name of space' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/topology.js
+++ b/packages/spaces/commands/topology.js
@@ -1,19 +1,18 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 
 const getProcessType = (s) => s.split('-', 2)[0].split('.', 2)[0]
 const getProcessNum = (s) => parseInt(s.split('-', 2)[0].split('.', 2)[1])
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let spaceName = context.flags.space || context.args.space
   if (!spaceName) throw new Error('Space name required.\nUSAGE: heroku spaces:topology my-space')
 
-  let topology = yield heroku.get(`/spaces/${spaceName}/topology`)
+  let topology = await heroku.get(`/spaces/${spaceName}/topology`)
   let appInfo = []
   if (topology.apps) {
-    appInfo = yield topology.apps.map((app) => heroku.get(`/apps/${app.id}`))
+    appInfo = await Promise.all(topology.apps.map((app) => heroku.get(`/apps/${app.id}`)))
   }
 
   render(spaceName, topology, appInfo, context.flags)
@@ -83,5 +82,5 @@ module.exports = {
     { name: 'json', description: 'output in json format' }
   ],
   render: render,
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/transfer.js
+++ b/packages/spaces/commands/transfer.js
@@ -1,9 +1,8 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   const space = context.flags.space
   const team = context.flags.team
   const request = heroku.request({
@@ -12,7 +11,7 @@ function * run (context, heroku) {
     body: { 'new_owner': team }
   })
   try {
-    yield cli.action(`Transferring space ${cli.color.yellow(space)} to team ${cli.color.green(team)}`, request)
+    await cli.action(`Transferring space ${cli.color.yellow(space)} to team ${cli.color.green(team)}`, request)
   } catch (err) {
     cli.error(err.body.message)
   }
@@ -33,5 +32,5 @@ module.exports = {
     { name: 'space', hasValue: true, required: true, description: 'name of space' },
     { name: 'team', hasValue: true, required: true, description: 'desired owner of space' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/trusted-ips/add.js
+++ b/packages/spaces/commands/trusted-ips/add.js
@@ -1,16 +1,15 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let lib = require('../../lib/trusted-ips')(heroku)
   let space = context.flags.space
-  let ruleset = yield lib.getRules(space)
+  let ruleset = await lib.getRules(space)
   ruleset.rules = ruleset.rules || []
   if (ruleset.rules.find((rs) => rs.source === context.args.source)) throw new Error(`A rule already exists for ${context.args.source}.`)
   ruleset.rules.push({ action: 'allow', source: context.args.source })
-  ruleset = yield lib.putRules(space, ruleset)
+  ruleset = await lib.putRules(space, ruleset)
   cli.log(`Added ${cli.color.cyan.bold(context.args.source)} to trusted IP ranges on ${cli.color.cyan.bold(space)}`)
   cli.warn('It may take a few moments for the changes to take effect.')
 }
@@ -36,5 +35,5 @@ Example:
     { name: 'space', char: 's', hasValue: true, description: 'space to add rule to' },
     { name: 'confirm', hasValue: true, description: 'set to space name to bypass confirm prompt' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/trusted-ips/index.js
+++ b/packages/spaces/commands/trusted-ips/index.js
@@ -1,17 +1,16 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
 function displayJSON (rules) {
   cli.log(JSON.stringify(rules, null, 2))
 }
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let lib = require('../../lib/trusted-ips')(heroku)
   let space = context.flags.space || context.args.space
   if (!space) throw new Error('Space name required.\nUSAGE: heroku trusted-ips my-space')
-  let rules = yield lib.getRules(space)
+  let rules = await lib.getRules(space)
   if (context.flags.json) displayJSON(rules)
   else lib.displayRules(space, rules)
 }
@@ -33,5 +32,5 @@ a time to the commands listed below. For example 1.2.3.4/20 and 5.6.7.8/20 can b
     { name: 'space', char: 's', hasValue: true, description: 'space to get inbound rules from' },
     { name: 'json', description: 'output in json format' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/trusted-ips/remove.js
+++ b/packages/spaces/commands/trusted-ips/remove.js
@@ -1,18 +1,17 @@
 'use strict'
 
 let cli = require('heroku-cli-util')
-let co = require('co')
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let lib = require('../../lib/trusted-ips')(heroku)
   let space = context.flags.space
-  let rules = yield lib.getRules(space)
+  let rules = await lib.getRules(space)
   rules.rules = rules.rules || []
   if (rules.rules.length === 0) throw new Error('No IP ranges are configured. Nothing to do.')
   let originalLength = rules.rules.length
   rules.rules = rules.rules.filter((r) => r.source !== context.args.source)
   if (rules.rules.length === originalLength) throw new Error(`No IP range matching ${context.args.source} was found.`)
-  rules = yield lib.putRules(space, rules)
+  rules = await lib.putRules(space, rules)
   cli.log(`Removed ${cli.color.cyan.bold(context.args.source)} from trusted IP ranges on ${cli.color.cyan.bold(space)}`)
   cli.warn('It may take a few moments for the changes to take effect.')
 }
@@ -38,5 +37,5 @@ Example:
     { name: 'space', hasValue: true, optional: false, description: 'space to remove rule from' },
     { name: 'confirm', hasValue: true, description: 'set to space name to bypass confirm prompt' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/vpn/config.js
+++ b/packages/spaces/commands/vpn/config.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 
 function displayVPNConfigInfo (space, name, config) {
   cli.styledHeader(`${name} VPN Tunnels`)
@@ -27,7 +26,7 @@ function check (val, message) {
   if (!val) throw new Error(`${message}.\nUSAGE: heroku spaces:vpn:config --space my-space vpn-connection-name`)
 }
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let space = context.flags.space || context.args.space
   check(space, 'Space name required')
 
@@ -35,7 +34,7 @@ function * run (context, heroku) {
   check(name, 'VPN connection name required')
 
   let lib = require('../../lib/vpn-connections')(heroku)
-  let config = yield lib.getVPNConnection(space, name)
+  let config = await lib.getVPNConnection(space, name)
 
   if (context.flags.json) {
     cli.styledJSON(config)
@@ -73,6 +72,6 @@ You will use the information provided by this command to establish a Private Spa
     { name: 'name', char: 'n', hasValue: true, description: 'name or id of the VPN connection to retrieve config from' },
     { name: 'json', description: 'output in json format' }
   ],
-  run: cli.command(co.wrap(run)),
+  run: cli.command(run),
   displayVPNConfigInfo: displayVPNConfigInfo
 }

--- a/packages/spaces/commands/vpn/connect.js
+++ b/packages/spaces/commands/vpn/connect.js
@@ -1,14 +1,13 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 const parsers = require('../../lib/parsers')()
 
 function check (val, message) {
   if (!val) throw new Error(`${message}.\nUSAGE: heroku spaces:vpn:connect --name office --ip 35.161.69.30 --cidrs 172.16.0.0/16,10.0.0.0/24 --space example-space`)
 }
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let lib = require('../../lib/vpn-connections')(heroku)
 
   let space = context.flags.space
@@ -24,7 +23,7 @@ function * run (context, heroku) {
   check(cidrs, 'CIDRs required')
   cidrs = parsers.splitCsv(cidrs)
 
-  yield cli.action(`Creating VPN Connection in space ${cli.color.green(space)}`, lib.postVPNConnections(space, name, ip, cidrs))
+  await cli.action(`Creating VPN Connection in space ${cli.color.green(space)}`, lib.postVPNConnections(space, name, ip, cidrs))
   cli.warn('Use spaces:vpn:wait to track allocation.')
 }
 
@@ -49,5 +48,5 @@ The connection is established over the public Internet but all traffic is encryp
     { name: 'cidrs', char: 'c', hasValue: true, description: 'a list of routable CIDRs separated by commas' },
     { name: 'space', char: 's', hasValue: true, description: 'space name' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/vpn/destroy.js
+++ b/packages/spaces/commands/vpn/destroy.js
@@ -1,13 +1,12 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 
 function check (val, message) {
   if (!val) throw new Error(`${message}.\nUSAGE: heroku spaces:vpn:destroy --space example-space vpn-connection-name`)
 }
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let space = context.flags.space
   check(space, 'Space name required')
 
@@ -16,9 +15,9 @@ function * run (context, heroku) {
 
   let lib = require('../../lib/vpn-connections')(heroku)
 
-  yield cli.confirmApp(name, context.flags.confirm, `Destructive Action
+  await cli.confirmApp(name, context.flags.confirm, `Destructive Action
 This command will attempt to destroy the specified VPN Connection in space ${cli.color.green(space)}`)
-  yield cli.action(`Tearing down VPN Connection ${cli.color.cyan(name)} in space ${cli.color.cyan(space)}`, lib.deleteVPNConnection(space, name))
+  await cli.action(`Tearing down VPN Connection ${cli.color.cyan(name)} in space ${cli.color.cyan(space)}`, lib.deleteVPNConnection(space, name))
 }
 
 module.exports = {
@@ -40,5 +39,5 @@ module.exports = {
     { name: 'name', char: 'n', hasValue: true, description: 'name or id of the VPN connection to retrieve config from' },
     { name: 'confirm', hasValue: true, description: 'set to VPN connection name to bypass confirm prompt' }
   ],
-  run: cli.command(co.wrap(run))
+  run: cli.command(run)
 }

--- a/packages/spaces/commands/vpn/index.js
+++ b/packages/spaces/commands/vpn/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 const format = require('../../lib/format')()
 
 function displayVPNConnections (space, connections) {
@@ -32,12 +31,12 @@ function render (space, connections, flags) {
   }
 }
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let space = context.flags.space || context.args.space
   if (!space) throw new Error('Space name required.\nUSAGE: heroku spaces:vpn:connections --space my-space')
 
   let lib = require('../../lib/vpn-connections')(heroku)
-  let connections = yield lib.getVPNConnections(space)
+  let connections = await lib.getVPNConnections(space)
   render(space, connections, context.flags)
 }
 
@@ -60,6 +59,6 @@ module.exports = {
     { name: 'space', char: 's', hasValue: true, description: 'space to get VPN connections from' },
     { name: 'json', description: 'output in json format' }
   ],
-  run: cli.command(co.wrap(run)),
+  run: cli.command(run),
   render: render
 }

--- a/packages/spaces/commands/vpn/info.js
+++ b/packages/spaces/commands/vpn/info.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const cli = require('heroku-cli-util')
-const co = require('co')
 const format = require('../../lib/format')()
 
 function displayVPNInfo (space, name, info) {
@@ -41,7 +40,7 @@ function check (val, message) {
   if (!val) throw new Error(`${message}.\nUSAGE: heroku spaces:vpn:info --space my-space vpn-connection-name`)
 }
 
-function * run (context, heroku) {
+async function run (context, heroku) {
   let space = context.flags.space || context.args.space
   check(space, 'Space name required')
 
@@ -49,7 +48,7 @@ function * run (context, heroku) {
   check(name, 'VPN connection name required')
 
   let lib = require('../../lib/vpn-connections')(heroku)
-  let info = yield lib.getVPNConnection(space, name)
+  let info = await lib.getVPNConnection(space, name)
 
   if (info.name) {
     name = info.name
@@ -84,6 +83,6 @@ module.exports = {
     { name: 'json', description: 'output in json format' },
     { name: 'name', char: 'n', hasValue: true, description: 'name or id of the VPN connection to get info from' }
   ],
-  run: cli.command(co.wrap(run)),
+  run: cli.command(run),
   render: render
 }

--- a/packages/spaces/package.json
+++ b/packages/spaces/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "@heroku-cli/command": "^8.4.1",
     "@heroku-cli/notifications": "^1.2.2",
-    "co": "4.6.0",
     "heroku-cli-util": "^8.0.11",
     "lodash": "^4.17.11",
     "strftime": "^0.10.0"


### PR DESCRIPTION
Removes [co](https://www.npmjs.com/package/co), the library we previously needed to achieve an `async/await` like syntax using generators and `yield`. Our current supported node.js version range is `^10.0 || ^12.0 || ^14.0`, which allows us to use native `async-await` built into Node instead of using `co`. Removing `co` will make debugging easier and stack traces nicer when testing or when we get error reports from customers.

I ran the [co-to-async](https://github.com/albinekb/co-to-async) codemod over the codebase to help achieve this.

## How to verify?

* CI should pass. Our test suite seems to have caught a lot of the cases the codemod couldn't convert automatically
* Pull down the branch locally and run a few commands with `bin/run` in the `packages/cli` directly. It should work