### PR TITLE
feat(redis-v5): exit if trying to use redis:cli with shield plan

### DIFF
--- a/packages/redis-v5/commands/cli.js
+++ b/packages/redis-v5/commands/cli.js
@@ -183,6 +183,15 @@ module.exports = {
     let configVars = await getRedisConfigVars(addon, heroku)
 
     let redis = await api.request(`/redis/v0/databases/${addon.name}`)
+    
+    if (redis.plan.startsWith('shield-')) {
+      cli.error(`
+      Using redis:cli on Heroku Redis shield plans is not supported.
+      Please see Heroku DevCenter for more details: https://devcenter.heroku.com/articles/shield-private-space#shield-features
+      `)
+      cli.exit(1)
+    }
+
     let hobby = redis.plan.indexOf('hobby') === 0
 
     if (hobby) {


### PR DESCRIPTION
Using `heroku redis:cli` with Heroku Redis Shield plans is not supported. Exit with an error and guide users toward DevCenter for more information.

[W-8974490](https://gus.lightning.force.com/a07B0000008xDSPIA2)

