### PR TITLE
build: convert tests to async-await

### DIFF
--- a/packages/addons-v5/test/commands/addons.--all.js
+++ b/packages/addons-v5/test/commands/addons.--all.js
@@ -24,30 +24,26 @@ describe('addons --all', function () {
         .reply(200, addons)
     })
 
-    it('prints add-ons in a table', function () {
-      return cmd.run({ flags: {} }).then(function () {
-        util.expectOutput(cli.stdout,
-          `Owning App    Add-on     Plan                         Price      State
+    it('prints add-ons in a table', async function() {
+      await cmd.run({ flags: {} })
+      util.expectOutput(cli.stdout,
+        `Owning App    Add-on     Plan                         Price      State
 ────────────  ─────────  ───────────────────────────  ─────────  ────────
 acme-inc-api  api-redis  heroku-redis:premium-2       $60/month  created
 acme-inc-www  www-db     heroku-postgresql:hobby-dev  free       created
 acme-inc-www  www-redis  heroku-redis:premium-2       $60/month  creating`)
-      })
     })
 
-    it('orders by app, then by add-on name', function () {
-      return cmd.run({ flags: {} }).then(function () {
-        expect(cli.stdout.indexOf('acme-inc-api')).to.be.lt(cli.stdout.indexOf('acme-inc-www'))
-        expect(cli.stdout.indexOf('www-db')).to.be.lt(cli.stdout.indexOf('www-redis'))
-      })
+    it('orders by app, then by add-on name', async function() {
+      await cmd.run({ flags: {} })
+      expect(cli.stdout.indexOf('acme-inc-api')).to.be.lt(cli.stdout.indexOf('acme-inc-www'))
+      expect(cli.stdout.indexOf('www-db')).to.be.lt(cli.stdout.indexOf('www-redis'))
     })
 
     context('--json', function () {
-      it('prints the output in json format', function () {
-        return cmd.run({ flags: { json: true } })
-          .then(function () {
-            expect(JSON.parse(cli.stdout)[0].name).to.eq('www-db')
-          })
+      it('prints the output in json format', async function() {
+        await cmd.run({ flags: { json: true } })
+        expect(JSON.parse(cli.stdout)[0].name).to.eq('www-db')
       })
     })
   })
@@ -64,13 +60,12 @@ acme-inc-www  www-redis  heroku-redis:premium-2       $60/month  creating`)
         .reply(200, [addon])
     })
 
-    it('prints add-ons in a table with the grandfathered price', function () {
-      return cmd.run({ flags: {} }).then(function () {
-        util.expectOutput(cli.stdout,
-          `Owning App    Add-on  Plan                          Price       State
+    it('prints add-ons in a table with the grandfathered price', async function() {
+      await cmd.run({ flags: {} })
+      util.expectOutput(cli.stdout,
+        `Owning App    Add-on  Plan                          Price       State
 ────────────  ──────  ────────────────────────────  ──────────  ───────
 acme-inc-dwh  dwh-db  heroku-postgresql:standard-2  $100/month  created`)
-      })
     })
   })
 
@@ -86,20 +81,18 @@ acme-inc-dwh  dwh-db  heroku-postgresql:standard-2  $100/month  created`)
         .reply(200, [addon])
     })
 
-    it('prints add-ons in a table with contract', function () {
-      return cmd.run({ flags: {} }).then(function () {
-        util.expectOutput(cli.stdout,
-          `Owning App    Add-on  Plan                          Price     State
+    it('prints add-ons in a table with contract', async function() {
+      await cmd.run({ flags: {} })
+      util.expectOutput(cli.stdout,
+        `Owning App    Add-on  Plan                          Price     State
 ────────────  ──────  ────────────────────────────  ────────  ───────
 acme-inc-dwh  dwh-db  heroku-postgresql:standard-2  contract  created`)
-      })
     })
   })
 
-  it('prints message when there are no add-ons', function () {
+  it('prints message when there are no add-ons', async function() {
     nock('https://api.heroku.com').get('/addons').reply(200, [])
-    return cmd.run({ flags: {} }).then(function () {
-      util.expectOutput(cli.stdout, 'No add-ons.')
-    })
+    await cmd.run({ flags: {} })
+    util.expectOutput(cli.stdout, 'No add-ons.')
   })
 })

--- a/packages/addons-v5/test/commands/addons.--app.js
+++ b/packages/addons-v5/test/commands/addons.--app.js
@@ -26,8 +26,9 @@ describe('addons --app', function () {
 
   beforeEach(() => cli.mockConsole())
 
-  function run (app, cb) {
-    return cmd.run({ flags: {}, app: app }).then(cb)
+  async function run(app, cb) {
+    const runResult = await cmd.run({ flags: {}, app: app })
+    return cb(runResult)
   }
 
   it('prints message when there are no add-ons', function () {

--- a/packages/addons-v5/test/commands/addons/attach.js
+++ b/packages/addons-v5/test/commands/addons/attach.js
@@ -17,7 +17,7 @@ describe('addons:attach', function () {
     nock.cleanAll()
   })
 
-  it('attaches an add-on', function () {
+  it('attaches an add-on', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/addons/redis-123')
       .reply(200, { name: 'redis-123' })
@@ -25,15 +25,19 @@ describe('addons:attach', function () {
       .reply(201, { name: 'REDIS' })
       .get('/apps/myapp/releases')
       .reply(200, [{ version: 10 }])
-    return cmd.run({ app: 'myapp', args: { addon_name: 'redis-123' }, flags: {} })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal(`Attaching redis-123 to myapp... done
+
+    await cmd.run({ app: 'myapp', args: { addon_name: 'redis-123' }, flags: {} })
+
+    expect(cli.stdout, 'to be empty');
+
+    expect(cli.stderr).to.equal(`Attaching redis-123 to myapp... done
 Setting REDIS config vars and restarting myapp... done, v10
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 
-  it('attaches an add-on as foo', function () {
+  it('attaches an add-on as foo', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/addons/redis-123')
       .reply(200, { name: 'redis-123' })
@@ -41,15 +45,19 @@ Setting REDIS config vars and restarting myapp... done, v10
       .reply(201, { name: 'foo' })
       .get('/apps/myapp/releases')
       .reply(200, [{ version: 10 }])
-    return cmd.run({ app: 'myapp', args: { addon_name: 'redis-123' }, flags: { as: 'foo' } })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal(`Attaching redis-123 as foo to myapp... done
+
+    await cmd.run({ app: 'myapp', args: { addon_name: 'redis-123' }, flags: { as: 'foo' } })
+
+    expect(cli.stdout, 'to be empty');
+
+    expect(cli.stderr).to.equal(`Attaching redis-123 as foo to myapp... done
 Setting foo config vars and restarting myapp... done, v10
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 
-  it('overwrites an add-on as foo when confirmation is set', function () {
+  it('overwrites an add-on as foo when confirmation is set', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/addons/redis-123')
       .reply(200, { name: 'redis-123' })
@@ -59,16 +67,20 @@ Setting foo config vars and restarting myapp... done, v10
       .reply(201, { name: 'foo' })
       .get('/apps/myapp/releases')
       .reply(200, [{ version: 10 }])
-    return cmd.run({ app: 'myapp', args: { addon_name: 'redis-123' }, flags: { as: 'foo' } })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal(`Attaching redis-123 as foo to myapp... !
+
+    await cmd.run({ app: 'myapp', args: { addon_name: 'redis-123' }, flags: { as: 'foo' } })
+
+    expect(cli.stdout, 'to be empty');
+
+    expect(cli.stderr).to.equal(`Attaching redis-123 as foo to myapp... !
 Attaching redis-123 as foo to myapp... done
 Setting foo config vars and restarting myapp... done, v10
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 
-  it('attaches an addon without a namespace if the credential flag is set to default', function () {
+  it('attaches an addon without a namespace if the credential flag is set to default', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/addons/postgres-123')
       .reply(200, { name: 'postgres-123' })
@@ -76,15 +88,19 @@ Setting foo config vars and restarting myapp... done, v10
       .reply(201, { name: 'POSTGRES_HELLO' })
       .get('/apps/myapp/releases')
       .reply(200, [{ version: 10 }])
-    return cmd.run({ app: 'myapp', args: { addon_name: 'postgres-123' }, flags: { credential: 'default' } })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal(`Attaching default of postgres-123 to myapp... done
+
+    await cmd.run({ app: 'myapp', args: { addon_name: 'postgres-123' }, flags: { credential: 'default' } })
+
+    expect(cli.stdout, 'to be empty');
+
+    expect(cli.stderr).to.equal(`Attaching default of postgres-123 to myapp... done
 Setting POSTGRES_HELLO config vars and restarting myapp... done, v10
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 
-  it('attaches in the credential namespace if the credential flag is specified', function () {
+  it('attaches in the credential namespace if the credential flag is specified', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/addons/postgres-123')
       .reply(200, { name: 'postgres-123' })
@@ -94,27 +110,35 @@ Setting POSTGRES_HELLO config vars and restarting myapp... done, v10
       .reply(201, { name: 'POSTGRES_HELLO' })
       .get('/apps/myapp/releases')
       .reply(200, [{ version: 10 }])
-    return cmd.run({ app: 'myapp', args: { addon_name: 'postgres-123' }, flags: { credential: 'hello' } })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal(`Attaching hello of postgres-123 to myapp... done
+
+    await cmd.run({ app: 'myapp', args: { addon_name: 'postgres-123' }, flags: { credential: 'hello' } })
+
+    expect(cli.stdout, 'to be empty');
+
+    expect(cli.stderr).to.equal(`Attaching hello of postgres-123 to myapp... done
 Setting POSTGRES_HELLO config vars and restarting myapp... done, v10
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 
-  it('errors if the credential flag is specified but that credential does not exist for that addon', function () {
+  it('errors if the credential flag is specified but that credential does not exist for that addon', async function() {
     nock('https://api.heroku.com:443')
       .get('/addons/postgres-123')
       .reply(200, { name: 'postgres-123' })
       .get('/addons/postgres-123/config/credential:hello')
       .reply(200, [])
 
-    return cmd.run({
-      app: 'myapp',
-      args: { addon_name: 'postgres-123' },
-      flags: { credential: 'hello' }
-    })
-      .then(() => { throw new Error('unreachable') })
-      .catch((err) => expect(err.message).to.equal('Could not find credential hello for database postgres-123'))
+    try {
+      await cmd.run({
+        app: 'myapp',
+        args: { addon_name: 'postgres-123' },
+        flags: { credential: 'hello' }
+      })
+
+      throw new Error('unreachable')
+    } catch (err) {
+      return expect(err.message).to.equal('Could not find credential hello for database postgres-123')
+    }
   })
 })

--- a/packages/addons-v5/test/commands/addons/destroy.js
+++ b/packages/addons-v5/test/commands/addons/destroy.js
@@ -8,7 +8,7 @@ describe('addons:destroy', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
-  it('destroys an add-on', () => {
+  it('destroys an add-on', async () => {
     let addon = { id: 201, name: 'db3-swiftly-123', addon_service: { name: 'heroku-db3' }, app: { name: 'myapp', id: 101 } }
 
     let api = nock('https://api.heroku.com:443')
@@ -16,23 +16,26 @@ describe('addons:destroy', () => {
       .delete('/apps/101/addons/201', { force: false })
       .reply(200, { plan: { price: { cents: 0 } }, provision_message: 'provision msg' })
 
-    return cmd.run({ app: 'myapp', args: ['heroku-db3'], flags: { confirm: 'myapp' } })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('Destroying db3-swiftly-123 on myapp... done\n'))
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: ['heroku-db3'], flags: { confirm: 'myapp' } })
+
+    expect(cli.stdout).to.equal('');
+    expect(cli.stderr).to.equal('Destroying db3-swiftly-123 on myapp... done\n');
+
+    return api.done()
   })
 
-  it('fails when addon app is not the app specified', () => {
+  it('fails when addon app is not the app specified', async () => {
     let addon = { id: 201, name: 'db4-swiftly-123', addon_service: { name: 'heroku-db4' }, app: { name: 'myotherapp', id: 101 } }
 
     let api = nock('https://api.heroku.com:443')
       .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'heroku-db4' }).reply(200, [addon])
 
-    return cmd.run({ app: 'myapp', args: ['heroku-db4'], flags: { confirm: 'myapp' } })
-      .then(() => { throw new Error('unreachable') })
-      .catch((err) => {
-        api.done()
-        expect(err.message).to.equal('db4-swiftly-123 is on myotherapp not myapp')
-      })
+    try {
+      await cmd.run({ app: 'myapp', args: ['heroku-db4'], flags: { confirm: 'myapp' } })
+      throw new Error('unreachable')
+    } catch (err) {
+      api.done()
+      expect(err.message).to.equal('db4-swiftly-123 is on myotherapp not myapp')
+    }
   })
 })

--- a/packages/addons-v5/test/commands/addons/detach.js
+++ b/packages/addons-v5/test/commands/addons/detach.js
@@ -8,7 +8,7 @@ describe('addons:detach', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
-  it('detaches an add-on', function () {
+  it('detaches an add-on', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/addon-attachments/redis-123')
       .reply(200, { id: 100, name: 'redis-123', addon: { name: 'redis' } })
@@ -16,11 +16,15 @@ describe('addons:detach', () => {
       .reply(200)
       .get('/apps/myapp/releases')
       .reply(200, [{ version: 10 }])
-    return cmd.run({ app: 'myapp', args: { attachment_name: 'redis-123' } })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal(`Detaching redis-123 to redis from myapp... done
+
+    await cmd.run({ app: 'myapp', args: { attachment_name: 'redis-123' } })
+
+    expect(cli.stdout, 'to be empty');
+
+    expect(cli.stderr).to.equal(`Detaching redis-123 to redis from myapp... done
 Unsetting redis-123 config vars and restarting myapp... done, v10
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 })

--- a/packages/addons-v5/test/commands/addons/docs.js
+++ b/packages/addons-v5/test/commands/addons/docs.js
@@ -6,40 +6,46 @@ let cmd = commands.find((c) => c.topic === 'addons' && c.command === 'docs')
 describe('addons:docs', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('opens an addon by name', function () {
+  it('opens an addon by name', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/addon-services/slowdb')
       .reply(200, { name: 'slowdb' })
 
-    return cmd.run({ args: { addon: 'slowdb:free' }, flags: { 'show-url': true } })
-      .then(() => expect(cli.stdout).to.equal('https://devcenter.heroku.com/articles/slowdb\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => api.done())
+    await cmd.run({ args: { addon: 'slowdb:free' }, flags: { 'show-url': true } })
+
+    expect(cli.stdout).to.equal('https://devcenter.heroku.com/articles/slowdb\n');
+    expect(cli.stderr).to.equal('');
+
+    return api.done()
   })
 
-  it('opens an addon by attachment name', function () {
+  it('opens an addon by attachment name', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/addon-services/my-attachment-1111')
       .reply(404)
       .post('/actions/addons/resolve', { 'addon': 'my-attachment-1111' })
       .reply(200, [{ addon_service: { name: 'slowdb' } }])
 
-    return cmd.run({ args: { addon: 'my-attachment-1111' }, flags: { 'show-url': true } })
-      .then(() => expect(cli.stdout).to.equal('https://devcenter.heroku.com/articles/slowdb\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => api.done())
+    await cmd.run({ args: { addon: 'my-attachment-1111' }, flags: { 'show-url': true } })
+
+    expect(cli.stdout).to.equal('https://devcenter.heroku.com/articles/slowdb\n');
+    expect(cli.stderr).to.equal('');
+
+    return api.done()
   })
 
-  it('opens an addon by app/attachment name', function () {
+  it('opens an addon by app/attachment name', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/addon-services/my-attachment-1111')
       .reply(404)
       .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'my-attachment-1111' })
       .reply(200, [{ addon_service: { name: 'slowdb' } }])
 
-    return cmd.run({ app: 'myapp', args: { addon: 'my-attachment-1111' }, flags: { 'show-url': true } })
-      .then(() => expect(cli.stdout).to.equal('https://devcenter.heroku.com/articles/slowdb\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: { addon: 'my-attachment-1111' }, flags: { 'show-url': true } })
+
+    expect(cli.stdout).to.equal('https://devcenter.heroku.com/articles/slowdb\n');
+    expect(cli.stderr).to.equal('');
+
+    return api.done()
   })
 })

--- a/packages/addons-v5/test/commands/addons/info.js
+++ b/packages/addons-v5/test/commands/addons/info.js
@@ -32,10 +32,10 @@ describe('addons:info', function () {
         .reply(200, [fixtures.attachments['acme-inc-www::DATABASE']])
     })
 
-    it('prints add-ons in a table', function () {
-      return cmd.run({ flags: {}, args: { addon: 'www-db' } }).then(function () {
-        util.expectOutput(cli.stdout,
-          `=== www-db
+    it('prints add-ons in a table', async function() {
+      await cmd.run({ flags: {}, args: { addon: 'www-db' } })
+      util.expectOutput(cli.stdout,
+        `=== www-db
 Attachments:  acme-inc-www::DATABASE
 Installed at: Invalid Date
 Owning app:   acme-inc-www
@@ -43,7 +43,6 @@ Plan:         heroku-postgresql:hobby-dev
 Price:        free
 State:        created
 `)
-      })
     })
   })
 
@@ -64,10 +63,10 @@ State:        created
         .reply(200, [fixtures.attachments['acme-inc-www::DATABASE']])
     })
 
-    it('prints add-ons in a table', function () {
-      return cmd.run({ flags: {}, args: { addon: 'www-db' }, app: 'example' }).then(function () {
-        util.expectOutput(cli.stdout,
-          `=== www-db
+    it('prints add-ons in a table', async function() {
+      await cmd.run({ flags: {}, args: { addon: 'www-db' }, app: 'example' })
+      util.expectOutput(cli.stdout,
+        `=== www-db
 Attachments:  acme-inc-www::DATABASE
 Installed at: Invalid Date
 Owning app:   acme-inc-www
@@ -75,7 +74,6 @@ Plan:         heroku-postgresql:hobby-dev
 Price:        free
 State:        created
 `)
-      })
     })
   })
 
@@ -102,10 +100,10 @@ State:        created
         .reply(200, [fixtures.attachments['acme-inc-www::DATABASE']])
     })
 
-    it('prints add-ons in a table', function () {
-      return cmd.run({ flags: {}, args: { addon: 'www-db' }, app: 'example' }).then(function () {
-        util.expectOutput(cli.stdout,
-          `=== www-db
+    it('prints add-ons in a table', async function() {
+      await cmd.run({ flags: {}, args: { addon: 'www-db' }, app: 'example' })
+      util.expectOutput(cli.stdout,
+        `=== www-db
 Attachments:  acme-inc-www::DATABASE
 Installed at: Invalid Date
 Owning app:   acme-inc-www
@@ -113,7 +111,6 @@ Plan:         heroku-postgresql:hobby-dev
 Price:        free
 State:        created
 `)
-      })
     })
   })
 
@@ -137,10 +134,10 @@ State:        created
         .reply(200, [fixtures.attachments['acme-inc-dwh::DATABASE']])
     })
 
-    it('prints add-ons in a table with grandfathered price', function () {
-      return cmd.run({ flags: {}, args: { addon: 'dwh-db' } }).then(function () {
-        util.expectOutput(cli.stdout,
-          `=== dwh-db
+    it('prints add-ons in a table with grandfathered price', async function() {
+      await cmd.run({ flags: {}, args: { addon: 'dwh-db' } })
+      util.expectOutput(cli.stdout,
+        `=== dwh-db
 Attachments:  acme-inc-dwh::DATABASE
 Installed at: Invalid Date
 Owning app:   acme-inc-dwh
@@ -148,7 +145,6 @@ Plan:         heroku-postgresql:standard-2
 Price:        $100/month
 State:        created
 `)
-      })
     })
   })
 
@@ -172,10 +168,10 @@ State:        created
         .reply(200, [fixtures.attachments['acme-inc-dwh::DATABASE']])
     })
 
-    it('prints add-ons in a table with contract', function () {
-      return cmd.run({ flags: {}, args: { addon: 'dwh-db' } }).then(function () {
-        util.expectOutput(cli.stdout,
-          `=== dwh-db
+    it('prints add-ons in a table with contract', async function() {
+      await cmd.run({ flags: {}, args: { addon: 'dwh-db' } })
+      util.expectOutput(cli.stdout,
+        `=== dwh-db
 Attachments:  acme-inc-dwh::DATABASE
 Installed at: Invalid Date
 Owning app:   acme-inc-dwh
@@ -183,7 +179,6 @@ Plan:         heroku-postgresql:standard-2
 Price:        contract
 State:        created
 `)
-      })
     })
   })
 })

--- a/packages/addons-v5/test/commands/addons/open.js
+++ b/packages/addons-v5/test/commands/addons/open.js
@@ -8,7 +8,7 @@ let cmd = commands.find((c) => c.topic === 'addons' && c.command === 'open')
 describe('addons:open', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('only prints the URL when --show-url passed', function () {
+  it('only prints the URL when --show-url passed', async function() {
     let api = nock('https://api.heroku.com:443')
 
     api.post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'db2' })
@@ -17,12 +17,14 @@ describe('addons:open', function () {
     api.get('/addons/db2/addon-attachments')
       .reply(200, [])
 
-    return cmd.run({ app: 'myapp', args: { addon: 'db2' }, flags: { 'show-url': true } })
-      .then(() => expect(cli.stdout).to.equal('http://db2\n'))
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: { addon: 'db2' }, flags: { 'show-url': true } })
+
+    expect(cli.stdout).to.equal('http://db2\n');
+
+    return api.done()
   })
 
-  it('opens the addon dashboard in a browser by default', function () {
+  it('opens the addon dashboard in a browser by default', async function() {
     let api = nock('https://api.heroku.com:443')
 
     api.post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'slowdb' })
@@ -31,13 +33,15 @@ describe('addons:open', function () {
     api.get('/addons/slowdb/addon-attachments')
       .reply(200, [])
 
-    return cmd.run({ app: 'myapp', args: { addon: 'slowdb' }, flags: { 'show-url': false } })
-      .then(() => expect(cli.open.url).to.equal('http://slowdb'))
-      .then(() => expect(cli.stdout).to.equal('Opening http://slowdb...\n'))
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: { addon: 'slowdb' }, flags: { 'show-url': false } })
+
+    expect(cli.open.url).to.equal('http://slowdb');
+    expect(cli.stdout).to.equal('Opening http://slowdb...\n');
+
+    return api.done()
   })
 
-  it('opens an attached addon, by slug, with the correct `context_app`', function () {
+  it('opens an attached addon, by slug, with the correct `context_app`', async function() {
     let api = nock('https://api.heroku.com:443')
 
     api.post('/actions/addon-attachments/resolve', { 'app': 'myapp-2', 'addon_attachment': 'slowdb' })
@@ -54,9 +58,11 @@ describe('addons:open', function () {
         { app: { name: 'myapp' }, web_url: 'http://myapp-slowdb' },
         { app: { name: 'myapp-2' }, web_url: 'http://myapp-2-slowdb' }])
 
-    return cmd.run({ app: 'myapp-2', args: { addon: 'slowdb' }, flags: { 'show-url': false } })
-      .then(() => expect(cli.open.url).to.equal('http://myapp-2-slowdb'))
-      .then(() => expect(cli.stdout).to.equal('Opening http://myapp-2-slowdb...\n'))
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp-2', args: { addon: 'slowdb' }, flags: { 'show-url': false } })
+
+    expect(cli.open.url).to.equal('http://myapp-2-slowdb');
+    expect(cli.stdout).to.equal('Opening http://myapp-2-slowdb...\n');
+
+    return api.done()
   })
 })

--- a/packages/addons-v5/test/commands/addons/plans.js
+++ b/packages/addons-v5/test/commands/addons/plans.js
@@ -6,7 +6,7 @@ let cmd = commands.find((c) => c.topic === 'addons' && c.command === 'plans')
 describe('addons:plans', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('shows add-on plans', function () {
+  it('shows add-on plans', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/addon-services/daservice/plans')
       .reply(200, [
@@ -15,14 +15,17 @@ describe('addons:plans', function () {
         { name: 'third', human_name: 'Third', price: { cents: 10000, unit: 'month', contract: false }, default: false },
         { name: 'fourth', human_name: 'Fourth', price: { cents: 0, unit: 'month', contract: true }, default: false }
       ])
-    return cmd.run({ args: { service: 'daservice' }, flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`         slug    name    price
+
+    await cmd.run({ args: { service: 'daservice' }, flags: {} })
+
+    expect(cli.stdout).to.equal(`         slug    name    price
 ───────  ──────  ──────  ──────────
 default  first   First   free
          second  Second  $20/month
          third   Third   $100/month
          fourth  Fourth  contract
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 })

--- a/packages/addons-v5/test/commands/addons/services.js
+++ b/packages/addons-v5/test/commands/addons/services.js
@@ -6,21 +6,24 @@ let cmd = commands.find((c) => c.topic === 'addons' && c.command === 'services')
 describe('addons:services', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('shows addon services', function () {
+  it('shows addon services', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/addon-services')
       .reply(200, [
         { name: 'foo', human_name: 'Foo', state: 'ga' },
         { name: 'bar', human_name: 'Bar', state: 'ga' }
       ])
-    return cmd.run({ flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`slug  name  state
+
+    await cmd.run({ flags: {} })
+
+    expect(cli.stdout).to.equal(`slug  name  state
 ────  ────  ─────
 foo   Foo   ga
 bar   Bar   ga
 
 See plans with heroku addons:plans SERVICE
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 })

--- a/packages/addons-v5/test/commands/addons/upgrade.js
+++ b/packages/addons-v5/test/commands/addons/upgrade.js
@@ -13,52 +13,64 @@ describe('addons:upgrade', () => {
 
   afterEach(() => nock.cleanAll())
 
-  it('upgrades an add-on', () => {
+  it('upgrades an add-on', async () => {
     let addon = { name: 'kafka-swiftly-123', addon_service: { name: 'heroku-kafka' }, app: { name: 'myapp' }, plan: { name: 'premium-0' } }
 
     let api = nock('https://api.heroku.com:443')
       .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'heroku-kafka' }).reply(200, [addon])
       .patch('/apps/myapp/addons/kafka-swiftly-123', { plan: { name: 'heroku-kafka:hobby' } })
       .reply(200, { plan: { price: { cents: 0 } }, provision_message: 'provision msg' })
-    return cmd.run({ app: 'myapp', args: { addon: 'heroku-kafka', plan: 'heroku-kafka:hobby' } })
-      .then(() => expect(cli.stdout).to.equal('provision msg\n'))
-      .then(() => expect(cli.stderr).to.equal('Changing kafka-swiftly-123 on myapp from premium-0 to heroku-kafka:hobby... done, free\n'))
-      .then(() => api.done())
+
+    await cmd.run({ app: 'myapp', args: { addon: 'heroku-kafka', plan: 'heroku-kafka:hobby' } })
+
+    expect(cli.stdout).to.equal('provision msg\n');
+    expect(cli.stderr).to.equal('Changing kafka-swiftly-123 on myapp from premium-0 to heroku-kafka:hobby... done, free\n');
+
+    return api.done()
   })
 
-  it('upgrades to a contract add-on', () => {
+  it('upgrades to a contract add-on', async () => {
     let addon = { name: 'connect-swiftly-123', addon_service: { name: 'heroku-connect' }, app: { name: 'myapp' }, plan: { name: 'free' } }
 
     let api = nock('https://api.heroku.com:443')
       .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'heroku-connect' }).reply(200, [addon])
       .patch('/apps/myapp/addons/connect-swiftly-123', { plan: { name: 'heroku-connect:contract' } })
       .reply(200, { plan: { price: { cents: 0, contract: true } }, provision_message: 'provision msg' })
-    return cmd.run({ app: 'myapp', args: { addon: 'heroku-connect', plan: 'heroku-connect:contract' } })
-      .then(() => expect(cli.stdout).to.equal('provision msg\n'))
-      .then(() => expect(cli.stderr).to.equal('Changing connect-swiftly-123 on myapp from free to heroku-connect:contract... done, contract\n'))
-      .then(() => api.done())
+
+    await cmd.run({ app: 'myapp', args: { addon: 'heroku-connect', plan: 'heroku-connect:contract' } })
+
+    expect(cli.stdout).to.equal('provision msg\n');
+    expect(cli.stderr).to.equal('Changing connect-swiftly-123 on myapp from free to heroku-connect:contract... done, contract\n');
+
+    return api.done()
   })
 
-  it('upgrades an add-on with only one argument', () => {
+  it('upgrades an add-on with only one argument', async () => {
     let addon = { name: 'postgresql-swiftly-123', addon_service: { name: 'heroku-postgresql' }, app: { name: 'myapp' }, plan: { name: 'premium-0' } }
 
     let api = nock('https://api.heroku.com:443')
       .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'heroku-postgresql' }).reply(200, [addon])
       .patch('/apps/myapp/addons/postgresql-swiftly-123', { plan: { name: 'heroku-postgresql:hobby' } })
       .reply(200, { plan: { price: { cents: 0 } } })
-    return cmd.run({ app: 'myapp', args: { addon: 'heroku-postgresql:hobby' } })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal('Changing postgresql-swiftly-123 on myapp from premium-0 to heroku-postgresql:hobby... done, free\n'))
-      .then(() => api.done())
+
+    await cmd.run({ app: 'myapp', args: { addon: 'heroku-postgresql:hobby' } })
+
+    expect(cli.stdout, 'to be empty');
+    expect(cli.stderr).to.equal('Changing postgresql-swiftly-123 on myapp from premium-0 to heroku-postgresql:hobby... done, free\n');
+
+    return api.done()
   })
 
-  it('errors with no plan', () => {
-    return cmd.run({ app: 'myapp', args: { addon: 'heroku-redis' } })
-      .then(() => { throw new Error('unreachable') })
-      .catch((err) => expect(err, 'to satisfy', /Error: No plan specified/))
+  it('errors with no plan', async () => {
+    try {
+      await cmd.run({ app: 'myapp', args: { addon: 'heroku-redis' } })
+      throw new Error('unreachable')
+    } catch (err) {
+      return expect(err, 'to satisfy', /Error: No plan specified/)
+    }
   })
 
-  it('errors with invalid plan', () => {
+  it('errors with invalid plan', async () => {
     let addon = { name: 'db1-swiftly-123', addon_service: { name: 'heroku-db1' }, app: { name: 'myapp' }, plan: { name: 'premium-0' } }
 
     let api = nock('https://api.heroku.com:443')
@@ -69,8 +81,8 @@ describe('addons:upgrade', () => {
       ])
       .patch('/apps/myapp/addons/db1-swiftly-123', { plan: { name: 'heroku-db1:invalid' } })
       .reply(422, { message: 'Couldn\'t find either the add-on service or the add-on plan of "heroku-db1:invalid".' })
-    return cmd.run({ app: 'myapp', args: { addon: 'heroku-db1:invalid' } })
-      .then(() => { throw new Error('unreachable') })
+
+    await cmd.run({ app: 'myapp', args: { addon: 'heroku-db1:invalid' } })
       .catch((err) => expect(err.message).to.equal(`Couldn't find either the add-on service or the add-on plan of "heroku-db1:invalid".
 
 Here are the available plans for heroku-db1:
@@ -80,18 +92,23 @@ heroku-db1:premium-0
 See more plan information with heroku addons:plans heroku-db1
 
 https://devcenter.heroku.com/articles/managing-add-ons`))
-      .then(() => api.done())
+
+    throw new Error('unreachable')
+
+    return api.done()
   })
 
-  it('handles multiple add-ons', () => {
+  it('handles multiple add-ons', async () => {
     let api = nock('https://api.heroku.com:443')
       .post('/actions/addons/resolve', { 'app': null, 'addon': 'heroku-redis' })
       .reply(200, [{ 'name': 'db1-swiftly-123' }, { 'name': 'db1-swiftly-456' }])
-    return cmd.run({ args: { addon: 'heroku-redis:invalid' } })
-      .then(() => { throw new Error('unreachable') })
-      .catch((err) => {
-        api.done()
-        expect(err, 'to satisfy', /multiple matching add-ons found/)
-      })
+
+    try {
+      await cmd.run({ args: { addon: 'heroku-redis:invalid' } })
+      throw new Error('unreachable')
+    } catch (err) {
+      api.done()
+      expect(err, 'to satisfy', /multiple matching add-ons found/)
+    }
   })
 })

--- a/packages/addons-v5/test/lib/resolve.js
+++ b/packages/addons-v5/test/lib/resolve.js
@@ -14,267 +14,289 @@ describe('resolve', () => {
   afterEach(() => nock.cleanAll())
 
   describe('addon', () => {
-    it('finds a single matching addon', () => {
+    it('finds a single matching addon', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addons/resolve', { 'app': null, 'addon': 'myaddon-1' }).reply(200, [{ name: 'myaddon-1' }])
 
-      return resolve.addon(new Heroku(), null, 'myaddon-1')
-        .then((addon) => expect(addon, 'to satisfy', { name: 'myaddon-1' }))
-        .then(() => api.done())
+      await resolve.addon(new Heroku(), null, 'myaddon-1')
+
+      expect(addon, 'to satisfy', { name: 'myaddon-1' });
+
+      return api.done()
     })
 
-    it('finds a single matching addon for an app', () => {
+    it('finds a single matching addon for an app', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-2' }).reply(200, [{ name: 'myaddon-2' }])
 
-      return resolve.addon(new Heroku(), 'myapp', 'myaddon-2')
-        .then((addon) => expect(addon, 'to satisfy', { name: 'myaddon-2' }))
-        .then(() => api.done())
+      await resolve.addon(new Heroku(), 'myapp', 'myaddon-2')
+
+      expect(addon, 'to satisfy', { name: 'myaddon-2' });
+
+      return api.done()
     })
 
-    it('fails if no addon found', () => {
+    it('fails if no addon found', async () => {
       nock('https://api.heroku.com:443')
         .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-3' }).reply(404, { 'resource': 'add_on' })
         .post('/actions/addons/resolve', { 'app': null, 'addon': 'myaddon-3' }).reply(404, { 'resource': 'add_on' })
 
-      return resolve.addon(new Heroku(), 'myapp', 'myaddon-3')
-        .then(() => { throw new Error('unreachable') })
-        .catch((err) => expect(err, 'to satisfy', { statusCode: 404 }))
+      try {
+        await resolve.addon(new Heroku(), 'myapp', 'myaddon-3')
+        throw new Error('unreachable')
+      } catch (err) {
+        return expect(err, 'to satisfy', { statusCode: 404 })
+      }
     })
 
-    it('fails if no addon found with addon-service', () => {
+    it('fails if no addon found with addon-service', async () => {
       const api = nock('https://api.heroku.com:443')
         .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-3', 'addon_service': 'slowdb' }).reply(404, { 'resource': 'add_on' })
         .post('/actions/addons/resolve', { 'app': null, 'addon': 'myaddon-3', 'addon_service': 'slowdb' }).reply(404, { 'resource': 'add_on' })
 
-      return resolve.addon(new Heroku(), 'myapp', 'myaddon-3', { 'addon_service': 'slowdb' })
-        .then(() => { throw new Error('unreachable') })
+      await resolve.addon(new Heroku(), 'myapp', 'myaddon-3', { 'addon_service': 'slowdb' })
         .catch((err) => expect(err, 'to satisfy', { statusCode: 404 }))
-        .then(() => api.done())
+
+      throw new Error('unreachable')
+
+      return api.done()
     })
 
-    it('fails if errored', () => {
+    it('fails if errored', async () => {
       nock('https://api.heroku.com:443')
         .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-5' }).reply(401)
 
-      return resolve.addon(new Heroku(), 'myapp', 'myaddon-5')
-        .then(() => { throw new Error('unreachable') })
-        .catch((err) => expect(err, 'to satisfy', { statusCode: 401 }))
+      try {
+        await resolve.addon(new Heroku(), 'myapp', 'myaddon-5')
+        throw new Error('unreachable')
+      } catch (err) {
+        return expect(err, 'to satisfy', { statusCode: 401 })
+      }
     })
 
-    it('fails if ambiguous', () => {
+    it('fails if ambiguous', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-5' })
         .reply(200, [{ 'name': 'myaddon-5' }, { 'name': 'myaddon-6' }])
 
-      return resolve.addon(new Heroku(), 'myapp', 'myaddon-5')
-        .then(() => { throw new Error('unreachable') })
-        .catch(function (err) {
-          api.done()
-          expect(err, 'to satisfy', { message: 'Ambiguous identifier; multiple matching add-ons found: myaddon-5, myaddon-6.', type: 'addon' })
-        })
+      try {
+        await resolve.addon(new Heroku(), 'myapp', 'myaddon-5')
+        throw new Error('unreachable')
+      } catch (err) {
+        api.done()
+        expect(err, 'to satisfy', { message: 'Ambiguous identifier; multiple matching add-ons found: myaddon-5, myaddon-6.', type: 'addon' })
+      }
     })
 
-    it('fails if no addon found', () => {
+    it('fails if no addon found', async () => {
       const api = nock('https://api.heroku.com:443')
         .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-3', 'addon_service': 'slowdb' }).reply(404, { 'resource': 'add_on' })
         .post('/actions/addons/resolve', { 'app': null, 'addon': 'myaddon-3', 'addon_service': 'slowdb' }).reply(404, { 'resource': 'add_on' })
 
-      return resolve.addon(new Heroku(), 'myapp', 'myaddon-3', { 'addon_service': 'slowdb' })
-        .then(() => { throw new Error('unreachable') })
+      await resolve.addon(new Heroku(), 'myapp', 'myaddon-3', { 'addon_service': 'slowdb' })
         .catch((err) => expect(err, 'to satisfy', { statusCode: 404 }))
-        .then(() => { api.done() })
+
+      throw new Error('unreachable')
+
+      api.done()
     })
 
-    it('fails if app not found', () => {
+    it('fails if app not found', async () => {
       const api = nock('https://api.heroku.com:443')
         .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-3', 'addon_service': 'slowdb' }).reply(404, { 'resource': 'app' })
 
-      return resolve.addon(new Heroku(), 'myapp', 'myaddon-3', { 'addon_service': 'slowdb' })
-        .then(() => { throw new Error('unreachable') })
+      await resolve.addon(new Heroku(), 'myapp', 'myaddon-3', { 'addon_service': 'slowdb' })
         .catch((err) => expect(err, 'to satisfy', { statusCode: 404, body: { 'resource': 'app' } }))
-        .then(() => { api.done() })
+
+      throw new Error('unreachable')
+
+      api.done()
     })
 
-    it('finds the addon with null namespace for an app if no namespace is specified', () => {
+    it('finds the addon with null namespace for an app if no namespace is specified', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-1' })
         .reply(200, [{ 'name': 'myaddon-1', 'namespace': null }, { 'name': 'myaddon-1b', 'namespace': 'definitely-not-null' }])
 
-      return resolve.addon(new Heroku(), 'myapp', 'myaddon-1')
-        .then((addon) => expect(addon, 'to satisfy', { name: 'myaddon-1' }))
-        .then(() => api.done())
+      await resolve.addon(new Heroku(), 'myapp', 'myaddon-1')
+
+      expect(addon, 'to satisfy', { name: 'myaddon-1' });
+
+      return api.done()
     })
 
-    it('finds the addon with no namespace for an app if no namespace is specified', () => {
+    it('finds the addon with no namespace for an app if no namespace is specified', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-1' })
         .reply(200, [{ 'name': 'myaddon-1' }, { 'name': 'myaddon-1b', 'namespace': 'definitely-not-null' }])
 
-      return resolve.addon(new Heroku(), 'myapp', 'myaddon-1')
-        .then((addon) => expect(addon, 'to satisfy', { name: 'myaddon-1' }))
-        .then(() => api.done())
+      await resolve.addon(new Heroku(), 'myapp', 'myaddon-1')
+
+      expect(addon, 'to satisfy', { name: 'myaddon-1' });
+
+      return api.done()
     })
 
-    it('finds the addon with the specified namespace for an app if there are multiple addons', () => {
+    it('finds the addon with the specified namespace for an app if there are multiple addons', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-1' })
         .reply(200, [{ 'name': 'myaddon-1' }, { 'name': 'myaddon-1b', 'namespace': 'great-namespace' }])
 
-      return resolve.addon(new Heroku(), 'myapp', 'myaddon-1', { namespace: 'great-namespace' })
-        .then((addon) => expect(addon, 'to satisfy', { name: 'myaddon-1b' }))
-        .then(() => api.done())
+      await resolve.addon(new Heroku(), 'myapp', 'myaddon-1', { namespace: 'great-namespace' })
+
+      expect(addon, 'to satisfy', { name: 'myaddon-1b' });
+
+      return api.done()
     })
 
-    it('finds the addon with the specified namespace for an app if there is only one addon', () => {
+    it('finds the addon with the specified namespace for an app if there is only one addon', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-1' })
         .reply(200, [{ 'name': 'myaddon-1b', 'namespace': 'great-namespace' }])
 
-      return resolve.addon(new Heroku(), 'myapp', 'myaddon-1', { namespace: 'great-namespace' })
-        .then((addon) => expect(addon, 'to satisfy', { name: 'myaddon-1b' }))
-        .then(() => api.done())
+      await resolve.addon(new Heroku(), 'myapp', 'myaddon-1', { namespace: 'great-namespace' })
+
+      expect(addon, 'to satisfy', { name: 'myaddon-1b' });
+
+      return api.done()
     })
 
-    it('fails if there is no addon with the specified namespace for an app', () => {
+    it('fails if there is no addon with the specified namespace for an app', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-1' })
         .reply(200, [{ 'name': 'myaddon-1' }])
 
-      return resolve.addon(new Heroku(), 'myapp', 'myaddon-1', { 'namespace': 'amazing-namespace' })
-        .then(() => { throw new Error('unreachable') })
+      await resolve.addon(new Heroku(), 'myapp', 'myaddon-1', { 'namespace': 'amazing-namespace' })
         .catch((err) => expect(err, 'to satisfy', { statusCode: 404 }))
-        .then(() => { api.done() })
+
+      throw new Error('unreachable')
+
+      api.done()
     })
 
-    it('finds the addon with a namespace for an app if there is only match which happens to have a namespace', () => {
+    it('finds the addon with a namespace for an app if there is only match which happens to have a namespace', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-1' })
         .reply(200, [{ 'name': 'myaddon-1', 'namespace': 'definitely-not-null' }])
 
-      return resolve.addon(new Heroku(), 'myapp', 'myaddon-1')
-        .then((addon) => expect(addon, 'to satisfy', { name: 'myaddon-1' }))
-        .then(() => api.done())
+      await resolve.addon(new Heroku(), 'myapp', 'myaddon-1')
+
+      expect(addon, 'to satisfy', { name: 'myaddon-1' });
+
+      return api.done()
     })
 
     describe('memoization', () => {
-      it('memoizes an addon for an app', () => {
+      it('memoizes an addon for an app', async () => {
         let api = nock('https://api.heroku.com:443')
           .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-6' }).reply(200, [{ name: 'myaddon-6' }])
 
-        return resolve.addon(new Heroku(), 'myapp', 'myaddon-6')
-          .then(function (addon) {
-            expect(addon, 'to satisfy', { name: 'myaddon-6' })
-            api.done()
-          })
-          .then(function () {
-            nock.cleanAll()
+        await resolve.addon(new Heroku(), 'myapp', 'myaddon-6')
 
-            return resolve.addon(new Heroku(), 'myapp', 'myaddon-6')
-              .then(function (memoizedAddon) {
-                expect(memoizedAddon, 'to satisfy', { name: 'myaddon-6' })
-              })
-          })
-          .then(function () {
-            let diffId = nock('https://api.heroku.com:443')
-              .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-7' }).reply(200, [{ name: 'myaddon-7' }])
+        api.done()
+        expect(addon, 'to satisfy', { name: 'myaddon-6' })
+        expect(memoizedAddon, 'to satisfy', { name: 'myaddon-6' })
 
-            return resolve.addon(new Heroku(), 'myapp', 'myaddon-7')
-              .then(function (diffIdAddon) {
-                expect(diffIdAddon, 'to satisfy', { name: 'myaddon-7' })
-                diffId.done()
-              })
-          })
-          .then(function () {
-            let diffApp = nock('https://api.heroku.com:443')
-              .post('/actions/addons/resolve', { 'app': 'fooapp', 'addon': 'myaddon-6' }).reply(200, [{ name: 'myaddon-6' }])
+        const memoizedAddon = await resolve.addon(new Heroku(), 'myapp', 'myaddon-6')
+        nock.cleanAll()
 
-            return resolve.addon(new Heroku(), 'fooapp', 'myaddon-6')
-              .then(function (diffAppAddon) {
-                expect(diffAppAddon, 'to satisfy', { name: 'myaddon-6' })
-                diffApp.done()
-              })
-          })
-          .then(function () {
-            let diffAddonService = nock('https://api.heroku.com:443')
-              .post('/actions/addons/resolve', { 'app': 'fooapp', 'addon': 'myaddon-6', 'addon_service': 'slowdb' }).reply(200, [{ name: 'myaddon-6' }])
+        diffId.done()
+        expect(diffIdAddon, 'to satisfy', { name: 'myaddon-7' })
 
-            return resolve.addon(new Heroku(), 'fooapp', 'myaddon-6', { 'addon_service': 'slowdb' })
-              .then(function (diffAddonServiceAddon) {
-                expect(diffAddonServiceAddon, 'to satisfy', { name: 'myaddon-6' })
-                diffAddonService.done()
-              })
-          })
+        const diffIdAddon = await resolve.addon(new Heroku(), 'myapp', 'myaddon-7')
+        let diffId = nock('https://api.heroku.com:443')
+          .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-7' }).reply(200, [{ name: 'myaddon-7' }])
+
+        diffApp.done()
+        expect(diffAppAddon, 'to satisfy', { name: 'myaddon-6' })
+
+        const diffAppAddon = await resolve.addon(new Heroku(), 'fooapp', 'myaddon-6')
+        let diffApp = nock('https://api.heroku.com:443')
+          .post('/actions/addons/resolve', { 'app': 'fooapp', 'addon': 'myaddon-6' }).reply(200, [{ name: 'myaddon-6' }])
+
+        let diffAddonService = nock('https://api.heroku.com:443')
+          .post('/actions/addons/resolve', { 'app': 'fooapp', 'addon': 'myaddon-6', 'addon_service': 'slowdb' }).reply(200, [{ name: 'myaddon-6' }])
+
+        const diffAddonServiceAddon = await resolve.addon(new Heroku(), 'fooapp', 'myaddon-6', { 'addon_service': 'slowdb' })
+        expect(diffAddonServiceAddon, 'to satisfy', { name: 'myaddon-6' })
+        diffAddonService.done()
       })
 
-      it('does not memoize errors', () => {
+      it('does not memoize errors', async () => {
         let api = nock('https://api.heroku.com:443')
           .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-8' }).reply(403, { id: 'two_factor' })
 
-        return resolve.addon(new Heroku(), 'myapp', 'myaddon-8')
-          .then(() => { throw new Error('unreachable') })
+        await resolve.addon(new Heroku(), 'myapp', 'myaddon-8')
           .catch((err) => expect(err.body, 'to satisfy', { id: 'two_factor' }))
-          .then(() => api.done())
-          .then(function () {
-            nock.cleanAll()
 
-            let apiRetry = nock('https://api.heroku.com:443')
-              .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-8' }).reply(200, [{ name: 'myaddon-8' }])
+        throw new Error('unreachable')
+        api.done();
 
-            return resolve.addon(new Heroku(), 'myapp', 'myaddon-8')
-              .then((addon) => expect(addon, 'to satisfy', { name: 'myaddon-8' }))
-              .then(() => apiRetry.done())
-          })
-          .then(function () {
-            nock.cleanAll()
+        return apiRetry.done()
 
-            return resolve.addon(new Heroku(), 'myapp', 'myaddon-8')
-              .then((addon) => expect(addon, 'to satisfy', { name: 'myaddon-8' }))
-          })
+        await resolve.addon(new Heroku(), 'myapp', 'myaddon-8')
+
+        let apiRetry = nock('https://api.heroku.com:443')
+          .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-8' }).reply(200, [{ name: 'myaddon-8' }])
+
+        nock.cleanAll()
+
+        nock.cleanAll()
+
+        const addon = await resolve.addon(new Heroku(), 'myapp', 'myaddon-8')
+        return expect(addon, 'to satisfy', { name: 'myaddon-8' })
       })
     })
   })
 
   describe('attachment', () => {
-    it('finds a single matching attachment', () => {
+    it('finds a single matching attachment', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addon-attachments/resolve', { 'app': null, 'addon_attachment': 'myattachment' }).reply(200, [{ name: 'myattachment' }])
 
-      return resolve.attachment(new Heroku(), null, 'myattachment')
-        .then((addon) => expect(addon, 'to satisfy', { name: 'myattachment' }))
-        .then(() => api.done())
+      await resolve.attachment(new Heroku(), null, 'myattachment')
+
+      expect(addon, 'to satisfy', { name: 'myattachment' });
+
+      return api.done()
     })
 
-    it('finds a single matching attachment for an app', () => {
+    it('finds a single matching attachment for an app', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addon-attachments/resolve', { 'app': 'myapp', 'addon_attachment': 'myattachment-1' }).reply(200, [{ name: 'myattachment-1' }])
 
-      return resolve.attachment(new Heroku(), 'myapp', 'myattachment-1')
-        .then((addon) => expect(addon, 'to satisfy', { name: 'myattachment-1' }))
-        .then(() => api.done())
+      await resolve.attachment(new Heroku(), 'myapp', 'myattachment-1')
+
+      expect(addon, 'to satisfy', { name: 'myattachment-1' });
+
+      return api.done()
     })
 
-    it('passes on errors getting attachment', () => {
+    it('passes on errors getting attachment', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addon-attachments/resolve', { 'app': null, 'addon_attachment': 'myattachment' }).reply(401)
 
-      return resolve.attachment(new Heroku(), null, 'myattachment')
-        .then(() => { throw new Error('unreachable') })
+      await resolve.attachment(new Heroku(), null, 'myattachment')
         .catch((err) => expect(err, 'to satisfy', { statusCode: 401 }))
-        .then(() => api.done())
+
+      throw new Error('unreachable')
+
+      return api.done()
     })
 
-    it('passes on errors getting app/attachment', () => {
+    it('passes on errors getting app/attachment', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addon-attachments/resolve', { 'app': 'myapp', 'addon_attachment': 'myattachment-2' }).reply(401)
 
-      return resolve.attachment(new Heroku(), 'myapp', 'myattachment-2')
-        .then(() => { throw new Error('unreachable') })
+      await resolve.attachment(new Heroku(), 'myapp', 'myattachment-2')
         .catch((err) => expect(err, 'to satisfy', { statusCode: 401 }))
-        .then(() => api.done())
+
+      throw new Error('unreachable')
+
+      return api.done()
     })
 
-    it('falls back to searching by addon', () => {
+    it('falls back to searching by addon', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addon-attachments/resolve', { 'app': 'myapp', 'addon_attachment': 'myattachment-3' }).reply(404, { 'resource': 'add_on attachment' })
 
@@ -284,14 +306,16 @@ describe('resolve', () => {
       let appAttachment = nock('https://api.heroku.com:443')
         .get('/addons/1e97e8ba-fd24-48a4-8118-eaf287eb7a0f/addon-attachments').reply(200, [{ app: { name: 'myapp' }, name: 'some-random-name' }])
 
-      return resolve.attachment(new Heroku(), 'myapp', 'myattachment-3')
-        .then((addon) => expect(addon, 'to satisfy', { name: 'some-random-name' }))
-        .then(() => api.done())
-        .then(() => appAddon.done())
-        .then(() => appAttachment.done())
+      await resolve.attachment(new Heroku(), 'myapp', 'myattachment-3')
+
+      expect(addon, 'to satisfy', { name: 'some-random-name' });
+      api.done();
+      appAddon.done();
+
+      return appAttachment.done()
     })
 
-    it('falls back to searching by addon and addon_service', () => {
+    it('falls back to searching by addon and addon_service', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addon-attachments/resolve', { 'app': 'myapp', 'addon_attachment': 'myattachment-3', 'addon_service': 'slowdb' }).reply(404, { 'resource': 'add_on attachment' })
 
@@ -301,14 +325,16 @@ describe('resolve', () => {
       let appAttachment = nock('https://api.heroku.com:443')
         .get('/addons/1e97e8ba-fd24-48a4-8118-eaf287eb7a0f/addon-attachments').reply(200, [{ app: { name: 'myapp' }, name: 'some-random-name', addon_service: { name: 'slowdb' } }])
 
-      return resolve.attachment(new Heroku(), 'myapp', 'myattachment-3', { 'addon_service': 'slowdb' })
-        .then((addon) => expect(addon, 'to satisfy', { name: 'some-random-name' }))
-        .then(() => api.done())
-        .then(() => appAddon.done())
-        .then(() => appAttachment.done())
+      await resolve.attachment(new Heroku(), 'myapp', 'myattachment-3', { 'addon_service': 'slowdb' })
+
+      expect(addon, 'to satisfy', { name: 'some-random-name' });
+      api.done();
+      appAddon.done();
+
+      return appAttachment.done()
     })
 
-    it('falls back to searching by addon and addon_service when ambigious', () => {
+    it('falls back to searching by addon and addon_service when ambigious', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addon-attachments/resolve', { 'app': 'myapp', 'addon_attachment': 'myattachment-3', 'addon_service': 'slowdb' }).reply(200, [
           { app: { name: 'myapp' }, name: 'some-random-name-1' },
@@ -321,14 +347,16 @@ describe('resolve', () => {
       let appAttachment = nock('https://api.heroku.com:443')
         .get('/addons/1e97e8ba-fd24-48a4-8118-eaf287eb7a0f/addon-attachments').reply(200, [{ app: { name: 'myapp' }, name: 'some-random-name', addon_service: { name: 'slowdb' } }])
 
-      return resolve.attachment(new Heroku(), 'myapp', 'myattachment-3', { 'addon_service': 'slowdb' })
-        .then((addon) => expect(addon, 'to satisfy', { name: 'some-random-name' }))
-        .then(() => api.done())
-        .then(() => appAddon.done())
-        .then(() => appAttachment.done())
+      await resolve.attachment(new Heroku(), 'myapp', 'myattachment-3', { 'addon_service': 'slowdb' })
+
+      expect(addon, 'to satisfy', { name: 'some-random-name' });
+      api.done();
+      appAddon.done();
+
+      return appAttachment.done()
     })
 
-    it('throws original error when ambigious and searching by addon and addon_service is ambigious', () => {
+    it('throws original error when ambigious and searching by addon and addon_service is ambigious', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addon-attachments/resolve', { 'app': 'myapp', 'addon_attachment': 'myattachment-3', 'addon_service': 'slowdb' }).reply(200, [
           { app: { name: 'myapp' }, name: 'some-random-name-1' },
@@ -344,17 +372,18 @@ describe('resolve', () => {
           { app: { name: 'myapp' }, name: 'some-random-name-b', addon_service: { name: 'slowdb' } }
         ])
 
-      return resolve.attachment(new Heroku(), 'myapp', 'myattachment-3', { 'addon_service': 'slowdb' })
-        .then(() => { throw new Error('unreachable') })
-        .catch(function (err) {
-          api.done()
-          appAddon.done()
-          appAttachment.done()
-          expect(err, 'to satisfy', { message: 'Ambiguous identifier; multiple matching add-ons found: some-random-name-1, some-random-name-2.', type: 'addon_attachment' })
-        })
+      try {
+        await resolve.attachment(new Heroku(), 'myapp', 'myattachment-3', { 'addon_service': 'slowdb' })
+        throw new Error('unreachable')
+      } catch (err) {
+        api.done()
+        appAddon.done()
+        appAttachment.done()
+        expect(err, 'to satisfy', { message: 'Ambiguous identifier; multiple matching add-ons found: some-random-name-1, some-random-name-2.', type: 'addon_attachment' })
+      }
     })
 
-    it('falls back to searching by addon and ignores addon_service if not passed', () => {
+    it('falls back to searching by addon and ignores addon_service if not passed', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addon-attachments/resolve', { 'app': 'myapp', 'addon_attachment': 'myattachment-3' }).reply(404)
 
@@ -364,14 +393,16 @@ describe('resolve', () => {
       let appAttachment = nock('https://api.heroku.com:443')
         .get('/addons/1e97e8ba-fd24-48a4-8118-eaf287eb7a0f/addon-attachments').reply(200, [{ app: { name: 'myapp' }, name: 'some-random-name', addon_service: { name: 'slowdb' } }])
 
-      return resolve.attachment(new Heroku(), 'myapp', 'myattachment-3')
-        .then((addon) => expect(addon, 'to satisfy', { name: 'some-random-name' }))
-        .then(() => api.done())
-        .then(() => appAddon.done())
-        .then(() => appAttachment.done())
+      await resolve.attachment(new Heroku(), 'myapp', 'myattachment-3')
+
+      expect(addon, 'to satisfy', { name: 'some-random-name' });
+      api.done();
+      appAddon.done();
+
+      return appAttachment.done()
     })
 
-    it('throws an error when not found', () => {
+    it('throws an error when not found', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addon-attachments/resolve', { 'app': 'myapp', 'addon_attachment': 'myattachment-4' }).reply(404, { 'resource': 'add_on attachment' })
 
@@ -381,29 +412,33 @@ describe('resolve', () => {
       let appAttachment = nock('https://api.heroku.com:443')
         .get('/addons/1e97e8ba-fd24-48a4-8118-eaf287eb7a0f/addon-attachments').reply(200, [{ app: { name: 'not-myapp' }, name: 'some-random-name' }])
 
-      return resolve.attachment(new Heroku(), 'myapp', 'myattachment-4')
-        .then(() => { throw new Error('unreachable') })
+      await resolve.attachment(new Heroku(), 'myapp', 'myattachment-4')
         .catch((err) => expect(err, 'to satisfy', { message: 'Couldn\'t find that addon.' }))
-        .then(() => api.done())
-        .then(() => appAddon.done())
-        .then(() => appAttachment.done())
+
+      throw new Error('unreachable')
+      api.done();
+      appAddon.done();
+
+      return appAttachment.done()
     })
 
-    it('throws an error when app not found', () => {
+    it('throws an error when app not found', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addon-attachments/resolve', { 'app': 'myapp', 'addon_attachment': 'myattachment-4' }).reply(404, { 'resource': 'app' })
 
       let appAddon = nock('https://api.heroku.com:443')
         .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myattachment-4' }).reply(200, [{ id: '1e97e8ba-fd24-48a4-8118-eaf287eb7a0f', name: 'myaddon-4' }])
 
-      return resolve.attachment(new Heroku(), 'myapp', 'myattachment-4')
-        .then(() => { throw new Error('unreachable') })
+      await resolve.attachment(new Heroku(), 'myapp', 'myattachment-4')
         .catch((err) => expect(err, 'to satisfy', { body: { 'resource': 'app' } }))
-        .then(() => api.done())
-        .then(() => appAddon.done())
+
+      throw new Error('unreachable')
+      api.done();
+
+      return appAddon.done()
     })
 
-    it('throws an error when not found with addon_service', () => {
+    it('throws an error when not found with addon_service', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addon-attachments/resolve', { 'app': 'myapp', 'addon_attachment': 'myattachment-3', 'addon_service': 'slowdb' }).reply(404, { 'resource': 'add_on attachment' })
 
@@ -413,25 +448,29 @@ describe('resolve', () => {
       let appAttachment = nock('https://api.heroku.com:443')
         .get('/addons/1e97e8ba-fd24-48a4-8118-eaf287eb7a0f/addon-attachments').reply(200, [{ app: { name: 'myapp' }, name: 'some-random-name', addon_service: { name: 'not-slowdb' } }])
 
-      return resolve.attachment(new Heroku(), 'myapp', 'myattachment-3', { 'addon_service': 'slowdb' })
-        .then(() => { throw new Error('unreachable') })
+      await resolve.attachment(new Heroku(), 'myapp', 'myattachment-3', { 'addon_service': 'slowdb' })
         .catch((err) => expect(err, 'to satisfy', { message: 'Couldn\'t find that addon.' }))
-        .then(() => api.done())
-        .then(() => appAddon.done())
-        .then(() => appAttachment.done())
+
+      throw new Error('unreachable')
+      api.done();
+      appAddon.done();
+
+      return appAttachment.done()
     })
 
-    it('does not fallback and throws error when there is no app', () => {
+    it('does not fallback and throws error when there is no app', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addon-attachments/resolve', { 'app': null, 'addon_attachment': 'myattachment-4' }).reply(404, { 'resource': 'add_on attachment' })
 
-      return resolve.attachment(new Heroku(), null, 'myattachment-4')
-        .then(() => { throw new Error('unreachable') })
+      await resolve.attachment(new Heroku(), null, 'myattachment-4')
         .catch((err) => expect(err, 'to satisfy', { message: 'Couldn\'t find that addon.' }))
-        .then(() => api.done())
+
+      throw new Error('unreachable')
+
+      return api.done()
     })
 
-    it('throws an error when ambiguous', () => {
+    it('throws an error when ambiguous', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addon-attachments/resolve', { 'app': 'myapp', 'addon_attachment': 'myattachment-5' }).reply(404, { 'resource': 'add_on attachment' })
 
@@ -444,79 +483,92 @@ describe('resolve', () => {
           { app: { name: 'myapp' }, name: 'some-random-name-2' }
         ])
 
-      return resolve.attachment(new Heroku(), 'myapp', 'myattachment-5')
-        .then(() => { throw new Error('unreachable') })
+      await resolve.attachment(new Heroku(), 'myapp', 'myattachment-5')
         .catch((err) => expect(err, 'to satisfy', { message: 'Ambiguous identifier; multiple matching add-ons found: some-random-name-1, some-random-name-2.', type: 'addon_attachment' }))
-        .then(() => api.done())
-        .then(() => appAddon.done())
-        .then(() => appAttachment.done())
+
+      throw new Error('unreachable')
+      api.done();
+      appAddon.done();
+
+      return appAttachment.done()
     })
   })
 
   describe('appAddon', () => {
-    it('finds a single matching addon for an app', () => {
+    it('finds a single matching addon for an app', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-2' }).reply(200, [{ name: 'myaddon-2' }])
 
-      return resolve.appAddon(new Heroku(), 'myapp', 'myaddon-2')
-        .then((addon) => expect(addon, 'to satisfy', { name: 'myaddon-2' }))
-        .then(() => api.done())
+      await resolve.appAddon(new Heroku(), 'myapp', 'myaddon-2')
+
+      expect(addon, 'to satisfy', { name: 'myaddon-2' });
+
+      return api.done()
     })
 
-    it('fails if not found', () => {
+    it('fails if not found', async () => {
       nock('https://api.heroku.com:443')
         .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-5' }).reply(404)
 
-      return resolve.appAddon(new Heroku(), 'myapp', 'myaddon-5')
-        .then(() => { throw new Error('unreachable') })
-        .catch((err) => expect(err, 'to satisfy', { statusCode: 404 }))
+      try {
+        await resolve.appAddon(new Heroku(), 'myapp', 'myaddon-5')
+        throw new Error('unreachable')
+      } catch (err) {
+        return expect(err, 'to satisfy', { statusCode: 404 })
+      }
     })
 
-    it('fails if ambiguous', () => {
+    it('fails if ambiguous', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addons/resolve', { 'app': 'myapp', 'addon': 'myaddon-5' })
         .reply(200, [{ 'name': 'myaddon-5' }, { 'name': 'myaddon-6' }])
 
-      return resolve.appAddon(new Heroku(), 'myapp', 'myaddon-5')
-        .then(() => { throw new Error('unreachable') })
-        .catch(function (err) {
-          api.done()
-          expect(err, 'to satisfy', { message: 'Ambiguous identifier; multiple matching add-ons found: myaddon-5, myaddon-6.', type: 'addon' })
-        })
+      try {
+        await resolve.appAddon(new Heroku(), 'myapp', 'myaddon-5')
+        throw new Error('unreachable')
+      } catch (err) {
+        api.done()
+        expect(err, 'to satisfy', { message: 'Ambiguous identifier; multiple matching add-ons found: myaddon-5, myaddon-6.', type: 'addon' })
+      }
     })
   })
 
   describe('appAttachment', () => {
-    it('finds a single matching attachment for an app', () => {
+    it('finds a single matching attachment for an app', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addon-attachments/resolve', { 'app': 'myapp', 'addon_attachment': 'myattachment-1' }).reply(200, [{ name: 'myattachment-1' }])
 
-      return resolve.appAttachment(new Heroku(), 'myapp', 'myattachment-1')
-        .then((addon) => expect(addon, 'to satisfy', { name: 'myattachment-1' }))
-        .then(() => api.done())
+      await resolve.appAttachment(new Heroku(), 'myapp', 'myattachment-1')
+
+      expect(addon, 'to satisfy', { name: 'myattachment-1' });
+
+      return api.done()
     })
 
-    it('fails if not found', () => {
+    it('fails if not found', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addon-attachments/resolve', { 'app': null, 'addon_attachment': 'myattachment' }).reply(404)
 
-      return resolve.appAttachment(new Heroku(), null, 'myattachment')
-        .then(() => { throw new Error('unreachable') })
+      await resolve.appAttachment(new Heroku(), null, 'myattachment')
         .catch((err) => expect(err, 'to satisfy', { statusCode: 404 }))
-        .then(() => api.done())
+
+      throw new Error('unreachable')
+
+      return api.done()
     })
 
-    it('fails if ambiguous', () => {
+    it('fails if ambiguous', async () => {
       let api = nock('https://api.heroku.com:443')
         .post('/actions/addon-attachments/resolve', { 'app': 'myapp', 'addon_attachment': 'myaddon-5' })
         .reply(200, [{ 'name': 'myaddon-5' }, { 'name': 'myaddon-6' }])
 
-      return resolve.appAttachment(new Heroku(), 'myapp', 'myaddon-5')
-        .then(() => { throw new Error('unreachable') })
-        .catch(function (err) {
-          expect(err, 'to satisfy', { message: 'Ambiguous identifier; multiple matching add-ons found: myaddon-5, myaddon-6.', type: 'addon_attachment' })
-          api.done()
-        })
+      try {
+        await resolve.appAttachment(new Heroku(), 'myapp', 'myaddon-5')
+        throw new Error('unreachable')
+      } catch (err) {
+        expect(err, 'to satisfy', { message: 'Ambiguous identifier; multiple matching add-ons found: myaddon-5, myaddon-6.', type: 'addon_attachment' })
+        api.done()
+      }
     })
   })
 })

--- a/packages/apps-v5/test/assert_exit.js
+++ b/packages/apps-v5/test/assert_exit.js
@@ -3,15 +3,16 @@
 let expect = require('chai').expect
 let cli = require('heroku-cli-util')
 
-function exit (code, gen) {
+async function exit(code, gen) {
   var actual
-  return gen.catch(function (err) {
+
+  await gen.catch(function (err) {
     expect(err).to.be.an.instanceof(cli.exit.ErrorExit)
     actual = err.code
-  }).then(function () {
-    expect(actual).to.be.an('number', 'Expected error.exit(i) to be called with a number')
-    expect(actual).to.equal(code)
   })
+
+  expect(actual).to.be.an('number', 'Expected error.exit(i) to be called with a number')
+  expect(actual).to.equal(code)
 }
 
 module.exports = exit

--- a/packages/apps-v5/test/commands/apps/create.js
+++ b/packages/apps-v5/test/commands/apps/create.js
@@ -20,7 +20,7 @@ describe('apps:create', function () {
     expect(apps).to.have.own.property('wantsOrg', true)
   })
 
-  it('creates an app', function () {
+  it('creates an app', async function() {
     let mock = nock('https://api.heroku.com')
       .post('/apps', {
       })
@@ -30,14 +30,13 @@ describe('apps:create', function () {
         web_url: 'https://foobar.com'
       })
 
-    return apps.run({ flags: {}, args: {}, httpGitHost: 'git.heroku.com', config }).then(function () {
-      mock.done()
-      expect(cli.stderr).to.equal('Creating app... done, foobar\n')
-      expect(cli.stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n')
-    })
+    await apps.run({ flags: {}, args: {}, httpGitHost: 'git.heroku.com', config })
+    mock.done()
+    expect(cli.stderr).to.equal('Creating app... done, foobar\n')
+    expect(cli.stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n')
   })
 
-  it('creates an app with feature flags', function () {
+  it('creates an app with feature flags', async function() {
     let mock = nock('https://api.heroku.com')
       .post('/apps', {
         feature_flags: 'feature-1,feature-2'
@@ -48,14 +47,13 @@ describe('apps:create', function () {
         web_url: 'https://foobar.com'
       })
 
-    return apps.run({ flags: { features: 'feature-1,feature-2' }, args: {}, httpGitHost: 'git.heroku.com', config }).then(function () {
-      mock.done()
-      expect(cli.stderr).to.equal('Creating app... done, foobar\n')
-      expect(cli.stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n')
-    })
+    await apps.run({ flags: { features: 'feature-1,feature-2' }, args: {}, httpGitHost: 'git.heroku.com', config })
+    mock.done()
+    expect(cli.stderr).to.equal('Creating app... done, foobar\n')
+    expect(cli.stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n')
   })
 
-  it('creates an app in a space', function () {
+  it('creates an app in a space', async function() {
     let mock = nock('https://api.heroku.com')
       .post('/teams/apps', {
         space: 'my-space-name'
@@ -66,14 +64,13 @@ describe('apps:create', function () {
         web_url: 'https://foobar.com'
       })
 
-    return apps.run({ flags: { space: 'my-space-name' }, args: {}, httpGitHost: 'git.heroku.com', config }).then(function () {
-      mock.done()
-      expect(cli.stderr).to.equal('Creating app in space my-space-name... done, foobar\n')
-      expect(cli.stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n')
-    })
+    await apps.run({ flags: { space: 'my-space-name' }, args: {}, httpGitHost: 'git.heroku.com', config })
+    mock.done()
+    expect(cli.stderr).to.equal('Creating app in space my-space-name... done, foobar\n')
+    expect(cli.stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n')
   })
 
-  it('creates an Internal Web App in a space', function () {
+  it('creates an Internal Web App in a space', async function() {
     let mock = nock('https://api.heroku.com')
       .post('/teams/apps', {
         space: 'my-space-name',
@@ -86,25 +83,26 @@ describe('apps:create', function () {
         web_url: 'https://foobar.com'
       })
 
-    return apps.run({ flags: { space: 'my-space-name', 'internal-routing': true }, args: {}, httpGitHost: 'git.heroku.com', config }).then(function () {
-      mock.done()
-      expect(cli.stderr).to.equal('Creating app in space my-space-name... done, foobar\n')
-      expect(cli.stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n')
-    })
+    await apps.run({ flags: { space: 'my-space-name', 'internal-routing': true }, args: {}, httpGitHost: 'git.heroku.com', config })
+    mock.done()
+    expect(cli.stderr).to.equal('Creating app in space my-space-name... done, foobar\n')
+    expect(cli.stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n')
   })
 
-  it('does not create an Internal Web App outside of a space', function () {
+  it('does not create an Internal Web App outside of a space', async function() {
     let thrown = false
-    return apps.run({ flags: { 'internal-routing': true }, args: {}, httpGitHost: 'git.heroku.com', config })
+
+    await apps.run({ flags: { 'internal-routing': true }, args: {}, httpGitHost: 'git.heroku.com', config })
       .catch(function (err) {
         expect(err).to.be.an.instanceof(Error)
         expect(err.message).to.equal('Space name required.\nInternal Web Apps are only available for Private Spaces.\nUSAGE: heroku apps:create --space my-space --internal-routing')
         thrown = true
       })
-      .then(() => expect(thrown).to.equal(true))
+
+    return expect(thrown).to.equal(true)
   })
 
-  it('creates an app & returns as json', function () {
+  it('creates an app & returns as json', async function() {
     const json = {
       name: 'foobar',
       stack: { name: 'cedar-14' },
@@ -115,11 +113,10 @@ describe('apps:create', function () {
       })
       .reply(200, json)
 
-    return apps.run({ flags: { json: true }, args: {}, httpGitHost: 'git.heroku.com', config }).then(function () {
-      mock.done()
+    await apps.run({ flags: { json: true }, args: {}, httpGitHost: 'git.heroku.com', config })
+    mock.done()
 
-      expect(cli.stderr).to.equal('Creating app... done, foobar\n')
-      expect(JSON.parse(cli.stdout), 'to satisfy', json)
-    })
+    expect(cli.stderr).to.equal('Creating app... done, foobar\n')
+    expect(JSON.parse(cli.stdout), 'to satisfy', json)
   })
 })

--- a/packages/apps-v5/test/commands/apps/destroy.js
+++ b/packages/apps-v5/test/commands/apps/destroy.js
@@ -9,27 +9,32 @@ const cmd = commands.find(c => c.topic === 'apps' && c.command === 'destroy')
 describe('apps:destroy', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('deletes the app', function () {
+  it('deletes the app', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp').reply(200, { name: 'myapp' })
       .delete('/apps/myapp').reply(200)
 
-    return cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp' } })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('Destroying myapp (including all add-ons)... done\n'))
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp' } })
+
+    expect(cli.stdout).to.equal('');
+    expect(cli.stderr).to.equal('Destroying myapp (including all add-ons)... done\n');
+
+    return api.done()
   })
 
-  it('deletes the app via arg', function () {
+  it('deletes the app via arg', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp').reply(200, { name: 'myapp' })
       .delete('/apps/myapp').reply(200)
 
     let context = { args: { app: 'myapp' }, flags: { confirm: 'myapp' } }
-    return cmd.run(context)
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('Destroying myapp (including all add-ons)... done\n'))
-      .then(() => api.done())
-      .then(() => expect(context.app).to.equal('myapp'))
+
+    await cmd.run(context)
+
+    expect(cli.stdout).to.equal('');
+    expect(cli.stderr).to.equal('Destroying myapp (including all add-ons)... done\n');
+    api.done();
+
+    return expect(context.app).to.equal('myapp')
   })
 })

--- a/packages/apps-v5/test/commands/apps/errors.js
+++ b/packages/apps-v5/test/commands/apps/errors.js
@@ -38,7 +38,7 @@ describe('apps:errors', () => {
     }
   }
 
-  it('shows no errors', () => {
+  it('shows no errors', async () => {
     const heroku = nock('https://api.heroku.com:443')
       .get('/apps/myapp/formation')
       .reply(200, formation)
@@ -50,15 +50,18 @@ describe('apps:errors', () => {
       .get(`/apps/myapp/formation/web/metrics/errors?start_time=${yesterday.toISOString()}&end_time=${now.toISOString()}&step=1h`)
       .reply(200, { data: {} })
 
-    return cmd.run({ app: 'myapp', flags: { json: false } })
-      .then(() => expect(cli.stdout, 'to be', `No errors on myapp in the last 24 hours
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => metrics.done())
-      .then(() => heroku.done())
+    await cmd.run({ app: 'myapp', flags: { json: false } })
+
+    expect(cli.stdout, 'to be', `No errors on myapp in the last 24 hours
+`);
+
+    expect(cli.stderr, 'to be empty');
+    metrics.done();
+
+    return heroku.done()
   })
 
-  it('traps bad request', () => {
+  it('traps bad request', async () => {
     const heroku = nock('https://api.heroku.com:443')
       .get('/apps/myapp/formation')
       .reply(200, formation)
@@ -70,12 +73,15 @@ describe('apps:errors', () => {
       .get(`/apps/myapp/formation/web/metrics/errors?start_time=${yesterday.toISOString()}&end_time=${now.toISOString()}&step=1h`)
       .reply(400, { id: 'bad_request', message: 'invalid process_type provided (valid examples: web, worker, etc); ' })
 
-    return cmd.run({ app: 'myapp', flags: { json: false } })
-      .then(() => expect(cli.stdout, 'to be', `No errors on myapp in the last 24 hours
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => metrics.done())
-      .then(() => heroku.done())
+    await cmd.run({ app: 'myapp', flags: { json: false } })
+
+    expect(cli.stdout, 'to be', `No errors on myapp in the last 24 hours
+`);
+
+    expect(cli.stderr, 'to be empty');
+    metrics.done();
+
+    return heroku.done()
   })
 
   it('propagates other bad request', () => {
@@ -93,7 +99,7 @@ describe('apps:errors', () => {
     return expect(cmd.run({ app: 'myapp', flags: { json: false } })).to.be.rejected
   })
 
-  it('shows errors', () => {
+  it('shows errors', async () => {
     const heroku = nock('https://api.heroku.com:443')
       .get('/apps/myapp/formation')
       .reply(200, formation)
@@ -105,21 +111,24 @@ describe('apps:errors', () => {
       .get(`/apps/myapp/formation/web/metrics/errors?start_time=${yesterday.toISOString()}&end_time=${now.toISOString()}&step=1h`)
       .reply(200, { data: { R14: [1] } })
 
-    return cmd.run({ app: 'myapp', flags: { json: false } })
-      .then(() => expect(cli.stdout, 'to be', `=== Errors on myapp in the last 24 hours
+    await cmd.run({ app: 'myapp', flags: { json: false } })
+
+    expect(cli.stdout, 'to be', `=== Errors on myapp in the last 24 hours
 source  name  level     desc                        count
 ──────  ────  ────────  ──────────────────────────  ─────
 router  H12   critical  Request Timeout             2
 router  H25   critical  HTTP Restriction            3
 router  H27   info      Client Request Interrupted  9
 web     R14   critical  Memory quota exceeded       1
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => metrics.done())
-      .then(() => heroku.done())
+`);
+
+    expect(cli.stderr, 'to be empty');
+    metrics.done();
+
+    return heroku.done()
   })
 
-  it('shows errors as json', () => {
+  it('shows errors as json', async () => {
     const heroku = nock('https://api.heroku.com:443')
       .get('/apps/myapp/formation')
       .reply(200, formation)
@@ -131,10 +140,12 @@ web     R14   critical  Memory quota exceeded       1
       .get(`/apps/myapp/formation/web/metrics/errors?start_time=${yesterday.toISOString()}&end_time=${now.toISOString()}&step=1h`)
       .reply(200, { data: {} })
 
-    return cmd.run({ app: 'myapp', flags: { json: true } })
-      .then(() => expect(JSON.parse(cli.stdout), 'to satisfy', { router: { H12: 2 } }))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => metrics.done())
-      .then(() => heroku.done())
+    await cmd.run({ app: 'myapp', flags: { json: true } })
+
+    expect(JSON.parse(cli.stdout), 'to satisfy', { router: { H12: 2 } });
+    expect(cli.stderr, 'to be empty');
+    metrics.done();
+
+    return heroku.done()
   })
 })

--- a/packages/apps-v5/test/commands/apps/favorites/add.js
+++ b/packages/apps-v5/test/commands/apps/favorites/add.js
@@ -9,16 +9,18 @@ const cmd = commands.find((c) => c.topic === 'apps' && c.command === 'favorites:
 describe('apps:favorites:add', () => {
   beforeEach(() => cli.mockConsole())
 
-  it('adds the app as a favorite', () => {
+  it('adds the app as a favorite', async () => {
     let api = nock('https://particleboard.heroku.com')
       .get('/favorites?type=app')
       .reply(200, [])
       .post('/favorites', { type: 'app', resource_id: 'myapp' })
       .reply(201)
 
-    return cmd.run({ app: 'myapp' })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('Adding myapp to favorites... done\n'))
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp' })
+
+    expect(cli.stdout).to.equal('');
+    expect(cli.stderr).to.equal('Adding myapp to favorites... done\n');
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/apps/favorites/index.js
+++ b/packages/apps-v5/test/commands/apps/favorites/index.js
@@ -10,28 +10,33 @@ describe('apps:favorites:remove', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
-  it('shows all favorite apps', () => {
+  it('shows all favorite apps', async () => {
     let api = nock('https://particleboard.heroku.com:443')
       .get('/favorites?type=app')
       .reply(200, [{ resource_name: 'myapp' }, { resource_name: 'myotherapp' }])
 
-    return cmd.run({ app: 'myapp', flags: { json: false } })
-      .then(() => expect(cli.stdout).to.equal(`=== Favorited Apps
+    await cmd.run({ app: 'myapp', flags: { json: false } })
+
+    expect(cli.stdout).to.equal(`=== Favorited Apps
 myapp
 myotherapp
-`))
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr).to.equal('');
+
+    return api.done()
   })
 
-  it('shows all favorite apps as json', () => {
+  it('shows all favorite apps as json', async () => {
     let api = nock('https://particleboard.heroku.com:443')
       .get('/favorites?type=app')
       .reply(200, [{ resource_name: 'myapp' }, { resource_name: 'myotherapp' }])
 
-    return cmd.run({ app: 'myapp', flags: { json: true } })
-      .then(() => expect(JSON.parse(cli.stdout)[0].resource_name).to.equal('myapp'))
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', flags: { json: true } })
+
+    expect(JSON.parse(cli.stdout)[0].resource_name).to.equal('myapp');
+    expect(cli.stderr).to.equal('');
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/apps/favorites/remove.js
+++ b/packages/apps-v5/test/commands/apps/favorites/remove.js
@@ -9,16 +9,18 @@ const cmd = commands.find((c) => c.topic === 'apps' && c.command === 'favorites:
 describe('apps:favorites:remove', () => {
   beforeEach(() => cli.mockConsole())
 
-  it('removes the app as a favorite', () => {
+  it('removes the app as a favorite', async () => {
     let api = nock('https://particleboard.heroku.com:443')
       .get('/favorites?type=app')
       .reply(200, [{ id: 'favoriteid', resource_name: 'myapp' }])
       .delete('/favorites/favoriteid')
       .reply(201)
 
-    return cmd.run({ app: 'myapp' })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('Removing myapp from favorites... done\n'))
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp' })
+
+    expect(cli.stdout).to.equal('');
+    expect(cli.stderr).to.equal('Removing myapp from favorites... done\n');
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/apps/index.js
+++ b/packages/apps-v5/test/commands/apps/index.js
@@ -106,153 +106,142 @@ describe('heroku apps:list', function () {
   afterEach(() => nock.cleanAll())
 
   describe('with no args', function () {
-    it('displays a message when the user has no apps', function () {
+    it('displays a message when the user has no apps', async function() {
       let mock = stubUserApps([])
-      return apps.run({ flags: {}, args: {} }).then(function () {
-        mock.done()
-        expect(cli.stderr).to.equal('')
-        expect(cli.stdout).to.equal('You have no apps.\n')
-      })
+      await apps.run({ flags: {}, args: {} })
+      mock.done()
+      expect(cli.stderr).to.equal('')
+      expect(cli.stdout).to.equal('You have no apps.\n')
     })
 
-    it('list all user apps', function () {
+    it('list all user apps', async function() {
       let mock = stubUserApps([example, collabApp])
-      return apps.run({ flags: {}, args: {} }).then(function () {
-        mock.done()
-        expect(cli.stderr).to.equal('')
-        expect(cli.stdout).to.equal(
-          `=== foo@bar.com Apps
+      await apps.run({ flags: {}, args: {} })
+      mock.done()
+      expect(cli.stderr).to.equal('')
+      expect(cli.stdout).to.equal(
+        `=== foo@bar.com Apps
 example
 
 === Collaborated Apps
 collab-app  someone-else@bar.com
 `)
-      })
     })
 
-    it('lists all apps', function () {
+    it('lists all apps', async function() {
       let mock = stubApps([example, collabApp, teamApp1])
-      return apps.run({ flags: { all: true }, args: {} }).then(function () {
-        mock.done()
-        expect(cli.stderr).to.equal('')
-        expect(cli.stdout).to.equal(
-          `=== foo@bar.com Apps
+      await apps.run({ flags: { all: true }, args: {} })
+      mock.done()
+      expect(cli.stderr).to.equal('')
+      expect(cli.stdout).to.equal(
+        `=== foo@bar.com Apps
 example
 
 === Collaborated Apps
 collab-app  someone-else@bar.com
 team-app-1  test-team@herokumanager.com
 `)
-      })
     })
 
-    it('shows as json', function () {
+    it('shows as json', async function() {
       let mock = stubUserApps([example, collabApp])
-      return apps.run({ flags: { json: true }, args: {} }).then(function () {
-        mock.done()
-        expect(cli.stderr).to.equal('')
-        expect(JSON.parse(cli.stdout)[0].name).to.equal('collab-app')
-      })
+      await apps.run({ flags: { json: true }, args: {} })
+      mock.done()
+      expect(cli.stderr).to.equal('')
+      expect(JSON.parse(cli.stdout)[0].name).to.equal('collab-app')
     })
 
-    it('shows region if not us', function () {
+    it('shows region if not us', async function() {
       let mock = stubUserApps([example, euApp])
-      return apps.run({ flags: {}, args: {} }).then(function () {
-        mock.done()
-        expect(cli.stderr).to.equal('')
-        expect(cli.stdout).to.equal(`=== foo@bar.com Apps
+      await apps.run({ flags: {}, args: {} })
+      mock.done()
+      expect(cli.stderr).to.equal('')
+      expect(cli.stdout).to.equal(`=== foo@bar.com Apps
 example
 example-eu (eu)
 
 `)
-      })
     })
 
-    it('shows locked app', function () {
+    it('shows locked app', async function() {
       let mock = stubUserApps([example, euApp, lockedApp])
-      return apps.run({ flags: {}, args: {} }).then(function () {
-        mock.done()
-        expect(cli.stderr).to.equal('')
-        expect(cli.stdout).to.equal(`=== foo@bar.com Apps
+      await apps.run({ flags: {}, args: {} })
+      mock.done()
+      expect(cli.stderr).to.equal('')
+      expect(cli.stdout).to.equal(`=== foo@bar.com Apps
 example
 example-eu (eu)
 locked-app [locked]
 
 `)
-      })
     })
 
-    it('shows locked eu app', function () {
+    it('shows locked eu app', async function() {
       let euLockedApp = Object.assign(lockedApp, { region: { name: 'eu' } })
       let mock = stubUserApps([example, euApp, euLockedApp])
-      return apps.run({ flags: {}, args: {} }).then(function () {
-        mock.done()
-        expect(cli.stderr).to.equal('')
-        expect(cli.stdout).to.equal(`=== foo@bar.com Apps
+      await apps.run({ flags: {}, args: {} })
+      mock.done()
+      expect(cli.stderr).to.equal('')
+      expect(cli.stdout).to.equal(`=== foo@bar.com Apps
 example
 example-eu (eu)
 locked-app [locked] (eu)
 
 `)
-      })
     })
 
-    it('shows internal app', function () {
+    it('shows internal app', async function() {
       let mock = stubUserApps([example, euApp, internalApp])
-      return apps.run({ flags: {}, args: {} }).then(function () {
-        mock.done()
-        expect(cli.stderr).to.equal('')
-        expect(cli.stdout).to.equal(`=== foo@bar.com Apps
+      await apps.run({ flags: {}, args: {} })
+      mock.done()
+      expect(cli.stderr).to.equal('')
+      expect(cli.stdout).to.equal(`=== foo@bar.com Apps
 example
 example-eu (eu)
 internal-app [internal]
 
 `)
-      })
     })
 
-    it('shows internal locked app', function () {
+    it('shows internal locked app', async function() {
       let mock = stubUserApps([example, euApp, internalLockedApp])
-      return apps.run({ flags: {}, args: {} }).then(function () {
-        mock.done()
-        expect(cli.stderr).to.equal('')
-        expect(cli.stdout).to.equal(`=== foo@bar.com Apps
+      await apps.run({ flags: {}, args: {} })
+      mock.done()
+      expect(cli.stderr).to.equal('')
+      expect(cli.stdout).to.equal(`=== foo@bar.com Apps
 example
 example-eu (eu)
 internal-app [internal/locked]
 
 `)
-      })
     })
 
-    it('shows internal eu app', function () {
+    it('shows internal eu app', async function() {
       let euInternalApp = Object.assign(internalApp, { region: { name: 'eu' } })
       let mock = stubUserApps([example, euApp, euInternalApp])
-      return apps.run({ flags: {}, args: {} }).then(function () {
-        mock.done()
-        expect(cli.stderr).to.equal('')
-        expect(cli.stdout).to.equal(`=== foo@bar.com Apps
+      await apps.run({ flags: {}, args: {} })
+      mock.done()
+      expect(cli.stderr).to.equal('')
+      expect(cli.stdout).to.equal(`=== foo@bar.com Apps
 example
 example-eu (eu)
 internal-app [internal] (eu)
 
 `)
-      })
     })
 
-    it('shows internal locked eu app', function () {
+    it('shows internal locked eu app', async function() {
       let euInternalLockedApp = Object.assign(internalLockedApp, { region: { name: 'eu' } })
       let mock = stubUserApps([example, euApp, euInternalLockedApp])
-      return apps.run({ flags: {}, args: {} }).then(function () {
-        mock.done()
-        expect(cli.stderr).to.equal('')
-        expect(cli.stdout).to.equal(`=== foo@bar.com Apps
+      await apps.run({ flags: {}, args: {} })
+      mock.done()
+      expect(cli.stderr).to.equal('')
+      expect(cli.stdout).to.equal(`=== foo@bar.com Apps
 example
 example-eu (eu)
 internal-app [internal/locked] (eu)
 
 `)
-      })
     })
   })
 
@@ -261,54 +250,50 @@ internal-app [internal/locked] (eu)
       expect(apps).to.have.own.property('wantsOrg', true)
     })
 
-    it('displays a message when the team has no apps', function () {
+    it('displays a message when the team has no apps', async function() {
       let mock = stubteamApps('test-team', [])
-      return apps.run({ flags: { team: 'test-team' }, args: {} }).then(function () {
-        mock.done()
-        expect(cli.stderr).to.equal('')
-        expect(cli.stdout).to.equal(`There are no apps in team test-team.
+      await apps.run({ flags: { team: 'test-team' }, args: {} })
+      mock.done()
+      expect(cli.stderr).to.equal('')
+      expect(cli.stdout).to.equal(`There are no apps in team test-team.
 `)
-      })
     })
 
-    it('list all in a team', function () {
+    it('list all in a team', async function() {
       let mock = stubteamApps('test-team', [teamApp1, teamApp2])
-      return apps.run({ flags: { team: 'test-team' }, args: {} }).then(function () {
-        mock.done()
-        expect(cli.stderr).to.equal('')
-        expect(cli.stdout).to.equal(
-          `=== Apps in team test-team
+      await apps.run({ flags: { team: 'test-team' }, args: {} })
+      mock.done()
+      expect(cli.stderr).to.equal('')
+      expect(cli.stdout).to.equal(
+        `=== Apps in team test-team
 team-app-1
 team-app-2
 
 `)
-      })
     })
   })
 
   describe('with team', function () {
-    it('displays a message when the team has no apps', function () {
+    it('displays a message when the team has no apps', async function() {
       let mock = stubteamApps('test-team', [])
-      return apps.run({ flags: { team: 'test-team' }, args: {} }).then(function () {
-        mock.done()
-        expect(cli.stderr).to.equal('')
-        expect(cli.stdout).to.equal(`There are no apps in team test-team.
+      await apps.run({ flags: { team: 'test-team' }, args: {} })
+      mock.done()
+      expect(cli.stderr).to.equal('')
+      expect(cli.stdout).to.equal(`There are no apps in team test-team.
 `)
-      })
     })
 
-    it('list all in an team', function () {
+    it('list all in an team', async function() {
       let mock = stubteamApps('test-team', [teamApp1, teamApp2])
-      return apps.run({ flags: { team: 'test-team' }, args: {} }).then(function () {
-        mock.done()
-        expect(cli.stderr).to.equal('')
-        expect(cli.stdout).to.equal(
-          `=== Apps in team test-team
+      await apps.run({ flags: { team: 'test-team' }, args: {} })
+      mock.done()
+      expect(cli.stderr).to.equal('')
+      expect(cli.stdout).to.equal(
+        `=== Apps in team test-team
 team-app-1
 team-app-2
 
 `)
-      })
     })
   })
 
@@ -319,43 +304,40 @@ team-app-2
         .reply(200, { team: { name: 'test-team' } })
     })
 
-    it('displays a message when the space has no apps', function () {
+    it('displays a message when the space has no apps', async function() {
       let mock = stubteamApps('test-team', [])
-      return apps.run({ flags: { space: 'test-space' }, args: {} }).then(function () {
-        mock.done()
-        expect(cli.stderr).to.equal('')
-        expect(cli.stdout).to.equal(`There are no apps in space test-space.
+      await apps.run({ flags: { space: 'test-space' }, args: {} })
+      mock.done()
+      expect(cli.stderr).to.equal('')
+      expect(cli.stdout).to.equal(`There are no apps in space test-space.
 `)
-      })
     })
 
-    it('lists only apps in spaces by name', function () {
+    it('lists only apps in spaces by name', async function() {
       let mock = stubteamApps('test-team', [teamSpaceApp1, teamSpaceApp2, teamApp1])
-      return apps.run({ flags: { space: 'test-space' }, args: {} }).then(function () {
-        mock.done()
-        expect(cli.stderr).to.equal('')
-        expect(cli.stdout).to.equal(
-          `=== Apps in space test-space
+      await apps.run({ flags: { space: 'test-space' }, args: {} })
+      mock.done()
+      expect(cli.stderr).to.equal('')
+      expect(cli.stdout).to.equal(
+        `=== Apps in space test-space
 space-app-1
 space-app-2
 
 `
-        )
-      })
+      )
     })
 
-    it('lists only internal apps in spaces by name', function () {
+    it('lists only internal apps in spaces by name', async function() {
       let mock = stubteamApps('test-team', [teamSpaceApp1, teamSpaceApp2, teamApp1, teamSpaceInternalApp])
-      return apps.run({ flags: { space: 'test-space', 'internal-routing': true }, args: {} }).then(function () {
-        mock.done()
-        expect(cli.stderr).to.equal('')
-        expect(cli.stdout).to.equal(
-          `=== Apps in space test-space
+      await apps.run({ flags: { space: 'test-space', 'internal-routing': true }, args: {} })
+      mock.done()
+      expect(cli.stderr).to.equal('')
+      expect(cli.stdout).to.equal(
+        `=== Apps in space test-space
 space-internal-app [internal]
 
 `
-        )
-      })
+      )
     })
   })
 })

--- a/packages/apps-v5/test/commands/apps/info.js
+++ b/packages/apps-v5/test/commands/apps/info.js
@@ -51,7 +51,7 @@ let collaborators = [
 describe('apps:info', () => {
   beforeEach(() => cli.mockConsole())
 
-  it('shows app info', () => {
+  it('shows app info', async () => {
     let appApi = nock('https://api.heroku.com', {
       reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3.cedar-acm' }
     }).get('/apps/myapp').reply(200, appAcm)
@@ -60,9 +60,12 @@ describe('apps:info', () => {
       .get('/apps/myapp/addons').reply(200, addons)
       .get('/apps/myapp/collaborators').reply(200, collaborators)
       .get('/apps/myapp/dynos').reply(200, [{ type: 'web', size: 'Standard-1X', quantity: 2 }])
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(cli.stdout).to.equal(`=== myapp
+
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    expect(cli.stderr).to.equal('');
+
+    expect(cli.stdout).to.equal(`=== myapp
 Addons:           heroku-redis
                   papertrail
 Auto Cert Mgmt:   true
@@ -78,12 +81,14 @@ Slug Size:        1000 B
 Space:            myspace
 Stack:            cedar-14
 Web URL:          https://myapp.herokuapp.com
-`))
-      .then(() => appApi.done())
-      .then(() => api.done())
+`);
+
+    appApi.done();
+
+    return api.done()
   })
 
-  it('shows extended app info', () => {
+  it('shows extended app info', async () => {
     let appApi = nock('https://api.heroku.com', {
       reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3.cedar-acm' }
     }).get('/apps/myapp').reply(200, appAcm)
@@ -93,9 +98,12 @@ Web URL:          https://myapp.herokuapp.com
       .get('/apps/myapp/addons').reply(200, addons)
       .get('/apps/myapp/collaborators').reply(200, collaborators)
       .get('/apps/myapp/dynos').reply(200, [{ type: 'web', size: 'Standard-1X', quantity: 2 }])
-    return cmd.run({ app: 'myapp', args: {}, flags: { extended: true } })
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(cli.stdout).to.equal(`=== myapp
+
+    await cmd.run({ app: 'myapp', args: {}, flags: { extended: true } })
+
+    expect(cli.stderr).to.equal('');
+
+    expect(cli.stdout).to.equal(`=== myapp
 Addons:           heroku-redis
                   papertrail
 Auto Cert Mgmt:   true
@@ -117,12 +125,14 @@ Web URL:          https://myapp.herokuapp.com
 
 
 { foo: 'bar', id: 12345 }
-`))
-      .then(() => appApi.done())
-      .then(() => api.done())
+`);
+
+    appApi.done();
+
+    return api.done()
   })
 
-  it('shows empty extended app info when not defined', () => {
+  it('shows empty extended app info when not defined', async () => {
     let appApi = nock('https://api.heroku.com', {
       reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3.cedar-acm' }
     }).get('/apps/myapp').reply(200, appAcm)
@@ -132,9 +142,12 @@ Web URL:          https://myapp.herokuapp.com
       .get('/apps/myapp/addons').reply(200, addons)
       .get('/apps/myapp/collaborators').reply(200, collaborators)
       .get('/apps/myapp/dynos').reply(200, [{ type: 'web', size: 'Standard-1X', quantity: 2 }])
-    return cmd.run({ app: 'myapp', args: {}, flags: { extended: true } })
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(cli.stdout).to.equal(`=== myapp
+
+    await cmd.run({ app: 'myapp', args: {}, flags: { extended: true } })
+
+    expect(cli.stderr).to.equal('');
+
+    expect(cli.stdout).to.equal(`=== myapp
 Addons:           heroku-redis
                   papertrail
 Auto Cert Mgmt:   true
@@ -155,11 +168,13 @@ Web URL:          https://myapp.herokuapp.com
 --- Extended Information ---
 
 
-`))
-      .then(() => appApi.done())
-      .then(() => api.done())
+`);
+
+    appApi.done();
+
+    return api.done()
   })
-  it('shows app info via arg', () => {
+  it('shows app info via arg', async () => {
     let appApi = nock('https://api.heroku.com', {
       reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3.cedar-acm' }
     }).get('/apps/myapp').reply(200, appAcm)
@@ -169,9 +184,12 @@ Web URL:          https://myapp.herokuapp.com
       .get('/apps/myapp/collaborators').reply(200, collaborators)
       .get('/apps/myapp/dynos').reply(200, [{ type: 'web', size: 'Standard-1X', quantity: 2 }])
     let context = { args: { app: 'myapp' }, flags: {} }
-    return cmd.run(context)
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(cli.stdout).to.equal(`=== myapp
+
+    await cmd.run(context)
+
+    expect(cli.stderr).to.equal('');
+
+    expect(cli.stdout).to.equal(`=== myapp
 Addons:           heroku-redis
                   papertrail
 Auto Cert Mgmt:   true
@@ -187,13 +205,15 @@ Slug Size:        1000 B
 Space:            myspace
 Stack:            cedar-14
 Web URL:          https://myapp.herokuapp.com
-`))
-      .then(() => appApi.done())
-      .then(() => api.done())
-      .then(() => expect(context.app).to.equal('myapp'))
+`);
+
+    appApi.done();
+    api.done();
+
+    return expect(context.app).to.equal('myapp')
   })
 
-  it('shows app info via arg when the app is in a pipeline', () => {
+  it('shows app info via arg when the app is in a pipeline', async () => {
     let appApi = nock('https://api.heroku.com', {
       reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3.cedar-acm' }
     }).get('/apps/myapp').reply(200, appAcm)
@@ -204,9 +224,12 @@ Web URL:          https://myapp.herokuapp.com
       .get('/apps/myapp/collaborators').reply(200, collaborators)
       .get('/apps/myapp/dynos').reply(200, [{ type: 'web', size: 'Standard-1X', quantity: 2 }])
     let context = { args: { app: 'myapp' }, flags: {} }
-    return cmd.run(context)
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(cli.stdout).to.equal(`=== myapp
+
+    await cmd.run(context)
+
+    expect(cli.stderr).to.equal('');
+
+    expect(cli.stdout).to.equal(`=== myapp
 Addons:           heroku-redis
                   papertrail
 Auto Cert Mgmt:   true
@@ -223,13 +246,15 @@ Slug Size:        1000 B
 Space:            myspace
 Stack:            cedar-14
 Web URL:          https://myapp.herokuapp.com
-`))
-      .then(() => appApi.done())
-      .then(() => api.done())
-      .then(() => expect(context.app).to.equal('myapp'))
+`);
+
+    appApi.done();
+    api.done();
+
+    return expect(context.app).to.equal('myapp')
   })
 
-  it('shows app info in shell format', () => {
+  it('shows app info in shell format', async () => {
     let appApi = nock('https://api.heroku.com', {
       reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3.cedar-acm' }
     }).get('/apps/myapp').reply(200, appAcm)
@@ -238,9 +263,12 @@ Web URL:          https://myapp.herokuapp.com
       .get('/apps/myapp/addons').reply(200, addons)
       .get('/apps/myapp/collaborators').reply(200, collaborators)
       .get('/apps/myapp/dynos').reply(200, [{ type: 'web', size: 'Standard-1X', quantity: 2 }])
-    return cmd.run({ args: { app: 'myapp' }, flags: { shell: true } })
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(cli.stdout).to.equal(`auto_cert_mgmt=true
+
+    await cmd.run({ args: { app: 'myapp' }, flags: { shell: true } })
+
+    expect(cli.stderr).to.equal('');
+
+    expect(cli.stdout).to.equal(`auto_cert_mgmt=true
 addons=heroku-redis,papertrail
 collaborators=foo2@foo.com
 database_size=1000 B
@@ -252,12 +280,14 @@ owner=foo@foo.com
 region=eu
 dynos={ web: 1 }
 stack=cedar-14
-`))
-      .then(() => appApi.done())
-      .then(() => api.done())
+`);
+
+    appApi.done();
+
+    return api.done()
   })
 
-  it('shows app info in shell format when the app is in pipeline', () => {
+  it('shows app info in shell format when the app is in pipeline', async () => {
     let appApi = nock('https://api.heroku.com', {
       reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3.cedar-acm' }
     }).get('/apps/myapp').reply(200, appAcm)
@@ -267,9 +297,12 @@ stack=cedar-14
       .get('/apps/myapp/addons').reply(200, addons)
       .get('/apps/myapp/collaborators').reply(200, collaborators)
       .get('/apps/myapp/dynos').reply(200, [{ type: 'web', size: 'Standard-1X', quantity: 2 }])
-    return cmd.run({ args: { app: 'myapp' }, flags: { shell: true } })
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(cli.stdout).to.equal(`auto_cert_mgmt=true
+
+    await cmd.run({ args: { app: 'myapp' }, flags: { shell: true } })
+
+    expect(cli.stderr).to.equal('');
+
+    expect(cli.stdout).to.equal(`auto_cert_mgmt=true
 addons=heroku-redis,papertrail
 collaborators=foo2@foo.com
 database_size=1000 B
@@ -282,12 +315,14 @@ owner=foo@foo.com
 region=eu
 dynos={ web: 1 }
 stack=cedar-14
-`))
-      .then(() => appApi.done())
-      .then(() => api.done())
+`);
+
+    appApi.done();
+
+    return api.done()
   })
 
-  it('shows extended app info in json format', () => {
+  it('shows extended app info in json format', async () => {
     let appApi = nock('https://api.heroku.com', {
       reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3.cedar-acm' }
     }).get('/apps/myapp').reply(200, appAcm)
@@ -297,18 +332,19 @@ stack=cedar-14
       .get('/apps/myapp/addons').reply(200, addons)
       .get('/apps/myapp/collaborators').reply(200, collaborators)
       .get('/apps/myapp/dynos').reply(200, [{ type: 'web', size: 'Standard-1X', quantity: 2 }])
-    return cmd.run({ args: { app: 'myapp' }, flags: { json: true, extended: true } })
-      .then(() => {
-        let json = JSON.parse(cli.stdout)
-        expect(json.appExtended).to.equal(undefined)
-        expect(json.app.extended).not.to.equal(undefined)
-        expect(json.app.extended.id).to.equal(appExtended.extended.id)
-      })
-      .then(() => appApi.done())
-      .then(() => api.done())
+
+    await cmd.run({ args: { app: 'myapp' }, flags: { json: true, extended: true } })
+
+    expect(json.app.extended.id).to.equal(appExtended.extended.id)
+    expect(json.app.extended).not.to.equal(undefined)
+    expect(json.appExtended).to.equal(undefined)
+    let json = JSON.parse(cli.stdout)
+    appApi.done();
+
+    return api.done()
   })
 
-  it('shows app info in json format', () => {
+  it('shows app info in json format', async () => {
     let appApi = nock('https://api.heroku.com', {
       reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3.cedar-acm' }
     }).get('/apps/myapp').reply(200, appAcm)
@@ -318,21 +354,22 @@ stack=cedar-14
       .get('/apps/myapp/collaborators').reply(200, collaborators)
       .get('/apps/myapp/dynos').reply(200, [{ type: 'web', size: 'Standard-1X', quantity: 2 }])
       .get('/apps/myapp/pipeline-couplings').reply(200, { app: { id: appAcm.id }, pipeline: { name: 'my-pipeline' } })
-    return cmd.run({ args: { app: 'myapp' }, flags: { json: true } })
-      .then(() => {
-        let json = JSON.parse(cli.stdout)
-        expect(json.appExtended).to.equal(undefined)
-        expect(json.app.extended).to.equal(undefined)
-        expect(json.addons.length).to.equal(addons.length)
-        expect(json.collaborators.length).to.equal(collaborators.length)
-        expect(json.dynos[0].type).to.equal('web')
-        expect(json.pipeline_coupling.pipeline.name).to.equal('my-pipeline')
-      })
-      .then(() => appApi.done())
-      .then(() => api.done())
+
+    await cmd.run({ args: { app: 'myapp' }, flags: { json: true } })
+
+    expect(json.pipeline_coupling.pipeline.name).to.equal('my-pipeline')
+    expect(json.dynos[0].type).to.equal('web')
+    expect(json.collaborators.length).to.equal(collaborators.length)
+    expect(json.addons.length).to.equal(addons.length)
+    expect(json.app.extended).to.equal(undefined)
+    expect(json.appExtended).to.equal(undefined)
+    let json = JSON.parse(cli.stdout)
+    appApi.done();
+
+    return api.done()
   })
 
-  it('shows app info with a stack change', () => {
+  it('shows app info with a stack change', async () => {
     let appApi = nock('https://api.heroku.com', {
       reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3.cedar-acm' }
     }).get('/apps/myapp').reply(200, appStackChange)
@@ -341,9 +378,12 @@ stack=cedar-14
       .get('/apps/myapp/addons').reply(200, addons)
       .get('/apps/myapp/collaborators').reply(200, collaborators)
       .get('/apps/myapp/dynos').reply(200, [{ type: 'web', size: 'Standard-1X', quantity: 2 }])
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(cli.stdout).to.equal(`=== myapp
+
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    expect(cli.stderr).to.equal('');
+
+    expect(cli.stdout).to.equal(`=== myapp
 Addons:           heroku-redis
                   papertrail
 Collaborators:    foo2@foo.com
@@ -358,8 +398,10 @@ Slug Size:        1000 B
 Space:            myspace
 Stack:            cedar-14 (next build will use heroku-20)
 Web URL:          https://myapp.herokuapp.com
-`))
-      .then(() => appApi.done())
-      .then(() => api.done())
+`);
+
+    appApi.done();
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/apps/notifications/index.js
+++ b/packages/apps-v5/test/commands/apps/notifications/index.js
@@ -13,52 +13,64 @@ describe('notifications', () => {
 
   describe('no notifications', () => {
     describe('with app', () => {
-      it('warns about no read notifications', () => {
+      it('warns about no read notifications', async () => {
         let heroku = nock('https://api.heroku.com:443')
           .get('/apps/myapp').reply(200, { id: 'myapp', name: 'myapp' })
         let telex = nock('https://telex.heroku.com:443')
           .get('/user/notifications')
           .reply(200, [])
-        return cmd.run({ app: 'myapp', flags: { read: true } })
-          .then(() => expect(cli.stdout).to.equal(''))
-          .then(() => expect(unwrap(cli.stderr)).to.equal('You have no notifications on myapp. Run heroku notifications --all to view notifications for all apps.\n'))
-          .then(() => heroku.done())
-          .then(() => telex.done())
+
+        await cmd.run({ app: 'myapp', flags: { read: true } })
+
+        expect(cli.stdout).to.equal('');
+        expect(unwrap(cli.stderr)).to.equal('You have no notifications on myapp. Run heroku notifications --all to view notifications for all apps.\n');
+        heroku.done();
+
+        return telex.done()
       })
 
-      it('warns about no unread notifications', () => {
+      it('warns about no unread notifications', async () => {
         let heroku = nock('https://api.heroku.com:443')
           .get('/apps/myapp').reply(200, { id: 'myapp', name: 'myapp' })
         let telex = nock('https://telex.heroku.com:443')
           .get('/user/notifications')
           .reply(200, [])
-        return cmd.run({ app: 'myapp', flags: { read: false } })
-          .then(() => expect(cli.stdout).to.equal(''))
-          .then(() => expect(unwrap(cli.stderr)).to.equal('No unread notifications on myapp. Run heroku notifications --all to view notifications for all apps.\n'))
-          .then(() => heroku.done())
-          .then(() => telex.done())
+
+        await cmd.run({ app: 'myapp', flags: { read: false } })
+
+        expect(cli.stdout).to.equal('');
+        expect(unwrap(cli.stderr)).to.equal('No unread notifications on myapp. Run heroku notifications --all to view notifications for all apps.\n');
+        heroku.done();
+
+        return telex.done()
       })
     })
 
     describe('no app', () => {
-      it('warns about no read notifications', () => {
+      it('warns about no read notifications', async () => {
         let telex = nock('https://telex.heroku.com:443')
           .get('/user/notifications')
           .reply(200, [])
-        return cmd.run({ flags: { read: true } })
-          .then(() => expect(cli.stdout).to.equal(''))
-          .then(() => expect(unwrap(cli.stderr)).to.equal('You have no notifications.\n'))
-          .then(() => telex.done())
+
+        await cmd.run({ flags: { read: true } })
+
+        expect(cli.stdout).to.equal('');
+        expect(unwrap(cli.stderr)).to.equal('You have no notifications.\n');
+
+        return telex.done()
       })
 
-      it('warns about no unread notifications', () => {
+      it('warns about no unread notifications', async () => {
         let telex = nock('https://telex.heroku.com:443')
           .get('/user/notifications')
           .reply(200, [])
-        return cmd.run({ flags: { read: false } })
-          .then(() => expect(cli.stdout).to.equal(''))
-          .then(() => expect(unwrap(cli.stderr)).to.equal('No unread notifications. Run heroku notifications --read to view read notifications.\n'))
-          .then(() => telex.done())
+
+        await cmd.run({ flags: { read: false } })
+
+        expect(cli.stdout).to.equal('');
+        expect(unwrap(cli.stderr)).to.equal('No unread notifications. Run heroku notifications --read to view read notifications.\n');
+
+        return telex.done()
       })
     })
   })
@@ -90,15 +102,17 @@ describe('notifications', () => {
       }
     ]
 
-    it('shows all read app notifications', () => {
+    it('shows all read app notifications', async () => {
       let heroku = nock('https://api.heroku.com:443')
         .get('/apps/myapp')
         .reply(200, { id: 'myapp', name: 'myapp' })
       let telex = nock('https://telex.heroku.com:443')
         .get('/user/notifications')
         .reply(200, notifications)
-      return cmd.run({ app: 'myapp', flags: { read: true, json: false } })
-        .then(() => expect(cli.stdout).to.equal(`=== Read Notifications for myapp
+
+      await cmd.run({ app: 'myapp', flags: { read: true, json: false } })
+
+      expect(cli.stdout).to.equal(`=== Read Notifications for myapp
 
 title
 
@@ -113,20 +127,24 @@ title2
   msg
   ${time.ago(d)}
   followup
-`))
-        .then(() => expect(cli.stderr).to.equal(''))
-        .then(() => heroku.done())
-        .then(() => telex.done())
+`);
+
+      expect(cli.stderr).to.equal('');
+      heroku.done();
+
+      return telex.done()
     })
 
-    it('shows all unread notifications', () => {
+    it('shows all unread notifications', async () => {
       let telex = nock('https://telex.heroku.com:443')
         .get('/user/notifications')
         .reply(200, notifications)
         .patch('/user/notifications/101', { read: true })
         .reply(200)
-      return cmd.run({ flags: { json: false } })
-        .then(() => expect(cli.stdout).to.equal(`=== Unread Notifications
+
+      await cmd.run({ flags: { json: false } })
+
+      expect(cli.stdout).to.equal(`=== Unread Notifications
 
 title
 
@@ -134,19 +152,24 @@ title
   msg
   ${time.ago(d)}
   followup
-`))
-        .then(() => expect(cli.stderr).to.equal(''))
-        .then(() => telex.done())
+`);
+
+      expect(cli.stderr).to.equal('');
+
+      return telex.done()
     })
 
-    it('shows all read notifications as json', () => {
+    it('shows all read notifications as json', async () => {
       let telex = nock('https://telex.heroku.com:443')
         .get('/user/notifications')
         .reply(200, notifications)
-      return cmd.run({ flags: { read: true, json: true } })
-        .then(() => expect(JSON.parse(cli.stdout)[0].id).to.equal(101))
-        .then(() => expect(cli.stderr).to.equal(''))
-        .then(() => telex.done())
+
+      await cmd.run({ flags: { read: true, json: true } })
+
+      expect(JSON.parse(cli.stdout)[0].id).to.equal(101);
+      expect(cli.stderr).to.equal('');
+
+      return telex.done()
     })
   })
 })

--- a/packages/apps-v5/test/commands/apps/rename.js
+++ b/packages/apps-v5/test/commands/apps/rename.js
@@ -10,7 +10,7 @@ const cmd = commands.find((c) => c.topic === 'apps' && c.command === 'rename')
 describe('heroku apps:rename', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('renames an app', function () {
+  it('renames an app', async function() {
     let api = nock('https://api.heroku.com')
       .patch('/apps/myapp', { name: 'newname' })
       .reply(200, {
@@ -18,10 +18,13 @@ describe('heroku apps:rename', function () {
         web_url: 'https://foobar.com'
       })
 
-    return cmd.run({ app: 'myapp', flags: {}, args: { newname: 'newname' }, httpGitHost: 'git.heroku.com' })
-      .then(() => expect(unwrap(cli.stderr)).to.equal(`Renaming myapp to newname... done Don't forget to update git remotes for all other local checkouts of the app.
-`))
-      .then(() => expect(cli.stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n'))
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', flags: {}, args: { newname: 'newname' }, httpGitHost: 'git.heroku.com' })
+
+    expect(unwrap(cli.stderr)).to.equal(`Renaming myapp to newname... done Don't forget to update git remotes for all other local checkouts of the app.
+`);
+
+    expect(cli.stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n');
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/apps/stack/index.js
+++ b/packages/apps-v5/test/commands/apps/stack/index.js
@@ -10,7 +10,7 @@ describe('stack', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
-  it('show available stacks', () => {
+  it('show available stacks', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp').reply(200, {
         name: 'myapp',
@@ -22,16 +22,20 @@ describe('stack', () => {
         { name: 'cedar' },
         { name: 'cedar-14' }
       ])
-    return cmd.run({ app: 'myapp', flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== myapp Available Stacks
+
+    await cmd.run({ app: 'myapp', flags: {} })
+
+    expect(cli.stdout).to.equal(`=== myapp Available Stacks
   cedar-10
 * cedar-14
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('show an undeployed build stack', () => {
+  it('show an undeployed build stack', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp').reply(200, {
         name: 'myapp',
@@ -43,12 +47,16 @@ describe('stack', () => {
         { name: 'cedar' },
         { name: 'cedar-14' }
       ])
-    return cmd.run({ app: 'myapp', flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== myapp Available Stacks
+
+    await cmd.run({ app: 'myapp', flags: {} })
+
+    expect(cli.stdout).to.equal(`=== myapp Available Stacks
   cedar-10 (active on next deploy)
 * cedar-14
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/apps/stack/set.js
+++ b/packages/apps-v5/test/commands/apps/stack/set.js
@@ -29,40 +29,48 @@ const completedUpgradeApp = {
 describe('stack:set', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('sets the stack', function () {
+  it('sets the stack', async function() {
     let api = nock('https://api.heroku.com:443')
       .patch('/apps/myapp', { build_stack: 'heroku-20' })
       .reply(200, pendingUpgradeApp)
 
-    return cmd.run({ app: 'myapp', args: { stack: 'heroku-20' }, flags: {} })
-      .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-20... done\n'))
-      .then(() => expect(cli.stdout).to.equal(`You will need to redeploy myapp for the change to take effect.
+    await cmd.run({ app: 'myapp', args: { stack: 'heroku-20' }, flags: {} })
+
+    expect(cli.stderr).to.equal('Setting stack to heroku-20... done\n');
+
+    expect(cli.stdout).to.equal(`You will need to redeploy myapp for the change to take effect.
 Run git push heroku main to create a new release on myapp.
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 
-  it('sets the stack on a different remote', function () {
+  it('sets the stack on a different remote', async function() {
     let api = nock('https://api.heroku.com:443')
       .patch('/apps/myapp', { build_stack: 'heroku-20' })
       .reply(200, pendingUpgradeApp)
 
-    return cmd.run({ app: 'myapp', args: { stack: 'heroku-20' }, flags: { remote: 'staging' } })
-      .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-20... done\n'))
-      .then(() => expect(cli.stdout).to.equal(`You will need to redeploy myapp for the change to take effect.
+    await cmd.run({ app: 'myapp', args: { stack: 'heroku-20' }, flags: { remote: 'staging' } })
+
+    expect(cli.stderr).to.equal('Setting stack to heroku-20... done\n');
+
+    expect(cli.stdout).to.equal(`You will need to redeploy myapp for the change to take effect.
 Run git push staging main to create a new release on myapp.
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 
-  it('does not show the redeploy message if the stack was immediately updated by API', function () {
+  it('does not show the redeploy message if the stack was immediately updated by API', async function() {
     let api = nock('https://api.heroku.com:443')
       .patch('/apps/myapp', { build_stack: 'heroku-20' })
       .reply(200, completedUpgradeApp)
 
-    return cmd.run({ app: 'myapp', args: { stack: 'heroku-20' }, flags: {} })
-      .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-20... done\n'))
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: { stack: 'heroku-20' }, flags: {} })
+
+    expect(cli.stderr).to.equal('Setting stack to heroku-20... done\n');
+    expect(cli.stdout).to.equal('');
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/config/set.js
+++ b/packages/apps-v5/test/commands/config/set.js
@@ -18,34 +18,42 @@ describe('config:set', () => {
   })
   afterEach(() => nock.cleanAll())
 
-  it('sets a config var', () => {
+  it('sets a config var', async () => {
     const api = nock('https://api.heroku.com:443')
       .patch('/apps/myapp/config-vars', { RACK_ENV: 'production' })
       .reply(200, { RACK_ENV: 'production', RAILS_ENV: 'production' })
       .get('/apps/myapp/releases')
       .reply(200, [{ version: 10 }])
-    return cmd.run({ config, app: 'myapp', args: ['RACK_ENV=production'] })
-      .then(() => expect(cli.stdout).to.equal('RACK_ENV: production\n'))
-      .then(() => expect(cli.stderr).to.equal('Setting RACK_ENV and restarting myapp... done, v10\n'))
-      .then(() => api.done())
+
+    await cmd.run({ config, app: 'myapp', args: ['RACK_ENV=production'] })
+
+    expect(cli.stdout).to.equal('RACK_ENV: production\n');
+    expect(cli.stderr).to.equal('Setting RACK_ENV and restarting myapp... done, v10\n');
+
+    return api.done()
   })
 
-  it('sets a config var with an "=" in it', () => {
+  it('sets a config var with an "=" in it', async () => {
     const api = nock('https://api.heroku.com:443')
       .patch('/apps/myapp/config-vars', { RACK_ENV: 'production=foo' })
       .reply(200)
       .get('/apps/myapp/releases')
       .reply(200, [{ version: 10 }])
-    return cmd.run({ config, app: 'myapp', args: ['RACK_ENV=production=foo'] })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal('Setting RACK_ENV and restarting myapp... done, v10\n'))
-      .then(() => api.done())
+
+    await cmd.run({ config, app: 'myapp', args: ['RACK_ENV=production=foo'] })
+
+    expect(cli.stdout, 'to be empty');
+    expect(cli.stderr).to.equal('Setting RACK_ENV and restarting myapp... done, v10\n');
+
+    return api.done()
   })
 
-  it('errors out on empty', () => {
-    return assertExit(1, cmd.run({ config, app: 'myapp', args: [] }))
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(unwrap(cli.stderr)).to.equal(
-        'Usage: heroku config:set KEY1=VALUE1 [KEY2=VALUE2 ...] Must specify KEY and VALUE to set.\n'))
+  it('errors out on empty', async () => {
+    await assertExit(1, cmd.run({ config, app: 'myapp', args: [] }))
+
+    expect(cli.stdout).to.equal('');
+
+    return expect(unwrap(cli.stderr)).to.equal(
+        'Usage: heroku config:set KEY1=VALUE1 [KEY2=VALUE2 ...] Must specify KEY and VALUE to set.\n')
   })
 })

--- a/packages/apps-v5/test/commands/dashboard.js
+++ b/packages/apps-v5/test/commands/dashboard.js
@@ -53,7 +53,7 @@ runtest('Dashboard', () => {
     }
 
     describe('with no favorites', () => {
-      it('shows the dashboard', () => {
+      it('shows the dashboard', async () => {
         let longboard = nock('https://particleboard.heroku.com:443')
           .get('/favorites?type=app').reply(200, [])
         let heroku = nock('https://api.heroku.com:443')
@@ -61,22 +61,25 @@ runtest('Dashboard', () => {
         let telex = nock('https://telex.heroku.com:443')
           .get('/user/notifications').reply(200, [])
 
-        return cmd.run({})
-          .then(() => expect(cli.stdout, 'to be', `See all add-ons with heroku addons
+        await cmd.run({})
+
+        expect(cli.stdout, 'to be', `See all add-ons with heroku addons
 See all apps with heroku apps --all
 
 See other CLI commands with heroku help
 
-`))
-          .then(() => expect(unwrap(cli.stderr), 'to be', 'Loading... done Add apps to this dashboard by favoriting them with heroku apps:favorites:add\n'))
-          .then(() => longboard.done())
-          .then(() => telex.done())
-          .then(() => heroku.done())
+`);
+
+        expect(unwrap(cli.stderr), 'to be', 'Loading... done Add apps to this dashboard by favoriting them with heroku apps:favorites:add\n');
+        longboard.done();
+        telex.done();
+
+        return heroku.done()
       })
     })
 
     describe('with no telex', () => {
-      it('shows the dashboard', () => {
+      it('shows the dashboard', async () => {
         let longboard = nock('https://particleboard.heroku.com:443')
           .get('/favorites?type=app').reply(200, [])
         let heroku = nock('https://api.heroku.com:443')
@@ -84,22 +87,25 @@ See other CLI commands with heroku help
         let telex = nock('https://telex.heroku.com:443')
           .get('/user/notifications').reply(401, [])
 
-        return cmd.run({})
-          .then(() => expect(cli.stdout, 'to be', `See all add-ons with heroku addons
+        await cmd.run({})
+
+        expect(cli.stdout, 'to be', `See all add-ons with heroku addons
 See all apps with heroku apps --all
 
 See other CLI commands with heroku help
 
-`))
-          .then(() => expect(unwrap(cli.stderr), 'to be', 'Loading... done Add apps to this dashboard by favoriting them with heroku apps:favorites:add\n'))
-          .then(() => longboard.done())
-          .then(() => telex.done())
-          .then(() => heroku.done())
+`);
+
+        expect(unwrap(cli.stderr), 'to be', 'Loading... done Add apps to this dashboard by favoriting them with heroku apps:favorites:add\n');
+        longboard.done();
+        telex.done();
+
+        return heroku.done()
       })
     })
 
     describe('with a favorite app', () => {
-      it('shows the dashboard', () => {
+      it('shows the dashboard', async () => {
         let longboard = nock('https://particleboard.heroku.com:443')
           .get('/favorites?type=app').reply(200, [{ app_name: 'myapp' }])
         let heroku = nock('https://api.heroku.com:443')
@@ -124,8 +130,9 @@ See other CLI commands with heroku help
           .get(`/apps/myapp/formation/web/metrics/errors?start_time=${yesterday.toISOString()}&end_time=${now.toISOString()}&step=1h`)
           .reply(200, { data: {} })
 
-        return cmd.run({})
-          .then(() => expect(cli.stdout, 'to be', `myapp
+        await cmd.run({})
+
+        expect(cli.stdout, 'to be', `myapp
   Owner: foo@bar.com
   Dynos: 1 | Standard-1X
   Last release: ${time.ago(now)}
@@ -137,12 +144,14 @@ See all apps with heroku apps --all
 
 See other CLI commands with heroku help
 
-`))
-          .then(() => expect(cli.stderr, 'to be', 'Loading... done\n'))
-          .then(() => metrics.done())
-          .then(() => longboard.done())
-          .then(() => telex.done())
-          .then(() => heroku.done())
+`);
+
+        expect(cli.stderr, 'to be', 'Loading... done\n');
+        metrics.done();
+        longboard.done();
+        telex.done();
+
+        return heroku.done()
       })
     })
   })

--- a/packages/apps-v5/test/commands/drains/add.js
+++ b/packages/apps-v5/test/commands/drains/add.js
@@ -9,12 +9,15 @@ const expect = require('chai').expect
 describe('drains:add', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('adds a log drain', function () {
+  it('adds a log drain', async function() {
     let api = nock('https://api.heroku.com:443')
       .post('/apps/myapp/log-drains', { url: 'syslog://logs.example.com' })
       .reply(200, { url: 'syslog://logs.example.com' })
-    return cmd.run({ app: 'myapp', args: { url: 'syslog://logs.example.com' } })
-      .then(() => expect(cli.stdout).to.equal('Successfully added drain syslog://logs.example.com\n'))
-      .then(() => api.done())
+
+    await cmd.run({ app: 'myapp', args: { url: 'syslog://logs.example.com' } })
+
+    expect(cli.stdout).to.equal('Successfully added drain syslog://logs.example.com\n');
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/drains/index.js
+++ b/packages/apps-v5/test/commands/drains/index.js
@@ -9,21 +9,25 @@ const expect = require('chai').expect
 describe('drains', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('shows log drains', function () {
+  it('shows log drains', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/log-drains')
       .reply(200, [{
         token: 'd.8bf587e9-29d1-43c8-bd0e-36cdfaf35259',
         url: 'https://forker.herokuapp.com' }])
-    return cmd.run({ app: 'myapp', flags: {} })
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(cli.stdout).to.equal(`=== Drains
+
+    await cmd.run({ app: 'myapp', flags: {} })
+
+    expect(cli.stderr).to.equal('');
+
+    expect(cli.stdout).to.equal(`=== Drains
 https://forker.herokuapp.com (d.8bf587e9-29d1-43c8-bd0e-36cdfaf35259)
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 
-  it('shows add-on drains', function () {
+  it('shows add-on drains', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/log-drains')
       .reply(200, [{
@@ -32,15 +36,19 @@ https://forker.herokuapp.com (d.8bf587e9-29d1-43c8-bd0e-36cdfaf35259)
         url: 'https://forker.herokuapp.com' }])
       .get('/apps/myapp/addons/add-on-123')
       .reply(200, { name: 'add-on-123', plan: { name: 'add-on:test' } })
-    return cmd.run({ app: 'myapp', flags: {} })
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(cli.stdout).to.equal(`=== Add-on Drains
+
+    await cmd.run({ app: 'myapp', flags: {} })
+
+    expect(cli.stderr).to.equal('');
+
+    expect(cli.stdout).to.equal(`=== Add-on Drains
 add-on:test (add-on-123)
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 
-  it('shows drain_id for both', function () {
+  it('shows drain_id for both', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/log-drains?extended=true')
       .reply(200, [{
@@ -59,14 +67,18 @@ add-on:test (add-on-123)
       }])
       .get('/apps/myapp/addons/add-on-123')
       .reply(200, { name: 'add-on-123', plan: { name: 'add-on:test' } })
-    return cmd.run({ app: 'myapp', flags: { extended: true } })
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(cli.stdout).to.equal(
+
+    await cmd.run({ app: 'myapp', flags: { extended: true } })
+
+    expect(cli.stderr).to.equal('');
+
+    expect(cli.stdout).to.equal(
         `=== Drains
 https://forker.herokuapp.com (d.8bf587e9-29d1-43c8-bd0e-36cdfaf35259) drain_id=67890
 === Add-on Drains
 add-on:test (add-on-123) drain_id=12345
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/drains/remove.js
+++ b/packages/apps-v5/test/commands/drains/remove.js
@@ -9,12 +9,15 @@ const expect = require('chai').expect
 describe('drains:remove', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('adds a log drain', function () {
+  it('adds a log drain', async function() {
     let api = nock('https://api.heroku.com:443')
       .delete('/apps/myapp/log-drains/syslog%3A%2F%2Flogs.example.com')
       .reply(200, { url: 'syslog://logs.example.com' })
-    return cmd.run({ app: 'myapp', args: { url: 'syslog://logs.example.com' } })
-      .then(() => expect(cli.stdout).to.equal('Successfully removed drain syslog://logs.example.com\n'))
-      .then(() => api.done())
+
+    await cmd.run({ app: 'myapp', args: { url: 'syslog://logs.example.com' } })
+
+    expect(cli.stdout).to.equal('Successfully removed drain syslog://logs.example.com\n');
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/features/disable.js
+++ b/packages/apps-v5/test/commands/features/disable.js
@@ -8,13 +8,13 @@ const cmd = commands.find((c) => c.topic === 'features' && c.command === 'disabl
 describe('features:disable', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('disables an app feature', function () {
+  it('disables an app feature', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/features/feature-a')
       .reply(200, { enabled: true })
       .patch('/apps/myapp/features/feature-a', { enabled: false })
       .reply(200)
-    return cmd.run({ app: 'myapp', args: { feature: 'feature-a' } })
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: { feature: 'feature-a' } })
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/features/enable.js
+++ b/packages/apps-v5/test/commands/features/enable.js
@@ -8,13 +8,13 @@ const cmd = commands.find((c) => c.topic === 'features' && c.command === 'enable
 describe('features:enable', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('enables an app feature', function () {
+  it('enables an app feature', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/features/feature-a')
       .reply(200, { enabled: false })
       .patch('/apps/myapp/features/feature-a', { enabled: true })
       .reply(200)
-    return cmd.run({ app: 'myapp', args: { feature: 'feature-a' } })
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: { feature: 'feature-a' } })
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/features/index.js
+++ b/packages/apps-v5/test/commands/features/index.js
@@ -9,17 +9,21 @@ const cmd = commands.find((c) => c.topic === 'features' && !c.command)
 describe('features', () => {
   beforeEach(() => cli.mockConsole())
 
-  it('shows the app features', function () {
+  it('shows the app features', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/features')
       .reply(200, [
         { enabled: true, state: 'general', name: 'feature a', description: 'an app feature' }
       ])
-    return cmd.run({ app: 'myapp', flags: {} })
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(cli.stdout).to.equal(`=== App Features myapp
+
+    await cmd.run({ app: 'myapp', flags: {} })
+
+    expect(cli.stderr).to.equal('');
+
+    expect(cli.stdout).to.equal(`=== App Features myapp
 [+] feature a  an app feature
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/features/info.js
+++ b/packages/apps-v5/test/commands/features/info.js
@@ -9,16 +9,19 @@ const cmd = commands.find((c) => c.topic === 'features' && c.command === 'info')
 describe('features:info', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('shows feature info', function () {
+  it('shows feature info', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/features/feature-a')
       .reply(200, { name: 'myfeature', description: 'the description', doc_url: 'https://devcenter.heroku.com', enabled: true })
-    return cmd.run({ app: 'myapp', flags: {}, args: { feature: 'feature-a' } })
-      .then(() => expect(cli.stdout).to.eq(`=== myfeature
+
+    await cmd.run({ app: 'myapp', flags: {}, args: { feature: 'feature-a' } })
+
+    expect(cli.stdout).to.eq(`=== myfeature
 Description: the description
 Docs:        https://devcenter.heroku.com
 Enabled:     true
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/keys/add.js
+++ b/packages/apps-v5/test/commands/keys/add.js
@@ -36,19 +36,22 @@ describe('keys:add', () => {
     rimraf.sync(home)
   })
 
-  it('adds a given key', () => {
+  it('adds a given key', async () => {
     let api = nock('https://api.heroku.com:443')
       .post('/account/keys', { public_key: `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDsAbr7QvJUwDC0dfX3p884w7T06MgJcwbvKDeMpOGg7FXhVSjpXz0SrFrbzbUfs9LtIDIvBPfA5+LTA45+apQTt+A3fiMsKElFjiJgO0ag12vbttHxjda12tmm/Sc0CBpOOeLJxJYboWeN7G4LfW+llUXhb45gNp48qJKbCZKZN2RTd3F8BFUgLedVKg9xs1OyyioFaQJC0N8Ka4CyfTn0mpWnkyrzYvziG1KMELohbP74hAEmW7+/PM9KjXdLeFaOJXTYZLGYJR6DX2Wdd/AP1JFljtXNXlVQ224IPRuwrnVK/KqegY1tk+io4+Ju7mL9PyyXtFOESK+yinzQ3MJn` })
       .reply(200)
 
-    return cmd.run({ args: { key: path.join('test', 'fixtures', 'id_rsa.pub') } })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal(`Uploading ${path.join('.', 'test', 'fixtures', 'id_rsa.pub')} SSH key... done
-`))
-      .then(() => api.done())
+    await cmd.run({ args: { key: path.join('test', 'fixtures', 'id_rsa.pub') } })
+
+    expect(cli.stdout, 'to be empty');
+
+    expect(cli.stderr).to.equal(`Uploading ${path.join('.', 'test', 'fixtures', 'id_rsa.pub')} SSH key... done
+`);
+
+    return api.done()
   })
 
-  it('adds a key when prompted to generate one', () => {
+  it('adds a key when prompted to generate one', async () => {
     let api = nock('https://api.heroku.com:443')
       .post('/account/keys')
       .reply(200)
@@ -67,15 +70,18 @@ describe('keys:add', () => {
       return Promise.resolve('yes')
     }
 
-    return cmd.run({ args: {}, flags: { quiet: true } })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal(`Could not find an existing SSH key at ${path.join('~', '.ssh', 'id_rsa.pub')}
+    await cmd.run({ args: {}, flags: { quiet: true } })
+
+    expect(cli.stdout, 'to be empty');
+
+    expect(cli.stderr).to.equal(`Could not find an existing SSH key at ${path.join('~', '.ssh', 'id_rsa.pub')}
 Uploading ${path.join('tmp', 'home', '.ssh', 'id_rsa.pub')} SSH key... done
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 
-  it('adds a key when passed yes', () => {
+  it('adds a key when passed yes', async () => {
     let api = nock('https://api.heroku.com:443')
       .post('/account/keys')
       .reply(200)
@@ -88,15 +94,18 @@ Uploading ${path.join('tmp', 'home', '.ssh', 'id_rsa.pub')} SSH key... done
       throw new Error('should not prompt')
     }
 
-    return cmd.run({ args: {}, flags: { quiet: true, yes: true } })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal(`Could not find an existing SSH key at ${path.join('~', '.ssh', 'id_rsa.pub')}
+    await cmd.run({ args: {}, flags: { quiet: true, yes: true } })
+
+    expect(cli.stdout, 'to be empty');
+
+    expect(cli.stderr).to.equal(`Could not find an existing SSH key at ${path.join('~', '.ssh', 'id_rsa.pub')}
 Uploading ${path.join('tmp', 'home', '.ssh', 'id_rsa.pub')} SSH key... done
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 
-  it('adds a key when prompted to upload one', () => {
+  it('adds a key when prompted to upload one', async () => {
     let api = nock('https://api.heroku.com:443')
       .post('/account/keys', { public_key: `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDsAbr7QvJUwDC0dfX3p884w7T06MgJcwbvKDeMpOGg7FXhVSjpXz0SrFrbzbUfs9LtIDIvBPfA5+LTA45+apQTt+A3fiMsKElFjiJgO0ag12vbttHxjda12tmm/Sc0CBpOOeLJxJYboWeN7G4LfW+llUXhb45gNp48qJKbCZKZN2RTd3F8BFUgLedVKg9xs1OyyioFaQJC0N8Ka4CyfTn0mpWnkyrzYvziG1KMELohbP74hAEmW7+/PM9KjXdLeFaOJXTYZLGYJR6DX2Wdd/AP1JFljtXNXlVQ224IPRuwrnVK/KqegY1tk+io4+Ju7mL9PyyXtFOESK+yinzQ3MJn` })
       .reply(200)
@@ -115,16 +124,19 @@ Uploading ${path.join('tmp', 'home', '.ssh', 'id_rsa.pub')} SSH key... done
       return Promise.resolve('yes')
     }
 
-    return fs.copy('./test/fixtures/id_rsa.pub', home + '/.ssh/id_rsa.pub')
-      .then(() => cmd.run({ args: {}, flags: {} }))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal(`Found an SSH public key at ${path.join('tmp', 'home', '.ssh', 'id_rsa.pub')}
+    await fs.copy('./test/fixtures/id_rsa.pub', home + '/.ssh/id_rsa.pub')
+
+    cmd.run({ args: {}, flags: {} });
+    expect(cli.stdout, 'to be empty');
+
+    expect(cli.stderr).to.equal(`Found an SSH public key at ${path.join('tmp', 'home', '.ssh', 'id_rsa.pub')}
 Uploading ${path.join('tmp', 'home', '.ssh/id_rsa.pub')} SSH key... done
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 
-  it('adds a key when passed yes and has key', () => {
+  it('adds a key when passed yes and has key', async () => {
     let api = nock('https://api.heroku.com:443')
       .post('/account/keys', { public_key: `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDsAbr7QvJUwDC0dfX3p884w7T06MgJcwbvKDeMpOGg7FXhVSjpXz0SrFrbzbUfs9LtIDIvBPfA5+LTA45+apQTt+A3fiMsKElFjiJgO0ag12vbttHxjda12tmm/Sc0CBpOOeLJxJYboWeN7G4LfW+llUXhb45gNp48qJKbCZKZN2RTd3F8BFUgLedVKg9xs1OyyioFaQJC0N8Ka4CyfTn0mpWnkyrzYvziG1KMELohbP74hAEmW7+/PM9KjXdLeFaOJXTYZLGYJR6DX2Wdd/AP1JFljtXNXlVQ224IPRuwrnVK/KqegY1tk+io4+Ju7mL9PyyXtFOESK+yinzQ3MJn` })
       .reply(200)
@@ -137,16 +149,19 @@ Uploading ${path.join('tmp', 'home', '.ssh/id_rsa.pub')} SSH key... done
       throw new Error('should not prompt')
     }
 
-    return fs.copy('./test/fixtures/id_rsa.pub', home + '/.ssh/id_rsa.pub')
-      .then(() => cmd.run({ args: {}, flags: { yes: true } }))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal(`Found an SSH public key at ${path.join('tmp', 'home', '.ssh', 'id_rsa.pub')}
+    await fs.copy('./test/fixtures/id_rsa.pub', home + '/.ssh/id_rsa.pub')
+
+    cmd.run({ args: {}, flags: { yes: true } });
+    expect(cli.stdout, 'to be empty');
+
+    expect(cli.stderr).to.equal(`Found an SSH public key at ${path.join('tmp', 'home', '.ssh', 'id_rsa.pub')}
 Uploading ${path.join('tmp', 'home', '.ssh', 'id_rsa.pub')} SSH key... done
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 
-  it('adds a key when prompted to upload multiple', () => {
+  it('adds a key when prompted to upload multiple', async () => {
     let api = nock('https://api.heroku.com:443')
       .post('/account/keys', { public_key: `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDsAbr7QvJUwDC0dfX3p884w7T06MgJcwbvKDeMpOGg7FXhVSjpXz0SrFrbzbUfs9LtIDIvBPfA5+LTA45+apQTt+A3fiMsKElFjiJgO0ag12vbttHxjda12tmm/Sc0CBpOOeLJxJYboWeN7G4LfW+llUXhb45gNp48qJKbCZKZN2RTd3F8BFUgLedVKg9xs1OyyioFaQJC0N8Ka4CyfTn0mpWnkyrzYvziG1KMELohbP74hAEmW7+/PM9KjXdLeFaOJXTYZLGYJR6DX2Wdd/AP1JFljtXNXlVQ224IPRuwrnVK/KqegY1tk+io4+Ju7mL9PyyXtFOESK+yinzQ3MJn` })
       .reply(200)
@@ -161,12 +176,15 @@ Uploading ${path.join('tmp', 'home', '.ssh', 'id_rsa.pub')} SSH key... done
       }
     }
 
-    return fs.copy(path.join('test', 'fixtures', 'id_rsa.pub'), path.join(home, '.ssh', 'id_rsa.pub'))
-      .then(() => fs.copy(path.join('test', 'fixtures', 'id_rsa.pub'), path.join(home, '.ssh', 'id_rsa2.pub')))
-      .then(() => cmd.run({ args: {} }))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal(`Uploading ${path.join('tmp', 'home', '.ssh', 'id_rsa.pub')} SSH key... done
-`))
-      .then(() => api.done())
+    await fs.copy(path.join('test', 'fixtures', 'id_rsa.pub'), path.join(home, '.ssh', 'id_rsa.pub'))
+
+    fs.copy(path.join('test', 'fixtures', 'id_rsa.pub'), path.join(home, '.ssh', 'id_rsa2.pub'));
+    cmd.run({ args: {} });
+    expect(cli.stdout, 'to be empty');
+
+    expect(cli.stderr).to.equal(`Uploading ${path.join('tmp', 'home', '.ssh', 'id_rsa.pub')} SSH key... done
+`);
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/keys/clear.js
+++ b/packages/apps-v5/test/commands/keys/clear.js
@@ -10,15 +10,18 @@ describe('keys:clear', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
-  it('removes all SSH keys', () => {
+  it('removes all SSH keys', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/account/keys')
       .reply(200, [{ id: 1 }, { id: 2 }])
       .delete('/account/keys/1').reply(200)
       .delete('/account/keys/2').reply(200)
-    return cmd.run({ args: { key: 'user@machine' } })
-      .then(() => expect('').to.equal(cli.stdout))
-      .then(() => expect('Removing all SSH keys... done\n').to.equal(cli.stderr))
-      .then(() => api.done())
+
+    await cmd.run({ args: { key: 'user@machine' } })
+
+    expect('').to.equal(cli.stdout);
+    expect('Removing all SSH keys... done\n').to.equal(cli.stderr);
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/keys/index.js
+++ b/packages/apps-v5/test/commands/keys/index.js
@@ -11,52 +11,66 @@ describe('heroku keys', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
-  it('warns if no keys', () => {
+  it('warns if no keys', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/account/keys').reply(200, [])
-    return cmd.run({ flags: {} })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(unwrap(cli.stderr)).to.equal('You have no SSH keys.\n'))
-      .then(() => api.done())
+
+    await cmd.run({ flags: {} })
+
+    expect(cli.stdout, 'to be empty');
+    expect(unwrap(cli.stderr)).to.equal('You have no SSH keys.\n');
+
+    return api.done()
   })
 
-  it('shows ssh keys', () => {
+  it('shows ssh keys', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/account/keys')
       .reply(200, [
         { email: 'user@example.com', public_key: 'ssh-rsa AAAAB3NzxCXXXXXXXXXXXXXXXXXXXV7iHuYrZxd user@machine' }
       ])
-    return cmd.run({ flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== user@example.com keys
+
+    await cmd.run({ flags: {} })
+
+    expect(cli.stdout).to.equal(`=== user@example.com keys
 ssh-rsa AAAAB3NzxC...V7iHuYrZxd user@machine
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows ssh keys as json', () => {
+  it('shows ssh keys as json', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/account/keys')
       .reply(200, [
         { email: 'user@example.com', public_key: 'ssh-rsa AAAAB3NzxCXXXXXXXXXXXXXXXXXXXV7iHuYrZxd user@machine' }
       ])
-    return cmd.run({ flags: { json: true } })
-      .then(() => expect(JSON.parse(cli.stdout)[0], 'to satisfy', { email: 'user@example.com' }))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+
+    await cmd.run({ flags: { json: true } })
+
+    expect(JSON.parse(cli.stdout)[0], 'to satisfy', { email: 'user@example.com' });
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows full SSH keys', () => {
+  it('shows full SSH keys', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/account/keys')
       .reply(200, [
         { email: 'user@example.com', public_key: 'ssh-rsa AAAAB3NzxCXXXXXXXXXXXXXXXXXXXV7iHuYrZxd user@machine' }
       ])
-    return cmd.run({ flags: { long: true } })
-      .then(() => expect(cli.stdout).to.equal(`=== user@example.com keys
+
+    await cmd.run({ flags: { long: true } })
+
+    expect(cli.stdout).to.equal(`=== user@example.com keys
 ssh-rsa AAAAB3NzxCXXXXXXXXXXXXXXXXXXXV7iHuYrZxd user@machine
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/keys/remove.js
+++ b/packages/apps-v5/test/commands/keys/remove.js
@@ -10,15 +10,18 @@ describe('keys:remove', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
-  it('removes an SSH key', () => {
+  it('removes an SSH key', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/account/keys')
       .reply(200, [{ id: 1, comment: 'user@machine' }])
       .delete('/account/keys/1')
       .reply(200)
-    return cmd.run({ args: { key: 'user@machine' } })
-      .then(() => expect('').to.equal(cli.stdout))
-      .then(() => expect('Removing user@machine SSH key... done\n').to.equal(cli.stderr))
-      .then(() => api.done())
+
+    await cmd.run({ args: { key: 'user@machine' } })
+
+    expect('').to.equal(cli.stdout);
+    expect('Removing user@machine SSH key... done\n').to.equal(cli.stderr);
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/labs/enable.js
+++ b/packages/apps-v5/test/commands/labs/enable.js
@@ -9,7 +9,7 @@ const cmd = require('../../../src/commands/labs/enable')
 describe('labs:enable', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('enables a user lab feature', function () {
+  it('enables a user lab feature', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/account')
       .reply(200, { email: 'jeff@heroku.com' })
@@ -22,8 +22,8 @@ describe('labs:enable', function () {
       })
       .patch('/account/features/feature-a', { enabled: true })
       .reply(200)
-    return cmd.run({ args: { feature: 'feature-a' } })
-      .then(() => api.done())
+    await cmd.run({ args: { feature: 'feature-a' } })
+    return api.done()
   })
 
   it('enables an app feature', async function () {
@@ -37,9 +37,12 @@ describe('labs:enable', function () {
         doc_url: 'https://devcenter.heroku.com'
       })
       .patch('/apps/myapp/features/feature-a', { enabled: true }).reply(200)
-    return cmd.run({ app: 'myapp', args: { feature: 'feature-a' } })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal('Enabling feature-a for myapp... done\n'))
-      .then(() => api.done())
+
+    await cmd.run({ app: 'myapp', args: { feature: 'feature-a' } })
+
+    expect(cli.stdout, 'to be empty');
+    expect(cli.stderr).to.equal('Enabling feature-a for myapp... done\n');
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/labs/index.js
+++ b/packages/apps-v5/test/commands/labs/index.js
@@ -9,7 +9,7 @@ const expect = require('chai').expect
 describe('labs', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('shows labs features', function () {
+  it('shows labs features', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/account')
       .reply(200, { email: 'jeff@heroku.com' })
@@ -22,14 +22,17 @@ describe('labs', function () {
       .reply(200, [
         { enabled: true, name: 'lab feature c', description: 'an app lab feature' }
       ])
-    return cmd.run({ app: 'myapp', flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== User Features jeff@heroku.com
+
+    await cmd.run({ app: 'myapp', flags: {} })
+
+    expect(cli.stdout).to.equal(`=== User Features jeff@heroku.com
 [+] lab feature a  a user lab feature
 [ ] lab feature b  a user lab feature
 
 === App Features myapp
 [+] lab feature c  an app lab feature
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/labs/info.js
+++ b/packages/apps-v5/test/commands/labs/info.js
@@ -9,7 +9,7 @@ const { expect } = require('chai')
 describe('labs:info', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('shows user labs feature info', function () {
+  it('shows user labs feature info', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/account/features/feature-a')
       .reply(200, {
@@ -18,17 +18,21 @@ describe('labs:info', function () {
         description: 'a user lab feature',
         doc_url: 'https://devcenter.heroku.com'
       })
-    return cmd.run({ args: { feature: 'feature-a' }, flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== feature-a
+
+    await cmd.run({ args: { feature: 'feature-a' }, flags: {} })
+
+    expect(cli.stdout).to.equal(`=== feature-a
 Description: a user lab feature
 Docs:        https://devcenter.heroku.com
 Enabled:     true
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows user labs feature info as json', () => {
+  it('shows user labs feature info as json', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/account/features/feature-a')
       .reply(200, {
@@ -37,13 +41,16 @@ Enabled:     true
         description: 'a user lab feature',
         doc_url: 'https://devcenter.heroku.com'
       })
-    return cmd.run({ args: { feature: 'feature-a' }, flags: { json: true } })
-      .then(() => expect(JSON.parse(cli.stdout), 'to satisfy', { name: 'feature-a' }))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+
+    await cmd.run({ args: { feature: 'feature-a' }, flags: { json: true } })
+
+    expect(JSON.parse(cli.stdout), 'to satisfy', { name: 'feature-a' });
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows app labs feature info', function () {
+  it('shows app labs feature info', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/account/features/feature-a').reply(404)
       .get('/apps/myapp/features/feature-a')
@@ -53,13 +60,17 @@ Enabled:     true
         description: 'an app labs feature',
         doc_url: 'https://devcenter.heroku.com'
       })
-    return cmd.run({ app: 'myapp', args: { feature: 'feature-a' }, flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== feature-a
+
+    await cmd.run({ app: 'myapp', args: { feature: 'feature-a' }, flags: {} })
+
+    expect(cli.stdout).to.equal(`=== feature-a
 Description: an app labs feature
 Docs:        https://devcenter.heroku.com
 Enabled:     true
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/maintenance/index.js
+++ b/packages/apps-v5/test/commands/maintenance/index.js
@@ -17,29 +17,32 @@ describe('maintenance', () => {
   // useful if the test fails since it could screw up other tests
   afterEach(() => nock.cleanAll())
 
-  it('shows that maintenance is on', () => {
+  it('shows that maintenance is on', async () => {
     // mock out API
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp')
       .reply(200, { maintenance: true })
 
     // run the command
-    return cmd.run({ app: 'myapp' })
-      // check stdout
-      .then(() => expect(cli.stdout).to.equal('on\n'))
-      // check stderr
-      .then(() => expect(cli.stderr, 'to be empty'))
-      // ensure all nock HTTP expectations are met
-      .then(() => api.done())
+    await // check stdout
+    cmd.run({ app: 'myapp' })
+
+    expect(cli.stdout).to.equal('on\n');
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows that maintenance is off', () => {
+  it('shows that maintenance is off', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp')
       .reply(200, { maintenance: false })
-    return cmd.run({ app: 'myapp' })
-      .then(() => expect(cli.stdout).to.equal('off\n'))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+
+    await cmd.run({ app: 'myapp' })
+
+    expect(cli.stdout).to.equal('off\n');
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/maintenance/off.js
+++ b/packages/apps-v5/test/commands/maintenance/off.js
@@ -8,11 +8,11 @@ const cmd = require('../../../src/commands/maintenance/off')
 describe('maintenance:off', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('turns maintenance mode off', function () {
+  it('turns maintenance mode off', async function() {
     let api = nock('https://api.heroku.com:443')
       .patch('/apps/myapp', { maintenance: false })
       .reply(200)
-    return cmd.run({ app: 'myapp' })
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp' })
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/maintenance/on.js
+++ b/packages/apps-v5/test/commands/maintenance/on.js
@@ -8,11 +8,11 @@ const cmd = require('../../../src/commands/maintenance/on')
 describe('maintenance:on', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('turns maintenance mode on', function () {
+  it('turns maintenance mode on', async function() {
     let api = nock('https://api.heroku.com:443')
       .patch('/apps/myapp', { maintenance: true })
       .reply(200)
-    return cmd.run({ app: 'myapp' })
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp' })
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/ps/index.js
+++ b/packages/apps-v5/test/commands/ps/index.js
@@ -54,7 +54,7 @@ describe('ps', function () {
     nock.cleanAll()
   })
 
-  it('shows dyno list', function () {
+  it('shows dyno list', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/dynos')
       .reply(200, [
@@ -64,19 +64,22 @@ describe('ps', function () {
 
     stubAppAndAccount()
 
-    return cmd.run({ app: 'myapp', args: [], flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== run: one-off processes (1)
+    await cmd.run({ app: 'myapp', args: [], flags: {} })
+
+    expect(cli.stdout).to.equal(`=== run: one-off processes (1)
 run.1 (Free): up ${hourAgoStr} (~ 1h ago): bash
 
 === web (Free): npm start (1)
 web.1: up ${hourAgoStr} (~ 1h ago)
 
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows shield dynos in dyno list for apps in a shielded private space', function () {
+  it('shows shield dynos in dyno list for apps in a shielded private space', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp')
       .reply(200, { space: { shield: true } })
@@ -88,16 +91,19 @@ web.1: up ${hourAgoStr} (~ 1h ago)
 
     stubAppAndAccount()
 
-    return cmd.run({ app: 'myapp', args: [], flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== run: one-off processes (1)
+    await cmd.run({ app: 'myapp', args: [], flags: {} })
+
+    expect(cli.stdout).to.equal(`=== run: one-off processes (1)
 run.1 (Shield-L): up ${hourAgoStr} (~ 1h ago): bash
 
 === web (Shield-M): npm start (1)
 web.1: up ${hourAgoStr} (~ 1h ago)
 
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
   it('errors when no dynos found', function () {
@@ -113,7 +119,7 @@ web.1: up ${hourAgoStr} (~ 1h ago)
     return expect(cmd.run({ app: 'myapp', args: ['foo'], flags: {} })).to.be.rejectedWith('No foo dynos on myapp')
   })
 
-  it('shows dyno list as json', function () {
+  it('shows dyno list as json', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/account')
       .reply(200, { id: '1234' })
@@ -124,13 +130,15 @@ web.1: up ${hourAgoStr} (~ 1h ago)
         { command: 'npm start', size: 'Free', name: 'web.1', type: 'web', updated_at: hourAgo, state: 'up' }
       ])
 
-    return cmd.run({ app: 'myapp', args: [], flags: { json: true } })
-      .then(() => expect(JSON.parse(cli.stdout)[0], 'to satisfy', { command: 'npm start' }))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: [], flags: { json: true } })
+
+    expect(JSON.parse(cli.stdout)[0], 'to satisfy', { command: 'npm start' });
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows extended info', function () {
+  it('shows extended info', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/account')
       .reply(200, { id: '1234' })
@@ -142,17 +150,20 @@ web.1: up ${hourAgoStr} (~ 1h ago)
         { id: 101, command: 'bash', size: 'Free', name: 'run.1', type: 'run', updated_at: hourAgo, state: 'up', extended: { region: 'us', instance: 'instance', ip: '10.0.0.2', port: 8000, az: 'us-east', route: 'da route' } }
       ])
 
-    return cmd.run({ app: 'myapp', args: [], flags: { extended: true } })
-      .then(() => expect(cli.stdout).to.equal(`ID   Process  State                                    Region  Instance  IP        Port  AZ       Release  Command    Route     Size
+    await cmd.run({ app: 'myapp', args: [], flags: { extended: true } })
+
+    expect(cli.stdout).to.equal(`ID   Process  State                                    Region  Instance  IP        Port  AZ       Release  Command    Route     Size
 ───  ───────  ───────────────────────────────────────  ──────  ────────  ────────  ────  ───────  ───────  ─────────  ────────  ────
 101  run.1    up ${hourAgoStr} (~ 1h ago)  us      instance  10.0.0.2  8000  us-east           bash       da route  Free
 100  web.1    up ${hourAgoStr} (~ 1h ago)  us      instance  10.0.0.1  8000  us-east           npm start  da route  Free
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows shield dynos in extended info if app is in a shielded private space', function () {
+  it('shows shield dynos in extended info if app is in a shielded private space', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/account')
       .reply(200, { id: '1234' })
@@ -164,17 +175,20 @@ web.1: up ${hourAgoStr} (~ 1h ago)
         { id: 101, command: 'bash', size: 'Private-L', name: 'run.1', type: 'run', updated_at: hourAgo, state: 'up', extended: { region: 'us', instance: 'instance', ip: '10.0.0.2', port: 8000, az: 'us-east', route: 'da route' } }
       ])
 
-    return cmd.run({ app: 'myapp', args: [], flags: { extended: true } })
-      .then(() => expect(cli.stdout).to.equal(`ID   Process  State                                    Region  Instance  IP        Port  AZ       Release  Command    Route     Size
+    await cmd.run({ app: 'myapp', args: [], flags: { extended: true } })
+
+    expect(cli.stdout).to.equal(`ID   Process  State                                    Region  Instance  IP        Port  AZ       Release  Command    Route     Size
 ───  ───────  ───────────────────────────────────────  ──────  ────────  ────────  ────  ───────  ───────  ─────────  ────────  ────────
 101  run.1    up ${hourAgoStr} (~ 1h ago)  us      instance  10.0.0.2  8000  us-east           bash       da route  Shield-L
 100  web.1    up ${hourAgoStr} (~ 1h ago)  us      instance  10.0.0.1  8000  us-east           npm start  da route  Shield-M
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows free quota remaining', function () {
+  it('shows free quota remaining', async function() {
     stubAccountQuota(200, { account_quota: 1000, quota_used: 1, apps: [] })
 
     let freeExpression =
@@ -187,12 +201,15 @@ https://devcenter.heroku.com/articles/dyno-sleeping
 run.1 (Free): up ${hourAgoStr} (~ 1h ago): bash
 
 `
-    return cmd.run({ app: 'myapp', args: [], flags: {} })
-      .then(() => expect(cli.stdout).to.equal(freeExpression))
-      .then(() => expect(cli.stderr, 'to be empty'))
+
+    await cmd.run({ app: 'myapp', args: [], flags: {} })
+
+    expect(cli.stdout).to.equal(freeExpression);
+
+    return expect(cli.stderr, 'to be empty')
   })
 
-  it('shows free quota remaining in hours and minutes', function () {
+  it('shows free quota remaining in hours and minutes', async function() {
     stubAccountQuota(200, { account_quota: 3600000, quota_used: 178200, apps: [] })
 
     let freeExpression =
@@ -205,12 +222,15 @@ https://devcenter.heroku.com/articles/dyno-sleeping
 run.1 (Free): up ${hourAgoStr} (~ 1h ago): bash
 
 `
-    return cmd.run({ app: 'myapp', args: [], flags: {} })
-      .then(() => expect(cli.stdout).to.equal(freeExpression))
-      .then(() => expect(cli.stderr, 'to be empty'))
+
+    await cmd.run({ app: 'myapp', args: [], flags: {} })
+
+    expect(cli.stdout).to.equal(freeExpression);
+
+    return expect(cli.stderr, 'to be empty')
   })
 
-  it('shows free quota usage of free apps', function () {
+  it('shows free quota usage of free apps', async function() {
     stubAccountQuota(200, { account_quota: 3600000, quota_used: 178200, apps: [{ app_uuid: '6789', quota_used: 178200 }] })
 
     let freeExpression =
@@ -223,12 +243,15 @@ https://devcenter.heroku.com/articles/dyno-sleeping
 run.1 (Free): up ${hourAgoStr} (~ 1h ago): bash
 
 `
-    return cmd.run({ app: 'myapp', args: [], flags: {} })
-      .then(() => expect(cli.stdout).to.equal(freeExpression))
-      .then(() => expect(cli.stderr, 'to be empty'))
+
+    await cmd.run({ app: 'myapp', args: [], flags: {} })
+
+    expect(cli.stdout).to.equal(freeExpression);
+
+    return expect(cli.stderr, 'to be empty')
   })
 
-  it('shows free quota remaining even when account_quota is zero', function () {
+  it('shows free quota remaining even when account_quota is zero', async function() {
     stubAccountQuota(200, { account_quota: 0, quota_used: 0, apps: [] })
 
     let freeExpression =
@@ -241,12 +264,15 @@ https://devcenter.heroku.com/articles/dyno-sleeping
 run.1 (Free): up ${hourAgoStr} (~ 1h ago): bash
 
 `
-    return cmd.run({ app: 'myapp', args: [], flags: {} })
-      .then(() => expect(cli.stdout).to.equal(freeExpression))
-      .then(() => expect(cli.stderr, 'to be empty'))
+
+    await cmd.run({ app: 'myapp', args: [], flags: {} })
+
+    expect(cli.stdout).to.equal(freeExpression);
+
+    return expect(cli.stderr, 'to be empty')
   })
 
-  it('handles quota 404 properly', function () {
+  it('handles quota 404 properly', async function() {
     stubAccountQuota(404, { id: 'not_found' })
 
     let freeExpression = `=== run: one-off processes (1)
@@ -254,24 +280,29 @@ run.1 (Free): up ${hourAgoStr} (~ 1h ago): bash
 
 `
 
-    return cmd.run({ app: 'myapp', args: [], flags: {} })
-      .then(() => expect(cli.stdout).to.equal(freeExpression))
-      .then(() => expect(cli.stderr, 'to be empty'))
+    await cmd.run({ app: 'myapp', args: [], flags: {} })
+
+    expect(cli.stdout).to.equal(freeExpression);
+
+    return expect(cli.stderr, 'to be empty')
   })
 
-  it('handles quota 200 not_found properly', function () {
+  it('handles quota 200 not_found properly', async function() {
     stubAccountQuota(200, { id: 'not_found' })
 
     let freeExpression = `=== run: one-off processes (1)
 run.1 (Free): up ${hourAgoStr} (~ 1h ago): bash
 
 `
-    return cmd.run({ app: 'myapp', args: [], flags: {} })
-      .then(() => expect(cli.stdout).to.equal(freeExpression))
-      .then(() => expect(cli.stderr, 'to be empty'))
+
+    await cmd.run({ app: 'myapp', args: [], flags: {} })
+
+    expect(cli.stdout).to.equal(freeExpression);
+
+    return expect(cli.stderr, 'to be empty')
   })
 
-  it('does not print out for apps that are not owned', function () {
+  it('does not print out for apps that are not owned', async function() {
     nock('https://api.heroku.com:443')
       .get('/account')
       .reply(200, { id: '1234' })
@@ -299,13 +330,16 @@ run.1 (Free): up ${hourAgoStr} (~ 1h ago): bash
 run.1 (Free): up ${hourAgoStr} (~ 1h ago): bash
 
 `
-    return cmd.run({ app: 'myapp', args: [], flags: {} })
-      .then(() => expect(cli.stdout).to.equal(freeExpression))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => dynos.done())
+
+    await cmd.run({ app: 'myapp', args: [], flags: {} })
+
+    expect(cli.stdout).to.equal(freeExpression);
+    expect(cli.stderr, 'to be empty');
+
+    return dynos.done()
   })
 
-  it('does not print out for non-free apps', function () {
+  it('does not print out for non-free apps', async function() {
     nock('https://api.heroku.com:443')
       .get('/account')
       .reply(200, { id: '1234' })
@@ -324,13 +358,16 @@ run.1 (Free): up ${hourAgoStr} (~ 1h ago): bash
 run.1 (Free): up ${hourAgoStr} (~ 1h ago): bash
 
 `
-    return cmd.run({ app: 'myapp', args: [], flags: {} })
-      .then(() => expect(cli.stdout).to.equal(freeExpression))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => dynos.done())
+
+    await cmd.run({ app: 'myapp', args: [], flags: {} })
+
+    expect(cli.stdout).to.equal(freeExpression);
+    expect(cli.stderr, 'to be empty');
+
+    return dynos.done()
   })
 
-  it('traps errors properly', function () {
+  it('traps errors properly', async function() {
     stubAccountQuota(503, { id: 'server_error' })
 
     let freeExpression = `=== run: one-off processes (1)
@@ -338,21 +375,25 @@ run.1 (Free): up ${hourAgoStr} (~ 1h ago): bash
 
 `
 
-    return cmd.run({ app: 'myapp', args: [], flags: {} })
-      .then(() => expect(cli.stdout).to.equal(freeExpression))
-      .then(() => expect(cli.stderr, 'to be empty'))
+    await cmd.run({ app: 'myapp', args: [], flags: {} })
+
+    expect(cli.stdout).to.equal(freeExpression);
+
+    return expect(cli.stderr, 'to be empty')
   })
 
-  it('logs to stdout and exits zero when no dynos', function () {
+  it('logs to stdout and exits zero when no dynos', async function() {
     let dynos = nock('https://api.heroku.com:443')
       .get('/apps/myapp/dynos')
       .reply(200, [])
 
     stubAppAndAccount()
 
-    return cmd.run({ app: 'myapp', args: [], flags: {} })
-      .then(() => expect(cli.stdout).to.equal('No dynos on myapp\n'))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => dynos.done())
+    await cmd.run({ app: 'myapp', args: [], flags: {} })
+
+    expect(cli.stdout).to.equal('No dynos on myapp\n');
+    expect(cli.stderr, 'to be empty');
+
+    return dynos.done()
   })
 })

--- a/packages/apps-v5/test/commands/ps/restart.js
+++ b/packages/apps-v5/test/commands/ps/restart.js
@@ -11,11 +11,11 @@ describe('ps:restart', function () {
     nock.cleanAll()
   })
 
-  it('restarts all dynos', function () {
+  it('restarts all dynos', async function() {
     let api = nock('https://api.heroku.com')
       .delete('/apps/myapp/dynos').reply(200)
 
-    return cmd.run({ app: 'myapp', args: {} })
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: {} })
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/ps/scale.js
+++ b/packages/apps-v5/test/commands/ps/scale.js
@@ -11,82 +11,94 @@ describe('ps:scale', () => {
 
   afterEach(() => nock.cleanAll())
 
-  it('shows formation with no args', () => {
+  it('shows formation with no args', async () => {
     let api = nock('https://api.heroku.com')
       .get('/apps/myapp/formation')
       .reply(200, [{ type: 'web', quantity: 1, size: 'Free' }, { type: 'worker', quantity: 2, size: 'Free' }])
       .get('/apps/myapp')
       .reply(200, { name: 'myapp' })
 
-    return cmd.run({ app: 'myapp', args: [] })
-      .then(() => expect(cli.stdout).to.equal('web=1:Free worker=2:Free\n'))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: [] })
+
+    expect(cli.stdout).to.equal('web=1:Free worker=2:Free\n');
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows formation with shield dynos for apps in a shielded private space', () => {
+  it('shows formation with shield dynos for apps in a shielded private space', async () => {
     let api = nock('https://api.heroku.com')
       .get('/apps/myapp/formation')
       .reply(200, [{ type: 'web', quantity: 1, size: 'Private-L' }, { type: 'worker', quantity: 2, size: 'Private-M' }])
       .get('/apps/myapp')
       .reply(200, { name: 'myapp', space: { shield: true } })
 
-    return cmd.run({ app: 'myapp', args: [] })
-      .then(() => expect(cli.stdout).to.equal('web=1:Shield-L worker=2:Shield-M\n'))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: [] })
+
+    expect(cli.stdout).to.equal('web=1:Shield-L worker=2:Shield-M\n');
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('errors with no process types', () => {
+  it('errors with no process types', async () => {
     let api = nock('https://api.heroku.com')
       .get('/apps/myapp/formation')
       .reply(200, [])
       .get('/apps/myapp')
       .reply(200, { name: 'myapp' })
 
-    return expect(cmd.run({ app: 'myapp', args: [] }))
+    await expect(cmd.run({ app: 'myapp', args: [] }))
       .to.be.rejectedWith(Error, /^No process types on myapp./)
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+
+    expect(cli.stdout, 'to be empty');
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('scales web=1 worker=2', () => {
+  it('scales web=1 worker=2', async () => {
     let api = nock('https://api.heroku.com:443')
       .patch('/apps/myapp/formation', { updates: [{ type: 'web', quantity: '1' }, { type: 'worker', quantity: '2' }] })
       .reply(200, [{ type: 'web', quantity: 1, size: 'Free' }, { type: 'worker', quantity: 2, size: 'Free' }])
       .get('/apps/myapp')
       .reply(200, { name: 'myapp' })
 
-    return cmd.run({ app: 'myapp', args: ['web=1', 'worker=2'] })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal('Scaling dynos... done, now running web at 1:Free, worker at 2:Free\n'))
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: ['web=1', 'worker=2'] })
+
+    expect(cli.stdout, 'to be empty');
+    expect(cli.stderr).to.equal('Scaling dynos... done, now running web at 1:Free, worker at 2:Free\n');
+
+    return api.done()
   })
 
-  it('scales up a shield dyno if the app is in a shielded private space', () => {
+  it('scales up a shield dyno if the app is in a shielded private space', async () => {
     let api = nock('https://api.heroku.com:443')
       .patch('/apps/myapp/formation', { updates: [{ type: 'web', quantity: '1', size: 'Private-L' }] })
       .reply(200, [{ type: 'web', quantity: 1, size: 'Private-L' }])
       .get('/apps/myapp')
       .reply(200, { name: 'myapp', space: { shield: true } })
 
-    return cmd.run({ app: 'myapp', args: ['web=1:Shield-L'] })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal('Scaling dynos... done, now running web at 1:Shield-L\n'))
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: ['web=1:Shield-L'] })
+
+    expect(cli.stdout, 'to be empty');
+    expect(cli.stderr).to.equal('Scaling dynos... done, now running web at 1:Shield-L\n');
+
+    return api.done()
   })
 
-  it('scales web-1', () => {
+  it('scales web-1', async () => {
     let api = nock('https://api.heroku.com:443')
       .patch('/apps/myapp/formation', { updates: [{ type: 'web', quantity: '+1' }] })
       .reply(200, [{ type: 'web', quantity: 2, size: 'Free' }])
       .get('/apps/myapp')
       .reply(200, { name: 'myapp' })
 
-    return cmd.run({ app: 'myapp', args: ['web+1'] })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal('Scaling dynos... done, now running web at 2:Free\n'))
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: ['web+1'] })
+
+    expect(cli.stdout, 'to be empty');
+    expect(cli.stderr).to.equal('Scaling dynos... done, now running web at 2:Free\n');
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/ps/stop.js
+++ b/packages/apps-v5/test/commands/ps/stop.js
@@ -11,19 +11,19 @@ describe('ps:stop', function () {
     nock.cleanAll()
   })
 
-  it('stops all web dynos', function () {
+  it('stops all web dynos', async function() {
     let api = nock('https://api.heroku.com')
       .post('/apps/myapp/dynos/web/actions/stop').reply(200)
 
-    return cmd.run({ app: 'myapp', args: { dyno: 'web' } })
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: { dyno: 'web' } })
+    return api.done()
   })
 
-  it('stops run.10 dyno', function () {
+  it('stops run.10 dyno', async function() {
     let api = nock('https://api.heroku.com')
       .post('/apps/myapp/dynos/run.10/actions/stop').reply(200)
 
-    return cmd.run({ app: 'myapp', args: { dyno: 'run.10' } })
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: { dyno: 'run.10' } })
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/ps/type.js
+++ b/packages/apps-v5/test/commands/ps/type.js
@@ -17,7 +17,7 @@ describe('ps:type', function () {
     nock.cleanAll()
   })
 
-  it('switches to hobby dynos', function () {
+  it('switches to hobby dynos', async function() {
     let api = nock('https://api.heroku.com')
       .get('/apps/myapp')
       .reply(200, app())
@@ -28,17 +28,20 @@ describe('ps:type', function () {
       .get('/apps/myapp/formation')
       .reply(200, [{ type: 'web', quantity: 1, size: 'Hobby' }, { type: 'worker', quantity: 2, size: 'Hobby' }])
 
-    return cmd.run({ app: 'myapp', args: ['hobby'] })
-      .then(() => expect(cli.stdout).to.eq(`type    size   qty  cost/mo
+    await cmd.run({ app: 'myapp', args: ['hobby'] })
+
+    expect(cli.stdout).to.eq(`type    size   qty  cost/mo
 ──────  ─────  ───  ───────
 web     Hobby  1    7
 worker  Hobby  2    14
-`))
-      .then(() => expect(cli.stderr).to.eq('Scaling dynos on myapp... done\n'))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr).to.eq('Scaling dynos on myapp... done\n');
+
+    return api.done()
   })
 
-  it('switches to standard-1x and standard-2x dynos', function () {
+  it('switches to standard-1x and standard-2x dynos', async function() {
     let api = nock('https://api.heroku.com')
       .get('/apps/myapp')
       .reply(200, app())
@@ -49,29 +52,34 @@ worker  Hobby  2    14
       .get('/apps/myapp/formation')
       .reply(200, [{ type: 'web', quantity: 1, size: 'Standard-1X' }, { type: 'worker', quantity: 2, size: 'Standard-2X' }])
 
-    return cmd.run({ app: 'myapp', args: ['web=standard-1x', 'worker=standard-2x'] })
-      .then(() => expect(cli.stdout).to.eq(`type    size         qty  cost/mo
+    await cmd.run({ app: 'myapp', args: ['web=standard-1x', 'worker=standard-2x'] })
+
+    expect(cli.stdout).to.eq(`type    size         qty  cost/mo
 ──────  ───────────  ───  ───────
 web     Standard-1X  1    25
 worker  Standard-2X  2    100
-`))
-      .then(() => expect(cli.stderr).to.eq('Scaling dynos on myapp... done\n'))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr).to.eq('Scaling dynos on myapp... done\n');
+
+    return api.done()
   })
 
-  it('displays Shield dynos for apps in shielded spaces', function () {
+  it('displays Shield dynos for apps in shielded spaces', async function() {
     let api = nock('https://api.heroku.com')
       .get('/apps/myapp')
       .reply(200, app({ space: { shield: true } }))
       .get('/apps/myapp/formation')
       .reply(200, [{ type: 'web', quantity: 0, size: 'Private-M' }, { type: 'web', quantity: 0, size: 'Private-L' }])
 
-    return cmd.run({ app: 'myapp', args: [] })
-      .then(() => expect(cli.stdout).to.eq(`type  size      qty  cost/mo
+    await cmd.run({ app: 'myapp', args: [] })
+
+    expect(cli.stdout).to.eq(`type  size      qty  cost/mo
 ────  ────────  ───  ───────
 web   Shield-M  0
 web   Shield-L  0
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/releases/index.js
+++ b/packages/apps-v5/test/commands/releases/index.js
@@ -231,7 +231,7 @@ describe('releases', () => {
     }
   }
 
-  it('shows releases', () => {
+  it('shows releases', async () => {
     process.stdout.isTTY = true
     process.stdout.columns = 80
     let api = nock('https://api.heroku.com:443')
@@ -239,39 +239,47 @@ describe('releases', () => {
       .reply(200, releases)
       .get('/apps/myapp/slugs/37994c83-39a3-4cbf-b318-8f9dc648f701')
       .reply(200, slug)
-    return cmd.run({ app: 'myapp', flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== myapp Releases - Current: v37
+
+    await cmd.run({ app: 'myapp', flags: {} })
+
+    expect(cli.stdout).to.equal(`=== myapp Releases - Current: v37
 v41  thir… release command executing  jeff@heroku.com  2015/11/18 01:36:38 +0000
 v40  Set foo config vars              jeff@heroku.com  2015/11/18 01:37:41 +0000
 v39  Remove … release command failed  jeff@heroku.com  2015/11/18 01:36:38 +0000
 v38  seco… release command executing  jeff@heroku.com  2015/11/18 01:36:38 +0000
 v37  first commit                     jeff@heroku.com  2015/11/18 01:36:38 +0000
-`))
-      .then(() => assertLineWidths(cli.stdout, 80))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    assertLineWidths(cli.stdout, 80);
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows successful releases', () => {
+  it('shows successful releases', async () => {
     process.stdout.isTTY = true
     process.stdout.columns = 80
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
       .reply(200, onlySuccessfulReleases)
-    return cmd.run({ app: 'myapp', flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== myapp Releases - Current: v37
+
+    await cmd.run({ app: 'myapp', flags: {} })
+
+    expect(cli.stdout).to.equal(`=== myapp Releases - Current: v37
 v41  third commit                     jeff@heroku.com  2015/11/18 01:36:38 +0000
 v40  Set foo config vars              jeff@heroku.com  2015/11/18 01:37:41 +0000
 v39  Remove AWS_SECRET_ACCESS_KEY c…  jeff@heroku.com  2015/11/18 01:36:38 +0000
 v38  second commit                    jeff@heroku.com  2015/11/18 01:36:38 +0000
 v37  first commit                     jeff@heroku.com  2015/11/18 01:36:38 +0000
-`))
-      .then(() => assertLineWidths(cli.stdout, 80))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    assertLineWidths(cli.stdout, 80);
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows releases in wider terminal', () => {
+  it('shows releases in wider terminal', async () => {
     process.stdout.isTTY = true
     process.stdout.columns = 100
     let api = nock('https://api.heroku.com:443')
@@ -279,39 +287,47 @@ v37  first commit                     jeff@heroku.com  2015/11/18 01:36:38 +0000
       .reply(200, releases)
       .get('/apps/myapp/slugs/37994c83-39a3-4cbf-b318-8f9dc648f701')
       .reply(200, slug)
-    return cmd.run({ app: 'myapp', flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== myapp Releases - Current: v37
+
+    await cmd.run({ app: 'myapp', flags: {} })
+
+    expect(cli.stdout).to.equal(`=== myapp Releases - Current: v37
 v41  third commit release command executing               jeff@heroku.com  2015/11/18 01:36:38 +0000
 v40  Set foo config vars                                  jeff@heroku.com  2015/11/18 01:37:41 +0000
 v39  Remove AWS_SECRET_ACCESS_KE… release command failed  jeff@heroku.com  2015/11/18 01:36:38 +0000
 v38  second commit release command executing              jeff@heroku.com  2015/11/18 01:36:38 +0000
 v37  first commit                                         jeff@heroku.com  2015/11/18 01:36:38 +0000
-`))
-      .then(() => assertLineWidths(cli.stdout, 100))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    assertLineWidths(cli.stdout, 100);
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows successful releases in wider terminal', () => {
+  it('shows successful releases in wider terminal', async () => {
     process.stdout.isTTY = true
     process.stdout.columns = 100
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
       .reply(200, onlySuccessfulReleases)
-    return cmd.run({ app: 'myapp', flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== myapp Releases - Current: v37
+
+    await cmd.run({ app: 'myapp', flags: {} })
+
+    expect(cli.stdout).to.equal(`=== myapp Releases - Current: v37
 v41  third commit                              jeff@heroku.com  2015/11/18 01:36:38 +0000
 v40  Set foo config vars                       jeff@heroku.com  2015/11/18 01:37:41 +0000
 v39  Remove AWS_SECRET_ACCESS_KEY config vars  jeff@heroku.com  2015/11/18 01:36:38 +0000
 v38  second commit                             jeff@heroku.com  2015/11/18 01:36:38 +0000
 v37  first commit                              jeff@heroku.com  2015/11/18 01:36:38 +0000
-`))
-      .then(() => assertLineWidths(cli.stdout, 89))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    assertLineWidths(cli.stdout, 89);
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows releases in narrow terminal', () => {
+  it('shows releases in narrow terminal', async () => {
     process.stdout.isTTY = true
     process.stdout.columns = 65
     let api = nock('https://api.heroku.com:443')
@@ -319,20 +335,24 @@ v37  first commit                              jeff@heroku.com  2015/11/18 01:36
       .reply(200, releases)
       .get('/apps/myapp/slugs/37994c83-39a3-4cbf-b318-8f9dc648f701')
       .reply(200, slug)
-    return cmd.run({ app: 'myapp', flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== myapp Releases - Current: v37
+
+    await cmd.run({ app: 'myapp', flags: {} })
+
+    expect(cli.stdout).to.equal(`=== myapp Releases - Current: v37
 v41  thir… release command executing  jeff@heroku.com  2015/11/18 01:36:38 +0000
 v40  Set foo config vars              jeff@heroku.com  2015/11/18 01:37:41 +0000
 v39  Remove … release command failed  jeff@heroku.com  2015/11/18 01:36:38 +0000
 v38  seco… release command executing  jeff@heroku.com  2015/11/18 01:36:38 +0000
 v37  first commit                     jeff@heroku.com  2015/11/18 01:36:38 +0000
-`))
-      .then(() => assertLineWidths(cli.stdout, 80))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    assertLineWidths(cli.stdout, 80);
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows pending releases without release phase', () => {
+  it('shows pending releases without release phase', async () => {
     process.stdout.isTTY = true
     process.stdout.columns = 80
     let api = nock('https://api.heroku.com:443')
@@ -340,83 +360,105 @@ v37  first commit                     jeff@heroku.com  2015/11/18 01:36:38 +0000
       .reply(200, releases)
       .get('/apps/myapp/slugs/37994c83-39a3-4cbf-b318-8f9dc648f701')
       .reply(200, {})
-    return cmd.run({ app: 'myapp', flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== myapp Releases - Current: v37
+
+    await cmd.run({ app: 'myapp', flags: {} })
+
+    expect(cli.stdout).to.equal(`=== myapp Releases - Current: v37
 v41  thir… release command executing  jeff@heroku.com  2015/11/18 01:36:38 +0000
 v40  Set foo config vars              jeff@heroku.com  2015/11/18 01:37:41 +0000
 v39  Remove … release command failed  jeff@heroku.com  2015/11/18 01:36:38 +0000
 v38  seco… release command executing  jeff@heroku.com  2015/11/18 01:36:38 +0000
 v37  first commit                     jeff@heroku.com  2015/11/18 01:36:38 +0000
-`))
-      .then(() => assertLineWidths(cli.stdout, 80))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    assertLineWidths(cli.stdout, 80);
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows pending releases without a slug', () => {
+  it('shows pending releases without a slug', async () => {
     process.stdout.isTTY = true
     process.stdout.columns = 80
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
       .reply(200, releasesNoSlug)
-    return cmd.run({ app: 'myapp', flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== myapp Releases
+
+    await cmd.run({ app: 'myapp', flags: {} })
+
+    expect(cli.stdout).to.equal(`=== myapp Releases
 v1  first… release command executing  jeff@heroku.com  2015/11/18 01:36:38 +0000
-`))
-      .then(() => assertLineWidths(cli.stdout, 80))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    assertLineWidths(cli.stdout, 80);
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows releases as json', () => {
+  it('shows releases as json', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
       .reply(200, releases)
       .get('/apps/myapp/slugs/37994c83-39a3-4cbf-b318-8f9dc648f701')
       .reply(200, slug)
-    return cmd.run({ app: 'myapp', flags: { json: true } })
-      .then(() => expect(JSON.parse(cli.stdout)[0], 'to satisfy', { version: 41 }))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+
+    await cmd.run({ app: 'myapp', flags: { json: true } })
+
+    expect(JSON.parse(cli.stdout)[0], 'to satisfy', { version: 41 });
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows message if no releases', () => {
+  it('shows message if no releases', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
       .reply(200, [])
-    return cmd.run({ app: 'myapp', flags: {} })
-      .then(() => expect(cli.stdout).to.equal('myapp has no releases.\n'))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+
+    await cmd.run({ app: 'myapp', flags: {} })
+
+    expect(cli.stdout).to.equal('myapp has no releases.\n');
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows extended info', () => {
+  it('shows extended info', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases?extended=true')
       .reply(200, extended)
-    return cmd.run({ app: 'myapp', flags: { extended: true } })
-      .then(() => expect(cli.stdout).to.equal(`=== myapp Releases
+
+    await cmd.run({ app: 'myapp', flags: { extended: true } })
+
+    expect(cli.stdout).to.equal(`=== myapp Releases
 v40      Set foo config vars  jeff@heroku.com  2015/11/18 01:37:41 +0000  1                 uuid
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows extended info in wider terminal', () => {
+  it('shows extended info in wider terminal', async () => {
     process.stdout.isTTY = true
     process.stdout.columns = 100
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases?extended=true')
       .reply(200, extended)
-    return cmd.run({ app: 'myapp', flags: { extended: true } })
-      .then(() => expect(cli.stdout).to.equal(`=== myapp Releases
+
+    await cmd.run({ app: 'myapp', flags: { extended: true } })
+
+    expect(cli.stdout).to.equal(`=== myapp Releases
 v40      Set foo config vars  jeff@heroku.com  2015/11/18 01:37:41 +0000  1                 uuid
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows no current release', () => {
+  it('shows no current release', async () => {
     process.stdout.isTTY = true
     process.stdout.columns = 80
     releases[releases.length - 1].current = false
@@ -426,16 +468,20 @@ v40      Set foo config vars  jeff@heroku.com  2015/11/18 01:37:41 +0000  1     
       .reply(200, releases)
       .get('/apps/myapp/slugs/37994c83-39a3-4cbf-b318-8f9dc648f701')
       .reply(200, slug)
-    return cmd.run({ app: 'myapp', flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== myapp Releases
+
+    await cmd.run({ app: 'myapp', flags: {} })
+
+    expect(cli.stdout).to.equal(`=== myapp Releases
 v41  thir… release command executing  jeff@heroku.com  2015/11/18 01:36:38 +0000
 v40  Set foo config vars              jeff@heroku.com  2015/11/18 01:37:41 +0000
 v39  Remove … release command failed  jeff@heroku.com  2015/11/18 01:36:38 +0000
 v38  seco… release command executing  jeff@heroku.com  2015/11/18 01:36:38 +0000
 v37  first commit                     jeff@heroku.com  2015/11/18 01:36:38 +0000
-`))
-      .then(() => assertLineWidths(cli.stdout, 80))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    assertLineWidths(cli.stdout, 80);
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/releases/info.js
+++ b/packages/apps-v5/test/commands/releases/info.js
@@ -23,14 +23,16 @@ describe('releases:info', function () {
   }
   let configVars = { FOO: 'foo', BAR: 'bar' }
 
-  it('shows most recent release info', function () {
+  it('shows most recent release info', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
       .reply(200, [release])
       .get('/apps/myapp/releases/10/config-vars')
       .reply(200, configVars)
-    return cmd.run({ app: 'myapp', flags: {}, args: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== Release v10
+
+    await cmd.run({ app: 'myapp', flags: {}, args: {} })
+
+    expect(cli.stdout).to.equal(`=== Release v10
 Add-ons: addon1
          addon2
 By:      foo@foo.com
@@ -40,19 +42,23 @@ When:    ${d.toISOString()}
 === v10 Config vars
 BAR: bar
 FOO: foo
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows most recent release info config vars as shell', function () {
+  it('shows most recent release info config vars as shell', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
       .reply(200, [release])
       .get('/apps/myapp/releases/10/config-vars')
       .reply(200, configVars)
-    return cmd.run({ app: 'myapp', flags: { shell: true }, args: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== Release v10
+
+    await cmd.run({ app: 'myapp', flags: { shell: true }, args: {} })
+
+    expect(cli.stdout).to.equal(`=== Release v10
 Add-ons: addon1
          addon2
 By:      foo@foo.com
@@ -62,19 +68,23 @@ When:    ${d.toISOString()}
 === v10 Config vars
 FOO=foo
 BAR=bar
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows release info by id', function () {
+  it('shows release info by id', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases/10')
       .reply(200, release)
       .get('/apps/myapp/releases/10/config-vars')
       .reply(200, configVars)
-    return cmd.run({ app: 'myapp', flags: {}, args: { release: 'v10' } })
-      .then(() => expect(cli.stdout).to.equal(`=== Release v10
+
+    await cmd.run({ app: 'myapp', flags: {}, args: { release: 'v10' } })
+
+    expect(cli.stdout).to.equal(`=== Release v10
 Add-ons: addon1
          addon2
 By:      foo@foo.com
@@ -84,24 +94,29 @@ When:    ${d.toISOString()}
 === v10 Config vars
 BAR: bar
 FOO: foo
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows recent release as json', function () {
+  it('shows recent release as json', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases/10')
       .reply(200, release)
       .get('/apps/myapp/releases/10/config-vars')
       .reply(200, configVars)
-    return cmd.run({ app: 'myapp', flags: { json: true }, args: { release: 'v10' } })
-      .then(() => expect(JSON.parse(cli.stdout), 'to satisfy', { version: 10 }))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+
+    await cmd.run({ app: 'myapp', flags: { json: true }, args: { release: 'v10' } })
+
+    expect(JSON.parse(cli.stdout), 'to satisfy', { version: 10 });
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows a failed release info', function () {
+  it('shows a failed release info', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
       .reply(200, [{
@@ -113,8 +128,10 @@ FOO: foo
       }])
       .get('/apps/myapp/releases/10/config-vars')
       .reply(200, configVars)
-    return cmd.run({ app: 'myapp', flags: {}, args: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== Release v10
+
+    await cmd.run({ app: 'myapp', flags: {}, args: {} })
+
+    expect(cli.stdout).to.equal(`=== Release v10
 By:      foo@foo.com
 Change:  something changed (release command failed)
 When:    ${d.toISOString()}
@@ -122,12 +139,14 @@ When:    ${d.toISOString()}
 === v10 Config vars
 BAR: bar
 FOO: foo
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 
-  it('shows a pending release info', function () {
+  it('shows a pending release info', async function() {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
       .reply(200, [{
@@ -140,8 +159,10 @@ FOO: foo
       }])
       .get('/apps/myapp/releases/10/config-vars')
       .reply(200, configVars)
-    return cmd.run({ app: 'myapp', flags: {}, args: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== Release v10
+
+    await cmd.run({ app: 'myapp', flags: {}, args: {} })
+
+    expect(cli.stdout).to.equal(`=== Release v10
 Add-ons: addon1
          addon2
 By:      foo@foo.com
@@ -151,8 +172,10 @@ When:    ${d.toISOString()}
 === v10 Config vars
 BAR: bar
 FOO: foo
-`))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
+`);
+
+    expect(cli.stderr, 'to be empty');
+
+    return api.done()
   })
 })

--- a/packages/apps-v5/test/commands/releases/output.js
+++ b/packages/apps-v5/test/commands/releases/output.js
@@ -11,18 +11,21 @@ const unwrap = require('../../unwrap')
 describe('releases:output', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('warns if there is no output available', function () {
+  it('warns if there is no output available', async function() {
     process.stdout.columns = 80
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases/10')
       .reply(200, { 'version': 40 })
-    return cmd.run({ app: 'myapp', args: { release: 'v10' } })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(unwrap(cli.stderr)).to.equal('Release v40 has no release output available.\n'))
-      .then(() => api.done())
+
+    await cmd.run({ app: 'myapp', args: { release: 'v10' } })
+
+    expect(cli.stdout).to.equal('');
+    expect(unwrap(cli.stderr)).to.equal('Release v40 has no release output available.\n');
+
+    return api.done()
   })
 
-  it('shows the output from a specific release', function () {
+  it('shows the output from a specific release', async function() {
     stdMocks.use()
     process.stdout.columns = 80
     let busl = nock('https://busl.test:443')
@@ -31,16 +34,22 @@ describe('releases:output', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases/10')
       .reply(200, { 'version': 40, output_stream_url: 'https://busl.test/streams/release.log' })
-    return cmd.run({ app: 'myapp', args: { release: 'v10' } })
-      .then(() => expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content'))
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => busl.done())
-      .then(() => api.done())
-      .then(() => stdMocks.restore())
-      .catch(() => stdMocks.restore())
+
+    try {
+      await cmd.run({ app: 'myapp', args: { release: 'v10' } })
+
+      expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content');
+      expect(cli.stderr).to.equal('');
+      busl.done();
+      api.done();
+
+      return stdMocks.restore()
+    } catch (error) {
+      return stdMocks.restore()
+    }
   })
 
-  it('shows the output from the latest release', function () {
+  it('shows the output from the latest release', async function() {
     stdMocks.use()
     process.stdout.columns = 80
     let busl = nock('https://busl.test:443')
@@ -49,16 +58,22 @@ describe('releases:output', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
       .reply(200, [{ 'version': 40, output_stream_url: 'https://busl.test/streams/release.log' }])
-    return cmd.run({ app: 'myapp', args: {} })
-      .then(() => expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content'))
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => busl.done())
-      .then(() => api.done())
-      .then(() => stdMocks.restore())
-      .catch(() => stdMocks.restore())
+
+    try {
+      await cmd.run({ app: 'myapp', args: {} })
+
+      expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content');
+      expect(cli.stderr).to.equal('');
+      busl.done();
+      api.done();
+
+      return stdMocks.restore()
+    } catch (error) {
+      return stdMocks.restore()
+    }
   })
 
-  it('has a missing output', function () {
+  it('has a missing output', async function() {
     process.stdout.columns = 80
     let busl = nock('https://busl.test:443')
       .get('/streams/release.log')
@@ -67,10 +82,12 @@ describe('releases:output', function () {
       .get('/apps/myapp/releases')
       .reply(200, [{ 'version': 40, output_stream_url: 'https://busl.test/streams/release.log' }])
 
-    return cmd.run({ app: 'myapp', args: {} })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.contain('Release command not started yet. Please try again in a few seconds.\n'))
-      .then(() => api.done())
-      .then(() => busl.done())
+    await cmd.run({ app: 'myapp', args: {} })
+
+    expect(cli.stdout).to.equal('');
+    expect(cli.stderr).to.contain('Release command not started yet. Please try again in a few seconds.\n');
+    api.done();
+
+    return busl.done()
   })
 })

--- a/packages/apps-v5/test/commands/releases/rollback.js
+++ b/packages/apps-v5/test/commands/releases/rollback.js
@@ -15,40 +15,40 @@ describe('releases:rollback', function () {
     stdMocks.restore()
   })
 
-  it('rolls back the release', function () {
+  it('rolls back the release', async function() {
     process.stdout.columns = 80
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases/10')
       .reply(200, { 'id': '5efa3510-e8df-4db0-a176-83ff8ad91eb5', 'version': 40 })
       .post('/apps/myapp/releases', { release: '5efa3510-e8df-4db0-a176-83ff8ad91eb5' })
       .reply(200, {})
-    return cmd.run({ app: 'myapp', args: { release: 'v10' } })
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: { release: 'v10' } })
+    return api.done()
   })
 
-  it('rolls back to the latest release', function () {
+  it('rolls back to the latest release', async function() {
     process.stdout.columns = 80
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
       .reply(200, [{ 'id': 'current_release', 'version': 41, status: 'succeeded' }, { 'id': 'previous_release', 'version': 40, status: 'succeeded' }])
       .post('/apps/myapp/releases', { release: 'previous_release' })
       .reply(200, {})
-    return cmd.run({ app: 'myapp', args: {} })
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: {} })
+    return api.done()
   })
 
-  it('does not roll back to a failed release', function () {
+  it('does not roll back to a failed release', async function() {
     process.stdout.columns = 80
     let api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
       .reply(200, [{ 'id': 'current_release', 'version': 41, status: 'succeeded' }, { 'id': 'failed_release', 'version': 40, status: 'failed' }, { 'id': 'succeeded_release', 'version': 39, status: 'succeeded' }])
       .post('/apps/myapp/releases', { release: 'succeeded_release' })
       .reply(200, {})
-    return cmd.run({ app: 'myapp', args: {} })
-      .then(() => api.done())
+    await cmd.run({ app: 'myapp', args: {} })
+    return api.done()
   })
 
-  it('streams the release command output', function () {
+  it('streams the release command output', async function() {
     stdMocks.use()
     process.stdout.columns = 80
     let busl = nock('https://busl.test:443')
@@ -59,15 +59,18 @@ describe('releases:rollback', function () {
       .reply(200, { id: '5efa3510-e8df-4db0-a176-83ff8ad91eb5', version: 40 })
       .post('/apps/myapp/releases', { release: '5efa3510-e8df-4db0-a176-83ff8ad91eb5' })
       .reply(200, { version: 40, output_stream_url: 'https://busl.test/streams/release.log' })
-    return cmd.run({ app: 'myapp', args: { release: 'v10' } })
-      .then(() => expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content'))
-      .then(() => expect(unwrap(cli.stderr)).to.equal(`Rolling back myapp to v40... done, v40 Rollback affects code and config vars; it doesn't add or remove addons. To undo, run: heroku rollback v39\n`))
-      .then(() => api.done())
-      .then(() => busl.done())
-      .then(() => stdMocks.restore())
+
+    await cmd.run({ app: 'myapp', args: { release: 'v10' } })
+
+    expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content');
+    expect(unwrap(cli.stderr)).to.equal(`Rolling back myapp to v40... done, v40 Rollback affects code and config vars; it doesn't add or remove addons. To undo, run: heroku rollback v39\n`);
+    api.done();
+    busl.done();
+
+    return stdMocks.restore()
   })
 
-  it('has a missing missing output', function () {
+  it('has a missing missing output', async function() {
     stdMocks.use()
     process.stdout.columns = 80
     let busl = nock('https://busl.test:443')
@@ -79,10 +82,12 @@ describe('releases:rollback', function () {
       .post('/apps/myapp/releases', { release: '5efa3510-e8df-4db0-a176-83ff8ad91eb5' })
       .reply(200, { output_stream_url: 'https://busl.test/streams/release.log' })
 
-    return cmd.run({ app: 'myapp', args: { release: 'v10' } })
-      .then(() => expect(cli.stdout).to.equal('Running release command...\n'))
-      .then(() => expect(cli.stderr).to.contain('Release command starting. Use `heroku releases:output` to view the log.\n'))
-      .then(() => api.done())
-      .then(() => busl.done())
+    await cmd.run({ app: 'myapp', args: { release: 'v10' } })
+
+    expect(cli.stdout).to.equal('Running release command...\n');
+    expect(cli.stderr).to.contain('Release command starting. Use `heroku releases:output` to view the log.\n');
+    api.done();
+
+    return busl.done()
   })
 })

--- a/packages/container-registry-v5/test/commands/login.js
+++ b/packages/container-registry-v5/test/commands/login.js
@@ -17,27 +17,31 @@ describe('container login', () => {
   })
   afterEach(() => sandbox.restore())
 
-  it('logs to the docker registry', () => {
+  it('logs to the docker registry', async () => {
     let version = sandbox.stub(Sanbashi, 'version').returns([19, 12])
     let login = sandbox.stub(Sanbashi, 'cmd')
       .withArgs('docker', ['login', '--username=_', '--password-stdin', 'registry.heroku.com'], { input: 'heroku_token' })
 
-    return cmd.run({ flags: {} })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => sandbox.assert.calledOnce(version))
-      .then(() => sandbox.assert.calledOnce(login))
+    await cmd.run({ flags: {} })
+
+    expect(cli.stdout, 'to be empty');
+    expect(cli.stderr, 'to be empty');
+    sandbox.assert.calledOnce(version);
+
+    return sandbox.assert.calledOnce(login)
   })
 
-  it('logs to the docker registry with an old version', () => {
+  it('logs to the docker registry with an old version', async () => {
     let version = sandbox.stub(Sanbashi, 'version').returns([17, 0])
     let login = sandbox.stub(Sanbashi, 'cmd')
       .withArgs('docker', ['login', '--username=_', '--password=heroku_token', 'registry.heroku.com'])
 
-    return cmd.run({ flags: {}, auth: { password: 'token' } })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => sandbox.assert.calledOnce(version))
-      .then(() => sandbox.assert.calledOnce(login))
+    await cmd.run({ flags: {}, auth: { password: 'token' } })
+
+    expect(cli.stdout, 'to be empty');
+    expect(cli.stderr, 'to be empty');
+    sandbox.assert.calledOnce(version);
+
+    return sandbox.assert.calledOnce(login)
   })
 })

--- a/packages/container-registry-v5/test/commands/logout.js
+++ b/packages/container-registry-v5/test/commands/logout.js
@@ -16,13 +16,15 @@ describe('container logout', () => {
   })
   afterEach(() => sandbox.restore())
 
-  it('logs out of the docker registry', () => {
+  it('logs out of the docker registry', async () => {
     let logout = sandbox.stub(Sanbashi, 'cmd')
       .withArgs('docker', ['logout', 'registry.heroku.com'])
 
-    return cmd.run({ flags: {} })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => sandbox.assert.calledOnce(logout))
+    await cmd.run({ flags: {} })
+
+    expect(cli.stdout, 'to be empty');
+    expect(cli.stderr, 'to be empty');
+
+    return sandbox.assert.calledOnce(logout)
   })
 })

--- a/packages/container-registry-v5/test/commands/pull.js
+++ b/packages/container-registry-v5/test/commands/pull.js
@@ -20,18 +20,20 @@ describe('container pull', () => {
     sandbox.stub(process, 'exit')
 
     await cmd.run({ app: 'testapp', args: [], flags: {} })
-      .then(() => expect(cli.stderr).to.contain('Requires one or more process types'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(process.exit.calledWith(1)).to.equal(true))
+    expect(cli.stderr).to.contain('Requires one or more process types');
+    expect(cli.stdout, 'to be empty');
+    expect(process.exit.calledWith(1)).to.equal(true);
   })
 
-  it('pulls from the docker registry', () => {
+  it('pulls from the docker registry', async () => {
     let pull = sandbox.stub(Sanbashi, 'pullImage')
       .withArgs('registry.heroku.com/testapp/web')
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => expect(cli.stdout).to.contain('Pulling web as registry.heroku.com/testapp/web'))
-      .then(() => sandbox.assert.calledOnce(pull))
+    await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+    expect(cli.stderr, 'to be empty');
+    expect(cli.stdout).to.contain('Pulling web as registry.heroku.com/testapp/web');
+
+    return sandbox.assert.calledOnce(pull)
   })
 })

--- a/packages/container-registry-v5/test/commands/push.js
+++ b/packages/container-registry-v5/test/commands/push.js
@@ -17,7 +17,7 @@ describe('container push', () => {
   })
   afterEach(() => sandbox.restore())
 
-  it('gets a build error', () => {
+  it('gets a build error', async () => {
     sandbox.stub(process, 'exit')
 
     let api = nock('https://api.heroku.com:443')
@@ -28,16 +28,18 @@ describe('container push', () => {
       .returns(['/path/to/Dockerfile'])
     let build = sandbox.stub(Sanbashi, 'buildImage').throws()
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(cli.stderr).to.contain('docker build exited with Error: Error'))
-      .then(() => expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile)'))
-      .then(() => expect(process.exit.calledWith(1)).to.equal(true))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
-      .then(() => sandbox.assert.calledOnce(build))
-      .then(() => api.done())
+    await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+    expect(cli.stderr).to.contain('docker build exited with Error: Error');
+    expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile)');
+    expect(process.exit.calledWith(1)).to.equal(true);
+    sandbox.assert.calledOnce(dockerfiles);
+    sandbox.assert.calledOnce(build);
+
+    return api.done()
   })
 
-  it('gets a push error', () => {
+  it('gets a push error', async () => {
     sandbox.stub(process, 'exit')
 
     let api = nock('https://api.heroku.com:443')
@@ -49,17 +51,19 @@ describe('container push', () => {
     let build = sandbox.stub(Sanbashi, 'buildImage')
     let push = sandbox.stub(Sanbashi, 'pushImage').throws()
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(cli.stderr).to.contain('docker push exited with Error: Error'))
-      .then(() => expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile)'))
-      .then(() => expect(process.exit.calledWith(1)).to.equal(true))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
-      .then(() => sandbox.assert.calledOnce(build))
-      .then(() => sandbox.assert.calledOnce(push))
-      .then(() => api.done())
+    await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+    expect(cli.stderr).to.contain('docker push exited with Error: Error');
+    expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile)');
+    expect(process.exit.calledWith(1)).to.equal(true);
+    sandbox.assert.calledOnce(dockerfiles);
+    sandbox.assert.calledOnce(build);
+    sandbox.assert.calledOnce(push);
+
+    return api.done()
   })
 
-  it('pushes to the docker registry', () => {
+  it('pushes to the docker registry', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/testapp')
       .reply(200, { name: 'testapp' })
@@ -71,16 +75,18 @@ describe('container push', () => {
     let push = sandbox.stub(Sanbashi, 'pushImage')
       .withArgs('registry.heroku.com/testapp/web')
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile)'))
-      .then(() => expect(cli.stdout).to.contain('Pushing web (/path/to/Dockerfile)'))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
-      .then(() => sandbox.assert.calledOnce(build))
-      .then(() => sandbox.assert.calledOnce(push))
-      .then(() => api.done())
+    await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+    expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile)');
+    expect(cli.stdout).to.contain('Pushing web (/path/to/Dockerfile)');
+    sandbox.assert.calledOnce(dockerfiles);
+    sandbox.assert.calledOnce(build);
+    sandbox.assert.calledOnce(push);
+
+    return api.done()
   })
 
-  it('pushes the standard dockerfile to non-web', () => {
+  it('pushes the standard dockerfile to non-web', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/testapp')
       .reply(200, { name: 'testapp' })
@@ -92,16 +98,18 @@ describe('container push', () => {
     let push = sandbox.stub(Sanbashi, 'pushImage')
       .withArgs('registry.heroku.com/testapp/worker')
 
-    return cmd.run({ app: 'testapp', args: ['worker'], flags: {} })
-      .then(() => expect(cli.stdout).to.contain('Building worker (/path/to/Dockerfile)'))
-      .then(() => expect(cli.stdout).to.contain('Pushing worker (/path/to/Dockerfile)'))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
-      .then(() => sandbox.assert.calledOnce(build))
-      .then(() => sandbox.assert.calledOnce(push))
-      .then(() => api.done())
+    await cmd.run({ app: 'testapp', args: ['worker'], flags: {} })
+
+    expect(cli.stdout).to.contain('Building worker (/path/to/Dockerfile)');
+    expect(cli.stdout).to.contain('Pushing worker (/path/to/Dockerfile)');
+    sandbox.assert.calledOnce(dockerfiles);
+    sandbox.assert.calledOnce(build);
+    sandbox.assert.calledOnce(push);
+
+    return api.done()
   })
 
-  it('pushes several dockerfiles recursively', () => {
+  it('pushes several dockerfiles recursively', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/testapp')
       .reply(200, { name: 'testapp' })
@@ -115,18 +123,20 @@ describe('container push', () => {
     push.withArgs('registry.heroku.com/testapp/web')
     push.withArgs('registry.heroku.com/testapp/worker')
 
-    return cmd.run({ app: 'testapp', args: ['web', 'worker'], flags: { recursive: true } })
-      .then(() => expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile.web)'))
-      .then(() => expect(cli.stdout).to.contain('Building worker (/path/to/Dockerfile.worker)'))
-      .then(() => expect(cli.stdout).to.contain('Pushing web (/path/to/Dockerfile.web)'))
-      .then(() => expect(cli.stdout).to.contain('Pushing worker (/path/to/Dockerfile.worker)'))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
-      .then(() => sandbox.assert.calledTwice(build))
-      .then(() => sandbox.assert.calledTwice(push))
-      .then(() => api.done())
+    await cmd.run({ app: 'testapp', args: ['web', 'worker'], flags: { recursive: true } })
+
+    expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile.web)');
+    expect(cli.stdout).to.contain('Building worker (/path/to/Dockerfile.worker)');
+    expect(cli.stdout).to.contain('Pushing web (/path/to/Dockerfile.web)');
+    expect(cli.stdout).to.contain('Pushing worker (/path/to/Dockerfile.worker)');
+    sandbox.assert.calledOnce(dockerfiles);
+    sandbox.assert.calledTwice(build);
+    sandbox.assert.calledTwice(push);
+
+    return api.done()
   })
 
-  it('builds with custom context path and pushes to the docker registry', () => {
+  it('builds with custom context path and pushes to the docker registry', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/testapp')
       .reply(200, { name: 'testapp' })
@@ -138,16 +148,18 @@ describe('container push', () => {
     let push = sandbox.stub(Sanbashi, 'pushImage')
       .withArgs('registry.heroku.com/testapp/web')
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: { 'context-path': '/custom/context/path' } })
-      .then(() => expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile)'))
-      .then(() => expect(cli.stdout).to.contain('Pushing web (/path/to/Dockerfile)'))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
-      .then(() => sandbox.assert.calledOnce(build))
-      .then(() => sandbox.assert.calledOnce(push))
-      .then(() => api.done())
+    await cmd.run({ app: 'testapp', args: ['web'], flags: { 'context-path': '/custom/context/path' } })
+
+    expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile)');
+    expect(cli.stdout).to.contain('Pushing web (/path/to/Dockerfile)');
+    sandbox.assert.calledOnce(dockerfiles);
+    sandbox.assert.calledOnce(build);
+    sandbox.assert.calledOnce(push);
+
+    return api.done()
   })
 
-  it('does not find an image to push', () => {
+  it('does not find an image to push', async () => {
     sandbox.stub(process, 'exit')
 
     let api = nock('https://api.heroku.com:443')
@@ -157,29 +169,35 @@ describe('container push', () => {
     let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
       .returns([])
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(cli.stderr).to.contain('No images to push'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(process.exit.calledWith(1)).to.equal(true))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
-      .then(() => api.done())
+    await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+    expect(cli.stderr).to.contain('No images to push');
+    expect(cli.stdout, 'to be empty');
+    expect(process.exit.calledWith(1)).to.equal(true);
+    sandbox.assert.calledOnce(dockerfiles);
+
+    return api.done()
   })
 
-  it('requires a process type if we are not recursive', () => {
+  it('requires a process type if we are not recursive', async () => {
     sandbox.stub(process, 'exit')
 
-    return cmd.run({ app: 'testapp', args: [], flags: {} })
-      .then(() => expect(cli.stderr).to.contain('Requires either --recursive or one or more process types'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(process.exit.calledWith(1)).to.equal(true))
+    await cmd.run({ app: 'testapp', args: [], flags: {} })
+
+    expect(cli.stderr).to.contain('Requires either --recursive or one or more process types');
+    expect(cli.stdout, 'to be empty');
+
+    return expect(process.exit.calledWith(1)).to.equal(true)
   })
 
-  it('rejects multiple process types if we are not recursive', () => {
+  it('rejects multiple process types if we are not recursive', async () => {
     sandbox.stub(process, 'exit')
 
-    return cmd.run({ app: 'testapp', args: ['web', 'worker'], flags: {} })
-      .then(() => expect(cli.stderr).to.contain('Requires exactly one target process type, or --recursive option'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(process.exit.calledWith(1)).to.equal(true))
+    await cmd.run({ app: 'testapp', args: ['web', 'worker'], flags: {} })
+
+    expect(cli.stderr).to.contain('Requires exactly one target process type, or --recursive option');
+    expect(cli.stdout, 'to be empty');
+
+    return expect(process.exit.calledWith(1)).to.equal(true)
   })
 })

--- a/packages/container-registry-v5/test/commands/release.js
+++ b/packages/container-registry-v5/test/commands/release.js
@@ -17,16 +17,18 @@ describe('container release', () => {
   })
   afterEach(() => sandbox.restore())
 
-  it('has no process type specified', () => {
+  it('has no process type specified', async () => {
     sandbox.stub(process, 'exit')
 
-    return cmd.run({ app: 'testapp', args: [], flags: {} })
-      .then(() => expect(cli.stderr).to.contain('Requires one or more process types'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(process.exit.calledWith(1)).to.equal(true))
+    await cmd.run({ app: 'testapp', args: [], flags: {} })
+
+    expect(cli.stderr).to.contain('Requires one or more process types');
+    expect(cli.stdout, 'to be empty');
+
+    return expect(process.exit.calledWith(1)).to.equal(true)
   })
 
-  it('releases a single process type, no previous release', () => {
+  it('releases a single process type, no previous release', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/testapp')
       .reply(200, { name: 'testapp' })
@@ -44,14 +46,16 @@ describe('container release', () => {
       .get('/v2/testapp/web/manifests/latest')
       .reply(200, { schemaVersion: 2, config: { digest: 'image_id' } })
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(cli.stderr).to.contain('Releasing images web to testapp... done'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => api.done())
-      .then(() => registry.done())
+    await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+    expect(cli.stderr).to.contain('Releasing images web to testapp... done');
+    expect(cli.stdout, 'to be empty');
+    api.done();
+
+    return registry.done()
   })
 
-  it('releases a single process type, with a previous release', () => {
+  it('releases a single process type, with a previous release', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/testapp')
       .reply(200, { name: 'testapp' })
@@ -69,14 +73,16 @@ describe('container release', () => {
       .get('/v2/testapp/web/manifests/latest')
       .reply(200, { schemaVersion: 2, config: { digest: 'image_id' } })
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(cli.stderr).to.contain('Releasing images web to testapp... done'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => api.done())
-      .then(() => registry.done())
+    await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+    expect(cli.stderr).to.contain('Releasing images web to testapp... done');
+    expect(cli.stdout, 'to be empty');
+    api.done();
+
+    return registry.done()
   })
 
-  it('retrieves data from a v1 schema version, no previous release', () => {
+  it('retrieves data from a v1 schema version, no previous release', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/testapp')
       .reply(200, { name: 'testapp' })
@@ -94,14 +100,16 @@ describe('container release', () => {
       .get('/v2/testapp/web/manifests/latest')
       .reply(200, { schemaVersion: 1, history: [{ v1Compatibility: '{"id":"image_id"}' }] })
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(cli.stderr).to.contain('Releasing images web to testapp... done'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => api.done())
-      .then(() => registry.done())
+    await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+    expect(cli.stderr).to.contain('Releasing images web to testapp... done');
+    expect(cli.stdout, 'to be empty');
+    api.done();
+
+    return registry.done()
   })
 
-  it('retrieves data from a v1 schema version, with a previous release', () => {
+  it('retrieves data from a v1 schema version, with a previous release', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/testapp')
       .reply(200, { name: 'testapp' })
@@ -119,14 +127,16 @@ describe('container release', () => {
       .get('/v2/testapp/web/manifests/latest')
       .reply(200, { schemaVersion: 1, history: [{ v1Compatibility: '{"id":"image_id"}' }] })
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(cli.stderr).to.contain('Releasing images web to testapp... done'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => api.done())
-      .then(() => registry.done())
+    await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+    expect(cli.stderr).to.contain('Releasing images web to testapp... done');
+    expect(cli.stdout, 'to be empty');
+    api.done();
+
+    return registry.done()
   })
 
-  it('releases multiple process types, no previous release', () => {
+  it('releases multiple process types, no previous release', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/testapp')
       .reply(200, { name: 'testapp' })
@@ -147,14 +157,16 @@ describe('container release', () => {
       .get('/v2/testapp/worker/manifests/latest')
       .reply(200, { schemaVersion: 2, config: { digest: 'worker_image_id' } })
 
-    return cmd.run({ app: 'testapp', args: ['web', 'worker'], flags: {} })
-      .then(() => expect(cli.stderr).to.contain('Releasing images web,worker to testapp... done'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => api.done())
-      .then(() => registry.done())
+    await cmd.run({ app: 'testapp', args: ['web', 'worker'], flags: {} })
+
+    expect(cli.stderr).to.contain('Releasing images web,worker to testapp... done');
+    expect(cli.stdout, 'to be empty');
+    api.done();
+
+    return registry.done()
   })
 
-  it('releases multiple process types, with a previous release', () => {
+  it('releases multiple process types, with a previous release', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/testapp')
       .reply(200, { name: 'testapp' })
@@ -175,14 +187,16 @@ describe('container release', () => {
       .get('/v2/testapp/worker/manifests/latest')
       .reply(200, { schemaVersion: 2, config: { digest: 'worker_image_id' } })
 
-    return cmd.run({ app: 'testapp', args: ['web', 'worker'], flags: {} })
-      .then(() => expect(cli.stderr).to.contain('Releasing images web,worker to testapp... done'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => api.done())
-      .then(() => registry.done())
+    await cmd.run({ app: 'testapp', args: ['web', 'worker'], flags: {} })
+
+    expect(cli.stderr).to.contain('Releasing images web,worker to testapp... done');
+    expect(cli.stdout, 'to be empty');
+    api.done();
+
+    return registry.done()
   })
 
-  it('releases with previous release and immediately successful release phase', () => {
+  it('releases with previous release and immediately successful release phase', async () => {
     stdMocks.use()
     let api = nock('https://api.heroku.com:443')
       .get('/apps/testapp')
@@ -201,17 +215,22 @@ describe('container release', () => {
       .get('/v2/testapp/web/manifests/latest')
       .reply(200, { schemaVersion: 2, config: { digest: 'image_id' } })
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content'))
-      .then(() => expect(cli.stderr).to.contain('Runnning release command...'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => api.done())
-      .then(() => registry.done())
-      .then(() => stdMocks.restore())
-      .catch(() => stdMocks.restore())
+    try {
+      await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+      expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content');
+      expect(cli.stderr).to.contain('Runnning release command...');
+      expect(cli.stdout, 'to be empty');
+      api.done();
+      registry.done();
+
+      return stdMocks.restore()
+    } catch (error) {
+      return stdMocks.restore()
+    }
   })
 
-  it('releases with previous release and pending then successful release phase', () => {
+  it('releases with previous release and pending then successful release phase', async () => {
     stdMocks.use()
     let busl = nock('https://busl.test:443')
       .get('/streams/release.log')
@@ -235,18 +254,23 @@ describe('container release', () => {
       .get('/v2/testapp/web/manifests/latest')
       .reply(200, { schemaVersion: 2, config: { digest: 'image_id' } })
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content'))
-      .then(() => expect(cli.stderr).to.contain('Runnning release command...'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => api.done())
-      .then(() => registry.done())
-      .then(() => busl.done())
-      .then(() => stdMocks.restore())
-      .catch(() => stdMocks.restore())
+    try {
+      await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+      expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content');
+      expect(cli.stderr).to.contain('Runnning release command...');
+      expect(cli.stdout, 'to be empty');
+      api.done();
+      registry.done();
+      busl.done();
+
+      return stdMocks.restore()
+    } catch (error) {
+      return stdMocks.restore()
+    }
   })
 
-  it('releases with previous release and immediately failed release phase', () => {
+  it('releases with previous release and immediately failed release phase', async () => {
     sandbox.stub(process, 'exit')
 
     stdMocks.use()
@@ -267,19 +291,24 @@ describe('container release', () => {
       .get('/v2/testapp/web/manifests/latest')
       .reply(200, { schemaVersion: 2, config: { digest: 'image_id' } })
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content'))
-      .then(() => expect(cli.stderr).to.contain('Runnning release command...'))
-      .then(() => expect(cli.stderr).to.contain('Error: release command failed'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.exit.calledWith(1)).to.equal(true))
-      .then(() => api.done())
-      .then(() => registry.done())
-      .then(() => stdMocks.restore())
-      .catch(() => stdMocks.restore())
+    try {
+      await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+      expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content');
+      expect(cli.stderr).to.contain('Runnning release command...');
+      expect(cli.stderr).to.contain('Error: release command failed');
+      expect(cli.stdout, 'to be empty');
+      expect(cli.exit.calledWith(1)).to.equal(true);
+      api.done();
+      registry.done();
+
+      return stdMocks.restore()
+    } catch (error) {
+      return stdMocks.restore()
+    }
   })
 
-  it('releases with previous release and pending then failed release phase', () => {
+  it('releases with previous release and pending then failed release phase', async () => {
     sandbox.stub(process, 'exit')
 
     stdMocks.use()
@@ -305,20 +334,25 @@ describe('container release', () => {
       .get('/v2/testapp/web/manifests/latest')
       .reply(200, { schemaVersion: 2, config: { digest: 'image_id' } })
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content'))
-      .then(() => expect(cli.stderr).to.contain('Runnning release command...'))
-      .then(() => expect(cli.stderr).to.contain('Error: release command failed'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(process.exit.calledWith(1)).to.equal(true))
-      .then(() => api.done())
-      .then(() => registry.done())
-      .then(() => busl.done())
-      .then(() => stdMocks.restore())
-      .catch(() => stdMocks.restore())
+    try {
+      await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+      expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content');
+      expect(cli.stderr).to.contain('Runnning release command...');
+      expect(cli.stderr).to.contain('Error: release command failed');
+      expect(cli.stdout, 'to be empty');
+      expect(process.exit.calledWith(1)).to.equal(true);
+      api.done();
+      registry.done();
+      busl.done();
+
+      return stdMocks.restore()
+    } catch (error) {
+      return stdMocks.restore()
+    }
   })
 
-  it('releases with no previous release and immediately successful release phase', () => {
+  it('releases with no previous release and immediately successful release phase', async () => {
     stdMocks.use()
     let api = nock('https://api.heroku.com:443')
       .get('/apps/testapp')
@@ -335,17 +369,22 @@ describe('container release', () => {
       .get('/v2/testapp/web/manifests/latest')
       .reply(200, { schemaVersion: 2, config: { digest: 'image_id' } })
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content'))
-      .then(() => expect(cli.stderr).to.contain('Runnning release command...'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => api.done())
-      .then(() => registry.done())
-      .then(() => stdMocks.restore())
-      .catch(() => stdMocks.restore())
+    try {
+      await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+      expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content');
+      expect(cli.stderr).to.contain('Runnning release command...');
+      expect(cli.stdout, 'to be empty');
+      api.done();
+      registry.done();
+
+      return stdMocks.restore()
+    } catch (error) {
+      return stdMocks.restore()
+    }
   })
 
-  it('releases with no previous release and pending then successful release phase', () => {
+  it('releases with no previous release and pending then successful release phase', async () => {
     stdMocks.use()
     let busl = nock('https://busl.test:443')
       .get('/streams/release.log')
@@ -369,18 +408,23 @@ describe('container release', () => {
       .get('/v2/testapp/web/manifests/latest')
       .reply(200, { schemaVersion: 2, config: { digest: 'image_id' } })
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content'))
-      .then(() => expect(cli.stderr).to.contain('Runnning release command...'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => api.done())
-      .then(() => registry.done())
-      .then(() => busl.done())
-      .then(() => stdMocks.restore())
-      .catch(() => stdMocks.restore())
+    try {
+      await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+      expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content');
+      expect(cli.stderr).to.contain('Runnning release command...');
+      expect(cli.stdout, 'to be empty');
+      api.done();
+      registry.done();
+      busl.done();
+
+      return stdMocks.restore()
+    } catch (error) {
+      return stdMocks.restore()
+    }
   })
 
-  it('releases with no previous release and immediately failed release phase', () => {
+  it('releases with no previous release and immediately failed release phase', async () => {
     sandbox.stub(process, 'exit')
 
     stdMocks.use()
@@ -401,19 +445,24 @@ describe('container release', () => {
       .get('/v2/testapp/web/manifests/latest')
       .reply(200, { schemaVersion: 2, config: { digest: 'image_id' } })
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content'))
-      .then(() => expect(cli.stderr).to.contain('Runnning release command...'))
-      .then(() => expect(cli.stderr).to.contain('Error: release command failed'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.exit.calledWith(1)).to.equal(true))
-      .then(() => api.done())
-      .then(() => registry.done())
-      .then(() => stdMocks.restore())
-      .catch(() => stdMocks.restore())
+    try {
+      await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+      expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content');
+      expect(cli.stderr).to.contain('Runnning release command...');
+      expect(cli.stderr).to.contain('Error: release command failed');
+      expect(cli.stdout, 'to be empty');
+      expect(cli.exit.calledWith(1)).to.equal(true);
+      api.done();
+      registry.done();
+
+      return stdMocks.restore()
+    } catch (error) {
+      return stdMocks.restore()
+    }
   })
 
-  it('releases with no previous release and pending then failed release phase', () => {
+  it('releases with no previous release and pending then failed release phase', async () => {
     sandbox.stub(process, 'exit')
 
     stdMocks.use()
@@ -439,20 +488,25 @@ describe('container release', () => {
       .get('/v2/testapp/web/manifests/latest')
       .reply(200, { schemaVersion: 2, config: { digest: 'image_id' } })
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content'))
-      .then(() => expect(cli.stderr).to.contain('Runnning release command...'))
-      .then(() => expect(cli.stderr).to.contain('Error: release command failed'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(process.exit.calledWith(1)).to.equal(true))
-      .then(() => api.done())
-      .then(() => registry.done())
-      .then(() => busl.done())
-      .then(() => stdMocks.restore())
-      .catch(() => stdMocks.restore())
+    try {
+      await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+      expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content');
+      expect(cli.stderr).to.contain('Runnning release command...');
+      expect(cli.stderr).to.contain('Error: release command failed');
+      expect(cli.stdout, 'to be empty');
+      expect(process.exit.calledWith(1)).to.equal(true);
+      api.done();
+      registry.done();
+      busl.done();
+
+      return stdMocks.restore()
+    } catch (error) {
+      return stdMocks.restore()
+    }
   })
 
-  it('has release phase but no new release', () => {
+  it('has release phase but no new release', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/testapp')
       .reply(200, { name: 'testapp' })
@@ -470,10 +524,12 @@ describe('container release', () => {
       .get('/v2/testapp/web/manifests/latest')
       .reply(200, { schemaVersion: 2, config: { digest: 'image_id' } })
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(cli.stderr, 'not to contain', 'Runnning release command...'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => api.done())
-      .then(() => registry.done())
+    await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+    expect(cli.stderr, 'not to contain', 'Runnning release command...');
+    expect(cli.stdout, 'to be empty');
+    api.done();
+
+    return registry.done()
   })
 })

--- a/packages/container-registry-v5/test/commands/rm.js
+++ b/packages/container-registry-v5/test/commands/rm.js
@@ -10,29 +10,33 @@ const sinon = require('sinon')
 describe('container removal', () => {
   beforeEach(() => cli.mockConsole())
 
-  it('removes one container', () => {
+  it('removes one container', async () => {
     let api = nock('https://api.heroku.com:443')
       .patch('/apps/testapp/formation/web')
       .reply(200, {})
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.contain('Removing container web for testapp... done'))
-      .then(() => api.done())
+    await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+    expect(cli.stdout, 'to be empty');
+    expect(cli.stderr).to.contain('Removing container web for testapp... done');
+
+    return api.done()
   })
 
-  it('removes two containers', () => {
+  it('removes two containers', async () => {
     let api = nock('https://api.heroku.com:443')
       .patch('/apps/testapp/formation/web')
       .reply(200, {})
       .patch('/apps/testapp/formation/worker')
       .reply(200, {})
 
-    return cmd.run({ app: 'testapp', args: ['web', 'worker'], flags: {} })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.contain('Removing container web for testapp... done'))
-      .then(() => expect(cli.stderr).to.contain('Removing container worker for testapp... done'))
-      .then(() => api.done())
+    await cmd.run({ app: 'testapp', args: ['web', 'worker'], flags: {} })
+
+    expect(cli.stdout, 'to be empty');
+    expect(cli.stderr).to.contain('Removing container web for testapp... done');
+    expect(cli.stderr).to.contain('Removing container worker for testapp... done');
+
+    return api.done()
   })
 
   it('requires a container to be specified', () => {

--- a/packages/container-registry-v5/test/commands/run.js
+++ b/packages/container-registry-v5/test/commands/run.js
@@ -17,48 +17,56 @@ describe('container run', () => {
   })
   afterEach(() => sandbox.restore())
 
-  it('requires a process type', () => {
+  it('requires a process type', async () => {
     sandbox.stub(process, 'exit')
 
-    return cmd.run({ app: 'testapp', args: [], flags: {} })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.contain('Requires one process type'))
-      .then(() => expect(process.exit.calledWith(1)).to.equal(true))
+    await cmd.run({ app: 'testapp', args: [], flags: {} })
+
+    expect(cli.stdout, 'to be empty');
+    expect(cli.stderr).to.contain('Requires one process type');
+
+    return expect(process.exit.calledWith(1)).to.equal(true)
   })
 
-  it('runs a container', () => {
+  it('runs a container', async () => {
     let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
       .returns(['/path/to/Dockerfile'])
     let run = sandbox.stub(Sanbashi, 'runImage')
       .withArgs('registry.heroku.com/testapp/web', [])
 
-    return cmd.run({ app: 'testapp', args: ['web'], flags: {} })
-      .then(() => expect(cli.stdout).to.contain('Running registry.heroku.com/testapp/web'))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
-      .then(() => sandbox.assert.calledOnce(run))
+    await cmd.run({ app: 'testapp', args: ['web'], flags: {} })
+
+    expect(cli.stdout).to.contain('Running registry.heroku.com/testapp/web');
+    expect(cli.stderr, 'to be empty');
+    sandbox.assert.calledOnce(dockerfiles);
+
+    return sandbox.assert.calledOnce(run)
   })
 
-  it('runs a container with a command', () => {
+  it('runs a container with a command', async () => {
     let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
       .returns(['/path/to/Dockerfile'])
     let run = sandbox.stub(Sanbashi, 'runImage')
       .withArgs('registry.heroku.com/testapp/web', ['bash'])
 
-    return cmd.run({ app: 'testapp', args: ['web', 'bash'], flags: {} })
-      .then(() => expect(cli.stdout).to.contain('Running \'bash\' on registry.heroku.com/testapp/web'))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
-      .then(() => sandbox.assert.calledOnce(run))
+    await cmd.run({ app: 'testapp', args: ['web', 'bash'], flags: {} })
+
+    expect(cli.stdout).to.contain('Running \'bash\' on registry.heroku.com/testapp/web');
+    expect(cli.stderr, 'to be empty');
+    sandbox.assert.calledOnce(dockerfiles);
+
+    return sandbox.assert.calledOnce(run)
   })
 
-  it('requires a known dockerfile', () => {
+  it('requires a known dockerfile', async () => {
     let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
       .returns([])
 
-    return cmd.run({ app: 'testapp', args: ['worker'], flags: {} })
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.contain('No images to run'))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
+    await cmd.run({ app: 'testapp', args: ['worker'], flags: {} })
+
+    expect(cli.stdout, 'to be empty');
+    expect(cli.stderr).to.contain('No images to run');
+
+    return sandbox.assert.calledOnce(dockerfiles)
   })
 })

--- a/packages/container-registry-v5/test/streamer.js
+++ b/packages/container-registry-v5/test/streamer.js
@@ -19,18 +19,20 @@ MockOut.prototype._write = function (d) {
 }
 
 describe('streaming', () => {
-  it('streams data', () => {
+  it('streams data', async () => {
     const ws = new MockOut()
     const api = nock('https://streamer.test:443')
       .get('/streams/data.log')
       .reply(200, 'My data')
 
-    return streamer('https://streamer.test/streams/data.log', ws)
-      .then(() => expect(ws.data.join('')).to.equal('My data'))
-      .then(() => api.done())
+    await streamer('https://streamer.test/streams/data.log', ws)
+
+    expect(ws.data.join('')).to.equal('My data');
+
+    return api.done()
   })
 
-  it('retries a missing stream', () => {
+  it('retries a missing stream', async () => {
     const ws = new MockOut()
     let attempts = 0
 
@@ -46,9 +48,11 @@ describe('streaming', () => {
         return [200, 'My retried data']
       })
 
-    return streamer('https://streamer.test/streams/data.log', ws)
-      .then(() => expect(ws.data.join('')).to.equal('My retried data'))
-      .then(() => api.done())
+    await streamer('https://streamer.test/streams/data.log', ws)
+
+    expect(ws.data.join('')).to.equal('My retried data');
+
+    return api.done()
   }).timeout(5 * 1000 * 1.2)
 
   it('errors on too many retries', async () => {

--- a/packages/git/test/commands/clone.js
+++ b/packages/git/test/commands/clone.js
@@ -14,7 +14,7 @@ describe('git:clone', function () {
       .to.be.rejectedWith(Error, 'Specify an app with --app')
   })
 
-  it('clones the repo', function () {
+  it('clones the repo', async function() {
     let git = require('../mock/git')
     let mock = sinon.mock(git)
     mock.expects('spawn').withExactArgs(['clone', '-o', 'heroku', 'https://git.heroku.com/myapp.git', 'myapp']).returns(Promise.resolve()).once()
@@ -23,11 +23,9 @@ describe('git:clone', function () {
       .get('/apps/myapp')
       .reply(200, { name: 'myapp' })
 
-    return clone.run({ flags: { app: 'myapp' }, args: [] })
-      .then(() => {
-        mock.verify()
-        mock.restore()
-        api.done()
-      })
+    await clone.run({ flags: { app: 'myapp' }, args: [] })
+    mock.verify()
+    mock.restore()
+    api.done()
   })
 })

--- a/packages/git/test/commands/remote.js
+++ b/packages/git/test/commands/remote.js
@@ -19,7 +19,7 @@ describe('git:remote', function () {
       .to.be.rejectedWith(Error, 'Specify an app with --app')
   })
 
-  it('replaces an http-git remote', function () {
+  it('replaces an http-git remote', async function() {
     let git = require('../mock/git')
     let mock = sinon.mock(git)
     mock.expects('exec').withExactArgs(['remote']).once().returns(Promise.resolve('heroku'))
@@ -29,16 +29,15 @@ describe('git:remote', function () {
       .get('/apps/myapp')
       .reply(200, { name: 'myapp' })
 
-    return remote.run({ flags: { app: 'myapp' }, args: [] })
-      .then(() => expect(cli.stdout.to.equal('set git remote heroku to https://git.heroku.com/myapp.git\n'))
-      .then(() => {
-        mock.verify()
-        mock.restore()
-        api.done()
-      })
+    await remote.run({ flags: { app: 'myapp' }, args: [] })
+    expect(cli.stdout.to.equal('set git remote heroku to https://git.heroku.com/myapp.git\n'))
+
+    mock.verify()
+    mock.restore()
+    api.done()
   })
 
-  it('adds an http-git remote', function () {
+  it('adds an http-git remote', async function() {
     let git = require('../mock/git')
     let mock = sinon.mock(git)
     mock.expects('exec').withExactArgs(['remote']).once().returns(Promise.resolve(''))
@@ -48,12 +47,11 @@ describe('git:remote', function () {
       .get('/apps/myapp')
       .reply(200, { name: 'myapp' })
 
-    return remote.run({ flags: { app: 'myapp' }, args: [] })
-      .then(() => expect(cli.stdout.to.equal('set git remote heroku to https://git.heroku.com/myapp.git\n'))
-      .then(() => {
-        mock.verify()
-        mock.restore()
-        api.done()
-      })
+    await remote.run({ flags: { app: 'myapp' }, args: [] })
+    expect(cli.stdout.to.equal('set git remote heroku to https://git.heroku.com/myapp.git\n'))
+
+    mock.verify()
+    mock.restore()
+    api.done()
   })
 })

--- a/packages/oauth-v5/test/authorizations/create.js
+++ b/packages/oauth-v5/test/authorizations/create.js
@@ -26,8 +26,8 @@ describe('authorizations:create', () => {
     return cmd.run({ flags: { description: 'awesome' } })
   })
 
-  it('creates the authorization and just shows the token', () => {
-    return cmd.run({ flags: { description: 'awesome', short: true } })
-      .then(() => expect(cli.stdout).to.equal('secrettoken\n'))
+  it('creates the authorization and just shows the token', async () => {
+    await cmd.run({ flags: { description: 'awesome', short: true } })
+    return expect(cli.stdout).to.equal('secrettoken\n')
   })
 })

--- a/packages/oauth-v5/test/authorizations/index.js
+++ b/packages/oauth-v5/test/authorizations/index.js
@@ -17,14 +17,14 @@ describe('authorizations', function () {
         .reply(200, [{ description: 'awesome', id: 'f6e8d969-129f-42d2-854b-c2eca9d5a42e', scope: ['app', 'user'] }])
     })
 
-    it('lists the authorizations', function () {
-      return cmd.run({ flags: {} })
-        .then(() => expect(cli.stdout).to.equal('awesome      f6e8d969-129f-42d2-854b-c2eca9d5a42e  app,user\n'))
+    it('lists the authorizations', async function() {
+      await cmd.run({ flags: {} })
+      return expect(cli.stdout).to.equal('awesome      f6e8d969-129f-42d2-854b-c2eca9d5a42e  app,user\n')
     })
 
-    it('lists the authorizations as json', function () {
-      return cmd.run({ flags: { json: true } })
-        .then(() => expect(JSON.parse(cli.stdout)[0], 'to satisfy', { description: 'awesome' }))
+    it('lists the authorizations as json', async function() {
+      await cmd.run({ flags: { json: true } })
+      return expect(JSON.parse(cli.stdout)[0], 'to satisfy', { description: 'awesome' })
     })
   })
 
@@ -35,9 +35,9 @@ describe('authorizations', function () {
         .reply(200, [])
     })
 
-    it('shows no authorizations message', function () {
-      return cmd.run({ flags: {} })
-        .then(() => expect(cli.stdout).to.equal('No OAuth authorizations.\n'))
+    it('shows no authorizations message', async function() {
+      await cmd.run({ flags: {} })
+      return expect(cli.stdout).to.equal('No OAuth authorizations.\n')
     })
   })
 })

--- a/packages/oauth-v5/test/authorizations/info.js
+++ b/packages/oauth-v5/test/authorizations/info.js
@@ -18,7 +18,7 @@ describe('authorizations:info', () => {
     api.done()
   })
 
-  it('shows the authorization', () => {
+  it('shows the authorization', async () => {
     api
       .get('/oauth/authorizations/10')
       .reply(200, {
@@ -28,17 +28,18 @@ describe('authorizations:info', () => {
         access_token: { token: 'secrettoken' },
         updated_at: new Date(0)
       })
-    return cmd.run({ args: { id: '10' }, flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`Client:      <none>
+    await cmd.run({ args: { id: '10' }, flags: {} })
+
+    return expect(cli.stdout).to.equal(`Client:      <none>
 ID:          10
 Description: desc
 Scope:       global
 Token:       secrettoken
 Updated at:  ${new Date(0)} (${distanceInWordsToNow(new Date(0))} ago)
-`))
+`)
   })
 
-  it('shows the authorization as json', () => {
+  it('shows the authorization as json', async () => {
     api
       .get('/oauth/authorizations/10')
       .reply(200, {
@@ -47,11 +48,11 @@ Updated at:  ${new Date(0)} (${distanceInWordsToNow(new Date(0))} ago)
         scope: ['global'],
         access_token: { token: 'secrettoken' }
       })
-    return cmd.run({ args: { id: '10' }, flags: { json: true } })
-      .then(() => expect(JSON.parse(cli.stdout), 'to satisfy', { id: '10' }))
+    await cmd.run({ args: { id: '10' }, flags: { json: true } })
+    return expect(JSON.parse(cli.stdout), 'to satisfy', { id: '10' })
   })
 
-  it('shows expires in', () => {
+  it('shows expires in', async () => {
     api
       .get('/oauth/authorizations/10')
       .reply(200, {
@@ -60,7 +61,7 @@ Updated at:  ${new Date(0)} (${distanceInWordsToNow(new Date(0))} ago)
         scope: ['global'],
         access_token: { token: 'secrettoken', expires_in: 100000 }
       })
-    return cmd.run({ args: { id: '10' }, flags: {} })
-      .then(() => expect(cli.stdout).to.contain('(in 1 day)'))
+    await cmd.run({ args: { id: '10' }, flags: {} })
+    return expect(cli.stdout).to.contain('(in 1 day)')
   })
 })

--- a/packages/oauth-v5/test/clients/create.js
+++ b/packages/oauth-v5/test/clients/create.js
@@ -9,7 +9,7 @@ let cmd = require('../../lib/commands/clients/create')
 describe('clients:create', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('creates the client', function () {
+  it('creates the client', async function() {
     let api = nock('https://api.heroku.com:443')
       .post('/oauth/clients', {
         name: 'awesome',
@@ -21,10 +21,13 @@ describe('clients:create', function () {
         redirect_uri: 'https://myapp.com',
         secret: 'clientsecret'
       })
-    return cmd.run({ args: { name: 'awesome', redirect_uri: 'https://myapp.com' }, flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`HEROKU_OAUTH_ID=f6e8d969-129f-42d2-854b-c2eca9d5a42e
+
+    await cmd.run({ args: { name: 'awesome', redirect_uri: 'https://myapp.com' }, flags: {} })
+
+    expect(cli.stdout).to.equal(`HEROKU_OAUTH_ID=f6e8d969-129f-42d2-854b-c2eca9d5a42e
 HEROKU_OAUTH_SECRET=clientsecret
-`))
-      .then(() => api.done())
+`);
+
+    return api.done()
   })
 })

--- a/packages/oauth-v5/test/clients/destroy.js
+++ b/packages/oauth-v5/test/clients/destroy.js
@@ -8,11 +8,11 @@ let cmd = require('../../lib/commands/clients/destroy')
 describe('clients:destroy', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('destroys the client', function () {
+  it('destroys the client', async function() {
     let api = nock('https://api.heroku.com:443')
       .delete('/oauth/clients/f6e8d969-129f-42d2-854b-c2eca9d5a42e')
       .reply(200)
-    return cmd.run({ args: { id: 'f6e8d969-129f-42d2-854b-c2eca9d5a42e' }, flags: {} })
-      .then(() => api.done())
+    await cmd.run({ args: { id: 'f6e8d969-129f-42d2-854b-c2eca9d5a42e' }, flags: {} })
+    return api.done()
   })
 })

--- a/packages/oauth-v5/test/clients/index.js
+++ b/packages/oauth-v5/test/clients/index.js
@@ -24,14 +24,14 @@ describe('clients', () => {
         .reply(200, [{ name: 'awesome', id: 'f6e8d969-129f-42d2-854b-c2eca9d5a42e', redirect_uri: 'https://myapp.com' }])
     })
 
-    it('lists the clients', () => {
-      return cmd.run({ flags: {} })
-        .then(() => expect(cli.stdout).to.equal('awesome  f6e8d969-129f-42d2-854b-c2eca9d5a42e  https://myapp.com\n'))
+    it('lists the clients', async () => {
+      await cmd.run({ flags: {} })
+      return expect(cli.stdout).to.equal('awesome  f6e8d969-129f-42d2-854b-c2eca9d5a42e  https://myapp.com\n')
     })
 
-    it('lists the clients as json', () => {
-      return cmd.run({ flags: { json: true } })
-        .then(() => expect(JSON.parse(cli.stdout)[0], 'to satisfy', { name: 'awesome' }))
+    it('lists the clients as json', async () => {
+      await cmd.run({ flags: { json: true } })
+      return expect(JSON.parse(cli.stdout)[0], 'to satisfy', { name: 'awesome' })
     })
   })
 
@@ -42,9 +42,9 @@ describe('clients', () => {
         .reply(200, [])
     })
 
-    it('shows no clients message', () => {
-      return cmd.run({ flags: {} })
-        .then(() => expect(cli.stdout).to.equal('No OAuth clients.\n'))
+    it('shows no clients message', async () => {
+      await cmd.run({ flags: {} })
+      return expect(cli.stdout).to.equal('No OAuth clients.\n')
     })
   })
 })

--- a/packages/oauth-v5/test/clients/info.js
+++ b/packages/oauth-v5/test/clients/info.js
@@ -20,25 +20,27 @@ describe('clients:info', function () {
   })
   afterEach(() => api.done())
 
-  it('gets the client info', function () {
-    return cmd.run({ args: { id }, flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`=== awesome
+  it('gets the client info', async function() {
+    await cmd.run({ args: { id }, flags: {} })
+
+    return expect(cli.stdout).to.equal(`=== awesome
 id:           f6e8d969-129f-42d2-854b-c2eca9d5a42e
 name:         awesome
 redirect_uri: https://myapp.com
 secret:       supersecretkey
-`))
+`)
   })
 
-  it('gets the client info as json', function () {
-    return cmd.run({ args: { id }, flags: { json: true } })
-      .then(() => expect(JSON.parse(cli.stdout), 'to satisfy', { name: 'awesome' }))
+  it('gets the client info as json', async function() {
+    await cmd.run({ args: { id }, flags: { json: true } })
+    return expect(JSON.parse(cli.stdout), 'to satisfy', { name: 'awesome' })
   })
 
-  it('gets the client info as shell', function () {
-    return cmd.run({ args: { id }, flags: { shell: true } })
-      .then(() => expect(cli.stdout).to.equal(`HEROKU_OAUTH_ID=f6e8d969-129f-42d2-854b-c2eca9d5a42e
+  it('gets the client info as shell', async function() {
+    await cmd.run({ args: { id }, flags: { shell: true } })
+
+    return expect(cli.stdout).to.equal(`HEROKU_OAUTH_ID=f6e8d969-129f-42d2-854b-c2eca9d5a42e
 HEROKU_OAUTH_SECRET=supersecretkey
-`))
+`)
   })
 })

--- a/packages/oauth-v5/test/sessions/index.js
+++ b/packages/oauth-v5/test/sessions/index.js
@@ -23,14 +23,14 @@ describe('clients', () => {
         .reply(200, [{ description: 'Session @ 166.176.184.223', id: 'f6e8d969-129f-42d2-854b-c2eca9d5a42e' }])
     })
 
-    it('lists the sessions', () => {
-      return cmd.run({ flags: {} })
-        .then(() => expect(cli.stdout).to.equal('Session @ 166.176.184.223  f6e8d969-129f-42d2-854b-c2eca9d5a42e\n'))
+    it('lists the sessions', async () => {
+      await cmd.run({ flags: {} })
+      return expect(cli.stdout).to.equal('Session @ 166.176.184.223  f6e8d969-129f-42d2-854b-c2eca9d5a42e\n')
     })
 
-    it('lists the sessions as json', () => {
-      return cmd.run({ flags: { json: true } })
-        .then(() => expect(JSON.parse(cli.stdout)[0], 'to satisfy', { description: 'Session @ 166.176.184.223' }))
+    it('lists the sessions as json', async () => {
+      await cmd.run({ flags: { json: true } })
+      return expect(JSON.parse(cli.stdout)[0], 'to satisfy', { description: 'Session @ 166.176.184.223' })
     })
   })
 
@@ -41,9 +41,9 @@ describe('clients', () => {
         .reply(200, [])
     })
 
-    it('shows no clients message', () => {
-      return cmd.run({ flags: {} })
-        .then(() => expect(cli.stdout).to.equal('No OAuth sessions.\n'))
+    it('shows no clients message', async () => {
+      await cmd.run({ flags: {} })
+      return expect(cli.stdout).to.equal('No OAuth sessions.\n')
     })
   })
 })

--- a/packages/orgs-v5/test/assert_exit.js
+++ b/packages/orgs-v5/test/assert_exit.js
@@ -3,15 +3,16 @@
 let expect = require('chai').expect
 let ErrorExit = require('../lib/error.js').ErrorExit
 
-function assertErrorExit (code, gen) {
+async function assertErrorExit(code, gen) {
   var actual
-  return gen.catch(function (err) {
+
+  await gen.catch(function (err) {
     expect(err).to.be.an.instanceof(ErrorExit)
     actual = err.code
-  }).then(function () {
-    expect(actual).to.be.an('number', 'Expected error.exit(i) to be called with a number')
-    expect(actual).to.equal(code)
   })
+
+  expect(actual).to.be.an('number', 'Expected error.exit(i) to be called with a number')
+  expect(actual).to.equal(code)
 }
 
 module.exports = assertErrorExit

--- a/packages/orgs-v5/test/commands/access/add.js
+++ b/packages/orgs-v5/test/commands/access/add.js
@@ -21,46 +21,56 @@ describe('heroku access:add', () => {
     })
     afterEach(() => nock.cleanAll())
 
-    it('adds user to the app with permissions, and view is implicit', () => {
-      return cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: { permissions: 'deploy' } })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Adding raulb@heroku.com access to the app myapp with deploy,view permissions... done
-`).to.eq(cli.stderr))
-        .then(() => apiGet.done())
-        .then(() => apiGetOrgFeatures.done())
-        .then(() => apiPost.done())
+    it('adds user to the app with permissions, and view is implicit', async () => {
+      await cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: { permissions: 'deploy' } })
+
+      expect('').to.eq(cli.stdout);
+
+      expect(`Adding raulb@heroku.com access to the app myapp with deploy,view permissions... done
+`).to.eq(cli.stderr);
+
+      apiGet.done();
+      apiGetOrgFeatures.done();
+
+      return apiPost.done()
     })
 
-    it('adds user to the app with permissions, even specifying the view permission', () => {
-      return cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: { permissions: 'deploy,view' } })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Adding raulb@heroku.com access to the app myapp with deploy,view permissions... done
-`).to.eq(cli.stderr))
-        .then(() => apiGet.done())
-        .then(() => apiGetOrgFeatures.done())
-        .then(() => apiPost.done())
+    it('adds user to the app with permissions, even specifying the view permission', async () => {
+      await cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: { permissions: 'deploy,view' } })
+
+      expect('').to.eq(cli.stdout);
+
+      expect(`Adding raulb@heroku.com access to the app myapp with deploy,view permissions... done
+`).to.eq(cli.stderr);
+
+      apiGet.done();
+      apiGetOrgFeatures.done();
+
+      return apiPost.done()
     })
 
-    it('raises an error when permissions are not specified', () => {
+    it('raises an error when permissions are not specified', async () => {
       error.exit.mock()
 
-      return assertExit(1, cmd.run({
+      await assertExit(1, cmd.run({
         app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: {}
-      }).then(() => {
-        apiGet.done()
-        apiGetOrgFeatures.done()
-        apiPost.done()
-      })).then(function () {
-        expect(unwrap(cli.stderr)).to.equal('Missing argument: permissions\n')
-      })
+      }))
+
+      apiPost.done()
+      apiGetOrgFeatures.done()
+      apiGet.done()
+
+      expect(unwrap(cli.stderr)).to.equal('Missing argument: permissions\n')
     })
 
-    it('supports --privileges, but shows deprecation warning', () => {
-      return cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: { privileges: 'deploy,view' } })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(unwrap(cli.stderr)).to.equal(`DEPRECATION WARNING: use \`--permissions\` not \`--privileges\`
+    it('supports --privileges, but shows deprecation warning', async () => {
+      await cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: { privileges: 'deploy,view' } })
+
+      expect('').to.eq(cli.stdout);
+
+      return expect(unwrap(cli.stderr)).to.equal(`DEPRECATION WARNING: use \`--permissions\` not \`--privileges\`
 Adding raulb@heroku.com access to the app myapp with deploy,view permissions... done
-`))
+`)
     })
   })
 
@@ -73,14 +83,18 @@ Adding raulb@heroku.com access to the app myapp with deploy,view permissions... 
     })
     afterEach(() => nock.cleanAll())
 
-    it('adds user to the app', () => {
-      return cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: {} })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Adding raulb@heroku.com access to the app myapp... done
-`).to.eq(cli.stderr))
-        .then(() => apiGet.done())
-        .then(() => apiGetOrgFeatures.done())
-        .then(() => apiPost.done())
+    it('adds user to the app', async () => {
+      await cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: {} })
+
+      expect('').to.eq(cli.stdout);
+
+      expect(`Adding raulb@heroku.com access to the app myapp... done
+`).to.eq(cli.stderr);
+
+      apiGet.done();
+      apiGetOrgFeatures.done();
+
+      return apiPost.done()
     })
   })
 
@@ -92,13 +106,17 @@ Adding raulb@heroku.com access to the app myapp with deploy,view permissions... 
     })
     afterEach(() => nock.cleanAll())
 
-    it('adds user to the app as a collaborator', () => {
-      return cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: {} })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Adding raulb@heroku.com access to the app myapp... done
-`).to.eq(cli.stderr))
-        .then(() => apiGet.done())
-        .then(() => apiPost.done())
+    it('adds user to the app as a collaborator', async () => {
+      await cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: {} })
+
+      expect('').to.eq(cli.stdout);
+
+      expect(`Adding raulb@heroku.com access to the app myapp... done
+`).to.eq(cli.stderr);
+
+      apiGet.done();
+
+      return apiPost.done()
     })
   })
 })

--- a/packages/orgs-v5/test/commands/access/index.js
+++ b/packages/orgs-v5/test/commands/access/index.js
@@ -9,18 +9,21 @@ describe('heroku access', () => {
     beforeEach(() => cli.mockConsole())
     afterEach(() => nock.cleanAll())
 
-    it('shows the app collaborators', () => {
+    it('shows the app collaborators', async () => {
       let apiGetPersonalApp = stubGet.personalApp()
       let apiGetAppCollaborators = stubGet.appCollaborators()
 
-      return cmd.run({ app: 'myapp', flags: {} })
-        .then(() => expect(
+      await cmd.run({ app: 'myapp', flags: {} })
+
+      expect(
           `jeff@heroku.com   collaborator
 raulb@heroku.com  owner
-`).to.eq(cli.stdout))
-        .then(() => expect('').to.eq(cli.stderr))
-        .then(() => apiGetPersonalApp.done())
-        .then(() => apiGetAppCollaborators.done())
+`).to.eq(cli.stdout);
+
+      expect('').to.eq(cli.stderr);
+      apiGetPersonalApp.done();
+
+      return apiGetAppCollaborators.done()
     })
   })
 
@@ -28,22 +31,25 @@ raulb@heroku.com  owner
     beforeEach(() => cli.mockConsole())
     afterEach(() => nock.cleanAll())
 
-    it('shows the app collaborators and hides the team collaborator record', () => {
+    it('shows the app collaborators and hides the team collaborator record', async () => {
       let apiGetteamApp = stubGet.teamApp()
       let apiGetOrgMembers = stubGet.teamMembers()
       let apiGetAppPermissions = stubGet.appPermissions()
       let apiGetteamAppCollaboratorsWithPermissions = stubGet.teamAppCollaboratorsWithPermissions()
 
-      return cmd.run({ app: 'myapp', flags: {} })
-        .then(() => expect(
+      await cmd.run({ app: 'myapp', flags: {} })
+
+      expect(
           `bob@heroku.com    member  deploy,view
 raulb@heroku.com  admin   deploy,manage,operate,view
-`).to.eq(cli.stdout))
-        .then(() => expect('').to.eq(cli.stderr))
-        .then(() => apiGetteamApp.done())
-        .then(() => apiGetOrgMembers.done())
-        .then(() => apiGetAppPermissions.done())
-        .then(() => apiGetteamAppCollaboratorsWithPermissions.done())
+`).to.eq(cli.stdout);
+
+      expect('').to.eq(cli.stderr);
+      apiGetteamApp.done();
+      apiGetOrgMembers.done();
+      apiGetAppPermissions.done();
+
+      return apiGetteamAppCollaboratorsWithPermissions.done()
     })
   })
 })

--- a/packages/orgs-v5/test/commands/access/remove.js
+++ b/packages/orgs-v5/test/commands/access/remove.js
@@ -13,12 +13,15 @@ describe('heroku access:remove', () => {
     })
     afterEach(() => nock.cleanAll())
 
-    it('removes the user from an app', () => {
-      return cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' } })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Removing raulb@heroku.com access from the app myapp... done
-`).to.eq(cli.stderr))
-        .then(() => apiDelete.done())
+    it('removes the user from an app', async () => {
+      await cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' } })
+
+      expect('').to.eq(cli.stdout);
+
+      expect(`Removing raulb@heroku.com access from the app myapp... done
+`).to.eq(cli.stderr);
+
+      return apiDelete.done()
     })
   })
 })

--- a/packages/orgs-v5/test/commands/access/update.js
+++ b/packages/orgs-v5/test/commands/access/update.js
@@ -15,41 +15,53 @@ describe('heroku access:update', () => {
     beforeEach(() => cli.mockConsole())
     afterEach(() => nock.cleanAll())
 
-    it('updates the app permissions, view being implicit', () => {
+    it('updates the app permissions, view being implicit', async () => {
       apiGetApp = stubGet.teamApp()
       apiPatchAppCollaborators = stubPatch.appCollaboratorWithPermissions({ email: 'raulb@heroku.com', permissions: ['deploy', 'view'] })
 
-      return cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: { permissions: 'deploy' } })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Updating raulb@heroku.com in application myapp with deploy,view permissions... done
-`).to.eq(cli.stderr))
-        .then(() => apiGetApp.done())
-        .then(() => apiPatchAppCollaborators.done())
+      await cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: { permissions: 'deploy' } })
+
+      expect('').to.eq(cli.stdout);
+
+      expect(`Updating raulb@heroku.com in application myapp with deploy,view permissions... done
+`).to.eq(cli.stderr);
+
+      apiGetApp.done();
+
+      return apiPatchAppCollaborators.done()
     })
 
-    it('updates the app permissions, even specifying view as a permission', () => {
+    it('updates the app permissions, even specifying view as a permission', async () => {
       apiGetApp = stubGet.teamApp()
       apiPatchAppCollaborators = stubPatch.appCollaboratorWithPermissions({ email: 'raulb@heroku.com', permissions: ['deploy', 'view'] })
 
-      return cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: { permissions: 'deploy,view' } })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Updating raulb@heroku.com in application myapp with deploy,view permissions... done
-`).to.eq(cli.stderr))
-        .then(() => apiGetApp.done())
-        .then(() => apiPatchAppCollaborators.done())
+      await cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: { permissions: 'deploy,view' } })
+
+      expect('').to.eq(cli.stdout);
+
+      expect(`Updating raulb@heroku.com in application myapp with deploy,view permissions... done
+`).to.eq(cli.stderr);
+
+      apiGetApp.done();
+
+      return apiPatchAppCollaborators.done()
     })
 
-    it('supports --privileges, but shows deprecation warning', () => {
+    it('supports --privileges, but shows deprecation warning', async () => {
       apiGetApp = stubGet.teamApp()
       apiPatchAppCollaborators = stubPatch.appCollaboratorWithPermissions({ email: 'raulb@heroku.com', permissions: ['deploy', 'view'] })
 
-      return cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: { privileges: 'deploy' } })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(unwrap(cli.stderr)).to.equal(`DEPRECATION WARNING: use \`--permissions\` not \`--privileges\`
+      await cmd.run({ app: 'myapp', args: { email: 'raulb@heroku.com' }, flags: { privileges: 'deploy' } })
+
+      expect('').to.eq(cli.stdout);
+
+      expect(unwrap(cli.stderr)).to.equal(`DEPRECATION WARNING: use \`--permissions\` not \`--privileges\`
 Updating raulb@heroku.com in application myapp with deploy,view permissions... done
-`))
-        .then(() => apiGetApp.done())
-        .then(() => apiPatchAppCollaborators.done())
+`);
+
+      apiGetApp.done();
+
+      return apiPatchAppCollaborators.done()
     })
   })
 
@@ -60,16 +72,18 @@ Updating raulb@heroku.com in application myapp with deploy,view permissions... d
     })
     afterEach(() => nock.cleanAll())
 
-    it('returns an error when passing permissions', () => {
+    it('returns an error when passing permissions', async () => {
       apiGetApp = stubGet.personalApp()
 
-      return assertExit(1, cmd.run({
+      await assertExit(1, cmd.run({
         app: 'myapp',
         args: { email: 'raulb@heroku.com' },
         flags: { permissions: 'view,deploy' }
-      }).then(() => apiGetApp.done())).then(function () {
-        expect(unwrap(cli.stderr)).to.equal('Error: cannot update permissions. The app myapp is not owned by a team\n')
-      })
+      }))
+
+      apiGetApp.done();
+
+      expect(unwrap(cli.stderr)).to.equal('Error: cannot update permissions. The app myapp is not owned by a team\n')
     })
   })
 })

--- a/packages/orgs-v5/test/commands/apps/join.js
+++ b/packages/orgs-v5/test/commands/apps/join.js
@@ -15,18 +15,22 @@ describe('heroku apps:join', () => {
   })
   afterEach(() => nock.cleanAll())
 
-  it('joins the app', () => {
+  it('joins the app', async () => {
     apiPostCollaborators = stubPost.teamAppCollaborators('raulb@heroku.com')
 
-    return cmd.run({ app: 'myapp' })
-      .then(() => expect('').to.eq(cli.stdout))
-      .then(() => expect(`Joining myapp... done
-`).to.eq(cli.stderr))
-      .then(() => apiGetUserAccount.done())
-      .then(() => apiPostCollaborators.done())
+    await cmd.run({ app: 'myapp' })
+
+    expect('').to.eq(cli.stdout);
+
+    expect(`Joining myapp... done
+`).to.eq(cli.stderr);
+
+    apiGetUserAccount.done();
+
+    return apiPostCollaborators.done()
   })
 
-  it('is forbidden from joining the app', () => {
+  it('is forbidden from joining the app', async () => {
     let response = {
       code: 403,
       description: { id: 'forbidden', error: 'You do not have access to the team heroku-tools.' }
@@ -35,15 +39,15 @@ describe('heroku apps:join', () => {
     apiPostCollaborators = stubPost.teamAppCollaborators('raulb@heroku.com', [], response)
     let thrown = false
 
-    return cmd.run({ app: 'myapp' })
-      .then(() => apiGetUserAccount.done())
+    await cmd.run({ app: 'myapp' })
       .catch(function (err) {
         thrown = true
         expect(err.body.error).to.eq('You do not have access to the team heroku-tools.')
       })
-      .then(function () {
-        expect(thrown).to.eq(true)
-      })
-      .then(() => apiPostCollaborators.done())
+
+    apiGetUserAccount.done();
+    expect(thrown).to.eq(true)
+
+    return apiPostCollaborators.done()
   })
 })

--- a/packages/orgs-v5/test/commands/apps/leave.js
+++ b/packages/orgs-v5/test/commands/apps/leave.js
@@ -17,24 +17,32 @@ describe('heroku apps:leave', () => {
   afterEach(() => nock.cleanAll())
 
   context('when it is an org app', () => {
-    it('leaves the app', () => {
-      return cmd.run({ app: 'myapp' })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Leaving myapp... done
-`).to.eq(cli.stderr))
-        .then(() => apiGetUserAccount.done())
-        .then(() => apiDeletePersonalAppCollaborator.done())
+    it('leaves the app', async () => {
+      await cmd.run({ app: 'myapp' })
+
+      expect('').to.eq(cli.stdout);
+
+      expect(`Leaving myapp... done
+`).to.eq(cli.stderr);
+
+      apiGetUserAccount.done();
+
+      return apiDeletePersonalAppCollaborator.done()
     })
   })
 
   context('when it is not an org app', () => {
-    it('leaves the app', () => {
-      return cmd.run({ app: 'myapp' })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Leaving myapp... done
-`).to.eq(cli.stderr))
-        .then(() => apiGetUserAccount.done())
-        .then(() => apiDeletePersonalAppCollaborator.done())
+    it('leaves the app', async () => {
+      await cmd.run({ app: 'myapp' })
+
+      expect('').to.eq(cli.stdout);
+
+      expect(`Leaving myapp... done
+`).to.eq(cli.stderr);
+
+      apiGetUserAccount.done();
+
+      return apiDeletePersonalAppCollaborator.done()
     })
   })
 })

--- a/packages/orgs-v5/test/commands/apps/lock.js
+++ b/packages/orgs-v5/test/commands/apps/lock.js
@@ -7,16 +7,20 @@ describe('heroku apps:lock', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
-  it('locks the app', () => {
+  it('locks the app', async () => {
     let apiGetApp = nock('https://api.heroku.com:443')
       .get('/teams/apps/myapp')
       .reply(200, { name: 'myapp', locked: false })
       .patch('/teams/apps/myapp', { locked: true })
       .reply(200)
-    return cmd.run({ app: 'myapp' })
-      .then(() => expect('').to.eq(cli.stdout))
-      .then(() => expect(`Locking myapp... done
-`).to.eq(cli.stderr))
-      .then(() => apiGetApp.done())
+
+    await cmd.run({ app: 'myapp' })
+
+    expect('').to.eq(cli.stdout);
+
+    expect(`Locking myapp... done
+`).to.eq(cli.stderr);
+
+    return apiGetApp.done()
   })
 })

--- a/packages/orgs-v5/test/commands/apps/transfer.js
+++ b/packages/orgs-v5/test/commands/apps/transfer.js
@@ -22,7 +22,7 @@ describe('heroku apps:transfer', () => {
       stubGet.apps()
     })
 
-    it('transfers selected apps to a team', () => {
+    it('transfers selected apps to a team', async () => {
       inquirer.prompt = (prompts) => {
         let choices = prompts[0].choices
         expect(choices).to.eql([
@@ -39,17 +39,15 @@ describe('heroku apps:transfer', () => {
       }
 
       let api = stubPatch.teamAppTransfer()
-      return cmd.run({ args: { recipient: 'team' }, flags: { bulk: true } })
-        .then(function () {
-          api.done()
-          expect(cli.stderr).to.equal(`Transferring applications to team...
+      await cmd.run({ args: { recipient: 'team' }, flags: { bulk: true } })
+      api.done()
+      expect(cli.stderr).to.equal(`Transferring applications to team...
 
 Transferring myapp... done
 `)
-        })
     })
 
-    it('transfers selected apps to a personal account', () => {
+    it('transfers selected apps to a personal account', async () => {
       inquirer.prompt = (prompts) => {
         let choices = prompts[0].choices
         expect(choices).to.eql([
@@ -66,14 +64,12 @@ Transferring myapp... done
       }
 
       let api = stubPost.personalToPersonal()
-      return cmd.run({ args: { recipient: 'raulb@heroku.com' }, flags: { bulk: true } })
-        .then(function () {
-          api.done()
-          expect(cli.stderr).to.equal(`Transferring applications to raulb@heroku.com...
+      await cmd.run({ args: { recipient: 'raulb@heroku.com' }, flags: { bulk: true } })
+      api.done()
+      expect(cli.stderr).to.equal(`Transferring applications to raulb@heroku.com...
 
 Initiating transfer of myapp... email sent
 `)
-        })
     })
   })
 
@@ -82,22 +78,30 @@ Initiating transfer of myapp... email sent
       stubGet.personalApp()
     })
 
-    it('transfers the app to a personal account', () => {
+    it('transfers the app to a personal account', async () => {
       let api = stubPost.personalToPersonal()
-      return cmd.run({ app: 'myapp', args: { recipient: 'raulb@heroku.com' }, flags: {} })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Initiating transfer of myapp to raulb@heroku.com... email sent
-`).to.eq(cli.stderr))
-        .then(() => api.done())
+
+      await cmd.run({ app: 'myapp', args: { recipient: 'raulb@heroku.com' }, flags: {} })
+
+      expect('').to.eq(cli.stdout);
+
+      expect(`Initiating transfer of myapp to raulb@heroku.com... email sent
+`).to.eq(cli.stderr);
+
+      return api.done()
     })
 
-    it('transfers the app to a team', () => {
+    it('transfers the app to a team', async () => {
       let api = stubPatch.teamAppTransfer()
-      return cmd.run({ app: 'myapp', args: { recipient: 'team' }, flags: {} })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Transferring myapp to team... done
-`).to.eq(cli.stderr))
-        .then(() => api.done())
+
+      await cmd.run({ app: 'myapp', args: { recipient: 'team' }, flags: {} })
+
+      expect('').to.eq(cli.stdout);
+
+      expect(`Transferring myapp to team... done
+`).to.eq(cli.stderr);
+
+      return api.done()
     })
   })
 
@@ -106,25 +110,33 @@ Initiating transfer of myapp... email sent
       stubGet.teamApp()
     })
 
-    it('transfers the app to a personal account confirming app name', () => {
+    it('transfers the app to a personal account confirming app name', async () => {
       let api = stubPatch.teamAppTransfer()
-      return cmd.run({ app: 'myapp', args: { recipient: 'team' }, flags: { confirm: 'myapp' } })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Transferring myapp to team... done
-`).to.eq(cli.stderr))
-        .then(() => api.done())
+
+      await cmd.run({ app: 'myapp', args: { recipient: 'team' }, flags: { confirm: 'myapp' } })
+
+      expect('').to.eq(cli.stdout);
+
+      expect(`Transferring myapp to team... done
+`).to.eq(cli.stderr);
+
+      return api.done()
     })
 
-    it('transfers the app to a team', () => {
+    it('transfers the app to a team', async () => {
       let api = stubPatch.teamAppTransfer()
-      return cmd.run({ app: 'myapp', args: { recipient: 'team' }, flags: {} })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Transferring myapp to team... done
-`).to.eq(cli.stderr))
-        .then(() => api.done())
+
+      await cmd.run({ app: 'myapp', args: { recipient: 'team' }, flags: {} })
+
+      expect('').to.eq(cli.stdout);
+
+      expect(`Transferring myapp to team... done
+`).to.eq(cli.stderr);
+
+      return api.done()
     })
 
-    it('transfers and locks the app if --locked is passed', () => {
+    it('transfers and locks the app if --locked is passed', async () => {
       let api = stubPatch.teamAppTransfer()
 
       let lockedAPI = nock('https://api.heroku.com:443')
@@ -133,13 +145,17 @@ Initiating transfer of myapp... email sent
         .patch('/teams/apps/myapp', { locked: true })
         .reply(200)
 
-      return cmd.run({ app: 'myapp', args: { recipient: 'team' }, flags: { locked: true } })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Transferring myapp to team... done
+      await cmd.run({ app: 'myapp', args: { recipient: 'team' }, flags: { locked: true } })
+
+      expect('').to.eq(cli.stdout);
+
+      expect(`Transferring myapp to team... done
 Locking myapp... done
-`).to.eq(cli.stderr))
-        .then(() => api.done())
-        .then(() => lockedAPI.done())
+`).to.eq(cli.stderr);
+
+      api.done();
+
+      return lockedAPI.done()
     })
   })
 })

--- a/packages/orgs-v5/test/commands/apps/unlock.js
+++ b/packages/orgs-v5/test/commands/apps/unlock.js
@@ -7,16 +7,20 @@ describe('heroku apps:unlock', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
-  it('unlocks the app', () => {
+  it('unlocks the app', async () => {
     let api = nock('https://api.heroku.com:443')
       .get('/teams/apps/myapp')
       .reply(200, { name: 'myapp', locked: true })
       .patch('/teams/apps/myapp', { locked: false })
       .reply(200)
-    return cmd.run({ app: 'myapp' })
-      .then(() => expect('').to.eq(cli.stdout))
-      .then(() => expect(`Unlocking myapp... done
-`).to.eq(cli.stderr))
-      .then(() => api.done())
+
+    await cmd.run({ app: 'myapp' })
+
+    expect('').to.eq(cli.stdout);
+
+    expect(`Unlocking myapp... done
+`).to.eq(cli.stderr);
+
+    return api.done()
   })
 })

--- a/packages/orgs-v5/test/commands/members/add.js
+++ b/packages/orgs-v5/test/commands/members/add.js
@@ -26,41 +26,50 @@ describe('heroku members:add', () => {
         stubGet.teamInfo('team')
       })
 
-      it('does not warn the user when under the free org limit', () => {
+      it('does not warn the user when under the free org limit', async () => {
         stubGet.variableSizeTeamMembers(1)
         stubGet.variableSizeTeamInvites(0)
         apiUpdateMemberRole = stubPut.updateMemberRole('foo@foo.com', 'admin')
 
-        return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
-          .then(() => expect('').to.eq(cli.stdout))
-          .then(() => expect(`Adding foo@foo.com to myteam as admin... done
-`).to.eq(cli.stderr))
-          .then(() => apiUpdateMemberRole.done())
+        await cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
+
+        expect('').to.eq(cli.stdout);
+
+        expect(`Adding foo@foo.com to myteam as admin... done
+`).to.eq(cli.stderr);
+
+        return apiUpdateMemberRole.done()
       })
 
-      it('does not warn the user when over the free org limit', () => {
+      it('does not warn the user when over the free org limit', async () => {
         stubGet.variableSizeTeamMembers(7)
         stubGet.variableSizeTeamInvites(0)
         apiUpdateMemberRole = stubPut.updateMemberRole('foo@foo.com', 'admin')
 
-        return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
-          .then(() => expect('').to.eq(cli.stdout))
-          .then(() => expect(`Adding foo@foo.com to myteam as admin... done
-`).to.eq(cli.stderr))
-          .then(() => apiUpdateMemberRole.done())
+        await cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
+
+        expect('').to.eq(cli.stdout);
+
+        expect(`Adding foo@foo.com to myteam as admin... done
+`).to.eq(cli.stderr);
+
+        return apiUpdateMemberRole.done()
       })
 
-      it('does warn the user when at the free org limit', () => {
+      it('does warn the user when at the free org limit', async () => {
         stubGet.variableSizeTeamMembers(6)
         stubGet.variableSizeTeamInvites(0)
         apiUpdateMemberRole = stubPut.updateMemberRole('foo@foo.com', 'admin')
 
-        return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
-          .then(() => expect('').to.eq(cli.stdout))
-          .then(() => expect(unwrap(cli.stderr)).to.equal(`Adding foo@foo.com to myteam as admin... done \
+        await cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
+
+        expect('').to.eq(cli.stdout);
+
+        expect(unwrap(cli.stderr)).to.equal(`Adding foo@foo.com to myteam as admin... done \
 You'll be billed monthly for teams over 5 members.
-`))
-          .then(() => apiUpdateMemberRole.done())
+`);
+
+        return apiUpdateMemberRole.done()
       })
     })
 
@@ -70,14 +79,17 @@ You'll be billed monthly for teams over 5 members.
         stubGet.variableSizeTeamMembers(1)
       })
 
-      it('adds a member to an org', () => {
+      it('adds a member to an org', async () => {
         apiUpdateMemberRole = stubPut.updateMemberRole('foo@foo.com', 'admin')
 
-        return cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myteam', role: 'admin' } })
-          .then(() => expect('').to.eq(cli.stdout))
-          .then(() => expect(`Adding foo@foo.com to myteam as admin... done
-`).to.eq(cli.stderr))
-          .then(() => apiUpdateMemberRole.done())
+        await cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myteam', role: 'admin' } })
+
+        expect('').to.eq(cli.stdout);
+
+        expect(`Adding foo@foo.com to myteam as admin... done
+`).to.eq(cli.stderr);
+
+        return apiUpdateMemberRole.done()
       })
     })
   })
@@ -88,32 +100,36 @@ You'll be billed monthly for teams over 5 members.
       stubGet.teamInfo('team')
     })
 
-    it('does warn the user when free org limit is caused by invites', () => {
+    it('does warn the user when free org limit is caused by invites', async () => {
       let apiSendInvite = stubPut.sendInvite('foo@foo.com', 'admin')
 
       let apiGetOrgMembers = stubGet.variableSizeTeamMembers(1)
       let apiGetTeamInvites = stubGet.variableSizeTeamInvites(5)
 
-      return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
-        .then(() => apiSendInvite.done())
-        .then(() => apiGetOrgMembers.done())
-        .then(() => apiGetTeamInvites.done())
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(unwrap(cli.stderr)).to.equal(`Inviting foo@foo.com to myteam as admin... email sent \
+      await cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
+
+      apiSendInvite.done();
+      apiGetOrgMembers.done();
+      apiGetTeamInvites.done();
+      expect('').to.eq(cli.stdout);
+
+      return expect(unwrap(cli.stderr)).to.equal(`Inviting foo@foo.com to myteam as admin... email sent \
 You'll be billed monthly for teams over 5 members.
-`))
+`)
     })
 
-    it('sends an invite when adding a new user to the team', () => {
+    it('sends an invite when adding a new user to the team', async () => {
       let apiSendInvite = stubPut.sendInvite('foo@foo.com', 'admin')
 
       stubGet.variableSizeTeamMembers(1)
       stubGet.variableSizeTeamInvites(0)
 
-      return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Inviting foo@foo.com to myteam as admin... email sent\n`).to.eq(cli.stderr))
-        .then(() => apiSendInvite.done())
+      await cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
+
+      expect('').to.eq(cli.stdout);
+      expect(`Inviting foo@foo.com to myteam as admin... email sent\n`).to.eq(cli.stderr);
+
+      return apiSendInvite.done()
     })
   })
 })

--- a/packages/orgs-v5/test/commands/members/index.js
+++ b/packages/orgs-v5/test/commands/members/index.js
@@ -19,59 +19,79 @@ describe('heroku members', () => {
       stubGet.teamInfo('enterprise')
     })
 
-    it('shows there are not team members if it is an orphan team', () => {
+    it('shows there are not team members if it is an orphan team', async () => {
       apiGetOrgMembers = stubGet.teamMembers([])
-      return cmd.run({ flags: { team: 'myteam' } })
-        .then(() => expect(
+
+      await cmd.run({ flags: { team: 'myteam' } })
+
+      expect(
           `No members in myteam
-`).to.eq(cli.stdout))
-        .then(() => expect('').to.eq(cli.stderr))
-        .then(() => apiGetOrgMembers.done())
+`).to.eq(cli.stdout);
+
+      expect('').to.eq(cli.stderr);
+
+      return apiGetOrgMembers.done()
     })
 
-    it('shows all the team members', () => {
+    it('shows all the team members', async () => {
       apiGetOrgMembers = stubGet.teamMembers([
         { email: 'a@heroku.com', role: 'admin' }, { email: 'b@heroku.com', role: 'collaborator' }
       ])
-      return cmd.run({ flags: { team: 'myteam' } })
-        .then(() => expect(
+
+      await cmd.run({ flags: { team: 'myteam' } })
+
+      expect(
           `a@heroku.com  admin
 b@heroku.com  collaborator
-`).to.eq(cli.stdout))
-        .then(() => expect('').to.eq(cli.stderr))
-        .then(() => apiGetOrgMembers.done())
+`).to.eq(cli.stdout);
+
+      expect('').to.eq(cli.stderr);
+
+      return apiGetOrgMembers.done()
     })
 
     let expectedOrgMembers = [{ email: 'a@heroku.com', role: 'admin' }, { email: 'b@heroku.com', role: 'member' }]
 
-    it('filters members by role', () => {
+    it('filters members by role', async () => {
       apiGetOrgMembers = stubGet.teamMembers(expectedOrgMembers)
-      return cmd.run({ flags: { team: 'myteam', role: 'member' } })
-        .then(() => expect(
+
+      await cmd.run({ flags: { team: 'myteam', role: 'member' } })
+
+      expect(
           `b@heroku.com  member
-`).to.eq(cli.stdout))
-        .then(() => expect('').to.eq(cli.stderr))
-        .then(() => apiGetOrgMembers.done())
+`).to.eq(cli.stdout);
+
+      expect('').to.eq(cli.stderr);
+
+      return apiGetOrgMembers.done()
     })
 
-    it("shows the right message when filter doesn't return results", () => {
+    it("shows the right message when filter doesn't return results", async () => {
       apiGetOrgMembers = stubGet.teamMembers(expectedOrgMembers)
-      return cmd.run({ flags: { team: 'myteam', role: 'collaborator' } })
-        .then(() => expect(
+
+      await cmd.run({ flags: { team: 'myteam', role: 'collaborator' } })
+
+      expect(
           `No members in myteam with role collaborator
-`).to.eq(cli.stdout))
-        .then(() => expect('').to.eq(cli.stderr))
-        .then(() => apiGetOrgMembers.done())
+`).to.eq(cli.stdout);
+
+      expect('').to.eq(cli.stderr);
+
+      return apiGetOrgMembers.done()
     })
 
-    it('filters members by role', () => {
+    it('filters members by role', async () => {
       apiGetOrgMembers = stubGet.teamMembers(expectedOrgMembers)
-      return cmd.run({ flags: { team: 'myteam', role: 'member' } })
-        .then(() => expect(
+
+      await cmd.run({ flags: { team: 'myteam', role: 'member' } })
+
+      expect(
           `b@heroku.com  member
-`).to.eq(cli.stdout))
-        .then(() => expect('').to.eq(cli.stderr))
-        .then(() => apiGetOrgMembers.done())
+`).to.eq(cli.stdout);
+
+      expect('').to.eq(cli.stderr);
+
+      return apiGetOrgMembers.done()
     })
   })
 
@@ -91,38 +111,44 @@ b@heroku.com  collaborator
         stubGet.teamFeatures([{ name: 'team-invite-acceptance', enabled: true }])
       })
 
-      it('shows all members including those with pending invites', () => {
+      it('shows all members including those with pending invites', async () => {
         let apiGetTeamInvites = stubGet.teamInvites()
 
         apiGetOrgMembers = stubGet.teamMembers([
           { email: 'a@heroku.com', role: 'admin' }, { email: 'b@heroku.com', role: 'collaborator' }
         ])
 
-        return cmd.run({ flags: { team: 'myteam' } })
-          .then(() => expect(
+        await cmd.run({ flags: { team: 'myteam' } })
+
+        expect(
             `a@heroku.com           admin
 b@heroku.com           collaborator
 invited-user@mail.com  admin         pending
-`).to.eq(cli.stdout))
-          .then(() => expect('').to.eq(cli.stderr))
-          .then(() => apiGetTeamInvites.done())
-          .then(() => apiGetOrgMembers.done())
+`).to.eq(cli.stdout);
+
+        expect('').to.eq(cli.stderr);
+        apiGetTeamInvites.done();
+
+        return apiGetOrgMembers.done()
       })
 
-      it('filters members by pending invites', () => {
+      it('filters members by pending invites', async () => {
         let apiGetTeamInvites = stubGet.teamInvites()
 
         apiGetOrgMembers = stubGet.teamMembers([
           { email: 'a@heroku.com', role: 'admin' }, { email: 'b@heroku.com', role: 'collaborator' }
         ])
 
-        return cmd.run({ flags: { team: 'myteam', pending: true } })
-          .then(() => expect(
+        await cmd.run({ flags: { team: 'myteam', pending: true } })
+
+        expect(
             `invited-user@mail.com  admin  pending
-`).to.eq(cli.stdout))
-          .then(() => expect('').to.eq(cli.stderr))
-          .then(() => apiGetTeamInvites.done())
-          .then(() => apiGetOrgMembers.done())
+`).to.eq(cli.stdout);
+
+        expect('').to.eq(cli.stderr);
+        apiGetTeamInvites.done();
+
+        return apiGetOrgMembers.done()
       })
     })
   })

--- a/packages/orgs-v5/test/commands/members/remove.js
+++ b/packages/orgs-v5/test/commands/members/remove.js
@@ -18,12 +18,15 @@ describe('heroku members:remove', () => {
       stubGet.teamInfo('enterprise')
     })
 
-    it('removes a member from an org', () => {
+    it('removes a member from an org', async () => {
       let apiRemoveMemberFromOrg = stubDelete.memberFromTeam()
-      return cmd.run({ flags: { team: 'myteam' }, args: { email: 'foo@foo.com' } })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Removing foo@foo.com from myteam... done\n`).to.eq(cli.stderr))
-        .then(() => apiRemoveMemberFromOrg.done())
+
+      await cmd.run({ flags: { team: 'myteam' }, args: { email: 'foo@foo.com' } })
+
+      expect('').to.eq(cli.stdout);
+      expect(`Removing foo@foo.com from myteam... done\n`).to.eq(cli.stderr);
+
+      return apiRemoveMemberFromOrg.done()
     })
   })
 
@@ -37,12 +40,15 @@ describe('heroku members:remove', () => {
         stubGet.teamFeatures([])
       })
 
-      it('removes a member from an org', () => {
+      it('removes a member from an org', async () => {
         let apiRemoveMemberFromOrg = stubDelete.memberFromTeam()
-        return cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myteam' } })
-          .then(() => expect('').to.eq(cli.stdout))
-          .then(() => expect(`Removing foo@foo.com from myteam... done\n`).to.eq(cli.stderr))
-          .then(() => apiRemoveMemberFromOrg.done())
+
+        await cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myteam' } })
+
+        expect('').to.eq(cli.stdout);
+        expect(`Removing foo@foo.com from myteam... done\n`).to.eq(cli.stderr);
+
+        return apiRemoveMemberFromOrg.done()
       })
     })
 
@@ -58,13 +64,16 @@ describe('heroku members:remove', () => {
           apiGetTeamInvites = stubGet.teamInvites([])
         })
 
-        it('removes a member', () => {
+        it('removes a member', async () => {
           let apiRemoveMemberFromOrg = stubDelete.memberFromTeam()
-          return cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myteam' } })
-            .then(() => expect('').to.eq(cli.stdout))
-            .then(() => expect(`Removing foo@foo.com from myteam... done\n`).to.eq(cli.stderr))
-            .then(() => apiGetTeamInvites.done())
-            .then(() => apiRemoveMemberFromOrg.done())
+
+          await cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myteam' } })
+
+          expect('').to.eq(cli.stdout);
+          expect(`Removing foo@foo.com from myteam... done\n`).to.eq(cli.stderr);
+          apiGetTeamInvites.done();
+
+          return apiRemoveMemberFromOrg.done()
         })
       })
 
@@ -75,14 +84,16 @@ describe('heroku members:remove', () => {
           ])
         })
 
-        it('revokes the invite', () => {
+        it('revokes the invite', async () => {
           let apiRevokeTeamInvite = stubDelete.teamInvite('foo@foo.com')
 
-          return cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myteam' } })
-            .then(() => expect('').to.eq(cli.stdout))
-            .then(() => expect(`Revoking invite for foo@foo.com in myteam... done\n`).to.eq(cli.stderr))
-            .then(() => apiGetTeamInvites.done())
-            .then(() => apiRevokeTeamInvite.done())
+          await cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myteam' } })
+
+          expect('').to.eq(cli.stdout);
+          expect(`Revoking invite for foo@foo.com in myteam... done\n`).to.eq(cli.stderr);
+          apiGetTeamInvites.done();
+
+          return apiRevokeTeamInvite.done()
         })
       })
     })

--- a/packages/orgs-v5/test/commands/members/set.js
+++ b/packages/orgs-v5/test/commands/members/set.js
@@ -24,41 +24,50 @@ describe('heroku members:set', () => {
       stubGet.teamInfo('team')
     })
 
-    it('does not warn the user when under the free org limit', () => {
+    it('does not warn the user when under the free org limit', async () => {
       stubGet.variableSizeTeamMembers(1)
       stubGet.variableSizeTeamInvites(0)
       apiUpdateMemberRole = stubPatch.updateMemberRole('foo@foo.com', 'admin')
 
-      return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Adding foo@foo.com to myteam as admin... done
-`).to.eq(cli.stderr))
-        .then(() => apiUpdateMemberRole.done())
+      await cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
+
+      expect('').to.eq(cli.stdout);
+
+      expect(`Adding foo@foo.com to myteam as admin... done
+`).to.eq(cli.stderr);
+
+      return apiUpdateMemberRole.done()
     })
 
-    it('does not warn the user when over the free org limit', () => {
+    it('does not warn the user when over the free org limit', async () => {
       stubGet.variableSizeTeamMembers(7)
       stubGet.variableSizeTeamInvites(0)
       apiUpdateMemberRole = stubPatch.updateMemberRole('foo@foo.com', 'admin')
 
-      return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Adding foo@foo.com to myteam as admin... done
-`).to.eq(cli.stderr))
-        .then(() => apiUpdateMemberRole.done())
+      await cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
+
+      expect('').to.eq(cli.stdout);
+
+      expect(`Adding foo@foo.com to myteam as admin... done
+`).to.eq(cli.stderr);
+
+      return apiUpdateMemberRole.done()
     })
 
-    it('does warn the user when at the free org limit', () => {
+    it('does warn the user when at the free org limit', async () => {
       stubGet.variableSizeTeamMembers(6)
       stubGet.variableSizeTeamInvites(0)
       apiUpdateMemberRole = stubPatch.updateMemberRole('foo@foo.com', 'admin')
 
-      return cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(unwrap(cli.stderr)).to.equal(`Adding foo@foo.com to myteam as admin... done \
+      await cmd.run({ args: { email: 'foo@foo.com' }, flags: { role: 'admin', team: 'myteam' } })
+
+      expect('').to.eq(cli.stdout);
+
+      expect(unwrap(cli.stderr)).to.equal(`Adding foo@foo.com to myteam as admin... done \
 You'll be billed monthly for teams over 5 members.
-`))
-        .then(() => apiUpdateMemberRole.done())
+`);
+
+      return apiUpdateMemberRole.done()
     })
   })
 
@@ -68,14 +77,17 @@ You'll be billed monthly for teams over 5 members.
       stubGet.variableSizeTeamMembers(1)
     })
 
-    it('adds a member to an org', () => {
+    it('adds a member to an org', async () => {
       apiUpdateMemberRole = stubPatch.updateMemberRole('foo@foo.com', 'admin')
 
-      return cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myteam', role: 'admin' } })
-        .then(() => expect('').to.eq(cli.stdout))
-        .then(() => expect(`Adding foo@foo.com to myteam as admin... done
-`).to.eq(cli.stderr))
-        .then(() => apiUpdateMemberRole.done())
+      await cmd.run({ args: { email: 'foo@foo.com' }, flags: { team: 'myteam', role: 'admin' } })
+
+      expect('').to.eq(cli.stdout);
+
+      expect(`Adding foo@foo.com to myteam as admin... done
+`).to.eq(cli.stderr);
+
+      return apiUpdateMemberRole.done()
     })
   })
 })

--- a/packages/orgs-v5/test/commands/orgs/default.js
+++ b/packages/orgs-v5/test/commands/orgs/default.js
@@ -8,12 +8,14 @@ describe('heroku orgs:default', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
-  it('shows a deprecation message', () => {
-    return cmd.run({})
-      .then(() => expect('').to.eq(cli.stdout))
-      .then(() => expect(unwrap(cli.stderr)).to.equal(`orgs:default is no longer in the CLI. \
+  it('shows a deprecation message', async () => {
+    await cmd.run({})
+
+    expect('').to.eq(cli.stdout);
+
+    return expect(unwrap(cli.stderr)).to.equal(`orgs:default is no longer in the CLI. \
 Use the HEROKU_ORGANIZATION environment variable instead. \
 See https://devcenter.heroku.com/articles/develop-orgs#default-org for more info.
-`))
+`)
   })
 })

--- a/packages/orgs-v5/test/commands/orgs/index.js
+++ b/packages/orgs-v5/test/commands/orgs/index.js
@@ -8,28 +8,34 @@ describe('heroku teams', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
-  it('shows Enterprise teams only when passing the --enterprise flag', () => {
+  it('shows Enterprise teams only when passing the --enterprise flag', async () => {
     let apiGetTeams = stubGet.teams()
 
-    return cmd.run({ flags: { enterprise: true } })
-      .then(() => expect(
+    await cmd.run({ flags: { enterprise: true } })
+
+    expect(
         `enterprise a  collaborator
-enterprise b  admin\n`).to.eq(cli.stdout))
-      .then(() => expect('').to.eq(cli.stderr))
-      .then(() => apiGetTeams.done())
+enterprise b  admin\n`).to.eq(cli.stdout);
+
+    expect('').to.eq(cli.stderr);
+
+    return apiGetTeams.done()
   })
 
-  it('shows teams', () => {
+  it('shows teams', async () => {
     let apiGetTeamsOnly = stubGet.teams([
       { name: 'enterprise a', role: 'collaborator', type: 'enterprise' },
       { name: 'enterprise b', role: 'admin', type: 'enterprise' }
     ])
 
-    return cmd.run({ flags: {} })
-      .then(() => expect(
+    await cmd.run({ flags: {} })
+
+    expect(
         `enterprise a  collaborator
-enterprise b  admin\n`).to.eq(cli.stdout))
-      .then(() => expect('').to.eq(cli.stderr))
-      .then(() => apiGetTeamsOnly.done())
+enterprise b  admin\n`).to.eq(cli.stdout);
+
+    expect('').to.eq(cli.stderr);
+
+    return apiGetTeamsOnly.done()
   })
 })

--- a/packages/orgs-v5/test/commands/teams/index.js
+++ b/packages/orgs-v5/test/commands/teams/index.js
@@ -8,17 +8,20 @@ describe('heroku teams', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
-  it('shows the teams you are a member of', () => {
+  it('shows the teams you are a member of', async () => {
     let apiGetOrgs = stubGet.teams()
 
-    return cmd.run({ flags: {} })
-      .then(() => expect(
+    await cmd.run({ flags: {} })
+
+    expect(
         `enterprise a  collaborator
 enterprise b  admin
 team a        collaborator
 team b        admin
-`).to.eq(cli.stdout))
-      .then(() => expect('').to.eq(cli.stderr))
-      .then(() => apiGetOrgs.done())
+`).to.eq(cli.stdout);
+
+    expect('').to.eq(cli.stderr);
+
+    return apiGetOrgs.done()
   })
 })

--- a/packages/pg-v5/test/commands/backups/cancel.js
+++ b/packages/pg-v5/test/commands/backups/cancel.js
@@ -27,9 +27,9 @@ const shouldCancel = function (cmdRun) {
       ])
     })
 
-    it('cancels backup', () => {
-      return cmdRun({ app: 'myapp', args: {} })
-        .then(() => expect(cli.stderr).to.equal('Cancelling b003... done\n'))
+    it('cancels backup', async () => {
+      await cmdRun({ app: 'myapp', args: {} })
+      return expect(cli.stderr).to.equal('Cancelling b003... done\n')
     })
   })
 
@@ -40,9 +40,9 @@ const shouldCancel = function (cmdRun) {
       })
     })
 
-    it('cancels backup', () => {
-      return cmdRun({ app: 'myapp', args: { backup_id: 'b003' } })
-        .then(() => expect(cli.stderr).to.equal('Cancelling b003... done\n'))
+    it('cancels backup', async () => {
+      await cmdRun({ app: 'myapp', args: { backup_id: 'b003' } })
+      return expect(cli.stderr).to.equal('Cancelling b003... done\n')
     })
   })
 }

--- a/packages/pg-v5/test/commands/backups/capture.js
+++ b/packages/pg-v5/test/commands/backups/capture.js
@@ -27,7 +27,7 @@ const shouldCapture = function (cmdRun) {
     api.done()
   })
 
-  it('captures a db', () => {
+  it('captures a db', async () => {
     addon.app.name = 'myapp'
     api = nock('https://api.heroku.com')
     api.post('/actions/addon-attachments/resolve', {
@@ -53,18 +53,21 @@ const shouldCapture = function (cmdRun) {
 
     cli.mockConsole()
 
-    return cmdRun({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`
+    await cmdRun({ app: 'myapp', args: {}, flags: {} })
+
+    expect(cli.stdout).to.equal(`
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue running.
 Use heroku pg:backups:info to check progress.
 Stop a running backup with heroku pg:backups:cancel.
 
-`))
-      .then(() => expect(cli.stderr, 'to match', new RegExp(`Starting backup of postgres-1... done\n${captureText()}`)))
-      .then(() => expect(cli.stderr, 'to match', new RegExp(`backups of large databases are likely to fail`)))
+`);
+
+    expect(cli.stderr, 'to match', new RegExp(`Starting backup of postgres-1... done\n${captureText()}`));
+
+    return expect(cli.stderr, 'to match', new RegExp(`backups of large databases are likely to fail`))
   })
 
-  it('captures a db (verbose)', () => {
+  it('captures a db (verbose)', async () => {
     addon.app.name = 'myapp'
     api = nock('https://api.heroku.com')
     api.post('/actions/addon-attachments/resolve', {
@@ -92,20 +95,24 @@ Stop a running backup with heroku pg:backups:cancel.
 
     cli.mockConsole()
 
-    return cmdRun({ app: 'myapp', args: {}, flags: { verbose: true } })
-      .then(() => expect(cli.stdout).to.equal(`
+    await cmdRun({ app: 'myapp', args: {}, flags: { verbose: true } })
+
+    expect(cli.stdout).to.equal(`
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue running.
 Use heroku pg:backups:info to check progress.
 Stop a running backup with heroku pg:backups:cancel.
 
 Backing up DATABASE to b005...
 100 log message 1
-`))
-      .then(() => expect(cli.stderr, 'to match', new RegExp(`Starting backup of postgres-1... done
-`))).then(() => expect(cli.stderr, 'not to match', new RegExp(`backups of large databases are likely to fail`)))
+`);
+
+    expect(cli.stderr, 'to match', new RegExp(`Starting backup of postgres-1... done
+`));
+
+    return expect(cli.stderr, 'not to match', new RegExp(`backups of large databases are likely to fail`))
   })
 
-  it('captures a db (verbose) with non billing app', () => {
+  it('captures a db (verbose) with non billing app', async () => {
     addon.app.name = 'mybillingapp'
     api = nock('https://api.heroku.com')
     api.post('/actions/addon-attachments/resolve', {
@@ -133,8 +140,9 @@ Backing up DATABASE to b005...
 
     cli.mockConsole()
 
-    return cmdRun({ app: 'myapp', args: {}, flags: { verbose: true } })
-      .then(() => expect(cli.stdout).to.equal(`
+    await cmdRun({ app: 'myapp', args: {}, flags: { verbose: true } })
+
+    expect(cli.stdout).to.equal(`
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue running.
 Use heroku pg:backups:info to check progress.
 Stop a running backup with heroku pg:backups:cancel.
@@ -144,12 +152,15 @@ Use heroku pg:backups -a mybillingapp to check the list of backups.
 
 Backing up DATABASE to b005...
 100 log message 1
-`))
-      .then(() => expect(cli.stderr, 'to match', new RegExp(`Starting backup of postgres-1... done
-`))).then(() => expect(cli.stderr, 'to match', new RegExp(`backups of large databases are likely to fail`)))
+`);
+
+    expect(cli.stderr, 'to match', new RegExp(`Starting backup of postgres-1... done
+`));
+
+    return expect(cli.stderr, 'to match', new RegExp(`backups of large databases are likely to fail`))
   })
 
-  it('captures a snapshot if called with the --snapshot flag', () => {
+  it('captures a snapshot if called with the --snapshot flag', async () => {
     addon.app.name = 'mybillingapp'
     api = nock('https://api.heroku.com')
     api.post('/actions/addon-attachments/resolve', {
@@ -163,9 +174,10 @@ Backing up DATABASE to b005...
 
     cli.mockConsole()
 
-    return cmdRun({ app: 'myapp', args: {}, flags: { snapshot: true } })
-      .then(() => expect(cli.stderr).to.equal(`Taking snapshot of postgres-1... done
-`))
+    await cmdRun({ app: 'myapp', args: {}, flags: { snapshot: true } })
+
+    return expect(cli.stderr).to.equal(`Taking snapshot of postgres-1... done
+`)
   })
 }
 

--- a/packages/pg-v5/test/commands/backups/delete.js
+++ b/packages/pg-v5/test/commands/backups/delete.js
@@ -22,9 +22,9 @@ const shouldDelete = function (cmdRun) {
     pg.done()
   })
 
-  it('shows URL', () => {
-    return cmd.run({ app: 'myapp', args: { backup_id: 'b003' }, flags: { confirm: 'myapp' } })
-      .then(() => expect(cli.stderr).to.equal('Deleting backup b003 on myapp... done\n'))
+  it('shows URL', async () => {
+    await cmd.run({ app: 'myapp', args: { backup_id: 'b003' }, flags: { confirm: 'myapp' } })
+    return expect(cli.stderr).to.equal('Deleting backup b003 on myapp... done\n')
   })
 }
 

--- a/packages/pg-v5/test/commands/backups/download.js
+++ b/packages/pg-v5/test/commands/backups/download.js
@@ -30,16 +30,16 @@ describe('pg:backups:download', () => {
         { succeeded: true, to_type: 'gof3r', num: 3 }
       ])
     })
-    it('downloads to latest.dump', () => {
-      return cmd.run({ app: 'myapp', args: {}, flags: { output: './tmp/latest.dump' } })
-        .then(() => expect(fs.readFileSync('./tmp/latest.dump', 'utf8')).to.equal('{}'))
+    it('downloads to latest.dump', async () => {
+      await cmd.run({ app: 'myapp', args: {}, flags: { output: './tmp/latest.dump' } })
+      return expect(fs.readFileSync('./tmp/latest.dump', 'utf8')).to.equal('{}')
     })
   })
 
   context('with id', () => {
-    it('downloads to latest.dump', () => {
-      return cmd.run({ app: 'myapp', args: { backup_id: 'b003' }, flags: { output: './tmp/latest.dump' } })
-        .then(() => expect(fs.readFileSync('./tmp/latest.dump', 'utf8')).to.equal('{}'))
+    it('downloads to latest.dump', async () => {
+      await cmd.run({ app: 'myapp', args: { backup_id: 'b003' }, flags: { output: './tmp/latest.dump' } })
+      return expect(fs.readFileSync('./tmp/latest.dump', 'utf8')).to.equal('{}')
     })
   })
 })

--- a/packages/pg-v5/test/commands/backups/index.js
+++ b/packages/pg-v5/test/commands/backups/index.js
@@ -25,9 +25,10 @@ describe('pg:backups', () => {
       transfers = []
     })
 
-    it('shows empty message', () => {
-      return cmd.run({ app: 'myapp', args: [] })
-        .then(() => expect(cli.stdout).to.equal(`=== Backups
+    it('shows empty message', async () => {
+      await cmd.run({ app: 'myapp', args: [] })
+
+      return expect(cli.stdout).to.equal(`=== Backups
 No backups. Capture one with heroku pg:backups:capture
 
 === Restores
@@ -36,7 +37,7 @@ No restores found. Use heroku pg:backups:restore to restore a backup
 === Copies
 No copies found. Use heroku pg:copy to copy a database to another
 
-`))
+`)
     })
   })
 
@@ -96,9 +97,10 @@ No copies found. Use heroku pg:copy to copy a database to another
       ]
     })
 
-    it('shows backups', () => {
-      return cmd.run({ app: 'myapp', args: [] })
-        .then(() => expect(cli.stdout).to.equal(`=== Backups
+    it('shows backups', async () => {
+      await cmd.run({ app: 'myapp', args: [] })
+
+      return expect(cli.stdout).to.equal(`=== Backups
 ID    Created at                 Status                               Size    Database
 ────  ─────────────────────────  ───────────────────────────────────  ──────  ────────
 b006  2016-10-08 00:42:54 +0000  Running (processed 1.40KB)           1.40KB  DATABASE
@@ -113,7 +115,7 @@ No restores found. Use heroku pg:backups:restore to restore a backup
 === Copies
 No copies found. Use heroku pg:copy to copy a database to another
 
-`))
+`)
     })
   })
 
@@ -134,9 +136,10 @@ No copies found. Use heroku pg:copy to copy a database to another
       ]
     })
 
-    it('shows restore', () => {
-      return cmd.run({ app: 'myapp', args: [] })
-        .then(() => expect(cli.stdout).to.equal(`=== Backups
+    it('shows restore', async () => {
+      await cmd.run({ app: 'myapp', args: [] })
+
+      return expect(cli.stdout).to.equal(`=== Backups
 No backups. Capture one with heroku pg:backups:capture
 
 === Restores
@@ -147,7 +150,7 @@ r003  2016-10-08 00:42:54 +0000  Completed 2016-10-08 00:43:00 +0000  1.40KB  IV
 === Copies
 No copies found. Use heroku pg:copy to copy a database to another
 
-`))
+`)
     })
   })
 
@@ -170,9 +173,10 @@ No copies found. Use heroku pg:copy to copy a database to another
       ]
     })
 
-    it('shows copy', () => {
-      return cmd.run({ app: 'myapp', args: [] })
-        .then(() => expect(cli.stdout).to.equal(`=== Backups
+    it('shows copy', async () => {
+      await cmd.run({ app: 'myapp', args: [] })
+
+      return expect(cli.stdout).to.equal(`=== Backups
 No backups. Capture one with heroku pg:backups:capture
 
 === Restores
@@ -183,7 +187,7 @@ ID    Started at                 Status                               Size    Fr
 ────  ─────────────────────────  ───────────────────────────────────  ──────  ────  ─────
 c003  2016-10-08 00:42:54 +0000  Completed 2016-10-08 00:43:00 +0000  1.40KB  RED   IVORY
 
-`))
+`)
     })
   })
 })

--- a/packages/pg-v5/test/commands/backups/info.js
+++ b/packages/pg-v5/test/commands/backups/info.js
@@ -41,9 +41,10 @@ const shouldInfo = function (cmdRun) {
       })
     })
 
-    it('shows the backup', () => {
-      return cmdRun({ app: 'myapp', args: { backup_id: 'b003' } })
-        .then(() => expect(cli.stdout).to.equal(`=== Backup b003
+    it('shows the backup', async () => {
+      await cmdRun({ app: 'myapp', args: { backup_id: 'b003' } })
+
+      return expect(cli.stdout).to.equal(`=== Backup b003
 Database:         RED
 Status:           Pending
 Type:             Manual
@@ -53,7 +54,7 @@ Backup Size:      97.66KB
 === Backup Logs
 100 foo
 
-`))
+`)
     })
   })
 
@@ -73,9 +74,10 @@ Backup Size:      97.66KB
       })
     })
 
-    it('shows the backup', () => {
-      return cmdRun({ app: 'myapp', args: { backup_id: 'ob001' } })
-        .then(() => expect(cli.stdout).to.equal(`=== Backup ob001
+    it('shows the backup', async () => {
+      await cmdRun({ app: 'myapp', args: { backup_id: 'ob001' } })
+
+      return expect(cli.stdout).to.equal(`=== Backup ob001
 Database:         RED
 Status:           Pending
 Type:             Manual
@@ -85,7 +87,7 @@ Backup Size:      97.66KB
 === Backup Logs
 100 foo
 
-`))
+`)
     })
   })
 
@@ -105,9 +107,10 @@ Backup Size:      97.66KB
       })
     })
 
-    it('shows the latest backup', () => {
-      return cmdRun({ app: 'myapp', args: {} })
-        .then(() => expect(cli.stdout).to.equal(`=== Backup b003
+    it('shows the latest backup', async () => {
+      await cmdRun({ app: 'myapp', args: {} })
+
+      return expect(cli.stdout).to.equal(`=== Backup b003
 Database:         RED
 Finished at:      100
 Status:           Completed
@@ -118,7 +121,7 @@ Backup Size:      97.66KB (90% compression)
 === Backup Logs
 100 foo
 
-`))
+`)
     })
   })
 }

--- a/packages/pg-v5/test/commands/backups/restore.js
+++ b/packages/pg-v5/test/commands/backups/restore.js
@@ -51,37 +51,43 @@ const shouldRestore = function (cmdRun) {
       })
     })
 
-    it('restores a db', () => {
-      return cmdRun({ app: 'myapp', args: {}, flags: { confirm: 'myapp' } })
-        .then(() => expect(cli.stdout).to.equal(`
+    it('restores a db', async () => {
+      await cmdRun({ app: 'myapp', args: {}, flags: { confirm: 'myapp' } })
+
+      expect(cli.stdout).to.equal(`
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue restoring.
 Use heroku pg:backups to check progress.
 Stop a running restore with heroku pg:backups:cancel.
 
-`))
-        .then(() => expect(cli.stderr).to.equal(`Starting restore of b005 to postgres-1... done\n${restoringText()}`))
+`);
+
+      return expect(cli.stderr).to.equal(`Starting restore of b005 to postgres-1... done\n${restoringText()}`)
     })
 
-    it('restores a specific db', () => {
-      return cmdRun({ app: 'myapp', args: { backup: 'b005' }, flags: { confirm: 'myapp' } })
-        .then(() => expect(cli.stdout).to.equal(`
+    it('restores a specific db', async () => {
+      await cmdRun({ app: 'myapp', args: { backup: 'b005' }, flags: { confirm: 'myapp' } })
+
+      expect(cli.stdout).to.equal(`
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue restoring.
 Use heroku pg:backups to check progress.
 Stop a running restore with heroku pg:backups:cancel.
 
-`))
-        .then(() => expect(cli.stderr).to.equal(`Starting restore of b005 to postgres-1... done\n${restoringText()}`))
+`);
+
+      return expect(cli.stderr).to.equal(`Starting restore of b005 to postgres-1... done\n${restoringText()}`)
     })
 
-    it('restores a specific app db', () => {
-      return cmdRun({ app: 'myapp', args: { backup: 'myapp::b005' }, flags: { confirm: 'myapp' } })
-        .then(() => expect(cli.stdout).to.equal(`
+    it('restores a specific app db', async () => {
+      await cmdRun({ app: 'myapp', args: { backup: 'myapp::b005' }, flags: { confirm: 'myapp' } })
+
+      expect(cli.stdout).to.equal(`
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue restoring.
 Use heroku pg:backups to check progress.
 Stop a running restore with heroku pg:backups:cancel.
 
-`))
-        .then(() => expect(cli.stderr).to.equal(`Starting restore of b005 to postgres-1... done\n${restoringText()}`))
+`);
+
+      return expect(cli.stderr).to.equal(`Starting restore of b005 to postgres-1... done\n${restoringText()}`)
     })
   })
 
@@ -102,17 +108,19 @@ Stop a running restore with heroku pg:backups:cancel.
       })
     })
 
-    it('shows verbose output', () => {
-      return cmdRun({ app: 'myapp', args: {}, flags: { confirm: 'myapp', verbose: true } })
-        .then(() => expect(cli.stdout).to.equal(`
+    it('shows verbose output', async () => {
+      await cmdRun({ app: 'myapp', args: {}, flags: { confirm: 'myapp', verbose: true } })
+
+      expect(cli.stdout).to.equal(`
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue restoring.
 Use heroku pg:backups to check progress.
 Stop a running restore with heroku pg:backups:cancel.
 
 Restoring...
 100 log message 1
-`))
-        .then(() => expect(cli.stderr).to.equal('Starting restore of b005 to postgres-1... done\n'))
+`);
+
+      return expect(cli.stderr).to.equal('Starting restore of b005 to postgres-1... done\n')
     })
   })
 
@@ -129,15 +137,17 @@ Restoring...
       })
     })
 
-    it('restores a db from a URL', () => {
-      return cmdRun({ app: 'myapp', args: { backup: 'https://www.dropbox.com' }, flags: { confirm: 'myapp' } })
-        .then(() => expect(cli.stdout).to.equal(`
+    it('restores a db from a URL', async () => {
+      await cmdRun({ app: 'myapp', args: { backup: 'https://www.dropbox.com' }, flags: { confirm: 'myapp' } })
+
+      expect(cli.stdout).to.equal(`
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue restoring.
 Use heroku pg:backups to check progress.
 Stop a running restore with heroku pg:backups:cancel.
 
-`))
-        .then(() => expect(cli.stderr).to.equal(`Starting restore of https://www.dropbox.com to postgres-1... done\n${restoringText()}`))
+`);
+
+      return expect(cli.stderr).to.equal(`Starting restore of https://www.dropbox.com to postgres-1... done\n${restoringText()}`)
     })
   })
 }

--- a/packages/pg-v5/test/commands/backups/schedules.js
+++ b/packages/pg-v5/test/commands/backups/schedules.js
@@ -38,25 +38,24 @@ const shouldSchedules = function (cmdRun) {
       ])
     })
 
-    it('shows empty message with no schedules', () => {
+    it('shows empty message with no schedules', async () => {
       pg.get('/client/v11/databases/1/transfer-schedules').reply(200, [])
-      return cmd.run({ app: 'myapp' }).then(() => {
-        expect(cli.stderr).to.contain('No backup schedules found on myapp\n')
+      await cmd.run({ app: 'myapp' })
+      expect(cli.stderr).to.contain('No backup schedules found on myapp\n')
 
-        expect(cli.stderr).to.contain('Use heroku pg:backups:schedule to set one up\n')
-      })
+      expect(cli.stderr).to.contain('Use heroku pg:backups:schedule to set one up\n')
     })
 
-    it('shows schedule', () => {
+    it('shows schedule', async () => {
       pg.get('/client/v11/databases/1/transfer-schedules').reply(200, [
         { name: 'DATABASE_URL', hour: 5, timezone: 'UTC' }
       ])
-      return cmdRun({ app: 'myapp' }).then(() =>
-        expect(cli.stdout).to.equal(
-          `=== Backup Schedules
+      await cmdRun({ app: 'myapp' })
+
+      return expect(cli.stdout).to.equal(
+        `=== Backup Schedules
 DATABASE_URL: daily at 5:00 UTC
 `
-        )
       )
     })
   })

--- a/packages/pg-v5/test/commands/backups/unschedule.js
+++ b/packages/pg-v5/test/commands/backups/unschedule.js
@@ -38,10 +38,12 @@ const shouldUnschedule = function (cmdRun) {
     pg.done()
   })
 
-  it('unschedules a backup', () => {
-    return cmdRun({ app: 'myapp', args: {}, flags: { at: '06:00 EDT' } })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('Unscheduling DATABASE_URL daily backups... done\n'))
+  it('unschedules a backup', async () => {
+    await cmdRun({ app: 'myapp', args: {}, flags: { at: '06:00 EDT' } })
+
+    expect(cli.stdout).to.equal('');
+
+    return expect(cli.stderr).to.equal('Unscheduling DATABASE_URL daily backups... done\n')
   })
 }
 

--- a/packages/pg-v5/test/commands/backups/url.js
+++ b/packages/pg-v5/test/commands/backups/url.js
@@ -28,16 +28,16 @@ const shouldUrl = function (cmdRun) {
         { succeeded: true, to_type: 'gof3r', num: 3 }
       ])
     })
-    it('shows URL', () => {
-      return cmdRun({ app: 'myapp', args: {} })
-        .then(() => expect(cli.stdout).to.equal('https://dburl\n'))
+    it('shows URL', async () => {
+      await cmdRun({ app: 'myapp', args: {} })
+      return expect(cli.stdout).to.equal('https://dburl\n')
     })
   })
 
   context('with id', () => {
-    it('shows URL', () => {
-      return cmdRun({ app: 'myapp', args: { backup_id: 'b003' } })
-        .then(() => expect(cli.stdout).to.equal('https://dburl\n'))
+    it('shows URL', async () => {
+      await cmdRun({ app: 'myapp', args: { backup_id: 'b003' } })
+      return expect(cli.stdout).to.equal('https://dburl\n')
     })
   })
 }

--- a/packages/pg-v5/test/commands/connection_pooling.js
+++ b/packages/pg-v5/test/commands/connection_pooling.js
@@ -61,11 +61,13 @@ describe('pg:connection-polling:attach', () => {
       }).reply(201, { name: attachmentName })
     })
 
-    it('attaches pgbouncer with attachment name', () => {
-      return cmd.run({ app: 'myapp', args: { database: 'postgres-1' }, flags: { as: attachmentName } })
-        .then(() => expect(cli.stdout).to.equal(``))
-        .then(() => expect(cli.stderr).to.contain('Enabling Connection Pooling on'))
-        .then(() => expect(cli.stderr).to.contain(`Setting ${attachmentName} config vars and restarting myapp... done, v0\n`))
+    it('attaches pgbouncer with attachment name', async () => {
+      await cmd.run({ app: 'myapp', args: { database: 'postgres-1' }, flags: { as: attachmentName } })
+
+      expect(cli.stdout).to.equal(``);
+      expect(cli.stderr).to.contain('Enabling Connection Pooling on');
+
+      return expect(cli.stderr).to.contain(`Setting ${attachmentName} config vars and restarting myapp... done, v0\n`)
     })
   })
 
@@ -77,11 +79,13 @@ describe('pg:connection-polling:attach', () => {
       }).reply(201, { name: 'HEROKU_COLOR' })
     })
 
-    it('attaches pgbouncer with default credential', () => {
-      return cmd.run({ app: 'myapp', args: { database: 'postgres-1' }, flags: {} })
-        .then(() => expect(cli.stdout).to.equal(``))
-        .then(() => expect(cli.stderr).to.contain('Enabling Connection Pooling on'))
-        .then(() => expect(cli.stderr).to.contain('Setting HEROKU_COLOR config vars and restarting myapp... done, v0\n'))
+    it('attaches pgbouncer with default credential', async () => {
+      await cmd.run({ app: 'myapp', args: { database: 'postgres-1' }, flags: {} })
+
+      expect(cli.stdout).to.equal(``);
+      expect(cli.stderr).to.contain('Enabling Connection Pooling on');
+
+      return expect(cli.stderr).to.contain('Setting HEROKU_COLOR config vars and restarting myapp... done, v0\n')
     })
   })
 })

--- a/packages/pg-v5/test/commands/copy.js
+++ b/packages/pg-v5/test/commands/copy.js
@@ -116,16 +116,20 @@ describe('pg:copy', () => {
       pg.get('/client/v11/apps/myapp/transfers/100-001').reply(200, { finished_at: '100', succeeded: true })
     })
 
-    it('copies', () => {
-      return cmd.run({ app: 'myapp', args: { source: 'postgres://foo.com/bar', target: 'HEROKU_POSTGRESQL_RED_URL' }, flags: { confirm: 'myapp' } })
-        .then(() => expect(cli.stdout).to.equal(''))
-        .then(() => expect(cli.stderr).to.equal(`Starting copy of database bar on foo.com:5432 to RED... done\n${copyingText()}`))
+    it('copies', async () => {
+      await cmd.run({ app: 'myapp', args: { source: 'postgres://foo.com/bar', target: 'HEROKU_POSTGRESQL_RED_URL' }, flags: { confirm: 'myapp' } })
+
+      expect(cli.stdout).to.equal('');
+
+      return expect(cli.stderr).to.equal(`Starting copy of database bar on foo.com:5432 to RED... done\n${copyingText()}`)
     })
 
-    it('copies (with port number)', () => {
-      return cmd.run({ app: 'myapp', args: { source: 'postgres://boop.com:5678/bar', target: 'HEROKU_POSTGRESQL_RED_URL' }, flags: { confirm: 'myapp' } })
-        .then(() => expect(cli.stdout).to.equal(''))
-        .then(() => expect(cli.stderr).to.equal(`Starting copy of database bar on boop.com:5678 to RED... done\n${copyingText()}`))
+    it('copies (with port number)', async () => {
+      await cmd.run({ app: 'myapp', args: { source: 'postgres://boop.com:5678/bar', target: 'HEROKU_POSTGRESQL_RED_URL' }, flags: { confirm: 'myapp' } })
+
+      expect(cli.stdout).to.equal('');
+
+      return expect(cli.stderr).to.equal(`Starting copy of database bar on boop.com:5678 to RED... done\n${copyingText()}`)
     })
   })
 
@@ -154,10 +158,12 @@ describe('pg:copy', () => {
       }).reply(200, { uuid: '100-001' })
       pg.get('/client/v11/apps/myotherapp/transfers/100-001').reply(200, { finished_at: '100', succeeded: true })
     })
-    it('copies', () => {
-      return cmd.run({ app: 'myapp', args: { source: 'HEROKU_POSTGRESQL_RED_URL', target: 'myotherapp::DATABASE_URL' }, flags: { confirm: 'myapp' } })
-        .then(() => expect(cli.stdout).to.equal(''))
-        .then(() => expect(unwrap(cli.stderr)).to.equal(`Starting copy of RED to BLUE... done ${credentialWarningText()}${copyingText()}`))
+    it('copies', async () => {
+      await cmd.run({ app: 'myapp', args: { source: 'HEROKU_POSTGRESQL_RED_URL', target: 'myotherapp::DATABASE_URL' }, flags: { confirm: 'myapp' } })
+
+      expect(cli.stdout).to.equal('');
+
+      return expect(unwrap(cli.stderr)).to.equal(`Starting copy of RED to BLUE... done ${credentialWarningText()}${copyingText()}`)
     })
   })
 
@@ -185,10 +191,12 @@ describe('pg:copy', () => {
       }).reply(200, { uuid: '100-001' })
       pg.get('/client/v11/apps/myotherapp/transfers/100-001').reply(200, { finished_at: '100', succeeded: true })
     })
-    it('copies', () => {
-      return cmd.run({ app: 'myapp', args: { source: 'HEROKU_POSTGRESQL_RED_URL', target: 'ATTACHED_BLUE' }, flags: { confirm: 'myapp' } })
-        .then(() => expect(cli.stdout).to.equal(''))
-        .then(() => expect(cli.stderr).to.equal(`Starting copy of RED to ATTACHED_BLUE... done\n${copyingText()}`))
+    it('copies', async () => {
+      await cmd.run({ app: 'myapp', args: { source: 'HEROKU_POSTGRESQL_RED_URL', target: 'ATTACHED_BLUE' }, flags: { confirm: 'myapp' } })
+
+      expect(cli.stdout).to.equal('');
+
+      return expect(cli.stderr).to.equal(`Starting copy of RED to ATTACHED_BLUE... done\n${copyingText()}`)
     })
   })
 
@@ -217,10 +225,12 @@ describe('pg:copy', () => {
       }).reply(200, { uuid: '100-001' })
       pg.get('/client/v11/apps/myotherapp/transfers/100-001').reply(200, { finished_at: '100', succeeded: true })
     })
-    it('copies', () => {
-      return cmd.run({ app: 'mylowercaseapp', args: { source: 'lowercase_database_URL', target: 'myotherapp::DATABASE_URL' }, flags: { confirm: 'mylowercaseapp' } })
-        .then(() => expect(cli.stdout).to.equal(''))
-        .then(() => expect(unwrap(cli.stderr)).to.equal(`Starting copy of lowercase_database to BLUE... done\n${copyingText()}`))
+    it('copies', async () => {
+      await cmd.run({ app: 'mylowercaseapp', args: { source: 'lowercase_database_URL', target: 'myotherapp::DATABASE_URL' }, flags: { confirm: 'mylowercaseapp' } })
+
+      expect(cli.stdout).to.equal('');
+
+      return expect(unwrap(cli.stderr)).to.equal(`Starting copy of lowercase_database to BLUE... done\n${copyingText()}`)
     })
   })
 
@@ -243,11 +253,14 @@ describe('pg:copy', () => {
       pg.get('/client/v11/apps/myapp/transfers/100-001?verbose=true').reply(200, { finished_at: '100', succeeded: false, num: 1, logs: [{ message: 'foobar' }] })
     })
 
-    it('fails to copy', () => {
+    it('fails to copy', async () => {
       let err = 'An error occurred and the backup did not finish.\n\nfoobar\n\nRun heroku pg:backups:info b001 for more details.'
-      return expect(cmd.run({ app: 'myapp', args: { source: 'postgres://foo.com/bar', target: 'HEROKU_POSTGRESQL_RED_URL' }, flags: { confirm: 'myapp' } })).to.be.rejectedWith(Error, err)
-        .then(() => expect(cli.stdout).to.equal(''))
-        .then(() => expect(cli.stderr).to.equal(`Starting copy of database bar on foo.com:5432 to RED... done\n${copyingFailText()}`))
+
+      await expect(cmd.run({ app: 'myapp', args: { source: 'postgres://foo.com/bar', target: 'HEROKU_POSTGRESQL_RED_URL' }, flags: { confirm: 'myapp' } })).to.be.rejectedWith(Error, err)
+
+      expect(cli.stdout).to.equal('');
+
+      return expect(cli.stderr).to.equal(`Starting copy of database bar on foo.com:5432 to RED... done\n${copyingFailText()}`)
     })
   })
 })

--- a/packages/pg-v5/test/commands/credentials.js
+++ b/packages/pg-v5/test/commands/credentials.js
@@ -45,7 +45,7 @@ describe('pg:credentials', () => {
     api.done()
   })
 
-  it('shows the correct credentials', () => {
+  it('shows the correct credentials', async () => {
     let credentials = [
       { uuid: 'aaaa',
         name: 'ransom',
@@ -119,11 +119,11 @@ ransom                                                                         a
  └─ as HEROKU_POSTGRESQL_BLUE on yet-another-app app
 `
 
-    return cmd.run({ app: 'myapp', args: {}, flags: { name: 'jeff' } })
-      .then(() => expect(cli.stdout).to.equal(displayed))
+    await cmd.run({ app: 'myapp', args: {}, flags: { name: 'jeff' } })
+    return expect(cli.stdout).to.equal(displayed)
   })
 
-  it('shows the correct rotation information if no connection information is available yet', () => {
+  it('shows the correct rotation information if no connection information is available yet', async () => {
     let credentials = [
       { uuid: 'aaaa',
         name: 'ransom',
@@ -192,7 +192,7 @@ ransom                                                active
  └─ as HEROKU_POSTGRESQL_BLUE on yet-another-app app
 `
 
-    return cmd.run({ app: 'myapp', args: {}, flags: { name: 'jeff' } })
-      .then(() => expect(cli.stdout).to.equal(displayed))
+    await cmd.run({ app: 'myapp', args: {}, flags: { name: 'jeff' } })
+    return expect(cli.stdout).to.equal(displayed)
   })
 })

--- a/packages/pg-v5/test/commands/credentials/create.js
+++ b/packages/pg-v5/test/commands/credentials/create.js
@@ -44,14 +44,17 @@ describe('pg:credentials:create', () => {
     api.done()
   })
 
-  it('creates the credential', () => {
+  it('creates the credential', async () => {
     pg.post('/postgres/v0/databases/postgres-1/credentials').reply(200)
-    return cmd.run({ app: 'myapp', args: {}, flags: { name: 'credname' } })
-      .then(() => expect(cli.stdout).to.equal(`
+
+    await cmd.run({ app: 'myapp', args: {}, flags: { name: 'credname' } })
+
+    expect(cli.stdout).to.equal(`
 Please attach the credential to the apps you want to use it in by running heroku addons:attach postgres-1 --credential credname -a myapp.
 Please define the new grants for the credential within Postgres: heroku pg:psql postgres-1 -a myapp.
-`))
-      .then(() => expect(cli.stderr).to.equal('Creating credential credname... done\n'))
+`);
+
+    return expect(cli.stderr).to.equal('Creating credential credname... done\n')
   })
 
   it('throws an error when the db is starter plan', () => {

--- a/packages/pg-v5/test/commands/credentials/destroy.js
+++ b/packages/pg-v5/test/commands/credentials/destroy.js
@@ -44,7 +44,7 @@ describe('pg:credentials:destroy', () => {
     api.done()
   })
 
-  it('destroys the credential', () => {
+  it('destroys the credential', async () => {
     pg.delete('/postgres/v0/databases/postgres-1/credentials/credname').reply(200)
     let attachments = [
       {
@@ -54,11 +54,14 @@ describe('pg:credentials:destroy', () => {
       }
     ]
     api.get('/addons/postgres-1/addon-attachments').reply(200, attachments)
-    return cmd.run({ app: 'myapp', args: {}, flags: { name: 'credname', confirm: 'myapp' } })
-      .then(() => expect(cli.stderr).to.equal('Destroying credential credname... done\n'))
-      .then(() => expect(cli.stdout).to.equal(`The credential has been destroyed within postgres-1.
+
+    await cmd.run({ app: 'myapp', args: {}, flags: { name: 'credname', confirm: 'myapp' } })
+
+    expect(cli.stderr).to.equal('Destroying credential credname... done\n');
+
+    return expect(cli.stdout).to.equal(`The credential has been destroyed within postgres-1.
 Database objects owned by credname will be assigned to the default credential.
-`))
+`)
   })
 
   it('throws an error when the db is starter plan', () => {

--- a/packages/pg-v5/test/commands/credentials/repair_default.js
+++ b/packages/pg-v5/test/commands/credentials/repair_default.js
@@ -44,11 +44,14 @@ describe('pg:credentials:repair-default', () => {
     api.done()
   })
 
-  it('resets the credential permissions', () => {
+  it('resets the credential permissions', async () => {
     pg.post('/postgres/v0/databases/postgres-1/repair-default').reply(200)
-    return cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp' } })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('Resetting permissions and object ownership for default role to factory settings... done\n'))
+
+    await cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp' } })
+
+    expect(cli.stdout).to.equal('');
+
+    return expect(cli.stderr).to.equal('Resetting permissions and object ownership for default role to factory settings... done\n')
   })
 
   it('throws an error when the db is starter plan', () => {

--- a/packages/pg-v5/test/commands/credentials/rotate.js
+++ b/packages/pg-v5/test/commands/credentials/rotate.js
@@ -74,25 +74,34 @@ describe('pg:credentials:rotate', () => {
     api.done()
   })
 
-  it('rotates credentials for a specific role with --name', () => {
+  it('rotates credentials for a specific role with --name', async () => {
     pg.post('/postgres/v0/databases/postgres-1/credentials/my_role/credentials_rotation').reply(200)
-    return cmd.run({ app: 'myapp', args: {}, flags: { name: 'my_role', confirm: 'myapp' } })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('Rotating my_role on postgres-1... done\n'))
+
+    await cmd.run({ app: 'myapp', args: {}, flags: { name: 'my_role', confirm: 'myapp' } })
+
+    expect(cli.stdout).to.equal('');
+
+    return expect(cli.stderr).to.equal('Rotating my_role on postgres-1... done\n')
   })
 
-  it('rotates credentials for all roles with --all', () => {
+  it('rotates credentials for all roles with --all', async () => {
     pg.post('/postgres/v0/databases/postgres-1/credentials_rotation').reply(200)
-    return cmd.run({ app: 'myapp', args: {}, flags: { all: true, confirm: 'myapp' } })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('Rotating all credentials on postgres-1... done\n'))
+
+    await cmd.run({ app: 'myapp', args: {}, flags: { all: true, confirm: 'myapp' } })
+
+    expect(cli.stdout).to.equal('');
+
+    return expect(cli.stderr).to.equal('Rotating all credentials on postgres-1... done\n')
   })
 
-  it('rotates credentials for a specific role with --name and --force', () => {
+  it('rotates credentials for a specific role with --name and --force', async () => {
     pg.post('/postgres/v0/databases/postgres-1/credentials/my_role/credentials_rotation').reply(200)
-    return cmd.run({ app: 'myapp', args: {}, flags: { name: 'my_role', confirm: 'myapp', force: true } })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('Rotating my_role on postgres-1... done\n'))
+
+    await cmd.run({ app: 'myapp', args: {}, flags: { name: 'my_role', confirm: 'myapp', force: true } })
+
+    expect(cli.stdout).to.equal('');
+
+    return expect(cli.stderr).to.equal('Rotating my_role on postgres-1... done\n')
   })
 
   it('fails with an error if both --all and --name are included', () => {
@@ -121,7 +130,7 @@ describe('pg:credentials:rotate', () => {
     return expect(cmd.run({ app: 'myapp', args: {}, flags: { name: 'jeff' } })).to.be.rejectedWith(Error, err)
   })
 
-  it('rotates credentials with no --name with starter plan', () => {
+  it('rotates credentials with no --name with starter plan', async () => {
     const hobbyAddon = {
       name: 'postgres-1',
       plan: { name: 'heroku-postgresql:hobby-dev' }
@@ -139,12 +148,15 @@ describe('pg:credentials:rotate', () => {
     })
 
     starter.post('/postgres/v0/databases/postgres-1/credentials/default/credentials_rotation').reply(200)
-    return cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp' } })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('Rotating default on postgres-1... done\n'))
+
+    await cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp' } })
+
+    expect(cli.stdout).to.equal('');
+
+    return expect(cli.stderr).to.equal('Rotating default on postgres-1... done\n')
   })
 
-  it('rotates credentials with --all with starter plan', () => {
+  it('rotates credentials with --all with starter plan', async () => {
     const hobbyAddon = {
       name: 'postgres-1',
       plan: { name: 'heroku-postgresql:hobby-dev' }
@@ -162,29 +174,31 @@ describe('pg:credentials:rotate', () => {
     })
 
     starter.post('/postgres/v0/databases/postgres-1/credentials_rotation').reply(200)
-    return cmd.run({ app: 'myapp', args: {}, flags: { all: true, confirm: 'myapp' } })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('Rotating all credentials on postgres-1... done\n'))
+
+    await cmd.run({ app: 'myapp', args: {}, flags: { all: true, confirm: 'myapp' } })
+
+    expect(cli.stdout).to.equal('');
+
+    return expect(cli.stderr).to.equal('Rotating all credentials on postgres-1... done\n')
   })
 
-  it('requires app confirmation for rotating all roles with --all', () => {
+  it('requires app confirmation for rotating all roles with --all', async () => {
     pg.post('/postgres/v0/databases/postgres-1/credentials_rotation').reply(200)
 
     const message = `WARNING: Destructive Action
 Connections will be reset and applications will be restarted.
 This command will affect the apps appname_1, appname_2, appname_3.`
 
-    return cmd.run({ app: 'myapp',
+    await cmd.run({ app: 'myapp',
       args: {},
       flags: { all: true, confirm: 'myapp' } })
-      .then(() => {
-        expect(lastApp).to.equal('myapp')
-        expect(lastConfirm).to.equal('myapp')
-        expect(lastMsg).to.equal(message)
-      })
+
+    expect(lastApp).to.equal('myapp')
+    expect(lastConfirm).to.equal('myapp')
+    expect(lastMsg).to.equal(message)
   })
 
-  it('requires app confirmation for rotating all roles with --all and --force', () => {
+  it('requires app confirmation for rotating all roles with --all and --force', async () => {
     pg.post('/postgres/v0/databases/postgres-1/credentials_rotation').reply(200)
 
     const message = `WARNING: Destructive Action
@@ -193,17 +207,16 @@ Connections will be reset and applications will be restarted.
 Any followers lagging in replication (see heroku pg:info) will be inaccessible until caught up.
 This command will affect the apps appname_1, appname_2, appname_3.`
 
-    return cmd.run({ app: 'myapp',
+    await cmd.run({ app: 'myapp',
       args: {},
       flags: { all: true, force: true, confirm: 'myapp' } })
-      .then(() => {
-        expect(lastApp).to.equal('myapp')
-        expect(lastConfirm).to.equal('myapp')
-        expect(lastMsg).to.equal(message)
-      })
+
+    expect(lastApp).to.equal('myapp')
+    expect(lastConfirm).to.equal('myapp')
+    expect(lastMsg).to.equal(message)
   })
 
-  it('requires app confirmation for rotating a specific role with --name', () => {
+  it('requires app confirmation for rotating a specific role with --name', async () => {
     pg.post('/postgres/v0/databases/postgres-1/credentials/my_role/credentials_rotation').reply(200)
 
     const message = `WARNING: Destructive Action
@@ -211,17 +224,16 @@ The password for the my_role credential will rotate.
 Connections older than 30 minutes will be reset, and a temporary rotation username will be used during the process.
 This command will affect the apps appname_1, appname_2.`
 
-    return cmd.run({ app: 'myapp',
+    await cmd.run({ app: 'myapp',
       args: {},
       flags: { name: 'my_role', confirm: 'myapp' } })
-      .then(() => {
-        expect(lastApp).to.equal('myapp')
-        expect(lastConfirm).to.equal('myapp')
-        expect(lastMsg).to.equal(message)
-      })
+
+    expect(lastApp).to.equal('myapp')
+    expect(lastConfirm).to.equal('myapp')
+    expect(lastMsg).to.equal(message)
   })
 
-  it('requires app confirmation for force rotating a specific role with --name and --force', () => {
+  it('requires app confirmation for force rotating a specific role with --name and --force', async () => {
     pg.post('/postgres/v0/databases/postgres-1/credentials/my_role/credentials_rotation').reply(200)
 
     const message = `WARNING: Destructive Action
@@ -230,13 +242,12 @@ Connections will be reset and applications will be restarted.
 Any followers lagging in replication (see heroku pg:info) will be inaccessible until caught up.
 This command will affect the apps appname_1, appname_2.`
 
-    return cmd.run({ app: 'myapp',
+    await cmd.run({ app: 'myapp',
       args: {},
       flags: { name: 'my_role', force: true, confirm: 'myapp' } })
-      .then(() => {
-        expect(lastApp).to.equal('myapp')
-        expect(lastConfirm).to.equal('myapp')
-        expect(lastMsg).to.equal(message)
-      })
+
+    expect(lastApp).to.equal('myapp')
+    expect(lastConfirm).to.equal('myapp')
+    expect(lastMsg).to.equal(message)
   })
 })

--- a/packages/pg-v5/test/commands/credentials/url.js
+++ b/packages/pg-v5/test/commands/credentials/url.js
@@ -45,7 +45,7 @@ describe('pg:credentials:url', () => {
     api.done()
   })
 
-  it('shows the correct credentials', () => {
+  it('shows the correct credentials', async () => {
     let roleInfo = {
       uuid: 'aaaa',
       name: 'jeff',
@@ -68,12 +68,13 @@ describe('pg:credentials:url', () => {
     }
     pg.get('/postgres/v0/databases/postgres-1/credentials/jeff').reply(200, roleInfo)
 
-    return cmd.run({ app: 'myapp', args: {}, flags: { name: 'jeff' } })
-      .then(() => expect(cli.stdout).to.equal(`Connection information for jeff credential.\nConnection info string:
+    await cmd.run({ app: 'myapp', args: {}, flags: { name: 'jeff' } })
+
+    return expect(cli.stdout).to.equal(`Connection information for jeff credential.\nConnection info string:
    "dbname=d123 host=localhost port=5442 user=jeff password=hunter2 sslmode=require"
 Connection URL:
    postgres://jeff:hunter2@localhost:5442/d123
-`))
+`)
   })
 
   it('throws an error when the db is starter plan but the name is specified', () => {
@@ -97,7 +98,7 @@ Connection URL:
     return expect(cmd.run({ app: 'myapp', args: {}, flags: { name: 'jeff' } })).to.be.rejectedWith(Error, err)
   })
 
-  it('shows the correct credentials with starter plan', () => {
+  it('shows the correct credentials with starter plan', async () => {
     const hobbyAddon = {
       name: 'postgres-1',
       plan: { name: 'heroku-postgresql:hobby-dev' }
@@ -131,11 +132,12 @@ Connection URL:
     }
     starter.get('/postgres/v0/databases/postgres-1/credentials/default').reply(200, roleInfo)
 
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stdout).to.equal(`Connection information for default credential.\nConnection info string:
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    return expect(cli.stdout).to.equal(`Connection information for default credential.\nConnection info string:
    "dbname=d123 host=localhost port=5442 user=abcdef password=hunter2 sslmode=require"
 Connection URL:
    postgres://abcdef:hunter2@localhost:5442/d123
-`))
+`)
   })
 })

--- a/packages/pg-v5/test/commands/diagnose.js
+++ b/packages/pg-v5/test/commands/diagnose.js
@@ -80,7 +80,7 @@ describe('pg:diagnose', () => {
   })
 
   describe('when not passing arguments', () => {
-    it('generates a report', () => {
+    it('generates a report', async () => {
       api.get(`/addons/${addon.name}`).reply(200, db)
       api.get(`/apps/${app.name}/config-vars`).reply(200, {
         DATABASE_ENDPOINT_042EExxx_URL: dbURL,
@@ -116,8 +116,9 @@ describe('pg:diagnose', () => {
           metrics: [],
         })
         .reply(200, report)
-      return cmd.run({ app: app.name, args: {}, flags: {} }).then(() =>
-        expect(cli.stdout).to.equal(`Report ${reportID} for ${app.name}::${report.database}
+      await cmd.run({ app: app.name, args: {}, flags: {} })
+
+      return expect(cli.stdout).to.equal(`Report ${reportID} for ${app.name}::${report.database}
 available for one month after creation on 101
 
 RED: Connection count
@@ -126,8 +127,7 @@ Count
 1
 RED: Load
 Load 100
-`),
-      )
+`)
     })
   })
 
@@ -174,7 +174,7 @@ Load 100
     })
 
     context('and this argument is a HEROKU_POSTGRESQL_SILVER_URL', () => {
-      it('generates a report for that DB', () => {
+      it('generates a report for that DB', async () => {
         api.get(`/addons/${addon.name}`).reply(200, db)
         api.get(`/apps/${app.name}/config-vars`).reply(200, {
           DATABASE_ENDPOINT_042EExxx_URL: dbURL,
@@ -210,10 +210,11 @@ Load 100
             metrics: [],
           })
           .reply(200, report)
-        return cmd
+
+        await cmd
           .run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': 'HEROKU_POSTGRESQL_SILVER_URL' }, flags: {} })
-          .then(() =>
-            expect(cli.stdout).to.equal(`Report ${reportID} for ${app.name}::${report.database}
+
+        return expect(cli.stdout).to.equal(`Report ${reportID} for ${app.name}::${report.database}
 available for one month after creation on 101
 
 RED: Connection count
@@ -222,12 +223,11 @@ Count
 1
 RED: Load
 Load 100
-`),
-          )
+`)
       })
 
       context('with the --json flag set', () => {
-        it('outputs in styled JSON', () => {
+        it('outputs in styled JSON', async () => {
           api.get(`/addons/${addon.name}`).reply(200, db)
           api.get(`/apps/${app.name}/config-vars`).reply(200, {
             DATABASE_URL: dbURL,
@@ -263,18 +263,19 @@ Load 100
             })
             .reply(200, report)
 
-          return cmd
+          await cmd
             .run({
               app: 'myapp',
               args: { 'DATABASE|REPORT_ID': 'DATABASE_URL' },
               flags: { json: true },
             })
-            .then(() => expect(cli.stdout).to.equal(JSON.stringify(report, null, 2)+'\n'))
+
+          return expect(cli.stdout).to.equal(JSON.stringify(report, null, 2)+'\n')
         })
       })
     })
 
-    it('displays an existing report with empty results', () => {
+    it('displays an existing report with empty results', async () => {
       diagnose.get('/reports/697c8bd7-dbba-4f2d-83b6-789c58cc3a9c').reply(200, {
         id: '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c',
         app: 'myapp',
@@ -293,19 +294,19 @@ Load 100
           },
         ],
       })
-      return cmd
+
+      await cmd
         .run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c' }, flags: {} })
-        .then(() =>
-          expect(cli.stdout).to.equal(`Report 697c8bd7-dbba-4f2d-83b6-789c58cc3a9c for myapp::postgres-1
+
+      return expect(cli.stdout).to.equal(`Report 697c8bd7-dbba-4f2d-83b6-789c58cc3a9c for myapp::postgres-1
 available for one month after creation on 101
 
 RED: Connection count
 RED: Load
-`),
-        )
+`)
     })
 
-    it('roughly conforms with Ruby output', () => {
+    it('roughly conforms with Ruby output', async () => {
       diagnose.get('/reports/697c8bd7-dbba-4f2d-83b6-789c58cc3a9c').reply(200, {
         id: 'abc123',
         app: 'appname',
@@ -328,10 +329,11 @@ RED: Load
           },
         ],
       })
-      return cmd
+
+      await cmd
         .run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c' }, flags: {} })
-        .then(() =>
-          expect(cli.stdout).to.equal(`Report abc123 for appname::dbcolor
+
+      return expect(cli.stdout).to.equal(`Report abc123 for appname::dbcolor
 available for one month after creation on 2014-06-24 01:26:11.941197+00
 
 RED: Connection Count
@@ -346,11 +348,10 @@ two
 GREEN: Hit Rate
 SKIPPED: Load
 Error Load check not supported on this plan
-`),
-        )
+`)
     })
 
-    it('converts underscores to spaces', () => {
+    it('converts underscores to spaces', async () => {
       diagnose.get('/reports/697c8bd7-dbba-4f2d-83b6-789c58cc3a9c').reply(200, {
         id: 'abc123',
         app: 'appname',
@@ -366,16 +367,16 @@ Error Load check not supported on this plan
           },
         ],
       })
-      return cmd
+
+      await cmd
         .run({ app: 'myapp', args: { 'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c' }, flags: {} })
-        .then(() =>
-          expect(cli.stdout).to.equal(`Report abc123 for appname::dbcolor
+
+      return expect(cli.stdout).to.equal(`Report abc123 for appname::dbcolor
 available for one month after creation on 2014-06-24 01:26:11.941197+00
 
 SKIPPED: Load
 Error Thing Load check not supported on this plan
-`),
-        )
+`)
     })
   })
 })

--- a/packages/pg-v5/test/commands/info.js
+++ b/packages/pg-v5/test/commands/info.js
@@ -36,13 +36,15 @@ describe('pg', () => {
   })
 
   context('with 0 dbs', () => {
-    it('shows empty state', () => {
+    it('shows empty state', async () => {
       all = []
       api.get('/apps/myapp/config-vars').reply(200, {})
 
-      return cmd.run({ app: 'myapp', args: {} })
-        .then(() => expect(cli.stdout).to.equal('myapp has no heroku-postgresql databases.\n'))
-        .then(() => expect(cli.stderr).to.equal(''))
+      await cmd.run({ app: 'myapp', args: {} })
+
+      expect(cli.stdout).to.equal('myapp has no heroku-postgresql databases.\n');
+
+      return expect(cli.stderr).to.equal('')
     })
   })
 
@@ -71,7 +73,7 @@ describe('pg', () => {
     resource_url: config.HEROKU_POSTGRESQL_PURPLE_URL
     }
 
-    it('shows postgres info', () => {
+    it('shows postgres info', async () => {
       all = addons
 
       api.get('/apps/myapp/config-vars').reply(200, config)
@@ -79,8 +81,9 @@ describe('pg', () => {
         .get('/client/v11/databases/1').reply(200, dbA)
         .get('/client/v11/databases/2').reply(200, dbB)
 
-      return cmd.run({ app: 'myapp', args: {} })
-        .then(() => expect(cli.stdout).to.equal(`=== DATABASE_URL, HEROKU_POSTGRESQL_COBALT_URL
+      await cmd.run({ app: 'myapp', args: {} })
+
+      expect(cli.stdout).to.equal(`=== DATABASE_URL, HEROKU_POSTGRESQL_COBALT_URL
 Plan:        Hobby-dev
 Following:   HEROKU_POSTGRESQL_COBALT
 Billing App: myapp2
@@ -91,11 +94,12 @@ Plan:      Hobby-dev
 Following: ec2-55-111-111-1.compute-1.amazonaws.com:5432/dxxxxxxxxxxxx
 Add-on:    postgres-2
 
-`))
-        .then(() => expect(cli.stderr).to.equal(''))
+`);
+
+      return expect(cli.stderr).to.equal('')
     })
 
-    it('shows postgres info using attachment names', () => {
+    it('shows postgres info using attachment names', async () => {
       all = [
         { id: 1, name: 'postgres-1', plan, app: { name: 'myapp2' }, attachment_names: ['DATABASE', 'ATTACHMENT_NAME'] },
         { id: 2, name: 'postgres-2', plan, app: { name: 'myapp' }, attachment_names: ['HEROKU_POSTGRESQL_PURPLE'] }
@@ -106,8 +110,9 @@ Add-on:    postgres-2
         .get('/client/v11/databases/1').reply(200, dbA)
         .get('/client/v11/databases/2').reply(200, dbB)
 
-      return cmd.run({ app: 'myapp', args: {} })
-        .then(() => expect(cli.stdout).to.equal(`=== DATABASE_URL, ATTACHMENT_NAME_URL
+      await cmd.run({ app: 'myapp', args: {} })
+
+      return expect(cli.stdout).to.equal(`=== DATABASE_URL, ATTACHMENT_NAME_URL
 Plan:        Hobby-dev
 Following:   HEROKU_POSTGRESQL_COBALT
 Billing App: myapp2
@@ -118,27 +123,30 @@ Plan:      Hobby-dev
 Following: ec2-55-111-111-1.compute-1.amazonaws.com:5432/dxxxxxxxxxxxx
 Add-on:    postgres-2
 
-`))
+`)
     })
 
-    it('shows postgres info for single database when arg sent in', () => {
+    it('shows postgres info for single database when arg sent in', async () => {
       addon = addons[1]
       api.get('/apps/myapp/config-vars').reply(200, config)
 
       pg
         .get('/client/v11/databases/2')
         .reply(200, dbB)
-      return cmd.run({ app: 'myapp', args: { database: 'postgres-2' } })
-        .then(() => expect(cli.stdout).to.equal(`=== HEROKU_POSTGRESQL_PURPLE_URL
+
+      await cmd.run({ app: 'myapp', args: { database: 'postgres-2' } })
+
+      expect(cli.stdout).to.equal(`=== HEROKU_POSTGRESQL_PURPLE_URL
 Plan:      Hobby-dev
 Following: ec2-55-111-111-1.compute-1.amazonaws.com:5432/dxxxxxxxxxxxx
 Add-on:    postgres-2
 
-`))
-        .then(() => expect(cli.stderr).to.equal(''))
+`);
+
+      return expect(cli.stderr).to.equal('')
     })
 
-    it('shows warning for 404', () => {
+    it('shows warning for 404', async () => {
       all = addons
 
       api.get('/apps/myapp/config-vars').reply(200, config)
@@ -146,16 +154,18 @@ Add-on:    postgres-2
         .get('/client/v11/databases/1').reply(404)
         .get('/client/v11/databases/2').reply(200, dbB)
 
-      return cmd.run({ app: 'myapp', args: {} })
-        .then(() => expect(cli.stdout).to.equal(`=== HEROKU_POSTGRESQL_PURPLE_URL
+      await cmd.run({ app: 'myapp', args: {} })
+
+      expect(cli.stdout).to.equal(`=== HEROKU_POSTGRESQL_PURPLE_URL
 Plan:      Hobby-dev
 Following: ec2-55-111-111-1.compute-1.amazonaws.com:5432/dxxxxxxxxxxxx
 Add-on:    postgres-2
 
-`))
-        .then(() => expect(unwrap(cli.stderr)).to.equal(`postgres-1 is not yet provisioned. \
+`);
+
+      return expect(unwrap(cli.stderr)).to.equal(`postgres-1 is not yet provisioned. \
 Run heroku addons:wait to wait until the db is provisioned.
-`))
+`)
     })
   })
 })

--- a/packages/pg-v5/test/commands/kill.js
+++ b/packages/pg-v5/test/commands/kill.js
@@ -38,13 +38,13 @@ describe('pg:kill', () => {
     api.done()
   })
 
-  it('kills pid 100', () => {
-    return cmd.run({ app: 'myapp', args: { pid: 100 }, flags: {} })
-      .then(() => expect(psql._query.trim()).to.equal('SELECT pg_cancel_backend(100);'))
+  it('kills pid 100', async () => {
+    await cmd.run({ app: 'myapp', args: { pid: 100 }, flags: {} })
+    return expect(psql._query.trim()).to.equal('SELECT pg_cancel_backend(100);')
   })
 
-  it('force kills pid 100', () => {
-    return cmd.run({ app: 'myapp', args: { pid: 100 }, flags: { force: true } })
-      .then(() => expect(psql._query.trim()).to.equal('SELECT pg_terminate_backend(100);'))
+  it('force kills pid 100', async () => {
+    await cmd.run({ app: 'myapp', args: { pid: 100 }, flags: { force: true } })
+    return expect(psql._query.trim()).to.equal('SELECT pg_terminate_backend(100);')
   })
 })

--- a/packages/pg-v5/test/commands/killall.js
+++ b/packages/pg-v5/test/commands/killall.js
@@ -31,12 +31,14 @@ describe('pg:killall', () => {
     nock.cleanAll()
   })
 
-  it('waits for all databases to be available', () => {
+  it('waits for all databases to be available', async () => {
     pg
       .post('/client/v11/databases/1/connection_reset').reply(200)
 
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('Terminating connections for all credentials... done\n'))
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    expect(cli.stdout).to.equal('');
+
+    return expect(cli.stderr).to.equal('Terminating connections for all credentials... done\n')
   })
 })

--- a/packages/pg-v5/test/commands/links/create.js
+++ b/packages/pg-v5/test/commands/links/create.js
@@ -37,10 +37,13 @@ describe('pg:links:create', () => {
     pg.done()
   })
 
-  it('creates a link', () => {
+  it('creates a link', async () => {
     pg.post('/client/v11/databases/1/links', { target: 'postgres-1', as: 'foobar' }).reply(200, { name: 'foobar' })
-    return cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp', as: 'foobar' } })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('Adding link from postgres-1 to postgres-1... done, foobar\n'))
+
+    await cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp', as: 'foobar' } })
+
+    expect(cli.stdout).to.equal('');
+
+    return expect(cli.stderr).to.equal('Adding link from postgres-1 to postgres-1... done, foobar\n')
   })
 })

--- a/packages/pg-v5/test/commands/links/destroy.js
+++ b/packages/pg-v5/test/commands/links/destroy.js
@@ -37,10 +37,13 @@ describe('pg:links:destroy', () => {
     pg.done()
   })
 
-  it('destroys a link', () => {
+  it('destroys a link', async () => {
     pg.delete('/client/v11/databases/1/links/redis').reply(200)
-    return cmd.run({ app: 'myapp', args: { link: 'redis' }, flags: { confirm: 'myapp' } })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('Destroying link redis from postgres-1... done\n'))
+
+    await cmd.run({ app: 'myapp', args: { link: 'redis' }, flags: { confirm: 'myapp' } })
+
+    expect(cli.stdout).to.equal('');
+
+    return expect(cli.stderr).to.equal('Destroying link redis from postgres-1... done\n')
   })
 })

--- a/packages/pg-v5/test/commands/links/index.js
+++ b/packages/pg-v5/test/commands/links/index.js
@@ -37,16 +37,17 @@ describe('pg:links', () => {
     pg.done()
   })
 
-  it('shows links', () => {
+  it('shows links', async () => {
     pg.get('/client/v11/databases/1/links').reply(200, [
       { name: 'redis-link-1', created_at: '100', remote: { attachment_name: 'REDIS', name: 'redis-001' } }
     ])
-    return cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp' } })
-      .then(() => expect(cli.stdout).to.equal(`=== postgres-1
+    await cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp' } })
+
+    return expect(cli.stdout).to.equal(`=== postgres-1
 
  * redis-link-1
 created_at: 100
 remote:     REDIS (redis-001)
-`))
+`)
   })
 })

--- a/packages/pg-v5/test/commands/maintenance/index.js
+++ b/packages/pg-v5/test/commands/maintenance/index.js
@@ -36,9 +36,9 @@ describe('pg:maintenance', () => {
     pg.done()
   })
 
-  it('shows maintenance', () => {
+  it('shows maintenance', async () => {
     pg.get('/client/v11/databases/1/maintenance').reply(200, { message: 'foo' })
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stdout).to.equal('foo\n'))
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+    return expect(cli.stdout).to.equal('foo\n')
   })
 })

--- a/packages/pg-v5/test/commands/maintenance/run.js
+++ b/packages/pg-v5/test/commands/maintenance/run.js
@@ -36,11 +36,14 @@ describe('pg:maintenance', () => {
     pg.done()
   })
 
-  it('runs maintenance', () => {
+  it('runs maintenance', async () => {
     api.get('/apps/myapp').reply(200, { maintenance: true })
     pg.post('/client/v11/databases/1/maintenance').reply(200, { message: 'foo' })
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stderr).to.equal('Starting maintenance for postgres-1... foo\n'))
-      .then(() => expect(cli.stdout).to.equal(''))
+
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    expect(cli.stderr).to.equal('Starting maintenance for postgres-1... foo\n');
+
+    return expect(cli.stdout).to.equal('')
   })
 })

--- a/packages/pg-v5/test/commands/maintenance/window.js
+++ b/packages/pg-v5/test/commands/maintenance/window.js
@@ -36,10 +36,13 @@ describe('pg:maintenance', () => {
     pg.done()
   })
 
-  it('sets maintenance window', () => {
+  it('sets maintenance window', async () => {
     pg.put('/client/v11/databases/1/maintenance_window', { description: 'Sunday 06:30' }).reply(200)
-    return cmd.run({ app: 'myapp', args: { window: 'Sunday 06:30' } })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('Setting maintenance window for postgres-1 to Sunday 06:30... done\n'))
+
+    await cmd.run({ app: 'myapp', args: { window: 'Sunday 06:30' } })
+
+    expect(cli.stdout).to.equal('');
+
+    return expect(cli.stderr).to.equal('Setting maintenance window for postgres-1 to Sunday 06:30... done\n')
   })
 })

--- a/packages/pg-v5/test/commands/outliers.js
+++ b/packages/pg-v5/test/commands/outliers.js
@@ -38,13 +38,13 @@ describe('pg:outliers', () => {
     api.done()
   })
 
-  it('reset queries stats', () => {
-    return cmd.run({ app: 'myapp', args: {}, flags: { reset: true } })
-      .then(() => expect(psql._query.trim()).to.equal('SELECT pg_stat_statements_reset()'))
+  it('reset queries stats', async () => {
+    await cmd.run({ app: 'myapp', args: {}, flags: { reset: true } })
+    return expect(psql._query.trim()).to.equal('SELECT pg_stat_statements_reset()')
   })
 
-  it('returns queries outliers', () => {
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(psql._query.trim()).to.contain('FROM pg_stat_statements'))
+  it('returns queries outliers', async () => {
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+    return expect(psql._query.trim()).to.contain('FROM pg_stat_statements')
   })
 })

--- a/packages/pg-v5/test/commands/promote.js
+++ b/packages/pg-v5/test/commands/promote.js
@@ -50,7 +50,7 @@ describe('pg:promote when argument is database', () => {
     pg.done()
   })
 
-  it('promotes db and attaches pgbouncer if DATABASE_CONNECTION_POOL is an attachemnt', () => {
+  it('promotes db and attaches pgbouncer if DATABASE_CONNECTION_POOL is an attachemnt', async () => {
     api.get('/apps/myapp/addon-attachments').reply(200, [
       { name: 'DATABASE', addon: { name: 'postgres-2' }, namespace: null },
       { name: 'DATABASE_CONNECTION_POOL', id: pgbouncerAddonID, addon: { name: 'postgres-2' }, namespace: 'connection-pooling:default' }
@@ -76,14 +76,15 @@ describe('pg:promote when argument is database', () => {
       namespace: 'connection-pooling:default',
       confirm: 'myapp'
     }).reply(201)
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stderr, 'to equal', `Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    return expect(cli.stderr, 'to equal', `Ensuring an alternate alias for existing DATABASE_URL... RED_URL
 Promoting postgres-1 to DATABASE_URL on myapp... done
 Reattaching pooler to new leader... done
-`))
+`)
   })
 
-  it('promotes db and does not detach pgbouncers attached to new leader under other name than DATABASE_CONNECTION_POOL', () => {
+  it('promotes db and does not detach pgbouncers attached to new leader under other name than DATABASE_CONNECTION_POOL', async () => {
     api.get('/apps/myapp/addon-attachments').reply(200, [
       { name: 'DATABASE', addon: { name: 'postgres-2' }, namespace: null },
       // { name: 'DATABASE_CONNECTION_POOL', id: pgbouncerAddonID, addon: { name: 'postgres-2', id: '2' }, namespace: "connection-pooling:default" },
@@ -102,13 +103,14 @@ Reattaching pooler to new leader... done
       namespace: null,
       confirm: 'myapp'
     }).reply(201)
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stderr, 'to equal', `Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    return expect(cli.stderr, 'to equal', `Ensuring an alternate alias for existing DATABASE_URL... RED_URL
 Promoting postgres-1 to DATABASE_URL on myapp... done
-`))
+`)
   })
 
-  it('promotes db and does not reattach pgbouncer if DATABASE_CONNECTION_POOL attached to database being promoted, but not old leader', () => {
+  it('promotes db and does not reattach pgbouncer if DATABASE_CONNECTION_POOL attached to database being promoted, but not old leader', async () => {
     api.get('/apps/myapp/addon-attachments').reply(200, [
       { name: 'DATABASE', addon: { name: 'postgres-2' }, namespace: null },
       { name: 'DATABASE_CONNECTION_POOL', id: '12345', addon: { name: 'postgres-1', id: '1' }, namespace: 'connection-pooling:default' }
@@ -126,13 +128,14 @@ Promoting postgres-1 to DATABASE_URL on myapp... done
       namespace: null,
       confirm: 'myapp'
     }).reply(201)
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stderr, 'to equal', `Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    return expect(cli.stderr, 'to equal', `Ensuring an alternate alias for existing DATABASE_URL... RED_URL
 Promoting postgres-1 to DATABASE_URL on myapp... done
-`))
+`)
   })
 
-  it('promotes the db and creates another attachment if current DATABASE does not have another', () => {
+  it('promotes the db and creates another attachment if current DATABASE does not have another', async () => {
     api.get('/apps/myapp/addon-attachments').reply(200, [
       { name: 'DATABASE', addon: { name: 'postgres-2' }, namespace: null }
     ])
@@ -149,13 +152,14 @@ Promoting postgres-1 to DATABASE_URL on myapp... done
       namespace: null,
       confirm: 'myapp'
     }).reply(201)
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    return expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
 Promoting postgres-1 to DATABASE_URL on myapp... done
-`))
+`)
   })
 
-  it('promotes the db and does not create another attachment if current DATABASE has another', () => {
+  it('promotes the db and does not create another attachment if current DATABASE has another', async () => {
     api.get('/apps/myapp/addon-attachments').reply(200, [
       { name: 'DATABASE', addon: { name: 'postgres-2' }, namespace: null },
       { name: 'RED', addon: { name: 'postgres-2' }, namespace: null }
@@ -167,10 +171,11 @@ Promoting postgres-1 to DATABASE_URL on myapp... done
       namespace: null,
       confirm: 'myapp'
     }).reply(201)
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    return expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
 Promoting postgres-1 to DATABASE_URL on myapp... done
-`))
+`)
   })
 
   it('does not promote the db if is already is DATABASE', () => {
@@ -225,7 +230,7 @@ describe('pg:promote when argument is a credential attachment', () => {
     pg.done()
   })
 
-  it('promotes the credential and creates another attachment if current DATABASE does not have another', () => {
+  it('promotes the credential and creates another attachment if current DATABASE does not have another', async () => {
     api.get('/apps/myapp/addon-attachments').reply(200, [
       { name: 'DATABASE', addon: { name: 'postgres-2' } },
       { name: 'RED', addon: { name: 'postgres-1' }, namespace: 'credential:hello' }
@@ -242,13 +247,14 @@ describe('pg:promote when argument is a credential attachment', () => {
       namespace: 'credential:hello',
       confirm: 'myapp'
     }).reply(201)
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    return expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
 Promoting PURPLE to DATABASE_URL on myapp... done
-`))
+`)
   })
 
-  it('promotes the credential and creates another attachment if current DATABASE does not have another and current DATABASE is a credential', () => {
+  it('promotes the credential and creates another attachment if current DATABASE does not have another and current DATABASE is a credential', async () => {
     api.get('/apps/myapp/addon-attachments').reply(200, [
       { name: 'PURPLE', addon: { name: 'postgres-1' }, namespace: 'credential:hello' },
       { name: 'DATABASE', addon: { name: 'postgres-1' }, namespace: 'credential:goodbye' }
@@ -266,13 +272,14 @@ Promoting PURPLE to DATABASE_URL on myapp... done
       namespace: 'credential:hello',
       confirm: 'myapp'
     }).reply(201)
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    return expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
 Promoting PURPLE to DATABASE_URL on myapp... done
-`))
+`)
   })
 
-  it('promotes the credential and does not create another attachment if current DATABASE has another', () => {
+  it('promotes the credential and does not create another attachment if current DATABASE has another', async () => {
     api.get('/apps/myapp/addon-attachments').reply(200, [
       { name: 'DATABASE', addon: { name: 'postgres-2' } },
       { name: 'RED', addon: { name: 'postgres-2' } },
@@ -285,13 +292,14 @@ Promoting PURPLE to DATABASE_URL on myapp... done
       namespace: 'credential:hello',
       confirm: 'myapp'
     }).reply(201)
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    return expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
 Promoting PURPLE to DATABASE_URL on myapp... done
-`))
+`)
   })
 
-  it('promotes the credential if the current promoted database is for the same addon, but the default credential', () => {
+  it('promotes the credential if the current promoted database is for the same addon, but the default credential', async () => {
     api.get('/apps/myapp/addon-attachments').reply(200, [
       { name: 'DATABASE', addon: { name: 'postgres-1' }, namespace: null },
       { name: 'RED', addon: { name: 'postgres-1' }, namespace: null },
@@ -304,13 +312,14 @@ Promoting PURPLE to DATABASE_URL on myapp... done
       namespace: 'credential:hello',
       confirm: 'myapp'
     }).reply(201)
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    return expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
 Promoting PURPLE to DATABASE_URL on myapp... done
-`))
+`)
   })
 
-  it('promotes the credential if the current promoted database is for the same addon, but another credential', () => {
+  it('promotes the credential if the current promoted database is for the same addon, but another credential', async () => {
     api.get('/apps/myapp/addon-attachments').reply(200, [
       { name: 'DATABASE', addon: { name: 'postgres-1' }, namespace: 'credential:goodbye' },
       { name: 'RED', addon: { name: 'postgres-1' }, namespace: 'credential:goodbye' },
@@ -323,10 +332,11 @@ Promoting PURPLE to DATABASE_URL on myapp... done
       namespace: 'credential:hello',
       confirm: 'myapp'
     }).reply(201)
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    return expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
 Promoting PURPLE to DATABASE_URL on myapp... done
-`))
+`)
   })
 
   it('does not promote the credential if it already is DATABASE', () => {
@@ -397,48 +407,52 @@ describe('pg:promote when release phase is present', () => {
     api.done()
   })
 
-  it('checks release phase', () => {
+  it('checks release phase', async () => {
     api.get('/apps/myapp/releases').reply(200, [{ id: 1, description: 'Attach DATABASE' }, { id: 2, description: 'Detach DATABASE' }])
     api.get('/apps/myapp/releases/1').reply(200, { status: 'succeeded' })
     api.get('/apps/myapp/releases/2').reply(200, { status: 'succeeded' })
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    return expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
 Promoting PURPLE to DATABASE_URL on myapp... done
 Checking release phase... pg:promote succeeded.
-`))
+`)
   })
 
-  it('checks release phase for detach failure', () => {
+  it('checks release phase for detach failure', async () => {
     api.get('/apps/myapp/releases').reply(200, [{ id: 1, description: 'Attach DATABASE' }, { id: 2, description: 'Detach DATABASE' }])
     api.get('/apps/myapp/releases/1').reply(200, { status: 'succeeded' })
     api.get('/apps/myapp/releases/2').reply(200, { status: 'failed', description: 'Detach DATABASE' })
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    return expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
 Promoting PURPLE to DATABASE_URL on myapp... done
 Checking release phase... pg:promote succeeded. It is safe to ignore the failed Detach DATABASE release.
-`))
+`)
   })
 
-  it('checks release phase for attach failure', () => {
+  it('checks release phase for attach failure', async () => {
     api.get('/apps/myapp/releases').reply(200, [{ id: 1, description: 'Attach DATABASE' }, { id: 2, description: 'Detach DATABASE' }])
     api.get('/apps/myapp/releases/1').reply(200, { status: 'failed', description: 'Attach DATABASE' })
     api.get('/apps/myapp/releases/2').reply(200, { status: 'failed', description: 'Attach DATABASE' })
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    return expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
 Promoting PURPLE to DATABASE_URL on myapp... done
 Checking release phase... pg:promote failed because Attach DATABASE release was unsuccessful. Your application is currently running with postgres-1 attached as DATABASE_URL. Check your release phase logs for failure causes.
-`))
+`)
   })
 
-  it('checks release phase for attach failure and detach success', () => {
+  it('checks release phase for attach failure and detach success', async () => {
     api.get('/apps/myapp/releases').reply(200, [{ id: 1, description: 'Attach DATABASE' }, { id: 2, description: 'Detach DATABASE' }])
     api.get('/apps/myapp/releases/1').reply(200, { status: 'failed', description: 'Attach DATABASE' })
     api.get('/apps/myapp/releases/2').reply(200, { status: 'succeeded', description: 'Attach DATABASE' })
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    return expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
 Promoting PURPLE to DATABASE_URL on myapp... done
 Checking release phase... pg:promote failed because Attach DATABASE release was unsuccessful. Your application is currently running without an attached DATABASE_URL. Check your release phase logs for failure causes.
-`))
+`)
   })
 
   it('checks release phase for attach failure and detach success', () => {
@@ -501,7 +515,7 @@ describe('pg:promote when database is not available or force flag is present', (
     return expect(cmd.run({ app: 'myapp', args: {}, flags: {} })).to.be.rejectedWith(Error, err)
   })
 
-  it('promotes database in unavailable state if --force flag is present', () => {
+  it('promotes database in unavailable state if --force flag is present', async () => {
     api.get('/apps/myapp/addon-attachments').reply(200, [
       { name: 'DATABASE', addon: { name: 'postgres-2' }, namespace: null },
       { name: 'RED', addon: { name: 'postgres-2' }, namespace: null }
@@ -517,12 +531,13 @@ describe('pg:promote when database is not available or force flag is present', (
 
     pg.get(`/client/v11/databases/${attachment.addon.id}/wait_status`).reply(200, { 'waiting?': true, message: 'pending' })
 
-    return cmd.run({ app: 'myapp', args: {}, flags: { force: true } })
-      .then(() => expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
-Promoting postgres-1 to DATABASE_URL on myapp... done\n`))
+    await cmd.run({ app: 'myapp', args: {}, flags: { force: true } })
+
+    return expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+Promoting postgres-1 to DATABASE_URL on myapp... done\n`)
   })
 
-  it('promotes database in available state if --force flag is present', () => {
+  it('promotes database in available state if --force flag is present', async () => {
     api.get('/apps/myapp/addon-attachments').reply(200, [
       { name: 'DATABASE', addon: { name: 'postgres-2' }, namespace: null },
       { name: 'RED', addon: { name: 'postgres-2' }, namespace: null }
@@ -538,8 +553,9 @@ Promoting postgres-1 to DATABASE_URL on myapp... done\n`))
       confirm: 'myapp'
     }).reply(201)
 
-    return cmd.run({ app: 'myapp', args: {}, flags: { force: true } })
-      .then(() => expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
-Promoting postgres-1 to DATABASE_URL on myapp... done\n`))
+    await cmd.run({ app: 'myapp', args: {}, flags: { force: true } })
+
+    return expect(cli.stderr).to.equal(`Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+Promoting postgres-1 to DATABASE_URL on myapp... done\n`)
   })
 })

--- a/packages/pg-v5/test/commands/psql.js
+++ b/packages/pg-v5/test/commands/psql.js
@@ -34,21 +34,27 @@ describe('psql', () => {
     cli.mockConsole()
   })
 
-  it('runs psql', () => {
+  it('runs psql', async () => {
     let psql = require('../../lib/psql')
     sinon.stub(psql, 'exec').returns(Promise.resolve(''))
-    return cmd.run({ args: {}, flags: { command: 'SELECT 1' } })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('--> Connecting to postgres-1\n'))
-      .then(() => psql.exec.restore())
+
+    await cmd.run({ args: {}, flags: { command: 'SELECT 1' } })
+
+    expect(cli.stdout).to.equal('');
+    expect(cli.stderr).to.equal('--> Connecting to postgres-1\n');
+
+    return psql.exec.restore()
   })
 
-  it('runs psql with file', () => {
+  it('runs psql with file', async () => {
     let psql = require('../../lib/psql')
     sinon.stub(psql, 'execFile').returns(Promise.resolve(''))
-    return cmd.run({ args: {}, flags: { file: 'test.sql' } })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('--> Connecting to postgres-1\n'))
-      .then(() => psql.execFile.restore())
+
+    await cmd.run({ args: {}, flags: { file: 'test.sql' } })
+
+    expect(cli.stdout).to.equal('');
+    expect(cli.stderr).to.equal('--> Connecting to postgres-1\n');
+
+    return psql.execFile.restore()
   })
 })

--- a/packages/pg-v5/test/commands/pull.js
+++ b/packages/pg-v5/test/commands/pull.js
@@ -107,7 +107,7 @@ describe('pg', () => {
       delete dumpOpts.env.PGPORT
     })
 
-    it('pushes out a db', () => {
+    it('pushes out a db', async () => {
       const dumpFlags = ['--verbose', '-F', 'c', '-Z', '0', '-N', '_heroku', 'localdb']
       const restoreFlags = ['--verbose', '-F', 'c', '--no-acl', '--no-owner', '-U', 'jeff', '-h', 'herokai.com', '-p', '5432', '-d', 'mydb']
 
@@ -124,13 +124,15 @@ describe('pg', () => {
         on: exitHandler
       })
 
-      return push.run({ args: { source: 'localdb', target: 'postgres-1' }, flags: {} })
-        .then(() => expect(spawnStub.callCount).to.equal(2))
-        .then(() => expect(cli.stdout).to.equal('heroku-cli: Pushing localdb ---> postgres-1\nheroku-cli: Pushing complete.\n'))
-        .then(() => expect(cli.stderr).to.equal(''))
+      await push.run({ args: { source: 'localdb', target: 'postgres-1' }, flags: {} })
+
+      expect(spawnStub.callCount).to.equal(2);
+      expect(cli.stdout).to.equal('heroku-cli: Pushing localdb ---> postgres-1\nheroku-cli: Pushing complete.\n');
+
+      return expect(cli.stderr).to.equal('')
     })
 
-    it('pushes out a db using url port', () => {
+    it('pushes out a db using url port', async () => {
       const dumpFlags = ['--verbose', '-F', 'c', '-Z', '0', '-N', '_heroku', '-h', 'localhost', '-p', '5433', 'localdb']
       const restoreFlags = ['--verbose', '-F', 'c', '--no-acl', '--no-owner', '-U', 'jeff', '-h', 'herokai.com', '-p', '5432', '-d', 'mydb']
 
@@ -147,13 +149,15 @@ describe('pg', () => {
         on: exitHandler
       })
 
-      return push.run({ args: { source: 'postgres://localhost:5433/localdb', target: 'postgres-1' }, flags: {} })
-        .then(() => expect(spawnStub.callCount).to.equal(2))
-        .then(() => expect(cli.stdout).to.equal('heroku-cli: Pushing postgres://localhost:5433/localdb ---> postgres-1\nheroku-cli: Pushing complete.\n'))
-        .then(() => expect(cli.stderr).to.equal(''))
+      await push.run({ args: { source: 'postgres://localhost:5433/localdb', target: 'postgres-1' }, flags: {} })
+
+      expect(spawnStub.callCount).to.equal(2);
+      expect(cli.stdout).to.equal('heroku-cli: Pushing postgres://localhost:5433/localdb ---> postgres-1\nheroku-cli: Pushing complete.\n');
+
+      return expect(cli.stderr).to.equal('')
     })
 
-    it('pushes out a db using PGPORT', () => {
+    it('pushes out a db using PGPORT', async () => {
       env.PGPORT = dumpOpts.env.PGPORT = '5433'
       restoreOpts.env.PGPORT = '5433'
 
@@ -173,13 +177,15 @@ describe('pg', () => {
         on: exitHandler
       })
 
-      return push.run({ args: { source: 'localdb', target: 'postgres-1' }, flags: {} })
-        .then(() => expect(spawnStub.callCount).to.equal(2))
-        .then(() => expect(cli.stdout).to.equal('heroku-cli: Pushing localdb ---> postgres-1\nheroku-cli: Pushing complete.\n'))
-        .then(() => expect(cli.stderr).to.equal(''))
+      await push.run({ args: { source: 'localdb', target: 'postgres-1' }, flags: {} })
+
+      expect(spawnStub.callCount).to.equal(2);
+      expect(cli.stdout).to.equal('heroku-cli: Pushing localdb ---> postgres-1\nheroku-cli: Pushing complete.\n');
+
+      return expect(cli.stderr).to.equal('')
     })
 
-    it('opens an SSH tunnel and runs pg_dump for bastion databases', () => {
+    it('opens an SSH tunnel and runs pg_dump for bastion databases', async () => {
       db.bastionHost = 'bastion-host'
       db.bastionKey = 'super-private-key'
 
@@ -209,11 +215,13 @@ describe('pg', () => {
         on: exitHandler
       })
 
-      return push.run({ args: { source: 'localdb', target: 'postgres-1' }, flags: {} })
-        .then(() => expect(spawnStub.callCount).to.equal(2))
-        .then(() => expect(cli.stdout).to.equal('heroku-cli: Pushing localdb ---> postgres-1\nheroku-cli: Pushing complete.\n'))
-        .then(() => expect(cli.stderr).to.equal(''))
-        .then(() => expect(tunnelStub.withArgs(tunnelConf).calledOnce).to.equal(true))
+      await push.run({ args: { source: 'localdb', target: 'postgres-1' }, flags: {} })
+
+      expect(spawnStub.callCount).to.equal(2);
+      expect(cli.stdout).to.equal('heroku-cli: Pushing localdb ---> postgres-1\nheroku-cli: Pushing complete.\n');
+      expect(cli.stderr).to.equal('');
+
+      return expect(tunnelStub.withArgs(tunnelConf).calledOnce).to.equal(true)
     })
 
     it('exits non-zero when there is an error', () => {
@@ -295,16 +303,18 @@ describe('pg', () => {
       spawnStub.restore()
     })
 
-    it('pulls a db in', () => {
-      return pull.run({ args: { source: 'postgres-1', target: 'localdb' }, flags: {} })
-        .then(() => expect(createDbStub.calledOnce).to.equal(true))
-        .then(() => expect(createDbStub.calledWithExactly('createdb localdb', { stdio: 'inherit' })).to.equal(true))
-        .then(() => expect(spawnStub.callCount).to.equal(2))
-        .then(() => expect(cli.stdout).to.equal('heroku-cli: Pulling postgres-1 ---> localdb\nheroku-cli: Pulling complete.\n'))
-        .then(() => expect(cli.stderr).to.equal(''))
+    it('pulls a db in', async () => {
+      await pull.run({ args: { source: 'postgres-1', target: 'localdb' }, flags: {} })
+
+      expect(createDbStub.calledOnce).to.equal(true);
+      expect(createDbStub.calledWithExactly('createdb localdb', { stdio: 'inherit' })).to.equal(true);
+      expect(spawnStub.callCount).to.equal(2);
+      expect(cli.stdout).to.equal('heroku-cli: Pulling postgres-1 ---> localdb\nheroku-cli: Pulling complete.\n');
+
+      return expect(cli.stderr).to.equal('')
     })
 
-    it('opens an SSH tunnel and runs pg_dump for bastion databases', () => {
+    it('opens an SSH tunnel and runs pg_dump for bastion databases', async () => {
       db.bastionHost = 'bastion-host'
       db.bastionKey = 'super-private-key'
 
@@ -318,13 +328,15 @@ describe('pg', () => {
         localPort: 49152
       }
 
-      return pull.run({ args: { source: 'postgres-1', target: 'localdb' }, flags: {} })
-        .then(() => expect(createDbStub.calledOnce).to.equal(true))
-        .then(() => expect(createDbStub.calledWithExactly('createdb localdb', { stdio: 'inherit' })).to.equal(true))
-        .then(() => expect(spawnStub.callCount).to.equal(2))
-        .then(() => expect(cli.stdout).to.equal('heroku-cli: Pulling postgres-1 ---> localdb\nheroku-cli: Pulling complete.\n'))
-        .then(() => expect(cli.stderr).to.equal(''))
-        .then(() => expect(tunnelStub.withArgs(tunnelConf).calledOnce).to.equal(true))
+      await pull.run({ args: { source: 'postgres-1', target: 'localdb' }, flags: {} })
+
+      expect(createDbStub.calledOnce).to.equal(true);
+      expect(createDbStub.calledWithExactly('createdb localdb', { stdio: 'inherit' })).to.equal(true);
+      expect(spawnStub.callCount).to.equal(2);
+      expect(cli.stdout).to.equal('heroku-cli: Pulling postgres-1 ---> localdb\nheroku-cli: Pulling complete.\n');
+      expect(cli.stderr).to.equal('');
+
+      return expect(tunnelStub.withArgs(tunnelConf).calledOnce).to.equal(true)
     })
   })
 })

--- a/packages/pg-v5/test/commands/repoint.js
+++ b/packages/pg-v5/test/commands/repoint.js
@@ -52,11 +52,11 @@ describe('pg:repoint', () => {
       .to.be.rejectedWith(Error, 'pg:repoint is only available for follower production databases')
   })
 
-  it('repoints db', () => {
+  it('repoints db', async () => {
     api.get('/apps/myapp/config-vars').reply(200, { DATABASE_URL: 'postgres://db1' })
     pg.get('/client/v11/databases/1').reply(200, { following: 'postgres://db1' })
     pg.post('/client/v11/databases/1/repoint').reply(200)
-    return cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp', follow: 'NEW_LEADER' } })
-      .then(() => expect(cli.stderr).to.contain('Starting repoint of postgres-1... heroku pg:wait to track status\n'))
+    await cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp', follow: 'NEW_LEADER' } })
+    return expect(cli.stderr).to.contain('Starting repoint of postgres-1... heroku pg:wait to track status\n')
   })
 })

--- a/packages/pg-v5/test/commands/reset.js
+++ b/packages/pg-v5/test/commands/reset.js
@@ -36,9 +36,9 @@ describe('pg:reset', () => {
     api.done()
   })
 
-  it('reset db', () => {
+  it('reset db', async () => {
     pg.put('/client/v11/databases/1/reset').reply(200)
-    return cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp' } })
-      .then(() => expect(cli.stderr).to.equal('Resetting postgres-1... done\n'))
+    await cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp' } })
+    return expect(cli.stderr).to.equal('Resetting postgres-1... done\n')
   })
 })

--- a/packages/pg-v5/test/commands/settings/index.js
+++ b/packages/pg-v5/test/commands/settings/index.js
@@ -36,10 +36,10 @@ describe('pg:settings', () => {
     pg.done()
   })
 
-  it('shows settings', () => {
+  it('shows settings', async () => {
     pg.get('/postgres/v0/databases/1/config').reply(200,
       { log_statement: { value: 'none' } })
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stdout).to.equal('=== postgres-1\nlog-statement: none\n'))
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+    return expect(cli.stdout).to.equal('=== postgres-1\nlog-statement: none\n')
   })
 })

--- a/packages/pg-v5/test/commands/unfollow.js
+++ b/packages/pg-v5/test/commands/unfollow.js
@@ -36,11 +36,11 @@ describe('pg:unfollow', () => {
     pg.done()
   })
 
-  it('unfollows db', () => {
+  it('unfollows db', async () => {
     api.get('/apps/myapp/config-vars').reply(200, { DATABASE_URL: 'postgres://db1' })
     pg.get('/client/v11/databases/1').reply(200, { following: 'postgres://db1' })
     pg.put('/client/v11/databases/1/unfollow').reply(200)
-    return cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp' } })
-      .then(() => expect(cli.stderr).to.equal('postgres-1 unfollowing... done\n'))
+    await cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp' } })
+    return expect(cli.stderr).to.equal('postgres-1 unfollowing... done\n')
   })
 })

--- a/packages/pg-v5/test/commands/upgrade.js
+++ b/packages/pg-v5/test/commands/upgrade.js
@@ -53,21 +53,21 @@ describe('pg:upgrade', () => {
       .to.be.rejectedWith(Error, 'pg:upgrade is only available for follower production databases')
   })
 
-  it('upgrades db', () => {
+  it('upgrades db', async () => {
     api.get('/apps/myapp/config-vars').reply(200, { DATABASE_URL: 'postgres://db1' })
     pg.get('/client/v11/databases/1').reply(200, { following: 'postgres://db1' })
     pg.get('/client/v11/databases/1/upgrade_status').reply(200, {})
     pg.post('/client/v11/databases/1/upgrade').reply(200)
-    return cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp' } })
-      .then(() => expect(cli.stderr).to.equal('Starting upgrade of postgres-1... heroku pg:wait to track status\n'))
+    await cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp' } })
+    return expect(cli.stderr).to.equal('Starting upgrade of postgres-1... heroku pg:wait to track status\n')
   })
 
-  it('upgrades db with version flag', () => {
+  it('upgrades db with version flag', async () => {
     api.get('/apps/myapp/config-vars').reply(200, { DATABASE_URL: 'postgres://db1' })
     pg.get('/client/v11/databases/1').reply(200, { following: 'postgres://db1' })
     pg.get('/client/v11/databases/1/upgrade_status').reply(200, {})
     pg.post('/client/v11/databases/1/upgrade').reply(200)
-    return cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp', version: '9.6' } })
-      .then(() => expect(cli.stderr).to.equal('Starting upgrade of postgres-1... heroku pg:wait to track status\n'))
+    await cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp', version: '9.6' } })
+    return expect(cli.stderr).to.equal('Starting upgrade of postgres-1... heroku pg:wait to track status\n')
   })
 })

--- a/packages/pg-v5/test/commands/wait.js
+++ b/packages/pg-v5/test/commands/wait.js
@@ -36,26 +36,30 @@ describe('pg:wait', () => {
     nock.cleanAll()
   })
 
-  it('waits for a database to be available', () => {
+  it('waits for a database to be available', async () => {
     pg
       .get('/client/v11/databases/1/wait_status').reply(200, { 'waiting?': true, message: 'pending' })
       .get('/client/v11/databases/1/wait_status').reply(200, { 'waiting?': false, message: 'available' })
 
-    return cmd.run({ app: 'myapp', args: { database: 'DATABASE_URL' }, flags: { 'wait-interval': '1' } })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal(`Waiting for database postgres-1... pending
+    await cmd.run({ app: 'myapp', args: { database: 'DATABASE_URL' }, flags: { 'wait-interval': '1' } })
+
+    expect(cli.stdout).to.equal('');
+
+    return expect(cli.stderr).to.equal(`Waiting for database postgres-1... pending
 Waiting for database postgres-1... available
-`))
+`)
   })
 
-  it('waits for all databases to be available', () => {
+  it('waits for all databases to be available', async () => {
     pg
       .get('/client/v11/databases/1/wait_status').reply(200, { 'waiting?': false })
       .get('/client/v11/databases/2/wait_status').reply(200, { 'waiting?': false })
 
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal(''))
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    expect(cli.stdout).to.equal('');
+
+    return expect(cli.stderr).to.equal('')
   })
 
   it('displays errors', () => {

--- a/packages/pg-v5/test/lib/config.js
+++ b/packages/pg-v5/test/lib/config.js
@@ -20,13 +20,13 @@ describe('config', () => {
     api.done()
   })
 
-  it('caches the config vars', () => {
+  it('caches the config vars', async () => {
     let expectedMyapp = { 'DATABASE_URL': 'postgres://pguser:pgpass@pghost.com/pgdb' }
     let expectedFooapp = { 'FOO_URL': 'postgres://pguser:pgpass@pghost.com/pgdb' }
 
     api.get('/apps/myapp/config-vars').reply(200, expectedMyapp)
 
-    return getConfig(new Heroku(), 'myapp')
+    const config = await getConfig(new Heroku(), 'myapp')
       .then(config => expect(config).to.deep.equal(expectedMyapp))
       .then(() => {
         api.get('/apps/fooapp/config-vars').reply(200, expectedFooapp)
@@ -37,6 +37,7 @@ describe('config', () => {
       .then(() => {
         return getConfig(new Heroku(), 'myapp')
       })
-      .then(config => expect(config).to.deep.equal(expectedMyapp))
+
+    return expect(config).to.deep.equal(expectedMyapp)
   })
 })

--- a/packages/pg-v5/test/lib/setter.js
+++ b/packages/pg-v5/test/lib/setter.js
@@ -44,18 +44,18 @@ describe('setter', () => {
     settings.forEach(([name, value, convert]) => {
       let fn = setter.generate(name, convert, () => '')
 
-      it(`shows the current value for ${name}`, () => {
+      it(`shows the current value for ${name}`, async () => {
         pg.get('/postgres/v0/databases/1/config').reply(200,
           { [name]: { value: value } })
-        return cli.command(fn)({ app: 'myapp', args: {}, flags: {} })
-          .then(() => expect(cli.stdout).to.equal(`${name.replace(/_/g, '-')} is set to ${value} for postgres-1.\n\n`))
+        await cli.command(fn)({ app: 'myapp', args: {}, flags: {} })
+        return expect(cli.stdout).to.equal(`${name.replace(/_/g, '-')} is set to ${value} for postgres-1.\n\n`)
       })
 
-      it(`change the value for ${name}`, () => {
+      it(`change the value for ${name}`, async () => {
         pg.patch('/postgres/v0/databases/1/config').reply(200,
           { [name]: { value: value } })
-        return cli.command(fn)({ app: 'myapp', args: { value: value }, flags: {} })
-          .then(() => expect(cli.stdout).to.equal(`${name.replace(/_/g, '-')} has been set to ${value} for postgres-1.\n\n`))
+        await cli.command(fn)({ app: 'myapp', args: { value: value }, flags: {} })
+        return expect(cli.stdout).to.equal(`${name.replace(/_/g, '-')} has been set to ${value} for postgres-1.\n\n`)
       })
     })
   })

--- a/packages/redis-v5/test/commands/cli.js
+++ b/packages/redis-v5/test/commands/cli.js
@@ -51,7 +51,7 @@ describe('heroku redis:cli', function () {
     command = proxyquire('../../commands/cli.js', { net, tls, ssh2 })
   })
 
-  it('# for hobby it uses net.connect', function () {
+  it('# for hobby it uses net.connect', async function() {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
         {
@@ -74,16 +74,19 @@ describe('heroku redis:cli', function () {
         resource_url: 'redis://foobar:password@example.com:8649',
         plan: 'hobby'
       })
-    return command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => configVars.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_FOO, REDIS_BAR):\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(net.connect.called).to.equal(true))
+
+    await command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
+
+    app.done();
+    configVars.done();
+    redis.done();
+    expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_FOO, REDIS_BAR):\n');
+    expect(cli.stderr).to.equal('');
+
+    return expect(net.connect.called).to.equal(true)
   })
 
-  it('# for hobby it uses TLS if prefer_native_tls', function () {
+  it('# for hobby it uses TLS if prefer_native_tls', async function() {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
         {
@@ -107,16 +110,19 @@ describe('heroku redis:cli', function () {
         plan: 'hobby',
         prefer_native_tls: true
       })
-    return command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => configVars.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_FOO, REDIS_BAR, REDIS_TLS_URL):\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(tls.connect.called).to.equal(true))
+
+    await command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
+
+    app.done();
+    configVars.done();
+    redis.done();
+    expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_FOO, REDIS_BAR, REDIS_TLS_URL):\n');
+    expect(cli.stderr).to.equal('');
+
+    return expect(tls.connect.called).to.equal(true)
   })
 
-  it('# for premium it uses tls.connect', function () {
+  it('# for premium it uses tls.connect', async function() {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
         {
@@ -140,16 +146,18 @@ describe('heroku redis:cli', function () {
         plan: 'premium-0'
       })
 
-    return command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => configVars.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_FOO, REDIS_BAR):\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(tls.connect.called).to.equal(true))
+    await command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
+
+    app.done();
+    configVars.done();
+    redis.done();
+    expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_FOO, REDIS_BAR):\n');
+    expect(cli.stderr).to.equal('');
+
+    return expect(tls.connect.called).to.equal(true)
   })
 
-  it('# for bastion it uses tunnel.connect', function () {
+  it('# for bastion it uses tunnel.connect', async function() {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
         {
@@ -173,15 +181,17 @@ describe('heroku redis:cli', function () {
         plan: 'premium-0'
       })
 
-    return command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => configVars.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_URL):\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
+    await command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
+
+    app.done();
+    configVars.done();
+    redis.done();
+    expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_URL):\n');
+
+    return expect(cli.stderr).to.equal('')
   })
 
-  it('# for private spaces bastion with prefer_native_tls, it uses tls.connect', function () {
+  it('# for private spaces bastion with prefer_native_tls, it uses tls.connect', async function() {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
         { id: addonId,
@@ -205,13 +215,15 @@ describe('heroku redis:cli', function () {
         prefer_native_tls: true
       })
 
-    return command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => configVars.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_URL):\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(tls.connect.called).to.equal(true))
+    await command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
+
+    app.done();
+    configVars.done();
+    redis.done();
+    expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_URL):\n');
+    expect(cli.stderr).to.equal('');
+
+    return expect(tls.connect.called).to.equal(true)
   })
 
   it('# selects correct connection information when multiple redises are present across multiple apps', async () => {

--- a/packages/redis-v5/test/commands/credentials.js
+++ b/packages/redis-v5/test/commands/credentials.js
@@ -16,7 +16,7 @@ describe('heroku redis:credentials', function () {
     nock.cleanAll()
   })
 
-  it('# displays the redis credentials', function () {
+  it('# displays the redis credentials', async function() {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
         { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
@@ -28,14 +28,16 @@ describe('heroku redis:credentials', function () {
         resource_url: 'redis://foobar:password@hostname:8649'
       })
 
-    return command.run({ app: 'example', flags: {}, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('redis://foobar:password@hostname:8649\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
+    await command.run({ app: 'example', flags: {}, args: {}, auth: { username: 'foobar', password: 'password' } })
+
+    app.done();
+    redis.done();
+    expect(cli.stdout).to.equal('redis://foobar:password@hostname:8649\n');
+
+    return expect(cli.stderr).to.equal('')
   })
 
-  it('# resets the redis credentials', function () {
+  it('# resets the redis credentials', async function() {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
         { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
@@ -44,10 +46,12 @@ describe('heroku redis:credentials', function () {
     let redis = nock('https://redis-api.heroku.com:443')
       .post('/redis/v0/databases/redis-haiku/credentials_rotation').reply(200, {})
 
-    return command.run({ app: 'example', flags: { reset: true }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('Resetting credentials for redis-haiku\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
+    await command.run({ app: 'example', flags: { reset: true }, args: {}, auth: { username: 'foobar', password: 'password' } })
+
+    app.done();
+    redis.done();
+    expect(cli.stdout).to.equal('Resetting credentials for redis-haiku\n');
+
+    return expect(cli.stderr).to.equal('')
   })
 })

--- a/packages/redis-v5/test/commands/info.js
+++ b/packages/redis-v5/test/commands/info.js
@@ -17,17 +17,19 @@ commands.forEach((cmd) => {
       nock.cleanAll()
     })
 
-    it('# prints out nothing when there is no redis DB', function () {
+    it('# prints out nothing when there is no redis DB', async function() {
       let app = nock('https://api.heroku.com:443')
         .get('/apps/example/addons').reply(200, [])
 
-      return command.run({ app: 'example', args: {} })
-        .then(() => app.done())
-        .then(() => expect(cli.stdout).to.equal(''))
-        .then(() => expect(cli.stderr).to.equal(''))
+      await command.run({ app: 'example', args: {} })
+
+      app.done();
+      expect(cli.stdout).to.equal('');
+
+      return expect(cli.stderr).to.equal('')
     })
 
-    it('# prints out redis info', function () {
+    it('# prints out redis info', async function() {
       let app = nock('https://api.heroku.com:443')
         .get('/apps/example/addons').reply(200, [
           { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
@@ -38,18 +40,21 @@ commands.forEach((cmd) => {
           { name: 'Foo', values: ['Bar', 'Biz'] }
         ] })
 
-      return command.run({ app: 'example', args: {}, auth: { username: 'foobar', password: 'password' } })
-        .then(() => app.done())
-        .then(() => redis.done())
-        .then(() => expect(cli.stdout).to.equal(
+      await command.run({ app: 'example', args: {}, auth: { username: 'foobar', password: 'password' } })
+
+      app.done();
+      redis.done();
+
+      expect(cli.stdout).to.equal(
           `=== redis-haiku (REDIS_FOO, REDIS_BAR)
 Foo: Bar
      Biz
-`))
-        .then(() => expect(cli.stderr).to.equal(''))
+`);
+
+      return expect(cli.stderr).to.equal('')
     })
 
-    it('# prints out redis info when not found', function () {
+    it('# prints out redis info when not found', async function() {
       let app = nock('https://api.heroku.com:443')
         .get('/apps/example/addons').reply(200, [
           { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
@@ -58,11 +63,13 @@ Foo: Bar
       let redis = nock('https://redis-api.heroku.com:443')
         .get('/redis/v0/databases/redis-haiku').reply(404, {})
 
-      return command.run({ app: 'example', args: {}, auth: { username: 'foobar', password: 'password' } })
-        .then(() => app.done())
-        .then(() => redis.done())
-        .then(() => expect(cli.stdout).to.equal(''))
-        .then(() => expect(cli.stderr).to.equal(''))
+      await command.run({ app: 'example', args: {}, auth: { username: 'foobar', password: 'password' } })
+
+      app.done();
+      redis.done();
+      expect(cli.stdout).to.equal('');
+
+      return expect(cli.stderr).to.equal('')
     })
 
     it('# prints out redis info when error', function () {

--- a/packages/redis-v5/test/commands/maintenance.js
+++ b/packages/redis-v5/test/commands/maintenance.js
@@ -19,7 +19,7 @@ describe('heroku redis:maintenance', function () {
     exit.mock()
   })
 
-  it('# shows the maintenance message', function () {
+  it('# shows the maintenance message', async function() {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
         { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, plan: { name: 'premium-0' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
@@ -28,14 +28,16 @@ describe('heroku redis:maintenance', function () {
     let redis = nock('https://redis-api.heroku.com:443')
       .get('/redis/v0/databases/redis-haiku/maintenance').reply(200, { message: 'Message' })
 
-    return command.run({ app: 'example', args: {}, flags: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('Message\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
+    await command.run({ app: 'example', args: {}, flags: {}, auth: { username: 'foobar', password: 'password' } })
+
+    await app.done();
+    await redis.done();
+    expect(cli.stdout).to.equal('Message\n');
+
+    return expect(cli.stderr).to.equal('')
   })
 
-  it('# sets the maintenance window', function () {
+  it('# sets the maintenance window', async function() {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
         { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, plan: { name: 'premium-0' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
@@ -46,14 +48,16 @@ describe('heroku redis:maintenance', function () {
         description: 'Mon 10:00'
       }).reply(200, { window: 'Mon 10:00' })
 
-    return expect(command.run({ app: 'example', args: {}, flags: { window: 'Mon 10:00' }, auth: { username: 'foobar', password: 'password' } })).to.be.rejectedWith(exit.ErrorExit)
-      .then(() => app.done())
-      .then(() => redis.done)
-      .then(() => expect(cli.stdout).to.equal('Maintenance window for redis-haiku (REDIS_FOO, REDIS_BAR) set to Mon 10:00.\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
+    await expect(command.run({ app: 'example', args: {}, flags: { window: 'Mon 10:00' }, auth: { username: 'foobar', password: 'password' } })).to.be.rejectedWith(exit.ErrorExit)
+
+    await app.done();
+    await redis.done();
+    expect(cli.stdout).to.equal('Maintenance window for redis-haiku (REDIS_FOO, REDIS_BAR) set to Mon 10:00.\n');
+
+    return expect(cli.stderr).to.equal('')
   })
 
-  it('# runs the maintenance', function () {
+  it('# runs the maintenance', async function() {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
         { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, plan: { name: 'premium-0' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
@@ -65,15 +69,17 @@ describe('heroku redis:maintenance', function () {
     let redis = nock('https://redis-api.heroku.com:443')
       .post('/redis/v0/databases/redis-haiku/maintenance').reply(200, { message: 'Message' })
 
-    return expect(command.run({ app: 'example', args: {}, flags: { run: true }, auth: { username: 'foobar', password: 'password' } })).to.be.rejectedWith(exit.ErrorExit)
-      .then(() => app.done())
-      .then(() => appInfo.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('Message\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
+    await expect(command.run({ app: 'example', args: {}, flags: { run: true }, auth: { username: 'foobar', password: 'password' } })).to.be.rejectedWith(exit.ErrorExit)
+
+    await app.done();
+    await appInfo.done();
+    await redis.done();
+    expect(cli.stdout).to.equal('Message\n');
+
+    return expect(cli.stderr).to.equal('')
   })
 
-  it('# run errors out when not in maintenance', function () {
+  it('# run errors out when not in maintenance', async function() {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
         { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, plan: { name: 'premium-0' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
@@ -82,33 +88,42 @@ describe('heroku redis:maintenance', function () {
     let appInfo = nock('https://api.heroku.com:443')
       .get('/apps/example').reply(200, { maintenance: false })
 
-    return expect(command.run({ app: 'example', args: {}, flags: { run: true }, auth: { username: 'foobar', password: 'password' } })).to.be.rejectedWith(exit.ErrorExit)
-      .then(() => app.done())
-      .then(() => appInfo.done())
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(unwrap(cli.stderr)).to.equal('Application must be in maintenance mode or --force flag must be used\n'))
+    await expect(command.run({ app: 'example', args: {}, flags: { run: true }, auth: { username: 'foobar', password: 'password' } })).to.be.rejectedWith(exit.ErrorExit)
+
+    await app.done();
+    await appInfo.done();
+    expect(cli.stdout).to.equal('');
+
+    return expect(unwrap(cli.stderr)).to.equal('Application must be in maintenance mode or --force flag must be used\n')
   })
 
-  it('# errors out on hobby dynos', function () {
+  it('# errors out on hobby dynos', async function() {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
         { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, plan: { name: 'hobby' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
       ])
 
-    return expect(command.run({ app: 'example', args: {}, auth: { username: 'foobar', password: 'password' } })).to.be.rejected
-      .then(() => expect(unwrap(cli.stderr)).to.equal('redis:maintenance is not available for hobby-dev instances\n'))
-      .then(() => app.done())
+    await expect(command.run({ app: 'example', args: {}, auth: { username: 'foobar', password: 'password' } })).to.be.rejected
+
+    expect(unwrap(cli.stderr)).to.equal('redis:maintenance is not available for hobby-dev instances\n')
+
+    expect(unwrap(cli.stderr)).to.equal('redis:maintenance is not available for hobby-dev instances\n');
+
+    return app.done()
   })
 
-  it('# errors out on bad maintenance window', function () {
+  it('# errors out on bad maintenance window', async function() {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
         { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, plan: { name: 'premium-0' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
       ])
 
-    return expect(command.run({ app: 'example', args: {}, flags: { window: 'Mon 10:45' }, auth: { username: 'foobar', password: 'password' } })).to.be.rejected
-      .then(() => app.done())
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(unwrap(cli.stderr)).to.equal('Maintenance windows must be "Day HH:MM", where MM is 00 or 30.\n'))
+    await expect(command.run({ app: 'example', args: {}, flags: { window: 'Mon 10:45' }, auth: { username: 'foobar', password: 'password' } })).to.be.rejected
+    await app.done()
+
+    await app.done();
+    expect(cli.stdout).to.equal('');
+
+    return expect(unwrap(cli.stderr)).to.equal('Maintenance windows must be "Day HH:MM", where MM is 00 or 30.\n')
   })
 })

--- a/packages/redis-v5/test/commands/maxmemory.js
+++ b/packages/redis-v5/test/commands/maxmemory.js
@@ -19,7 +19,7 @@ describe('heroku redis:maxmemory', function () {
     exit.mock()
   })
 
-  it('# sets the key eviction policy', function () {
+  it('# sets the key eviction policy', async function() {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
         { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
@@ -30,20 +30,25 @@ describe('heroku redis:maxmemory', function () {
         maxmemory_policy: { value: 'noeviction', values: { 'noeviction': 'return errors when memory limit is reached' } }
       })
 
-    return command.run({ app: 'example', flags: { policy: 'noeviction' }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal(
+    await command.run({ app: 'example', flags: { policy: 'noeviction' }, args: {}, auth: { username: 'foobar', password: 'password' } })
+
+    app.done();
+    redis.done();
+
+    expect(cli.stdout).to.equal(
         `Maxmemory policy for redis-haiku (REDIS_FOO, REDIS_BAR) set to noeviction.
 noeviction return errors when memory limit is reached.
 `
-      ))
-      .then(() => expect(cli.stderr).to.equal(''))
+      );
+
+    return expect(cli.stderr).to.equal('')
   })
 
-  it('# errors on missing eviction policy', function () {
-    return expect(command.run({ app: 'example', flags: {}, args: {} })).to.be.rejectedWith(exit.ErrorExit)
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(unwrap(cli.stderr)).to.equal('Please specify a valid maxmemory eviction policy.\n'))
+  it('# errors on missing eviction policy', async function() {
+    await expect(command.run({ app: 'example', flags: {}, args: {} })).to.be.rejectedWith(exit.ErrorExit)
+
+    expect(cli.stdout).to.equal('');
+
+    return expect(unwrap(cli.stderr)).to.equal('Please specify a valid maxmemory eviction policy.\n')
   })
 })

--- a/packages/redis-v5/test/commands/promote.js
+++ b/packages/redis-v5/test/commands/promote.js
@@ -16,7 +16,7 @@ describe('heroku redis:promote', function () {
     nock.cleanAll()
   })
 
-  it('# promotes', function () {
+  it('# promotes', async function() {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
         { name: 'redis-silver-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_URL', 'HEROKU_REDIS_SILVER_URL'] },
@@ -31,14 +31,16 @@ describe('heroku redis:promote', function () {
         'name': 'REDIS'
       }).reply(200, {})
 
-    return command.run({ app: 'example', flags: {}, args: { database: 'redis-gold-haiku' }, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => attach.done())
-      .then(() => expect(cli.stdout).to.equal('Promoting redis-gold-haiku to REDIS_URL on example\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
+    await command.run({ app: 'example', flags: {}, args: { database: 'redis-gold-haiku' }, auth: { username: 'foobar', password: 'password' } })
+
+    app.done();
+    attach.done();
+    expect(cli.stdout).to.equal('Promoting redis-gold-haiku to REDIS_URL on example\n');
+
+    return expect(cli.stderr).to.equal('')
   })
 
-  it('# promotes and replaces attachment of existing REDIS_URL if necessary', function () {
+  it('# promotes and replaces attachment of existing REDIS_URL if necessary', async function() {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
         {
@@ -69,11 +71,13 @@ describe('heroku redis:promote', function () {
         'name': 'REDIS'
       }).reply(200, {})
 
-    return command.run({ app: 'example', flags: {}, args: { database: 'redis-gold-haiku' }, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => attachRedisUrl.done())
-      .then(() => attach.done())
-      .then(() => expect(cli.stdout).to.equal('Promoting redis-gold-haiku to REDIS_URL on example\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
+    await command.run({ app: 'example', flags: {}, args: { database: 'redis-gold-haiku' }, auth: { username: 'foobar', password: 'password' } })
+
+    app.done();
+    attachRedisUrl.done();
+    attach.done();
+    expect(cli.stdout).to.equal('Promoting redis-gold-haiku to REDIS_URL on example\n');
+
+    return expect(cli.stderr).to.equal('')
   })
 })

--- a/packages/redis-v5/test/commands/timeout.js
+++ b/packages/redis-v5/test/commands/timeout.js
@@ -19,7 +19,7 @@ describe('heroku redis:timeout', function () {
     exit.mock()
   })
 
-  it('# sets the timout', function () {
+  it('# sets the timout', async function() {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
         { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
@@ -30,17 +30,20 @@ describe('heroku redis:timeout', function () {
         timeout: { value: 5 }
       })
 
-    return command.run({ app: 'example', flags: { seconds: '5' }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal(
+    await command.run({ app: 'example', flags: { seconds: '5' }, args: {}, auth: { username: 'foobar', password: 'password' } })
+
+    app.done();
+    redis.done();
+
+    expect(cli.stdout).to.equal(
         `Timeout for redis-haiku (REDIS_FOO, REDIS_BAR) set to 5 seconds.
 Connections to the Redis instance will be stopped after idling for 5 seconds.
-`))
-      .then(() => expect(cli.stderr).to.equal(''))
+`);
+
+    return expect(cli.stderr).to.equal('')
   })
 
-  it('# sets the timout to zero', function () {
+  it('# sets the timout to zero', async function() {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
         { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
@@ -51,19 +54,24 @@ Connections to the Redis instance will be stopped after idling for 5 seconds.
         timeout: { value: 0 }
       })
 
-    return command.run({ app: 'example', flags: { seconds: '0' }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal(
+    await command.run({ app: 'example', flags: { seconds: '0' }, args: {}, auth: { username: 'foobar', password: 'password' } })
+
+    app.done();
+    redis.done();
+
+    expect(cli.stdout).to.equal(
         `Timeout for redis-haiku (REDIS_FOO, REDIS_BAR) set to 0 seconds.
 Connections to the Redis instance can idle indefinitely.
-`))
-      .then(() => expect(cli.stderr).to.equal(''))
+`);
+
+    return expect(cli.stderr).to.equal('')
   })
 
-  it('# errors on missing timeout', function () {
-    return expect(command.run({ app: 'example', flags: {}, args: {} })).to.be.rejectedWith(exit.ErrorExit)
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(unwrap(cli.stderr)).to.equal('Please specify a valid timeout value.\n'))
+  it('# errors on missing timeout', async function() {
+    await expect(command.run({ app: 'example', flags: {}, args: {} })).to.be.rejectedWith(exit.ErrorExit)
+
+    expect(cli.stdout).to.equal('');
+
+    return expect(unwrap(cli.stderr)).to.equal('Please specify a valid timeout value.\n')
   })
 })

--- a/packages/redis-v5/test/commands/wait.js
+++ b/packages/redis-v5/test/commands/wait.js
@@ -95,7 +95,7 @@ describe('heroku redis:timeout waiting? error', function () {
     expect(unwrap(cli.stderr)).to.equal('Error\n')
   })
 
-  it('# waits until error', function () {
+  it('# waits until error', async function() {
     let app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons').reply(200, [
         { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
@@ -104,9 +104,11 @@ describe('heroku redis:timeout waiting? error', function () {
     let redisWaiting = nock('https://redis-api.heroku.com:443')
       .get('/redis/v0/databases/redis-haiku/wait').reply(503, { 'error': 'Error' })
 
-    return command.run({ app: 'example', flags: {}, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => clock.next())
-      .then(() => redisWaiting.done())
+    await command.run({ app: 'example', flags: {}, args: {}, auth: { username: 'foobar', password: 'password' } })
+
+    app.done();
+    clock.next();
+
+    return redisWaiting.done()
   })
 })

--- a/packages/redis-v5/test/lib/shared.js
+++ b/packages/redis-v5/test/lib/shared.js
@@ -16,25 +16,31 @@ exports.shouldHandleArgs = function (command, flags) {
       nock.cleanAll()
     })
 
-    it('# shows an error if an app has no addons', function () {
+    it('# shows an error if an app has no addons', async function() {
       let app = nock('https://api.heroku.com:443')
         .get('/apps/example/addons').reply(200, [])
-      return expect(command.run({ app: 'example', flags: flags, args: {} })).to.be.rejectedWith(exit.ErrorExit)
-        .then(() => app.done())
-        .then(() => expect(cli.stdout).to.equal(''))
-        .then(() => expect(unwrap(cli.stderr)).to.equal('No Redis instances found.\n'))
+
+      await expect(command.run({ app: 'example', flags: flags, args: {} })).to.be.rejectedWith(exit.ErrorExit)
+
+      app.done();
+      expect(cli.stdout).to.equal('');
+
+      return expect(unwrap(cli.stderr)).to.equal('No Redis instances found.\n')
     })
 
-    it('# shows an error if the addon is ambiguous', function () {
+    it('# shows an error if the addon is ambiguous', async function() {
       let app = nock('https://api.heroku.com:443')
         .get('/apps/example/addons').reply(200, [
           { name: 'redis-haiku-a', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO'] },
           { name: 'redis-haiku-b', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_BAR'] }
         ])
-      return expect(command.run({ app: 'example', flags: flags, args: {} })).to.be.rejectedWith(exit.ErrorExit)
-        .then(() => app.done())
-        .then(() => expect(cli.stdout).to.equal(''))
-        .then(() => expect(unwrap(cli.stderr)).to.equal('Please specify a single instance. Found: redis-haiku-a, redis-haiku-b\n'))
+
+      await expect(command.run({ app: 'example', flags: flags, args: {} })).to.be.rejectedWith(exit.ErrorExit)
+
+      app.done();
+      expect(cli.stdout).to.equal('');
+
+      return expect(unwrap(cli.stderr)).to.equal('Please specify a single instance. Found: redis-haiku-a, redis-haiku-b\n')
     })
   })
 }

--- a/packages/run-v5/test/assert_exit.js
+++ b/packages/run-v5/test/assert_exit.js
@@ -3,15 +3,16 @@
 let expect = require('chai').expect
 let cli = require('heroku-cli-util')
 
-function exit (code, gen) {
+async function exit(code, gen) {
   var actual
-  return gen.catch(function (err) {
+
+  await gen.catch(function (err) {
     expect(err).to.be.an.instanceof(cli.exit.ErrorExit)
     actual = err.code
-  }).then(function () {
-    expect(actual).to.be.an('number', 'Expected error.exit(i) to be called with a number')
-    expect(actual).to.equal(code)
   })
+
+  expect(actual).to.be.an('number', 'Expected error.exit(i) to be called with a number')
+  expect(actual).to.equal(code)
 }
 
 module.exports = exit

--- a/packages/run-v5/test/commands/console.js
+++ b/packages/run-v5/test/commands/console.js
@@ -15,9 +15,9 @@ describe('console', () => {
     })
   })
 
-  it('runs console', () => {
-    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {} })
-      .then(() => expect(dynoOpts.command).to.equal('console'))
+  it('runs console', async () => {
+    await cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {} })
+    return expect(dynoOpts.command).to.equal('console')
   })
 
   afterEach(() => {

--- a/packages/run-v5/test/commands/detached.js
+++ b/packages/run-v5/test/commands/detached.js
@@ -7,8 +7,8 @@ const cli = require('heroku-cli-util')
 describe('run:detached', () => {
   beforeEach(() => cli.mockConsole())
 
-  it('runs a command', () => {
-    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey }, args: ['echo', '1', '2', '3'] })
-      .then(() => expect(cli.stdout.startsWith('Run heroku logs --app heroku-cli-ci-smoke-test-app --dyno')).to.equal(true))
+  it('runs a command', async () => {
+    await cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey }, args: ['echo', '1', '2', '3'] })
+    return expect(cli.stdout.startsWith('Run heroku logs --app heroku-cli-ci-smoke-test-app --dyno')).to.equal(true)
   })
 })

--- a/packages/run-v5/test/commands/logs.js
+++ b/packages/run-v5/test/commands/logs.js
@@ -7,8 +7,8 @@ const { expect } = require('chai')
 describe('logs', () => {
   beforeEach(() => cli.mockConsole())
 
-  it('shows the logs', () => {
-    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey } })
-      .then(() => expect(cli.stdout.startsWith('20')).to.equal(true, 'starts with the year'))
+  it('shows the logs', async () => {
+    await cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey } })
+    return expect(cli.stdout.startsWith('20')).to.equal(true, 'starts with the year')
   })
 })

--- a/packages/run-v5/test/commands/rake.js
+++ b/packages/run-v5/test/commands/rake.js
@@ -15,9 +15,9 @@ describe('rake', () => {
     })
   })
 
-  it('runs rake', () => {
-    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, args: ['test'] })
-      .then(() => expect(dynoOpts.command).to.equal('rake test'))
+  it('runs rake', async () => {
+    await cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, args: ['test'] })
+    return expect(dynoOpts.command).to.equal('rake test')
   })
 
   afterEach(() => {

--- a/packages/run-v5/test/commands/run.js
+++ b/packages/run-v5/test/commands/run.js
@@ -9,40 +9,52 @@ const assertExit = require('../assert_exit')
 describe('run', () => {
   beforeEach(() => cli.mockConsole())
 
-  it('runs a command', () => {
+  it('runs a command', async () => {
     let stdout = ''
     let fixture = new StdOutFixture()
     fixture.capture(s => { stdout += s })
-    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey }, args: ['echo', '1', '2', '3'] })
-      .then(() => fixture.release())
-      .then(() => expect(stdout).to.contain('1 2 3\n'))
+
+    await cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey }, args: ['echo', '1', '2', '3'] })
+
+    fixture.release();
+
+    return expect(stdout).to.contain('1 2 3\n')
   })
 
-  it('runs a command with spaces', () => {
+  it('runs a command with spaces', async () => {
     let stdout = ''
     let fixture = new StdOutFixture()
     fixture.capture(s => { stdout += s })
-    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey }, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo": "bar"} '] })
-      .then(() => fixture.release())
-      .then(() => expect(stdout).to.equal('{"foo": "bar"} \n'))
+
+    await cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey }, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo": "bar"} '] })
+
+    fixture.release();
+
+    return expect(stdout).to.equal('{"foo": "bar"} \n')
   })
 
-  it('runs a command with quotes', () => {
+  it('runs a command with quotes', async () => {
     let stdout = ''
     let fixture = new StdOutFixture()
     fixture.capture(s => { stdout += s })
-    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey }, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo":"bar"}'] })
-      .then(() => fixture.release())
-      .then(() => expect(stdout).to.equal('{"foo":"bar"}\n'))
+
+    await cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey }, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo":"bar"}'] })
+
+    fixture.release();
+
+    return expect(stdout).to.equal('{"foo":"bar"}\n')
   })
 
-  it('runs a command with env vars', () => {
+  it('runs a command with env vars', async () => {
     let stdout = ''
     let fixture = new StdOutFixture()
     fixture.capture(s => { stdout += s })
-    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: { env: 'FOO=bar' }, auth: { password: global.apikey }, args: ['env'] })
-      .then(() => fixture.release())
-      .then(() => expect(stdout).to.contain('FOO=bar'))
+
+    await cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: { env: 'FOO=bar' }, auth: { password: global.apikey }, args: ['env'] })
+
+    fixture.release();
+
+    return expect(stdout).to.contain('FOO=bar')
   })
 
   it('gets 127 status for invalid command', () => {

--- a/packages/spaces/test/commands/create.js
+++ b/packages/spaces/test/commands/create.js
@@ -16,7 +16,7 @@ describe('spaces:create', function () {
     expect(cmd).to.have.own.property('wantsOrg', true)
   })
 
-  it('creates a Standard space', function () {
+  it('creates a Standard space', async function () {
     let api = nock('https://api.heroku.com:443')
       .post('/spaces', {
         name: 'my-space',
@@ -27,9 +27,11 @@ describe('spaces:create', function () {
       .reply(201,
         { shield: false, name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, features: [ 'one', 'two' ], state: 'enabled', created_at: now, cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' }
       )
-    return cmd.run({ flags: { team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== my-space
+
+    await cmd.run({ flags: { team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two' } })
+
+    expect(cli.stdout).to.equal(
+      `=== my-space
 Team:       my-team
 Region:     my-region
 CIDR:       10.0.0.0/16
@@ -37,11 +39,12 @@ Data CIDR:  172.23.0.0/20
 State:      enabled
 Shield:     off
 Created at: ${now.toISOString()}
-`))
-      .then(() => api.done())
+`)
+
+    return api.done()
   })
 
-  it('shows Standard Private Space Add-on cost warning', function () {
+  it('shows Standard Private Space Add-on cost warning', async function () {
     let api = nock('https://api.heroku.com:443')
       .post('/spaces', {
         name: 'my-space',
@@ -52,13 +55,16 @@ Created at: ${now.toISOString()}
       .reply(201,
         { shield: false, name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, features: [ 'one', 'two' ], state: 'enabled', created_at: now, cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' }
       )
-    return cmd.run({ flags: { team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two' } })
-      .then(() => expect(cli.stderr).to.include(
-        `Each Heroku Standard Private Space costs $1000`))
-      .then(() => api.done())
+
+    await cmd.run({ flags: { team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two' } })
+
+    expect(cli.stderr).to.include(
+      `Each Heroku Standard Private Space costs $1000`)
+
+    return api.done()
   })
 
-  it('creates a Shield space', function () {
+  it('creates a Shield space', async function () {
     let api = nock('https://api.heroku.com:443')
       .post('/spaces', {
         name: 'my-space',
@@ -70,9 +76,11 @@ Created at: ${now.toISOString()}
       .reply(201,
         { shield: true, name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, features: [ 'one', 'two' ], state: 'enabled', created_at: now, cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' }
       )
-    return cmd.run({ flags: { team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two', shield: true }, log_drain_url: 'https://logs.cheetah.com' })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== my-space
+
+    await cmd.run({ flags: { team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two', shield: true }, log_drain_url: 'https://logs.cheetah.com' })
+
+    expect(cli.stdout).to.equal(
+      `=== my-space
 Team:       my-team
 Region:     my-region
 CIDR:       10.0.0.0/16
@@ -80,11 +88,12 @@ Data CIDR:  172.23.0.0/20
 State:      enabled
 Shield:     on
 Created at: ${now.toISOString()}
-`))
-      .then(() => api.done())
+`)
+
+    return api.done()
   })
 
-  it('shows Shield Private Space Add-on cost warning', function () {
+  it('shows Shield Private Space Add-on cost warning', async function () {
     let api = nock('https://api.heroku.com:443')
       .post('/spaces', {
         name: 'my-space',
@@ -96,13 +105,16 @@ Created at: ${now.toISOString()}
       .reply(201,
         { shield: true, name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, features: [ 'one', 'two' ], state: 'enabled', created_at: now, cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' }
       )
-    return cmd.run({ flags: { team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two', shield: true }, log_drain_url: 'https://logs.cheetah.com' })
-      .then(() => expect(cli.stderr).to.include(
-        `Each Heroku Shield Private Space costs $3000`))
-      .then(() => api.done())
+
+    await cmd.run({ flags: { team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two', shield: true }, log_drain_url: 'https://logs.cheetah.com' })
+
+    expect(cli.stderr).to.include(
+      `Each Heroku Shield Private Space costs $3000`)
+
+    return api.done()
   })
 
-  it('creates a space with custom cidr and data cidr', function () {
+  it('creates a space with custom cidr and data cidr', async function () {
     let api = nock('https://api.heroku.com:443')
       .post('/spaces', {
         name: 'my-space',
@@ -115,9 +127,11 @@ Created at: ${now.toISOString()}
       .reply(201,
         { shield: false, name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, features: [ 'one', 'two' ], state: 'enabled', created_at: now, cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' }
       )
-    return cmd.run({ flags: { team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two', cidr: '10.0.0.0/16', 'data-cidr': '172.23.0.0/20' }, shield: true, log_drain_url: 'https://logs.cheetah.com', cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== my-space
+
+    await cmd.run({ flags: { team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two', cidr: '10.0.0.0/16', 'data-cidr': '172.23.0.0/20' }, shield: true, log_drain_url: 'https://logs.cheetah.com', cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' })
+
+    expect(cli.stdout).to.equal(
+      `=== my-space
 Team:       my-team
 Region:     my-region
 CIDR:       10.0.0.0/16
@@ -125,8 +139,9 @@ Data CIDR:  172.23.0.0/20
 State:      enabled
 Shield:     off
 Created at: ${now.toISOString()}
-`))
-      .then(() => api.done())
+`)
+
+    return api.done()
   })
 
   it('create fails without team name', function (done) {

--- a/packages/spaces/test/commands/destroy.js
+++ b/packages/spaces/test/commands/destroy.js
@@ -10,7 +10,7 @@ let now = new Date()
 describe('spaces:destroy', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('destroys a space', function () {
+  it('destroys a space', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space')
       .reply(200, { name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, state: 'allocated', created_at: now })
@@ -18,7 +18,7 @@ describe('spaces:destroy', function () {
       .reply(200, { state: 'enabled', sources: ['1.1.1.1', '2.2.2.2'] })
       .delete('/spaces/my-space')
       .reply(200)
-    return cmd.run({ flags: { space: 'my-space', confirm: 'my-space' } })
-      .then(() => api.done())
+    await cmd.run({ flags: { space: 'my-space', confirm: 'my-space' } })
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/drains/get.js
+++ b/packages/spaces/test/commands/drains/get.js
@@ -9,7 +9,7 @@ let cli = require('heroku-cli-util')
 describe('drains:get', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('shows the log drain', function () {
+  it('shows the log drain', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/log-drain')
       .reply(200, {
@@ -20,14 +20,18 @@ describe('drains:get', function () {
         updated_at: '2016-03-23T18:31:50Z',
         url: 'https://example.com'
       })
-    return cmd.run({ flags: { space: 'my-space' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `https://example.com (d.a55ecbe1-5513-4d19-91e4-58a08b419d19)
+
+    await cmd.run({ flags: { space: 'my-space' } })
+
+    expect(cli.stdout).to.equal(
+      `https://example.com (d.a55ecbe1-5513-4d19-91e4-58a08b419d19)
 `
-      )).then(() => api.done())
+    )
+
+    return api.done()
   })
 
-  it('shows the log drain --json', function () {
+  it('shows the log drain --json', async function () {
     let drain = {
       addon: null,
       created_at: '2016-03-23T18:31:50Z',
@@ -40,8 +44,11 @@ describe('drains:get', function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/log-drain')
       .reply(200, drain)
-    return cmd.run({ flags: { space: 'my-space', json: true } })
-      .then(() => expect(JSON.parse(cli.stdout)).to.eql(drain))
-      .then(() => api.done())
+
+    await cmd.run({ flags: { space: 'my-space', json: true } })
+
+    expect(JSON.parse(cli.stdout)).to.eql(drain)
+
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/drains/set.js
+++ b/packages/spaces/test/commands/drains/set.js
@@ -9,7 +9,7 @@ let cli = require('heroku-cli-util')
 describe('drains:set', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('shows the log drain', function () {
+  it('shows the log drain', async function () {
     let api = nock('https://api.heroku.com:443')
       .put('/spaces/my-space/log-drain', {
         url: 'https://example.com'
@@ -22,10 +22,14 @@ describe('drains:set', function () {
         updated_at: '2016-03-23T18:31:50Z',
         url: 'https://example.com'
       })
-    return cmd.run({ args: { url: 'https://example.com' }, flags: { space: 'my-space' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `Successfully set drain https://example.com for my-space.
+
+    await cmd.run({ args: { url: 'https://example.com' }, flags: { space: 'my-space' } })
+
+    expect(cli.stdout).to.equal(
+      `Successfully set drain https://example.com for my-space.
 `
-      )).then(() => api.done())
+    )
+
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/hosts/index.js
+++ b/packages/spaces/test/commands/hosts/index.js
@@ -25,30 +25,35 @@ let hosts = [
 describe('spaces:hosts', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('lists space hosts', function () {
+  it('lists space hosts', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/hosts')
       .reply(200,
         hosts
       )
-    return cmd.run({ flags: { space: 'my-space' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== my-space Hosts
+
+    await cmd.run({ flags: { space: 'my-space' } })
+
+    expect(cli.stdout).to.equal(
+      `=== my-space Hosts
 Host ID              State      Available Capacity  Allocated At          Released At
 ───────────────────  ─────────  ──────────────────  ────────────────────  ────────────────────
 h-0f927460a59aac18e  available  72%                 2020-05-28T04:15:59Z
 h-0e927460a59aac18f  released   0%                  2020-03-28T04:15:59Z  2020-04-28T04:15:59Z
-`))
-      .then(() => api.done())
+`)
+
+    return api.done()
   })
 
-  it('shows hosts:info --json', function () {
+  it('shows hosts:info --json', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/hosts')
       .reply(200, hosts)
 
-    return cmd.run({ flags: { space: 'my-space', json: true } })
-      .then(() => expect(JSON.parse(cli.stdout)).to.eql(hosts))
-      .then(() => api.done())
+    await cmd.run({ flags: { space: 'my-space', json: true } })
+
+    expect(JSON.parse(cli.stdout)).to.eql(hosts)
+
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/index.js
+++ b/packages/spaces/test/commands/index.js
@@ -21,61 +21,73 @@ describe('spaces', function () {
     expect(cmd).to.have.own.property('wantsOrg', true)
   })
 
-  it('shows spaces', function () {
+  it('shows spaces', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces')
       .reply(200, [
         { name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, state: 'enabled', created_at: now }
       ])
-    return cmd.run({ flags: {} })
-      .then(() => expect(cli.stdout).to.equal(
-        `Name      Team     Region     State    Created At
+
+    await cmd.run({ flags: {} })
+
+    expect(cli.stdout).to.equal(
+      `Name      Team     Region     State    Created At
 ────────  ───────  ─────────  ───────  ────────────────────────
 my-space  my-team  my-region  enabled  ${now.toISOString()}
-`))
-      .then(() => api.done())
+`)
+
+    return api.done()
   })
 
-  it('shows spaces with --json', function () {
+  it('shows spaces with --json', async function () {
     let spaces = [{ name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, state: 'enabled', created_at: now.toISOString() }]
     let api = nock('https://api.heroku.com:443')
       .get('/spaces')
       .reply(200, spaces)
-    return cmd.run({ flags: { json: true } })
-      .then(() => expect(JSON.parse(cli.stdout)).to.eql(spaces))
-      .then(() => api.done())
+
+    await cmd.run({ flags: { json: true } })
+
+    expect(JSON.parse(cli.stdout)).to.eql(spaces)
+
+    return api.done()
   })
 
-  it('shows spaces scoped by teams', function () {
+  it('shows spaces scoped by teams', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces')
       .reply(200, [
         { name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, state: 'enabled', created_at: now },
         { name: 'other-space', team: { name: 'other-team' }, region: { name: 'my-region' }, state: 'enabled', created_at: now }
       ])
-    return cmd.run({ flags: { team: 'my-team' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `Name      Team     Region     State    Created At
+
+    await cmd.run({ flags: { team: 'my-team' } })
+
+    expect(cli.stdout).to.equal(
+      `Name      Team     Region     State    Created At
 ────────  ───────  ─────────  ───────  ────────────────────────
 my-space  my-team  my-region  enabled  ${now.toISOString()}
-`))
-      .then(() => api.done())
+`)
+
+    return api.done()
   })
 
-  it('maps org option to team and shows spaces scoped by teams', function () {
+  it('maps org option to team and shows spaces scoped by teams', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces')
       .reply(200, [
         { name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, state: 'enabled', created_at: now },
         { name: 'other-space', team: { name: 'other-team' }, region: { name: 'my-region' }, state: 'enabled', created_at: now }
       ])
-    return cmd.run({ flags: { team: 'my-team' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `Name      Team     Region     State    Created At
+
+    await cmd.run({ flags: { team: 'my-team' } })
+
+    expect(cli.stdout).to.equal(
+      `Name      Team     Region     State    Created At
 ────────  ───────  ─────────  ───────  ────────────────────────
 my-space  my-team  my-region  enabled  ${now.toISOString()}
-`))
-      .then(() => api.done())
+`)
+
+    return api.done()
   })
 
   it('shows spaces team error message', function () {

--- a/packages/spaces/test/commands/info.js
+++ b/packages/spaces/test/commands/info.js
@@ -11,15 +11,17 @@ let now = new Date()
 describe('spaces:info', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('shows space info', function () {
+  it('shows space info', async function () {
     let api = nock('https://api.heroku.com:443', { reqheaders: { 'Accept-Expansion': 'region' } })
       .get('/spaces/my-space')
       .reply(200,
         { shield: false, name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region', description: 'region' }, state: 'enabled', created_at: now, cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' }
       )
-    return cmd.run({ flags: { space: 'my-space' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== my-space
+
+    await cmd.run({ flags: { space: 'my-space' } })
+
+    expect(cli.stdout).to.equal(
+      `=== my-space
 Team:         my-team
 Region:       region
 CIDR:         10.0.0.0/16
@@ -27,23 +29,26 @@ Data CIDR:    172.23.0.0/20
 State:        enabled
 Shield:       off
 Created at:   ${now.toISOString()}
-`))
-      .then(() => api.done())
+`)
+
+    return api.done()
   })
 
-  it('shows space info --json', function () {
+  it('shows space info --json', async function () {
     let space = { name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region' }, state: 'enabled', created_at: now.toISOString(), cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' }
 
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space')
       .reply(200, space)
 
-    return cmd.run({ flags: { space: 'my-space', json: true } })
-      .then(() => expect(JSON.parse(cli.stdout)).to.eql(space))
-      .then(() => api.done())
+    await cmd.run({ flags: { space: 'my-space', json: true } })
+
+    expect(JSON.parse(cli.stdout)).to.eql(space)
+
+    return api.done()
   })
 
-  it('shows allocated space with enabled nat', function () {
+  it('shows allocated space with enabled nat', async function () {
     let api = nock('https://api.heroku.com:443', { reqheaders: { 'Accept-Expansion': 'region' } })
       .get('/spaces/my-space')
       .reply(200,
@@ -54,9 +59,11 @@ Created at:   ${now.toISOString()}
       .reply(200,
         { state: 'enabled', sources: ['123.456.789.123'] }
       )
-    return cmd.run({ flags: { space: 'my-space' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== my-space
+
+    await cmd.run({ flags: { space: 'my-space' } })
+
+    expect(cli.stdout).to.equal(
+      `=== my-space
 Team:         my-team
 Region:       region
 CIDR:         10.0.0.0/16
@@ -65,12 +72,14 @@ State:        allocated
 Shield:       off
 Outbound IPs: 123.456.789.123
 Created at:   ${now.toISOString()}
-`))
-      .then(() => outbound.done())
-      .then(() => api.done())
+`)
+
+    outbound.done()
+
+    return api.done()
   })
 
-  it('shows allocated space with disabled nat', function () {
+  it('shows allocated space with disabled nat', async function () {
     let api = nock('https://api.heroku.com:443', { reqheaders: { 'Accept-Expansion': 'region' } })
       .get('/spaces/my-space')
       .reply(200,
@@ -81,9 +90,11 @@ Created at:   ${now.toISOString()}
       .reply(200,
         { state: 'disabled', sources: ['123.456.789.123'] }
       )
-    return cmd.run({ flags: { space: 'my-space' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== my-space
+
+    await cmd.run({ flags: { space: 'my-space' } })
+
+    expect(cli.stdout).to.equal(
+      `=== my-space
 Team:         my-team
 Region:       region
 CIDR:         10.0.0.0/16
@@ -92,20 +103,24 @@ State:        allocated
 Shield:       off
 Outbound IPs: disabled
 Created at:   ${now.toISOString()}
-`))
-      .then(() => outbound.done())
-      .then(() => api.done())
+`)
+
+    outbound.done()
+
+    return api.done()
   })
 
-  it('shows a space with Shield turned off', function () {
+  it('shows a space with Shield turned off', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space')
       .reply(200,
         { shield: false, name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region', description: 'region' }, state: 'enabled', created_at: now, cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' }
       )
-    return cmd.run({ flags: { space: 'my-space' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== my-space
+
+    await cmd.run({ flags: { space: 'my-space' } })
+
+    expect(cli.stdout).to.equal(
+      `=== my-space
 Team:         my-team
 Region:       region
 CIDR:         10.0.0.0/16
@@ -113,19 +128,22 @@ Data CIDR:    172.23.0.0/20
 State:        enabled
 Shield:       off
 Created at:   ${now.toISOString()}
-`))
-      .then(() => api.done())
+`)
+
+    return api.done()
   })
 
-  it('shows a space with Shield turned on', function () {
+  it('shows a space with Shield turned on', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space')
       .reply(200,
         { shield: true, name: 'my-space', team: { name: 'my-team' }, region: { name: 'my-region', description: 'region' }, state: 'enabled', created_at: now, cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20' }
       )
-    return cmd.run({ flags: { space: 'my-space' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== my-space
+
+    await cmd.run({ flags: { space: 'my-space' } })
+
+    expect(cli.stdout).to.equal(
+      `=== my-space
 Team:         my-team
 Region:       region
 CIDR:         10.0.0.0/16
@@ -133,7 +151,8 @@ Data CIDR:    172.23.0.0/20
 State:        enabled
 Shield:       on
 Created at:   ${now.toISOString()}
-`))
-      .then(() => api.done())
+`)
+
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/outbound-rules/add.js
+++ b/packages/spaces/test/commands/outbound-rules/add.js
@@ -9,7 +9,7 @@ let cli = require('heroku-cli-util')
 describe('outbound-rules:add', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('adds a rule entry to the outbound rules', function () {
+  it('adds a rule entry to the outbound rules', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/outbound-ruleset')
       .reply(200, {
@@ -26,11 +26,11 @@ describe('outbound-rules:add', function () {
         ]
       })
       .reply(200, { rules: [] })
-    return cmd.run({ flags: { space: 'my-space', dest: '128.0.1.1/20', port: '80', protocol: 'tcp' } })
-      .then(() => api.done())
+    await cmd.run({ flags: { space: 'my-space', dest: '128.0.1.1/20', port: '80', protocol: 'tcp' } })
+    return api.done()
   })
 
-  it('support ranges', function () {
+  it('support ranges', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/outbound-ruleset')
       .reply(200, {
@@ -47,11 +47,11 @@ describe('outbound-rules:add', function () {
         ]
       })
       .reply(200, { rules: [] })
-    return cmd.run({ flags: { space: 'my-space', dest: '128.0.1.1/20', port: '80-100', protocol: 'tcp' } })
-      .then(() => api.done())
+    await cmd.run({ flags: { space: 'my-space', dest: '128.0.1.1/20', port: '80-100', protocol: 'tcp' } })
+    return api.done()
   })
 
-  it('handles strange port range case of 80-', function () {
+  it('handles strange port range case of 80-', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/outbound-ruleset')
       .reply(200, {
@@ -68,8 +68,8 @@ describe('outbound-rules:add', function () {
         ]
       })
       .reply(200, { rules: [] })
-    return cmd.run({ flags: { space: 'my-space', dest: '128.0.1.1/20', port: '80-', protocol: 'tcp' } })
-      .then(() => api.done())
+    await cmd.run({ flags: { space: 'my-space', dest: '128.0.1.1/20', port: '80-', protocol: 'tcp' } })
+    return api.done()
   })
 
   it('handles strange port range case of 80-100-200', function () {
@@ -84,7 +84,7 @@ describe('outbound-rules:add', function () {
     return chai.assert.isRejected(cmd.run({ flags: { space: 'my-space', dest: '128.0.1.1/20', port: '80-100-200', protocol: 'tcp' } }), /^Specified --port range seems incorrect.$/)
   })
 
-  it('supports -1 as port', function () {
+  it('supports -1 as port', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/outbound-ruleset')
       .reply(200, {
@@ -101,11 +101,11 @@ describe('outbound-rules:add', function () {
         ]
       })
       .reply(200, { rules: [] })
-    return cmd.run({ flags: { space: 'my-space', dest: '128.0.1.1/20', port: '-1', protocol: 'tcp' } })
-      .then(() => api.done())
+    await cmd.run({ flags: { space: 'my-space', dest: '128.0.1.1/20', port: '-1', protocol: 'tcp' } })
+    return api.done()
   })
 
-  it('supports any as port', function () {
+  it('supports any as port', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/outbound-ruleset')
       .reply(200, {
@@ -122,11 +122,11 @@ describe('outbound-rules:add', function () {
         ]
       })
       .reply(200, { rules: [] })
-    return cmd.run({ flags: { space: 'my-space', dest: '128.0.1.1/20', port: 'any', protocol: 'tcp' } })
-      .then(() => api.done())
+    await cmd.run({ flags: { space: 'my-space', dest: '128.0.1.1/20', port: 'any', protocol: 'tcp' } })
+    return api.done()
   })
 
-  it('correct supports any as port for ICMP', function () {
+  it('correct supports any as port for ICMP', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/outbound-ruleset')
       .reply(200, {
@@ -143,7 +143,7 @@ describe('outbound-rules:add', function () {
         ]
       })
       .reply(200, { rules: [] })
-    return cmd.run({ flags: { space: 'my-space', dest: '128.0.1.1/20', port: 'any', protocol: 'icmp' } })
-      .then(() => api.done())
+    await cmd.run({ flags: { space: 'my-space', dest: '128.0.1.1/20', port: 'any', protocol: 'icmp' } })
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/outbound-rules/index.js
+++ b/packages/spaces/test/commands/outbound-rules/index.js
@@ -11,7 +11,7 @@ let now = new Date()
 describe('outbound-rules', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('shows the outbound rules', function () {
+  it('shows the outbound rules', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/outbound-ruleset')
       .reply(200, {
@@ -22,17 +22,20 @@ describe('outbound-rules', function () {
           { target: '128.0.0.1/20', from_port: 80, to_port: 80, protocol: 'tcp' }
         ]
       })
-    return cmd.run({ flags: { space: 'my-space' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== Outbound Rules
+
+    await cmd.run({ flags: { space: 'my-space' } })
+
+    expect(cli.stdout).to.equal(
+      `=== Outbound Rules
 Rule Number  Destination   From Port  To Port  Protocol
 ───────────  ────────────  ─────────  ───────  ────────
 1            128.0.0.1/20  80         80       tcp
-`))
-      .then(() => api.done())
+`)
+
+    return api.done()
   })
 
-  it('shows the empty ruleset message when empty', function () {
+  it('shows the empty ruleset message when empty', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/outbound-ruleset')
       .reply(200, {
@@ -42,14 +45,17 @@ Rule Number  Destination   From Port  To Port  Protocol
         created_by: 'dickeyxxx',
         rules: []
       })
-    return cmd.run({ flags: { space: 'my-space' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== my-space has no Outbound Rules. Your Dynos cannot communicate with hosts outside of my-space.
-`))
-      .then(() => api.done())
+
+    await cmd.run({ flags: { space: 'my-space' } })
+
+    expect(cli.stdout).to.equal(
+      `=== my-space has no Outbound Rules. Your Dynos cannot communicate with hosts outside of my-space.
+`)
+
+    return api.done()
   })
 
-  it('shows the outbound rules via JSON when --json is passed', function () {
+  it('shows the outbound rules via JSON when --json is passed', async function () {
     let ruleSet = {
       version: '1',
       default_action: 'allow',
@@ -64,8 +70,10 @@ Rule Number  Destination   From Port  To Port  Protocol
       .get('/spaces/my-space/outbound-ruleset')
       .reply(200, ruleSet)
 
-    return cmd.run({ flags: { space: 'my-space', json: true } })
-      .then(() => expect(JSON.parse(cli.stdout)).to.eql(ruleSet))
-      .then(() => api.done())
+    await cmd.run({ flags: { space: 'my-space', json: true } })
+
+    expect(JSON.parse(cli.stdout)).to.eql(ruleSet)
+
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/outbound-rules/remmove.js
+++ b/packages/spaces/test/commands/outbound-rules/remmove.js
@@ -8,7 +8,7 @@ let cli = require('heroku-cli-util')
 describe('outbound-rules:remove', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('removes a rule entry from the outbound rules', function () {
+  it('removes a rule entry from the outbound rules', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/outbound-ruleset')
       .reply(200, {
@@ -26,7 +26,7 @@ describe('outbound-rules:remove', function () {
         ]
       })
       .reply(200, { rules: [] })
-    return cmd.run({ args: { ruleNumber: 2 }, flags: { space: 'my-space', confirm: 'my-space' } })
-      .then(() => api.done())
+    await cmd.run({ args: { ruleNumber: 2 }, flags: { space: 'my-space', confirm: 'my-space' } })
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/peering/accept.js
+++ b/packages/spaces/test/commands/peering/accept.js
@@ -9,14 +9,17 @@ let cli = require('heroku-cli-util')
 describe('spaces:peerings:accept', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('accepts a pending peering connection', function () {
+  it('accepts a pending peering connection', async function () {
     let api = nock('https://api.heroku.com:443')
       .post('/spaces/my-space/peerings', {
         pcx_id: 'pcx-12345' })
       .reply(202)
-    return cmd.run({ flags: { space: 'my-space', 'pcxid': 'pcx-12345' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `Accepting and configuring peering connection pcx-12345\n`))
-      .then(() => api.done())
+
+    await cmd.run({ flags: { space: 'my-space', 'pcxid': 'pcx-12345' } })
+
+    expect(cli.stdout).to.equal(
+      `Accepting and configuring peering connection pcx-12345\n`)
+
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/peering/destroy.js
+++ b/packages/spaces/test/commands/peering/destroy.js
@@ -9,13 +9,16 @@ let cli = require('heroku-cli-util')
 describe('spaces:peerings:destroy', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('destroys an active peering connection', function () {
+  it('destroys an active peering connection', async function () {
     let api = nock('https://api.heroku.com:443')
       .delete('/spaces/my-space/peerings/pcx-12345')
       .reply(202)
-    return cmd.run({ flags: { space: 'my-space', 'pcxid': 'pcx-12345', confirm: 'pcx-12345' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `Tearing down peering connection pcx-12345\n`))
-      .then(() => api.done())
+
+    await cmd.run({ flags: { space: 'my-space', 'pcxid': 'pcx-12345', confirm: 'pcx-12345' } })
+
+    expect(cli.stdout).to.equal(
+      `Tearing down peering connection pcx-12345\n`)
+
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/peering/index.js
+++ b/packages/spaces/test/commands/peering/index.js
@@ -55,32 +55,37 @@ let peers = [
 describe('spaces:peerings', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('shows space peering info', function () {
+  it('shows space peering info', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/peerings')
       .reply(200,
         peers
       )
-    return cmd.run({ flags: { space: 'my-space' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== my-space Peerings
+
+    await cmd.run({ flags: { space: 'my-space' } })
+
+    expect(cli.stdout).to.equal(
+      `=== my-space Peerings
 PCX ID             Type      CIDR Blocks               Status              VPC ID         AWS Region  AWS Account ID  Expires
 ─────────────────  ────────  ────────────────────────  ──────────────────  ─────────────  ──────────  ──────────────  ───────
 ******             heroku    10.1.0.0/16               active              ******         ******      ******
 pcx-123456789012   external  10.2.0.0/16, 10.3.0.0/16  active              vpc-12345678   us-east-1   012345678901
 pcx-0987654321098  unknown   10.4.0.0/16               pending-acceptance  vpc-87654321   us-west-1   012345678901
 pcx-abcdefg        unknown   10.5.0.0/16               failed              vpc-665544332  us-east-2   012345678901
-`))
-      .then(() => api.done())
+`)
+
+    return api.done()
   })
 
-  it('shows peering:info --json', function () {
+  it('shows peering:info --json', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/peerings')
       .reply(200, peers)
 
-    return cmd.run({ flags: { space: 'my-space', json: true } })
-      .then(() => expect(JSON.parse(cli.stdout)).to.eql(peers))
-      .then(() => api.done())
+    await cmd.run({ flags: { space: 'my-space', json: true } })
+
+    expect(JSON.parse(cli.stdout)).to.eql(peers)
+
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/peering/info.js
+++ b/packages/spaces/test/commands/peering/info.js
@@ -16,32 +16,37 @@ let info = {
 describe('spaces:peering-info', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('shows space peering info', function () {
+  it('shows space peering info', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/peering-info')
       .reply(200,
         info
       )
-    return cmd.run({ flags: { space: 'my-space' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== my-space Peering Info
+
+    await cmd.run({ flags: { space: 'my-space' } })
+
+    expect(cli.stdout).to.equal(
+      `=== my-space Peering Info
 AWS Account ID:    012345678900
 AWS Region:        us-west-2
 AWS VPC ID:        vpc-1234568a
 AWS VPC CIDR:      10.0.0.0/16
 Space CIDRs:       10.0.128.0/20, 10.0.144.0/20
 Unavailable CIDRs: 192.168.2.0/30
-`))
-      .then(() => api.done())
+`)
+
+    return api.done()
   })
 
-  it('shows peering:info --json', function () {
+  it('shows peering:info --json', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/peering-info')
       .reply(200, info)
 
-    return cmd.run({ flags: { space: 'my-space', json: true } })
-      .then(() => expect(JSON.parse(cli.stdout)).to.eql(info))
-      .then(() => api.done())
+    await cmd.run({ flags: { space: 'my-space', json: true } })
+
+    expect(JSON.parse(cli.stdout)).to.eql(info)
+
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/ps.js
+++ b/packages/spaces/test/commands/ps.js
@@ -42,15 +42,16 @@ const privateDynos = [
 describe('spaces:ps', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('shows space dynos', function () {
+  it('shows space dynos', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/dynos').reply(200, spaceDynos)
     let apiSpace = nock('https://api.heroku.com:443')
       .get('/spaces/my-space').reply(200, { shield: false })
 
-    return cmd.run({ flags: { space: 'my-space' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== app_name1 web (Free): npm start (1)
+    await cmd.run({ flags: { space: 'my-space' } })
+
+    expect(cli.stdout).to.equal(
+      `=== app_name1 web (Free): npm start (1)
 web.1: up ${hourAgoStr} (~ 1h ago)
 
 === app_name1 run: one-off processes (1)
@@ -62,52 +63,62 @@ web.1: up ${hourAgoStr} (~ 1h ago)
 === app_name2 run: one-off processes (1)
 run.1 (Free): up ${hourAgoStr} (~ 1h ago): bash
 
-`))
-      .then(() => api.done())
-      .then(() => apiSpace.done())
+`)
+
+    api.done()
+
+    return apiSpace.done()
   })
 
-  it('shows shield space dynos', function () {
+  it('shows shield space dynos', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/dynos').reply(200, privateDynos)
     let apiSpace = nock('https://api.heroku.com:443')
       .get('/spaces/my-space').reply(200, { shield: true })
 
-    return cmd.run({ flags: { space: 'my-space' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== app_name1 web (Shield-M): npm start (1)
+    await cmd.run({ flags: { space: 'my-space' } })
+
+    expect(cli.stdout).to.equal(
+      `=== app_name1 web (Shield-M): npm start (1)
 web.1: up ${hourAgoStr} (~ 1h ago)
 
-`))
-      .then(() => api.done())
-      .then(() => apiSpace.done())
+`)
+
+    api.done()
+
+    return apiSpace.done()
   })
 
-  it('shows private space dynos', function () {
+  it('shows private space dynos', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/dynos').reply(200, privateDynos)
     let apiSpace = nock('https://api.heroku.com:443')
       .get('/spaces/my-space').reply(200, { shield: false })
 
-    return cmd.run({ flags: { space: 'my-space' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== app_name1 web (Private-M): npm start (1)
+    await cmd.run({ flags: { space: 'my-space' } })
+
+    expect(cli.stdout).to.equal(
+      `=== app_name1 web (Private-M): npm start (1)
 web.1: up ${hourAgoStr} (~ 1h ago)
 
-`))
-      .then(() => api.done())
-      .then(() => apiSpace.done())
+`)
+
+    api.done()
+
+    return apiSpace.done()
   })
 
-  it('shows space dynos with --json', function () {
+  it('shows space dynos with --json', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/dynos').reply(200, spaceDynos)
     let apiSpace = nock('https://api.heroku.com:443')
       .get('/spaces/my-space').reply(200, { shield: false })
 
-    return cmd.run({ flags: { space: 'my-space', json: true } })
-      .then(() => expect(JSON.parse(cli.stdout)).to.eql(spaceDynos))
-      .then(() => api.done())
-      .then(() => apiSpace.done())
+    await cmd.run({ flags: { space: 'my-space', json: true } })
+
+    expect(JSON.parse(cli.stdout)).to.eql(spaceDynos)
+    api.done()
+
+    return apiSpace.done()
   })
 })

--- a/packages/spaces/test/commands/rename.js
+++ b/packages/spaces/test/commands/rename.js
@@ -8,11 +8,11 @@ let cli = require('heroku-cli-util')
 describe('spaces:rename', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('renames a space', function () {
+  it('renames a space', async function () {
     let api = nock('https://api.heroku.com:443')
       .patch('/spaces/old-space-name', { name: 'new-space-name' })
       .reply(200)
-    return cmd.run({ flags: { from: 'old-space-name', to: 'new-space-name' } })
-      .then(() => api.done())
+    await cmd.run({ flags: { from: 'old-space-name', to: 'new-space-name' } })
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/topology.js
+++ b/packages/spaces/test/commands/topology.js
@@ -38,39 +38,45 @@ const app = {
 describe('spaces:toplogy', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('shows space topology', function () {
+  it('shows space topology', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/topology').reply(200, topo)
       .get(`/apps/${app['id']}`).reply(200, app)
 
-    return cmd.run({ flags: { space: 'my-space' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== app-name (web)
+    await cmd.run({ flags: { space: 'my-space' } })
+
+    expect(cli.stdout).to.equal(
+      `=== app-name (web)
 Domains: example.com
          example.net
 Dynos:   web.1 - 10.0.134.42 - 1.example-app-90210.app.localspace
 
-`))
-      .then(() => api.done())
+`)
+
+    return api.done()
   })
 
-  it('shows space toplogy  --json', function () {
+  it('shows space toplogy  --json', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/topology').reply(200, topo)
       .get(`/apps/${app['id']}`).reply(200, app)
 
-    return cmd.run({ flags: { space: 'my-space', json: true } })
-      .then(() => expect(JSON.parse(cli.stdout)).to.eql(topo))
-      .then(() => api.done())
+    await cmd.run({ flags: { space: 'my-space', json: true } })
+
+    expect(JSON.parse(cli.stdout)).to.eql(topo)
+
+    return api.done()
   })
 
-  it('shows space toplology --json', function () {
+  it('shows space toplology --json', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/topology').reply(200, topo)
       .get(`/apps/${app['id']}`).reply(200, app)
 
-    return cmd.run({ flags: { space: 'my-space', json: true } })
-      .then(() => expect(JSON.parse(cli.stdout)).to.eql(topo))
-      .then(() => api.done())
+    await cmd.run({ flags: { space: 'my-space', json: true } })
+
+    expect(JSON.parse(cli.stdout)).to.eql(topo)
+
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/transfer.js
+++ b/packages/spaces/test/commands/transfer.js
@@ -9,7 +9,7 @@ const cli = require('heroku-cli-util')
 describe('spaces:transfer', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('yields success when the API succeeds', function () {
+  it('yields success when the API succeeds', async function () {
     const space = 'dimension-c137'
     const team = 'jerry'
     const api = nock('https://api.heroku.com:443')
@@ -31,12 +31,15 @@ describe('spaces:transfer', function () {
           'updated_at': '2019-07-16T10:19:10Z'
         }
       )
-    return cmd.run({ flags: { team, space } })
-      .then(() => expect(cli.stderr).to.contain('done'))
-      .then(() => api.done())
+
+    await cmd.run({ flags: { team, space } })
+
+    expect(cli.stderr).to.contain('done')
+
+    return api.done()
   })
 
-  it('yields the API error messages when the API fails', function () {
+  it('yields the API error messages when the API fails', async function () {
     const space = 'dimension-c137'
     const team = 'jerry'
     const message = 'rikki tikki tavi!'
@@ -46,8 +49,10 @@ describe('spaces:transfer', function () {
       .post(`/spaces/${space}/transfer`, { 'new_owner': team })
       .reply(500, { id, message })
 
-    return cmd.run({ flags: { team, space } })
-      .then(() => expect(cli.stderr).to.contain(message))
-      .then(() => api.done())
+    await cmd.run({ flags: { team, space } })
+
+    expect(cli.stderr).to.contain(message)
+
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/trusted-ips/add.js
+++ b/packages/spaces/test/commands/trusted-ips/add.js
@@ -8,7 +8,7 @@ let cli = require('heroku-cli-util')
 describe('trusted-ips:add', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('adds a CIDR entry to the trusted IP ranges', function () {
+  it('adds a CIDR entry to the trusted IP ranges', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/inbound-ruleset')
       .reply(200, {
@@ -25,7 +25,7 @@ describe('trusted-ips:add', function () {
         ]
       })
       .reply(200, { rules: [] })
-    return cmd.run({ args: { source: '127.0.0.1/20' }, flags: { space: 'my-space' } })
-      .then(() => api.done())
+    await cmd.run({ args: { source: '127.0.0.1/20' }, flags: { space: 'my-space' } })
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/trusted-ips/index.js
+++ b/packages/spaces/test/commands/trusted-ips/index.js
@@ -11,7 +11,7 @@ let now = new Date()
 describe('trusted-ips', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('shows the trusted IP ranges', function () {
+  it('shows the trusted IP ranges', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/inbound-ruleset')
       .reply(200, {
@@ -23,15 +23,18 @@ describe('trusted-ips', function () {
           { source: '127.0.0.1/20', action: 'allow' }
         ]
       })
-    return cmd.run({ flags: { space: 'my-space' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== Trusted IP Ranges
+
+    await cmd.run({ flags: { space: 'my-space' } })
+
+    expect(cli.stdout).to.equal(
+      `=== Trusted IP Ranges
 127.0.0.1/20
-`))
-      .then(() => api.done())
+`)
+
+    return api.done()
   })
 
-  it('shows the trusted IP ranges with blank rules', function () {
+  it('shows the trusted IP ranges with blank rules', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/inbound-ruleset')
       .reply(200, {
@@ -41,14 +44,17 @@ describe('trusted-ips', function () {
         created_by: 'dickeyxxx',
         rules: []
       })
-    return cmd.run({ flags: { space: 'my-space' } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== my-space has no trusted IP ranges. All inbound web requests to dynos are blocked.
-`))
-      .then(() => api.done())
+
+    await cmd.run({ flags: { space: 'my-space' } })
+
+    expect(cli.stdout).to.equal(
+      `=== my-space has no trusted IP ranges. All inbound web requests to dynos are blocked.
+`)
+
+    return api.done()
   })
 
-  it('shows the trusted IP ranges --json', function () {
+  it('shows the trusted IP ranges --json', async function () {
     let ruleSet = {
       version: '1',
       default_action: 'allow',
@@ -63,8 +69,10 @@ describe('trusted-ips', function () {
       .get('/spaces/my-space/inbound-ruleset')
       .reply(200, ruleSet)
 
-    return cmd.run({ flags: { space: 'my-space', json: true } })
-      .then(() => expect(JSON.parse(cli.stdout)).to.eql(ruleSet))
-      .then(() => api.done())
+    await cmd.run({ flags: { space: 'my-space', json: true } })
+
+    expect(JSON.parse(cli.stdout)).to.eql(ruleSet)
+
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/trusted-ips/remove.js
+++ b/packages/spaces/test/commands/trusted-ips/remove.js
@@ -8,7 +8,7 @@ let cli = require('heroku-cli-util')
 describe('trusted-ips:remove', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('removes a CIDR entry from the trusted IP ranges', function () {
+  it('removes a CIDR entry from the trusted IP ranges', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/inbound-ruleset')
       .reply(200, {
@@ -26,7 +26,7 @@ describe('trusted-ips:remove', function () {
         ]
       })
       .reply(200, { rules: [] })
-    return cmd.run({ args: { source: '128.0.0.1/20' }, flags: { space: 'my-space' } })
-      .then(() => api.done())
+    await cmd.run({ args: { source: '128.0.0.1/20' }, flags: { space: 'my-space' } })
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/vpn/config.js
+++ b/packages/spaces/test/commands/vpn/config.js
@@ -38,34 +38,39 @@ let vpnResponse = {
 describe('spaces:vpn:config', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('gets VPN config', function () {
+  it('gets VPN config', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/vpn-connections/vpn-connection-name-config')
       .reply(200, vpnResponse)
-    return cmd.run({ flags: {
+
+    await cmd.run({ flags: {
       space: 'my-space',
       name: 'vpn-connection-name-config'
     } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== vpn-connection-name-config VPN Tunnels
+
+    expect(cli.stdout).to.equal(
+      `=== vpn-connection-name-config VPN Tunnels
 VPN Tunnel  Customer Gateway  VPN Gateway    Pre-shared Key  Routable Subnets  IKE Version
 ──────────  ────────────────  ─────────────  ──────────────  ────────────────  ───────────
 Tunnel 1    52.44.146.197     52.44.146.196  apresharedkey1  10.0.0.0/16       1
-Tunnel 2    52.44.146.199     52.44.146.198  apresharedkey2  10.0.0.0/16       1\n`))
-      .then(() => api.done())
+Tunnel 2    52.44.146.199     52.44.146.198  apresharedkey2  10.0.0.0/16       1\n`)
+
+    return api.done()
   })
 
-  it('gets VPN config in JSON', function () {
+  it('gets VPN config in JSON', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/vpn-connections/vpn-connection-name-config')
       .reply(200, vpnResponse)
-    return cmd.run({ flags: {
+
+    await cmd.run({ flags: {
       space: 'my-space',
       name: 'vpn-connection-name-config',
       json: true
     } })
-      .then(() => expect(cli.stdout).to.equal(
-        `{
+
+    expect(cli.stdout).to.equal(
+      `{
   "id": "123456789012",
   "name": "vpn-connection-name-config",
   "public_ip": "35.161.69.30",
@@ -94,7 +99,8 @@ Tunnel 2    52.44.146.199     52.44.146.198  apresharedkey2  10.0.0.0/16       1
       "status_message": "status message"
     }
   ]
-}\n`))
-      .then(() => api.done())
+}\n`)
+
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/vpn/connect.js
+++ b/packages/spaces/test/commands/vpn/connect.js
@@ -10,7 +10,7 @@ const unwrap = require('../../unwrap')
 describe('spaces:vpn:connect', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('creates VPN', function () {
+  it('creates VPN', async function () {
     let api = nock('https://api.heroku.com:443')
       .post('/spaces/my-space/vpn-connections', {
         name: 'office',
@@ -18,14 +18,17 @@ describe('spaces:vpn:connect', function () {
         routable_cidrs: [ '192.168.0.1/16', '192.168.0.2/16' ]
       })
       .reply(201)
-    return cmd.run({ flags: {
+
+    await cmd.run({ flags: {
       name: 'office',
       space: 'my-space',
       ip: '192.168.0.1',
       cidrs: '192.168.0.1/16,192.168.0.2/16'
     } })
-      .then(() => expect(unwrap(cli.stderr)).to.equal(
-        'Creating VPN Connection in space my-space... done Use spaces:vpn:wait to track allocation.\n'))
-      .then(() => api.done())
+
+    expect(unwrap(cli.stderr)).to.equal(
+      'Creating VPN Connection in space my-space... done Use spaces:vpn:wait to track allocation.\n')
+
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/vpn/destroy.js
+++ b/packages/spaces/test/commands/vpn/destroy.js
@@ -9,13 +9,16 @@ const cli = require('heroku-cli-util')
 describe('spaces:vpn:destroy', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('destroys VPN Connection when name is specified', function () {
+  it('destroys VPN Connection when name is specified', async function () {
     let api = nock('https://api.heroku.com:443')
       .delete('/spaces/my-space/vpn-connections/my-vpn-connection')
       .reply(202)
-    return cmd.run({ args: { name: 'my-vpn-connection' }, flags: { space: 'my-space', confirm: 'my-vpn-connection' } })
-      .then(() => expect(cli.stderr).to.equal(
-        `Tearing down VPN Connection my-vpn-connection in space my-space... done\n`))
-      .then(() => api.done())
+
+    await cmd.run({ args: { name: 'my-vpn-connection' }, flags: { space: 'my-space', confirm: 'my-vpn-connection' } })
+
+    expect(cli.stderr).to.equal(
+      `Tearing down VPN Connection my-vpn-connection in space my-space... done\n`)
+
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/vpn/index.js
+++ b/packages/spaces/test/commands/vpn/index.js
@@ -39,59 +39,70 @@ describe('spaces:vpn:connections', function () {
       }
     ]
   }
-  it('displays no connection message if none exist', function () {
+  it('displays no connection message if none exist', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/vpn-connections')
       .reply(200, [])
-    return cmd.run({ flags: {
+
+    await cmd.run({ flags: {
       space: 'my-space'
     } })
-      .then(() => expect(cli.stdout).to.equal('No VPN Connections have been created yet\n'))
-      .then(() => api.done())
+
+    expect(cli.stdout).to.equal('No VPN Connections have been created yet\n')
+
+    return api.done()
   })
-  it('displays VPN Connections', function () {
+  it('displays VPN Connections', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/vpn-connections')
       .reply(200, [ space ])
-    return cmd.run({ flags: {
+
+    await cmd.run({ flags: {
       space: 'my-space'
     } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== my-space VPN Connections
+
+    expect(cli.stdout).to.equal(
+      `=== my-space VPN Connections
 Name    Status  Tunnels
 ──────  ──────  ───────
 office  active  UP/UP
 `
-      ))
-      .then(() => api.done())
+    )
+
+    return api.done()
   })
-  it('displays VPN Connection ID when name is unavailable', function () {
+  it('displays VPN Connection ID when name is unavailable', async function () {
     let conn = { ...space, name: '' }
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/vpn-connections')
       .reply(200, [ conn ])
-    return cmd.run({ flags: {
+
+    await cmd.run({ flags: {
       space: 'my-space'
     } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== my-space VPN Connections
+
+    expect(cli.stdout).to.equal(
+      `=== my-space VPN Connections
 Name          Status  Tunnels
 ────────────  ──────  ───────
 123456789012  active  UP/UP
 `
-      ))
-      .then(() => api.done())
+    )
+
+    return api.done()
   })
-  it('displays VPN Connections in json', function () {
+  it('displays VPN Connections in json', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/vpn-connections')
       .reply(200, [ space ])
-    return cmd.run({ flags: {
+
+    await cmd.run({ flags: {
       space: 'my-space',
       json: true
     } })
-      .then(() => expect(cli.stdout).to.equal(
-        `[
+
+    expect(cli.stdout).to.equal(
+      `[
   {
     "id": "123456789012",
     "name": "office",
@@ -124,7 +135,8 @@ Name          Status  Tunnels
   }
 ]
 `
-      ))
-      .then(() => api.done())
+    )
+
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/vpn/info.js
+++ b/packages/spaces/test/commands/vpn/info.js
@@ -9,7 +9,7 @@ const cli = require('heroku-cli-util')
 describe('spaces:vpn:info', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('gets VPN info', function () {
+  it('gets VPN info', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/vpn-connections/vpn-connection-name')
       .reply(200, {
@@ -37,12 +37,14 @@ describe('spaces:vpn:info', function () {
           }
         ]
       })
-    return cmd.run({ flags: {
+
+    await cmd.run({ flags: {
       space: 'my-space',
       name: 'vpn-connection-name'
     } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== vpn-connection-name VPN Info
+
+    expect(cli.stdout).to.equal(
+      `=== vpn-connection-name VPN Info
 Name:           vpn-connection-name
 ID:             123456789012
 Public IP:      35.161.69.30
@@ -54,11 +56,12 @@ VPN Tunnel  IP Address     Status  Status Last Changed   Details
 ──────────  ─────────────  ──────  ────────────────────  ──────────────
 Tunnel 1    52.44.146.197  UP      2016-10-25T22:09:05Z  status message
 Tunnel 2    52.44.146.197  UP      2016-10-25T22:09:05Z  status message\n`
-      ))
-      .then(() => api.done())
+    )
+
+    return api.done()
   })
 
-  it('gets VPN info in JSON', function () {
+  it('gets VPN info in JSON', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/vpn-connections/vpn-connection-name')
       .reply(200, {
@@ -85,13 +88,15 @@ Tunnel 2    52.44.146.197  UP      2016-10-25T22:09:05Z  status message\n`
           }
         ]
       })
-    return cmd.run({ flags: {
+
+    await cmd.run({ flags: {
       space: 'my-space',
       name: 'vpn-connection-name',
       json: true
     } })
-      .then(() => expect(cli.stdout).to.equal(
-        `{
+
+    expect(cli.stdout).to.equal(
+      `{
   "id": "123456789012",
   "public_ip": "35.161.69.30",
   "routable_cidrs": [
@@ -116,10 +121,11 @@ Tunnel 2    52.44.146.197  UP      2016-10-25T22:09:05Z  status message\n`
       "status_message": "status message"
     }
   ]
-}\n`))
-      .then(() => api.done())
+}\n`)
+
+    return api.done()
   })
-  it('gets VPN info with id', function () {
+  it('gets VPN info with id', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/vpn-connections/123456789012')
       .reply(200, {
@@ -147,12 +153,14 @@ Tunnel 2    52.44.146.197  UP      2016-10-25T22:09:05Z  status message\n`
           }
         ]
       })
-    return cmd.run({ flags: {
+
+    await cmd.run({ flags: {
       space: 'my-space',
       name: '123456789012'
     } })
-      .then(() => expect(cli.stdout).to.equal(
-        `=== vpn-connection-name VPN Info
+
+    expect(cli.stdout).to.equal(
+      `=== vpn-connection-name VPN Info
 Name:           vpn-connection-name
 ID:             123456789012
 Public IP:      35.161.69.30
@@ -164,7 +172,8 @@ VPN Tunnel  IP Address     Status  Status Last Changed   Details
 ──────────  ─────────────  ──────  ────────────────────  ──────────────
 Tunnel 1    52.44.146.197  UP      2016-10-25T22:09:05Z  status message
 Tunnel 2    52.44.146.197  UP      2016-10-25T22:09:05Z  status message\n`
-      ))
-      .then(() => api.done())
+    )
+
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/vpn/wait.js
+++ b/packages/spaces/test/commands/vpn/wait.js
@@ -9,7 +9,7 @@ const cli = require('heroku-cli-util')
 describe('spaces:vpn:wait', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('waits for VPN to allocate and then shows space config', function () {
+  it('waits for VPN to allocate and then shows space config', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/vpn-connections/vpn-connection-name-wait')
       .reply(200)
@@ -101,20 +101,23 @@ describe('spaces:vpn:wait', function () {
         ]
       })
 
-    return cmd.run({ flags: { space: 'my-space', name: 'vpn-connection-name-wait', interval: 0 } })
-      .then(() => expect(cli.stderr).to.equal(
-        `Waiting for VPN Connection vpn-connection-name-wait to allocate... done\n\n`))
-      .then(() => expect(cli.stdout).to.equal(
-        `=== vpn-connection-name-wait VPN Tunnels
+    await cmd.run({ flags: { space: 'my-space', name: 'vpn-connection-name-wait', interval: 0 } })
+
+    expect(cli.stderr).to.equal(
+      `Waiting for VPN Connection vpn-connection-name-wait to allocate... done\n\n`)
+
+    expect(cli.stdout).to.equal(
+      `=== vpn-connection-name-wait VPN Tunnels
 VPN Tunnel  Customer Gateway  VPN Gateway    Pre-shared Key  Routable Subnets  IKE Version
 ──────────  ────────────────  ─────────────  ──────────────  ────────────────  ───────────
 Tunnel 1    52.44.146.197     52.44.146.196  apresharedkey1  10.0.0.0/16       1
 Tunnel 2    52.44.146.199     52.44.146.198  apresharedkey2  10.0.0.0/16       1\n`
-      ))
-      .then(() => api.done())
+    )
+
+    return api.done()
   })
 
-  it('returns an error if the VPN status is updated to failed', function () {
+  it('returns an error if the VPN status is updated to failed', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/vpn-connections/vpn-connection-name-wait')
       .reply(200)
@@ -177,14 +180,15 @@ Tunnel 2    52.44.146.199     52.44.146.198  apresharedkey2  10.0.0.0/16       1
         ]
       })
 
-    return cmd.run({ flags: { space: 'my-space', name: 'vpn-connection-name-wait', interval: 0 } })
+    await cmd.run({ flags: { space: 'my-space', name: 'vpn-connection-name-wait', interval: 0 } })
       .catch(reason => {
         expect(reason.message).to.equal('supplied CIDR block already in use')
       })
-      .then(() => api.done())
+
+    return api.done()
   })
 
-  it('tells the user if the VPN has been allocated', function () {
+  it('tells the user if the VPN has been allocated', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space/vpn-connections/vpn-connection-allocated')
       .reply(200, {
@@ -198,9 +202,11 @@ Tunnel 2    52.44.146.199     52.44.146.198  apresharedkey2  10.0.0.0/16       1
         status_message: ''
       })
 
-    return cmd.run({ flags: { space: 'my-space', name: 'vpn-connection-allocated', interval: 0 } })
-      .then(() => expect(cli.stdout).to.equal(
-        `VPN has been allocated.\n`))
-      .then(() => api.done())
+    await cmd.run({ flags: { space: 'my-space', name: 'vpn-connection-allocated', interval: 0 } })
+
+    expect(cli.stdout).to.equal(
+      `VPN has been allocated.\n`)
+
+    return api.done()
   })
 })

--- a/packages/spaces/test/commands/wait_test.js
+++ b/packages/spaces/test/commands/wait_test.js
@@ -12,7 +12,7 @@ let now = new Date()
 describe('spaces:wait', function () {
   beforeEach(() => cli.mockConsole())
 
-  it('waits for space to allocate and then shows space info', function () {
+  it('waits for space to allocate and then shows space info', async function () {
     const sandbox = sinon.createSandbox()
     const notifySpy = sandbox.spy(require('@heroku-cli/notifications'), 'notify')
 
@@ -30,25 +30,30 @@ describe('spaces:wait', function () {
         { state: 'enabled', sources: ['123.456.789.123'] }
       )
 
-    return cmd.run({ flags: { space: 'my-space', interval: 0 } })
-      .then(() => expect(cli.stderr).to.equal(
-        `Waiting for space my-space to allocate... done\n\n`))
-      .then(() => expect(cli.stdout).to.equal(`=== my-space
+    await cmd.run({ flags: { space: 'my-space', interval: 0 } })
+
+    expect(cli.stderr).to.equal(
+      `Waiting for space my-space to allocate... done\n\n`)
+
+    expect(cli.stdout).to.equal(`=== my-space
 Team:         my-team
 Region:       region
 State:        allocated
 Shield:       off
 Outbound IPs: 123.456.789.123
 Created at:   ${now.toISOString()}
-`))
-      .then(() => outbound.done())
-      .then(() => api.done())
-      .then(() => expect(notifySpy.called).to.be.true)
-      .then(() => expect(notifySpy.calledOnce).to.be.true)
-      .then(() => sandbox.restore())
+`)
+
+    await outbound.done()
+    await api.done()
+
+    expect(notifySpy.called).to.equal(true)
+    expect(notifySpy.calledOnce).to.equal(true)
+
+    return sandbox.restore()
   })
 
-  it('waits for space with --json', function () {
+  it('waits for space with --json', async function () {
     let api = nock('https://api.heroku.com:443')
       .get('/spaces/my-space')
       .reply(200,
@@ -63,10 +68,12 @@ Created at:   ${now.toISOString()}
         { state: 'enabled', sources: ['123.456.789.123'] }
       )
 
-    return cmd.run({ flags: { space: 'my-space', json: true, interval: 0 } })
-      .then(() => expect(cli.stderr).to.equal(
-        `Waiting for space my-space to allocate... done\n\n`))
-      .then(() => expect(cli.stdout).to.equal(`{
+    await cmd.run({ flags: { space: 'my-space', json: true, interval: 0 } })
+
+    expect(cli.stderr).to.equal(
+      `Waiting for space my-space to allocate... done\n\n`)
+
+    expect(cli.stdout).to.equal(`{
   "name": "my-space",
   "team": {
     "name": "my-team"
@@ -84,8 +91,10 @@ Created at:   ${now.toISOString()}
     ]
   }
 }
-`))
-      .then(() => outbound.done())
-      .then(() => api.done())
+`)
+
+    await outbound.done()
+
+    return api.done()
   })
 })


### PR DESCRIPTION
I ran the [async-await codemod][1] on the `test` directory of each
plugin. Makes reading most tests a lot nicer and easier to change later.

[1]: https://github.com/sgilroy/async-await-codemod

## How to verify?

* CI should pass. Only test files have been updated.