### PR TITLE
build: use git pull --ff-only instead of rebase

### DIFF
--- a/scripts/create-release-pr
+++ b/scripts/create-release-pr
@@ -27,7 +27,7 @@ if !(gh auth status --hostname "github.com" > /dev/null 2>&1); then
   exit 1
 fi
 
-git pull --rebase origin "${MAIN_BRANCH}"
+git pull --ff-only origin "${MAIN_BRANCH}"
 
 # Create a branch with the unix timestamp of the current second
 BRANCH_NAME="release-$(date +%s)"

--- a/scripts/publish-release
+++ b/scripts/publish-release
@@ -27,7 +27,7 @@ if !(gh auth status --hostname "github.com" > /dev/null 2>&1); then
   exit 1
 fi
 
-git pull --rebase origin "${MAIN_BRANCH}"
+git pull --ff-only origin "${MAIN_BRANCH}"
 # The --force overrides local tags.
 # This is needed if you've published the CLI previously,
 # otherwise git will exit with an error unnecessarily.


### PR DESCRIPTION
this should stop git from rebasing unrelated branches, while still
pulling the latest and avoiding warnings from git on choosing a pull
strategy.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
