### PR TITLE
fix: correct path to node for homebrew install

### DIFF
--- a/scripts/release/homebrew/templates/heroku-node.rb
+++ b/scripts/release/homebrew/templates/heroku-node.rb
@@ -11,7 +11,7 @@ class HerokuNode < Formula
   keg_only "heroku-node is only used by Heroku CLI (heroku/brew/heroku), which explicitly requires from Cellar"
 
   def install
-    bin.install  buildpath/"bin/node"
+    bin.install buildpath/"bin/node"
   end
 
   def test

--- a/scripts/release/homebrew/templates/heroku.rb
+++ b/scripts/release/homebrew/templates/heroku.rb
@@ -11,7 +11,7 @@ class Heroku < Formula
 
   def install
     inreplace "bin/heroku", /^CLIENT_HOME=/, "export HEROKU_OCLIF_CLIENT_HOME=#{lib/"client"}\nCLIENT_HOME="
-    inreplace "bin/heroku", "\"$DIR/node\"", Formula["heroku-node"].bin/"node"
+    inreplace "bin/heroku", "\"$DIR/node\"", Formula["heroku-node"].opt_bin/"node"
     libexec.install Dir["*"]
     bin.install_symlink libexec/"bin/heroku"
 

--- a/scripts/release/homebrew/templates/heroku.rb
+++ b/scripts/release/homebrew/templates/heroku.rb
@@ -11,7 +11,7 @@ class Heroku < Formula
 
   def install
     inreplace "bin/heroku", /^CLIENT_HOME=/, "export HEROKU_OCLIF_CLIENT_HOME=#{lib/"client"}\nCLIENT_HOME="
-    inreplace "bin/heroku", "\"$DIR/node\"", Formula["heroku-node"].opt_share/"node"
+    inreplace "bin/heroku", "\"$DIR/node\"", Formula["heroku-node"].bin/"node"
     libexec.install Dir["*"]
     bin.install_symlink libexec/"bin/heroku"
 


### PR DESCRIPTION
Bringing in https://github.com/heroku/cli/pull/1769 as a new PR so our internal CI integrations can pass