### PR TITLE
feat(ps-v5): Add total dynos table to ps:type output

### DIFF
--- a/packages/apps-v5/src/commands/ps/type.js
+++ b/packages/apps-v5/src/commands/ps/type.js
@@ -39,11 +39,25 @@ Types: ${cli.color.yellow(formation.map((f) => f.type).join(', '))}`)
     const shielded = appProps.space && appProps.space.shield
 
     formation = sortBy(formation, 'type')
-    if (shielded) {
-      formation.forEach((d) => {
+
+    let dynoTotals = [];
+
+    formation.forEach((d) => {
+
+      if (shielded) {
         d.size = d.size.replace('Private-', 'Shield-')
-      })
-    }
+      }
+      if(d.size in dynoTotals) {
+        dynoTotals[d.size] += d.quantity;
+      } else {
+        dynoTotals[d.size] = d.quantity;
+      }
+    });
+
+    dynoTotals = Object.keys(dynoTotals).map((k) => ({
+      type: cli.color.green(k), 
+      total: cli.color.yellow(dynoTotals[k])
+    }));
 
     formation = formation.map((d) => ({
       type: cli.color.green(d.type),
@@ -52,14 +66,25 @@ Types: ${cli.color.yellow(formation.map((f) => f.type).join(', '))}`)
       'cost/mo': costs[d.size] ? (costs[d.size] * d.quantity).toString() : ''
     }))
 
+
     if (formation.length === 0) throw emptyFormationErr()
 
+    cli.styledHeader('Dyno Types');
     cli.table(formation, {
       columns: [
         { key: 'type' },
         { key: 'size' },
         { key: 'qty' },
         { key: 'cost/mo' }
+      ]
+    })
+
+    cli.styledHeader('Dyno Totals');
+
+    cli.table(dynoTotals, {
+      columns: [
+        { key: 'type' },
+        { key: 'total' }
       ]
     })
   }

--- a/packages/apps-v5/test/commands/ps/type.js
+++ b/packages/apps-v5/test/commands/ps/type.js
@@ -29,10 +29,15 @@ describe('ps:type', function () {
       .reply(200, [{ type: 'web', quantity: 1, size: 'Hobby' }, { type: 'worker', quantity: 2, size: 'Hobby' }])
 
     return cmd.run({ app: 'myapp', args: ['hobby'] })
-      .then(() => expect(cli.stdout).to.eq(`type    size   qty  cost/mo
+      .then(() => expect(cli.stdout).to.eq(`=== Dyno Types
+type    size   qty  cost/mo
 ──────  ─────  ───  ───────
 web     Hobby  1    7
 worker  Hobby  2    14
+=== Dyno Totals
+type   total
+─────  ─────
+Hobby  3
 `))
       .then(() => expect(cli.stderr).to.eq('Scaling dynos on myapp... done\n'))
       .then(() => api.done())
@@ -50,10 +55,16 @@ worker  Hobby  2    14
       .reply(200, [{ type: 'web', quantity: 1, size: 'Standard-1X' }, { type: 'worker', quantity: 2, size: 'Standard-2X' }])
 
     return cmd.run({ app: 'myapp', args: ['web=standard-1x', 'worker=standard-2x'] })
-      .then(() => expect(cli.stdout).to.eq(`type    size         qty  cost/mo
+      .then(() => expect(cli.stdout).to.eq(`=== Dyno Types
+type    size         qty  cost/mo
 ──────  ───────────  ───  ───────
 web     Standard-1X  1    25
 worker  Standard-2X  2    100
+=== Dyno Totals
+type         total
+───────────  ─────
+Standard-1X  1
+Standard-2X  2
 `))
       .then(() => expect(cli.stderr).to.eq('Scaling dynos on myapp... done\n'))
       .then(() => api.done())
@@ -67,10 +78,16 @@ worker  Standard-2X  2    100
       .reply(200, [{ type: 'web', quantity: 0, size: 'Private-M' }, { type: 'web', quantity: 0, size: 'Private-L' }])
 
     return cmd.run({ app: 'myapp', args: [] })
-      .then(() => expect(cli.stdout).to.eq(`type  size      qty  cost/mo
+      .then(() => expect(cli.stdout).to.eq(`=== Dyno Types
+type  size      qty  cost/mo
 ────  ────────  ───  ───────
 web   Shield-M  0
 web   Shield-L  0
+=== Dyno Totals
+type      total
+────────  ─────
+Shield-M  0
+Shield-L  0
 `))
       .then(() => api.done())
   })


### PR DESCRIPTION
This PR is to add a total dynos section to `ps:type`. This helps when a large number of custom processes makes it difficult to see the total number of dynos running for an application (without checking through the dashboard). 

Example output below:

```
=== Dyno Types
type   size           qty  cost/mo
─────  ─────────────  ───  ───────
test   Standard-1X    2    50
test1  Standard-1X    3    75
test2  Standard-2X    1    50
web    Performance-M  1    250
=== Dyno Totals
type           total
─────────────  ─────
Standard-1X    5
Standard-2X    1
Performance-M  1
```