### PR TITLE
fix(pg-v5): handle databases without config vars

### DIFF
--- a/packages/pg-v5/lib/fetcher.js
+++ b/packages/pg-v5/lib/fetcher.js
@@ -58,10 +58,12 @@ module.exports = heroku => {
         throw new Error(`${cli.color.app(app)} has no databases`)
       }
 
-      matches = attachments.filter(attachment => config[db] && config[db] === config[pgUtil.getConfigVarName(attachment.config_vars)])
+      // there can be cases where we have attachments without config vars, so lets reject those
+      let filtered_attachments = attachments.filter(attachment => attachment.config_vars.length !== 0)
+      matches = filtered_attachments.filter(attachment => config[db] && config[db] === config[pgUtil.getConfigVarName(attachment.config_vars)])
 
       if (matches.length === 0) {
-        let validOptions = attachments.map(attachment => pgUtil.getConfigVarName(attachment.config_vars))
+        let validOptions = filtered_attachments.map(attachment => pgUtil.getConfigVarName(attachment.config_vars))
         throw new Error(`Unknown database: ${passedDb}. Valid options are: ${validOptions.join(', ')}`)
       }
     }


### PR DESCRIPTION
In rare cases, we can have a database that is attached, but has no
config vars, as the database provisioning has not yet updated API with
the config vars needed. This leaves the attachment in a state where
`config_vars` is empty, and thus breaks `getConfigVarName`, even when
asking for an entirely separate database.

This commit fixes this and adds a regression test to make sure this
doesn't happen.

Ref: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B00000097iB0IAI/view
