### PR TITLE
build: fix homebrew release script by actually comitting changes

### DIFF
--- a/scripts/release/homebrew.js
+++ b/scripts/release/homebrew.js
@@ -59,8 +59,9 @@ if (!process.env.CIRCLE_TAG) {
 
 async function calculateSHA256 (fileName) {
   const hash = crypto.createHash('sha256')
+  hash.setEncoding('hex')
   await promisify(pipeline)(fs.createReadStream(fileName), hash)
-  return hash.digest('hex')
+  return hash.read()
 }
 
 const ROOT = path.join(__dirname, 'homebrew')
@@ -144,6 +145,7 @@ async function updateHomebrew () {
   await git(['add', 'Formula'])
   await git(['config', '--local', 'core.pager', 'cat'])
   await git(['diff', '--cached'], { stdio: 'inherit' })
+  await git(['commit', '-m', `heroku v${SHORT_VERSION}`])
   if (process.env.SKIP_GIT_PUSH === undefined) {
     await git(['push', 'origin', 'master'])
   }


### PR DESCRIPTION
https://github.com/heroku/cli/commit/7526130c045bcf7ac2f28556ad93e61a3b0d3942 introduced a new build script for Homebrew. It generates the right files
but doesn't commit the changes before pushing :facepalm:.

The SHA256 was also calculated incorrectly due to use of the streaming api. Using `hash.setEncoding('hex')` and using `hash.read` at the end returns the correct SHA256 sum for a file

GUS: [W-8984115][1]

[1]: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008xKCsIAM/view

