### PR TITLE
fix: correct path to node for homebrew install

### DIFF
--- a/scripts/release/homebrew/templates/heroku-node.rb
+++ b/scripts/release/homebrew/templates/heroku-node.rb
@@ -11,7 +11,7 @@ class HerokuNode < Formula
   keg_only "heroku-node is only used by Heroku CLI (heroku/brew/heroku), which explicitly requires from Cellar"
 
   def install
-    bin.install  buildpath/"bin/node"
+    bin.install buildpath/"bin/node"
   end
 
   def test

--- a/scripts/release/homebrew/templates/heroku.rb
+++ b/scripts/release/homebrew/templates/heroku.rb
@@ -11,7 +11,7 @@ class Heroku < Formula
 
   def install
     inreplace "bin/heroku", /^CLIENT_HOME=/, "export HEROKU_OCLIF_CLIENT_HOME=#{lib/"client"}\nCLIENT_HOME="
-    inreplace "bin/heroku", "\"$DIR/node\"", Formula["heroku-node"].bin/"node"
+    inreplace "bin/heroku", "\"$DIR/node\"", Formula["heroku-node"].opt_bin/"node"
     libexec.install Dir["*"]
     bin.install_symlink libexec/"bin/heroku"
 

--- a/scripts/release/homebrew/templates/heroku.rb
+++ b/scripts/release/homebrew/templates/heroku.rb
@@ -11,7 +11,7 @@ class Heroku < Formula
 
   def install
     inreplace "bin/heroku", /^CLIENT_HOME=/, "export HEROKU_OCLIF_CLIENT_HOME=#{lib/"client"}\nCLIENT_HOME="
-    inreplace "bin/heroku", "\"$DIR/node\"", Formula["heroku-node"].opt_share/"node"
+    inreplace "bin/heroku", "\"$DIR/node\"", Formula["heroku-node"].bin/"node"
     libexec.install Dir["*"]
     bin.install_symlink libexec/"bin/heroku"
 


### PR DESCRIPTION
Heroku cli currently points to the wrong node path since the most recent homebrew update.

On my machine:

Correct heroku-node

```
$ /usr/local/opt/heroku-node/bin/node --version
v12.21.0
```

Heroku points to the system node

```
$ heroku version
heroku/7.51.0 darwin-x64 node-v14.8.0
```

After the fix

```
$ heroku version
heroku/7.51.0 darwin-x64 node-v12.21.0
```

Hope I'm not overstepping for submitting a PR.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
