### PR TITLE
fix(ci-v5,addons-v5,pg-v5,certs-v5): remove co-wait

### DIFF
--- a/packages/addons-v5/lib/addons_wait.js
+++ b/packages/addons-v5/lib/addons_wait.js
@@ -3,13 +3,12 @@
 const cli = require('heroku-cli-util')
 
 module.exports = async function (api, addon, interval) {
-  const wait = require('co-wait')
   const app = addon.app.name
   const addonName = addon.name
 
   await cli.action(`Creating ${cli.color.addon(addon.name)}`, async function () {
     while (addon.state === 'provisioning') {
-      await wait(interval * 1000)
+      await new Promise((resolve) => setTimeout(resolve, interval * 1000))
 
       addon = await api.request({
         method: 'GET',

--- a/packages/addons-v5/package.json
+++ b/packages/addons-v5/package.json
@@ -14,7 +14,6 @@
     "repositoryPrefix": "<%- repo %>/blob/v<%- version %>/packages/addons-v5/<%- commandPath %>"
   },
   "dependencies": {
-    "co-wait": "0.0.0",
     "heroku-cli-util": "^8.0.11",
     "lodash": "^4.17.11",
     "printf": "0.5.1"

--- a/packages/certs-v5/package.json
+++ b/packages/certs-v5/package.json
@@ -15,7 +15,6 @@
     "repositoryPrefix": "<%- repo %>/blob/v<%- version %>/packages/certs-v5/<%- commandPath %>"
   },
   "dependencies": {
-    "co-wait": "0.0.0",
     "date-fns": "^1.29.0",
     "heroku-cli-util": "^8.0.11",
     "inquirer": "^6.2.2",

--- a/packages/ci-v5/lib/test-run.js
+++ b/packages/ci-v5/lib/test-run.js
@@ -1,10 +1,9 @@
 const api = require('./heroku-api')
-const wait = require('co-wait')
 
 async function waitForStates(states, testRun, { heroku }) {
   while (!states.includes(testRun.status)) {
     testRun = await api.testRun(heroku, testRun.pipeline.id, testRun.number)
-    await wait(1000)
+    await new Promise((resolve) => setTimeout(resolve, 1000))
   }
   return testRun
 }

--- a/packages/ci-v5/package.json
+++ b/packages/ci-v5/package.json
@@ -17,7 +17,6 @@
     "@heroku-cli/plugin-run-v5": "^7.49.0",
     "ansi-escapes": "3.2.0",
     "bluebird": "^3.5.3",
-    "co-wait": "0.0.0",
     "github-url-to-object": "^4.0.4",
     "got": "^8.3.2",
     "heroku-cli-util": "^8.0.11",

--- a/packages/pg-v5/lib/pgbackups.js
+++ b/packages/pg-v5/lib/pgbackups.js
@@ -65,7 +65,6 @@ module.exports = (context, heroku) => ({
     if (app === undefined) {
       app = context.app
     }
-    const wait = require('co-wait')
     const host = require('./host')()
     const pgbackups = module.exports(context, heroku)
 
@@ -118,7 +117,7 @@ ${backup.logs.slice(-5).map(l => l.message).join('\n')}
 Run ${cli.color.cmd('heroku pg:backups:info ' + pgbackups.transfer.name(backup))} for more details.`)
           }
         }
-        await wait(interval * 1000)
+        await new Promise((resolve) => setTimeout(resolve, interval * 1000))
       }
     }
 

--- a/packages/pg-v5/package.json
+++ b/packages/pg-v5/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@heroku-cli/plugin-addons": "^1.2.29",
     "bytes": "^3.1.0",
-    "co-wait": "^0.0.0",
     "debug": "^4.1.1",
     "filesize": "^4.0.0",
     "heroku-cli-util": "^8.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2947,7 +2947,7 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
-co-wait@0.0.0, co-wait@^0.0.0:
+co-wait@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/co-wait/-/co-wait-0.0.0.tgz#c22372032218edbf6ed915e433546c21e445628b"
   integrity sha1-wiNyAyIY7b9u2RXkM1RsIeRFYos=


### PR DESCRIPTION
When `co` was removed in [#1746](https://github.com/heroku/cli/pull/1746), we did not remove `co-wait` since it was assumed to have used promises under the hood. It turns out that `co-wait` [returns a function](https://github.com/juliangruber/co-wait/blob/master/index.js#L11) that `co` knew how to call instead. When we switched to `async/await`, we stopped waiting since we didn't call the function returned by `co-wait`. We can remove the `co-wait` dependency by using the JavaScript standard library one-liner of `await new Promise((resolve) => setTimeout(resolve, timeInMS)`.

https://heroku.support/965732