### PR TITLE
fix(apps-v5): Improve UX of stack:set command output

### DIFF
--- a/packages/apps-v5/src/commands/apps/stacks/set.js
+++ b/packages/apps-v5/src/commands/apps/stacks/set.js
@@ -19,7 +19,7 @@ async function run(context, heroku) {
   // API updates the app's `stack` to match `build_stack` immediately.
   if (app.stack.name !== app.build_stack.name) {
     cli.log(`You will need to redeploy ${cli.color.app(context.app)} for the change to take effect.`)
-    cli.log(`Run ${cli.color.cmd(push(context.flags.remote))} to create a new release on ${cli.color.app(context.app)}.`)
+    cli.log(`Run ${cli.color.cmd(push(context.flags.remote))} to trigger a new build on ${cli.color.app(context.app)}.`)
   }
 }
 
@@ -28,8 +28,9 @@ let cmd = {
   needsAuth: true,
   description: 'set the stack of an app',
   examples: `$ heroku stack:set heroku-20 -a myapp
-Stack set. Next release on myapp will use heroku-20.
-Run git push heroku main to create a new release on myapp.`,
+Setting stack to heroku-20... done
+You will need to redeploy myapp for the change to take effect.
+Run git push heroku main to trigger a new build on myapp.`,
   args: [{ name: 'stack' }],
   run: cli.command(run)
 }

--- a/packages/apps-v5/test/commands/apps/stack/set.js
+++ b/packages/apps-v5/test/commands/apps/stack/set.js
@@ -37,7 +37,7 @@ describe('stack:set', function () {
     return cmd.run({ app: 'myapp', args: { stack: 'heroku-20' }, flags: {} })
       .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-20... done\n'))
       .then(() => expect(cli.stdout).to.equal(`You will need to redeploy myapp for the change to take effect.
-Run git push heroku main to create a new release on myapp.
+Run git push heroku main to trigger a new build on myapp.
 `))
       .then(() => api.done())
   })
@@ -50,7 +50,7 @@ Run git push heroku main to create a new release on myapp.
     return cmd.run({ app: 'myapp', args: { stack: 'heroku-20' }, flags: { remote: 'staging' } })
       .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-20... done\n'))
       .then(() => expect(cli.stdout).to.equal(`You will need to redeploy myapp for the change to take effect.
-Run git push staging main to create a new release on myapp.
+Run git push staging main to trigger a new build on myapp.
 `))
       .then(() => api.done())
   })


### PR DESCRIPTION
Previously the `stack:set` command's output mentioned needing to create a "new release" in order to complete the stack change.

However this is incorrect - a new build needs to be performed, so the wording has been updated accordingly.

In addition, the usage text has been updated so that it matches the actual output from the command.

Closes GUS-W-8797527.