### PR TITLE
Remove sni_ssl_cert variant

### DIFF
--- a/packages/certs-v5/commands/certs/add.js
+++ b/packages/certs-v5/commands/certs/add.js
@@ -228,18 +228,11 @@ async function configureDomains(context, heroku, meta, cert) {
 }
 
 async function run(context, heroku) {
-  let headers
   let features = await heroku.get(`/apps/${context.app}/features`)
   let canMultiSni = checkMultiSniFeature(features)
   context.canMultiSni = canMultiSni
 
   let meta = await getMeta(context, heroku)
-
-  if (meta.variant) {
-    headers = { 'Accept': `application/vnd.heroku+json; version=3.${meta.variant}` }
-  } else {
-    headers = { 'Accept': `application/vnd.heroku+json; version=3` }
-  }
 
   let files = await getCertAndKey(context)
 
@@ -247,7 +240,7 @@ async function run(context, heroku) {
     path: meta.path,
     method: 'POST',
     body: { certificate_chain: files.crt, private_key: files.key },
-    headers: headers
+    headers: { 'Accept': `application/vnd.heroku+json; version=3${meta.variant ? '.' + meta.variant : ''}` }
   }))
 
   cert._meta = meta

--- a/packages/certs-v5/commands/certs/add.js
+++ b/packages/certs-v5/commands/certs/add.js
@@ -228,11 +228,18 @@ async function configureDomains(context, heroku, meta, cert) {
 }
 
 async function run(context, heroku) {
+  let headers
   let features = await heroku.get(`/apps/${context.app}/features`)
   let canMultiSni = checkMultiSniFeature(features)
   context.canMultiSni = canMultiSni
 
   let meta = await getMeta(context, heroku)
+
+  if (meta.variant) {
+    headers = { 'Accept': `application/vnd.heroku+json; version=3.${meta.variant}` }
+  } else {
+    headers = { 'Accept': `application/vnd.heroku+json; version=3` }
+  }
 
   let files = await getCertAndKey(context)
 
@@ -240,7 +247,7 @@ async function run(context, heroku) {
     path: meta.path,
     method: 'POST',
     body: { certificate_chain: files.crt, private_key: files.key },
-    headers: { 'Accept': `application/vnd.heroku+json; version=3.${meta.variant}` }
+    headers: headers
   }))
 
   cert._meta = meta

--- a/packages/certs-v5/lib/endpoints.js
+++ b/packages/certs-v5/lib/endpoints.js
@@ -12,10 +12,7 @@ function sslCertsPromise (app, heroku) {
 }
 
 function sniCertsPromise (app, heroku) {
-  return heroku.request({
-    path: `/apps/${app}/sni-endpoints`,
-    headers: {'Accept': 'application/vnd.heroku+json; version=3'}
-  }).catch(function (err) {
+  return heroku.request({path: `/apps/${app}/sni-endpoints`}).catch(function (err) {
     if (err.statusCode === 422 && err.body && err.body.id === 'space_app_not_supported') {
       return []
     }

--- a/packages/certs-v5/lib/endpoints.js
+++ b/packages/certs-v5/lib/endpoints.js
@@ -14,7 +14,7 @@ function sslCertsPromise (app, heroku) {
 function sniCertsPromise (app, heroku) {
   return heroku.request({
     path: `/apps/${app}/sni-endpoints`,
-    headers: {'Accept': 'application/vnd.heroku+json; version=3.sni_ssl_cert'}
+    headers: {'Accept': 'application/vnd.heroku+json; version=3'}
   }).catch(function (err) {
     if (err.statusCode === 422 && err.body && err.body.id === 'space_app_not_supported') {
       return []
@@ -29,7 +29,6 @@ function meta (app, t, name) {
   var path, variant
   if (t === 'sni') {
     path = `/apps/${app}/sni-endpoints`
-    variant = 'sni_ssl_cert'
   } else if (t === 'ssl') {
     path = `/apps/${app}/ssl-endpoints`
     variant = 'ssl_cert'
@@ -39,7 +38,12 @@ function meta (app, t, name) {
   if (name) {
     path = `${path}/${name}`
   }
-  return {path, variant, flag: t}
+
+  if (variant) {
+    return {path, variant, flag: t}
+  } else {
+    return {path, flag: t}
+  }
 }
 
 function tagAndSort (app, allCerts) {

--- a/packages/certs-v5/test/commands/certs/add.js
+++ b/packages/certs-v5/test/commands/certs/add.js
@@ -1312,7 +1312,7 @@ SSL certificate is self signed.
     mockFile(fs, 'key_file', 'key content')
 
     let mockSni = nock('https://api.heroku.com', {
-      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3.sni_ssl_cert' }
+      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3' }
     })
       .post('/apps/example/sni-endpoints', {
         certificate_chain: 'pem content', private_key: 'key content'

--- a/packages/certs-v5/test/commands/certs/index.js
+++ b/packages/certs-v5/test/commands/certs/index.js
@@ -64,9 +64,7 @@ tokyo-1050  tokyo-1050.herokussl.com  example.org     2013-08-01 21:34 UTC  Fals
   })
 
   it('# shows a mix of certs ordered by name', function () {
-    let mockSni = nock('https://api.heroku.com', {
-      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3' }
-    })
+    let mockSni = nock('https://api.heroku.com')
       .get('/apps/example/sni-endpoints')
       .reply(200, [endpointStables])
 
@@ -120,9 +118,7 @@ tokyo-1050  tokyo-1050.japan-4321.herokuspace.com  heroku.com      2013-08-01 21
   })
 
   it('# shows ACM for the type when acm true', function () {
-    let mockSni = nock('https://api.heroku.com', {
-      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3' }
-    })
+    let mockSni = nock('https://api.heroku.com')
       .get('/apps/example/sni-endpoints')
       .reply(200, [endpointAcm])
 
@@ -147,9 +143,7 @@ tokyo-1050  heroku.com      2013-08-01 21:34 UTC  True     ACM
   })
 
   it('# shows certs with common names stacked and stable matches', function () {
-    let mockSni = nock('https://api.heroku.com', {
-      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3' }
-    })
+    let mockSni = nock('https://api.heroku.com')
       .get('/apps/example/sni-endpoints')
       .reply(200, [endpointStables])
 
@@ -228,9 +222,7 @@ tokyo-1050  *.example.org   2013-08-01 21:34 UTC  False    SNI   0
   })
 
   it('# shows certs with common names stacked and just stable cname matches', function () {
-    let mockSni = nock('https://api.heroku.com', {
-      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3' }
-    })
+    let mockSni = nock('https://api.heroku.com')
       .get('/apps/example/sni-endpoints')
       .reply(200, [endpointStables])
 

--- a/packages/certs-v5/test/commands/certs/index.js
+++ b/packages/certs-v5/test/commands/certs/index.js
@@ -65,7 +65,7 @@ tokyo-1050  tokyo-1050.herokussl.com  example.org     2013-08-01 21:34 UTC  Fals
 
   it('# shows a mix of certs ordered by name', function () {
     let mockSni = nock('https://api.heroku.com', {
-      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3.sni_ssl_cert' }
+      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3' }
     })
       .get('/apps/example/sni-endpoints')
       .reply(200, [endpointStables])
@@ -121,7 +121,7 @@ tokyo-1050  tokyo-1050.japan-4321.herokuspace.com  heroku.com      2013-08-01 21
 
   it('# shows ACM for the type when acm true', function () {
     let mockSni = nock('https://api.heroku.com', {
-      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3.sni_ssl_cert' }
+      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3' }
     })
       .get('/apps/example/sni-endpoints')
       .reply(200, [endpointAcm])
@@ -148,7 +148,7 @@ tokyo-1050  heroku.com      2013-08-01 21:34 UTC  True     ACM
 
   it('# shows certs with common names stacked and stable matches', function () {
     let mockSni = nock('https://api.heroku.com', {
-      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3.sni_ssl_cert' }
+      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3' }
     })
       .get('/apps/example/sni-endpoints')
       .reply(200, [endpointStables])
@@ -175,7 +175,7 @@ tokyo-1050  foo.example.org, bar.example.org, biz.example.com  2013-08-01 21:34 
 
   it('# shows certs with common names stacked and stable matches (bugfix)', function () {
     let mockSni = nock('https://api.heroku.com', {
-      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3.sni_ssl_cert' }
+      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3' }
     })
       .get('/apps/example/sni-endpoints')
       .reply(200, [endpointWildcardBug])
@@ -202,7 +202,7 @@ tokyo-1050  fooexample.org  2013-08-01 21:34 UTC  False    SNI   0
 
   it('# shows certs with common names stacked and stable matches wildcard', function () {
     let mockSni = nock('https://api.heroku.com', {
-      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3.sni_ssl_cert' }
+      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3' }
     })
       .get('/apps/example/sni-endpoints')
       .reply(200, [endpointWildcard])
@@ -229,7 +229,7 @@ tokyo-1050  *.example.org   2013-08-01 21:34 UTC  False    SNI   0
 
   it('# shows certs with common names stacked and just stable cname matches', function () {
     let mockSni = nock('https://api.heroku.com', {
-      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3.sni_ssl_cert' }
+      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3' }
     })
       .get('/apps/example/sni-endpoints')
       .reply(200, [endpointStables])

--- a/packages/certs-v5/test/commands/certs/remove.js
+++ b/packages/certs-v5/test/commands/certs/remove.js
@@ -57,7 +57,7 @@ describe('heroku certs:remove', function () {
       .reply(200, [endpoint])
 
     let mock = nock('https://api.heroku.com', {
-      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3.sni_ssl_cert' }
+      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3' }
     })
       .delete('/apps/example/sni-endpoints/tokyo-1050')
       .reply(200, endpoint)
@@ -86,7 +86,7 @@ describe('heroku certs:remove', function () {
       .reply(200, [endpoint])
 
     let mock = nock('https://api.heroku.com', {
-      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3.sni_ssl_cert' }
+      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3' }
     })
       .delete('/apps/example/sni-endpoints/tokyo-1050')
       .reply(200, endpoint)

--- a/packages/certs-v5/test/commands/certs/remove.js
+++ b/packages/certs-v5/test/commands/certs/remove.js
@@ -56,9 +56,7 @@ describe('heroku certs:remove', function () {
       .get('/apps/example/sni-endpoints')
       .reply(200, [endpoint])
 
-    let mock = nock('https://api.heroku.com', {
-      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3' }
-    })
+    let mock = nock('https://api.heroku.com')
       .delete('/apps/example/sni-endpoints/tokyo-1050')
       .reply(200, endpoint)
 
@@ -85,9 +83,7 @@ describe('heroku certs:remove', function () {
       .get('/apps/example/sni-endpoints')
       .reply(200, [endpoint])
 
-    let mock = nock('https://api.heroku.com', {
-      reqheaders: { 'Accept': 'application/vnd.heroku+json; version=3' }
-    })
+    let mock = nock('https://api.heroku.com')
       .delete('/apps/example/sni-endpoints/tokyo-1050')
       .reply(200, endpoint)
 

--- a/packages/certs-v5/test/commands/certs/shared_sni.js
+++ b/packages/certs-v5/test/commands/certs/shared_sni.js
@@ -36,7 +36,7 @@ exports.shouldHandleArgs = function (command, txt, certs, callback, options) {
         .get('/apps/example/sni-endpoints')
         .reply(200, [endpoint])
 
-      let mock = callback(null, '/apps/example/sni-endpoints/tokyo-1050', endpoint, 'sni_ssl_cert')
+      let mock = callback(null, '/apps/example/sni-endpoints/tokyo-1050', endpoint)
 
       return certs.run({ app: 'example', args: args, flags: Object.assign({}, flags, { name: 'tokyo-1050' }) }).then(function () {
         mockSsl.done()
@@ -56,7 +56,7 @@ exports.shouldHandleArgs = function (command, txt, certs, callback, options) {
         .get('/apps/example/sni-endpoints')
         .reply(200, [endpoint])
 
-      let mock = callback(null, '/apps/example/sni-endpoints/tokyo-1050', endpoint, 'sni_ssl_cert')
+      let mock = callback(null, '/apps/example/sni-endpoints/tokyo-1050', endpoint)
 
       return certs.run({ app: 'example', args: args, flags: Object.assign({}, flags, { name: 'tokyo-1050' }) }).then(function () {
         mockSsl.done()
@@ -93,7 +93,7 @@ exports.shouldHandleArgs = function (command, txt, certs, callback, options) {
         .get('/apps/example/sni-endpoints')
         .reply(200, [endpoint])
 
-      let mock = callback(null, '/apps/example/sni-endpoints/tokyo-1050', endpoint, 'sni_ssl_cert')
+      let mock = callback(null, '/apps/example/sni-endpoints/tokyo-1050', endpoint)
 
       return certs.run({ app: 'example', args: args, flags: Object.assign({}, flags, { endpoint: 'tokyo-1050.herokussl.com' }) }).then(function () {
         mockSsl.done()


### PR DESCRIPTION
Deprecating the `sni_ssl_cert` variant, which is no longer needed. Not sure if this is the way I should be conditionally setting up the headers -- https://github.com/heroku/cli/pull/1775/files#diff-2cd45100c77a5e44846f941a495e2ed915af0d5fabc5987ed2359b3826c6823bR238-R243 and https://github.com/heroku/cli/pull/1775/files#diff-03a3898d724b1554d1adf274591a483a6cfbaca87146dc91b3a5cec49e4ff760R42-R46

Please advise on the best way to do this, then I'll finish up the other places we make these requests. Thanks!