### PR TITLE
fix(apps-v5): add message for SSL Certificate provisioning delay for apps:rename

### DIFF
--- a/packages/apps-v5/src/commands/apps/rename.js
+++ b/packages/apps-v5/src/commands/apps/rename.js
@@ -18,6 +18,10 @@ async function run(context, heroku) {
   let app = await cli.action(`Renaming ${cli.color.cyan(oldApp)} to ${cli.color.green(newApp)}`, request)
   let gitUrl = context.flags['ssh-git'] ? git.sshGitHurl(app.name) : git.gitUrl(app.name)
   cli.log(`${app.web_url} | ${gitUrl}`)
+  
+  if (!app.web_url.includes('https')) {
+    cli.log(`Please note that it may take a few minutes for Heroku to provision a SSL certificate for your application.`)
+  }
 
   if (git.inGitRepo()) {
     // delete git remotes pointing to this app

--- a/packages/apps-v5/test/commands/apps/rename.js
+++ b/packages/apps-v5/test/commands/apps/rename.js
@@ -24,4 +24,19 @@ describe('heroku apps:rename', function () {
       .then(() => expect(cli.stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n'))
       .then(() => api.done())
   })
+
+  it('gives a message if the web_url is still http', function() {
+    let api = nock('https://api.heroku.com')
+    .patch('/apps/myapp', { name: 'newname' })
+    .reply(200, {
+      name: 'foobar',
+      web_url: 'http://foobar.com'
+    })
+
+    return cmd.run({ app: 'myapp', flags: {}, args: { newname: 'newname' }, httpGitHost: 'git.heroku.com' })
+      .then(() => expect(unwrap(cli.stderr)).to.contain(`Renaming myapp to newname... done Don\'t forget to update git remotes for all other local checkouts of the app.
+`))
+    .then(() => expect(cli.stdout).to.equal('http://foobar.com | https://git.heroku.com/foobar.git\nPlease note that it may take a few minutes for Heroku to provision a SSL certificate for your application.\n'))
+    .then(() => api.done())
+  })
 })


### PR DESCRIPTION
Adding a message that SSL certificate provisioning may take a few minutes when renaming an app if the `web_url` is `http` instead of `https`


To verify:
- Tests pass
- Code looks good