### PR TITLE
Adding H31

### DIFF
--- a/packages/apps-v5/src/error_info.js
+++ b/packages/apps-v5/src/error_info.js
@@ -95,6 +95,11 @@ module.exports = [
     'level': 'warning'
   },
   {
+    'name': 'H31',
+    'title': 'Misdirected Request',
+    'level': 'critical'
+  },
+  {
     'name': 'H80',
     'title': 'Maintenance Mode',
     'level': 'warning'


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

We've added a new H code in Runtime land - https://devcenter.heroku.com/articles/error-codes#h31-misdirected-request-error