### PR TITLE
Change CLI login default to 30 days

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -58,7 +58,7 @@ USAGE
   $ heroku auth:login
 
 OPTIONS
-  -e, --expires-in=expires-in  duration of token in seconds (default 1 year)
+  -e, --expires-in=expires-in  duration of token in seconds (default 30 days)
   -i, --interactive            login with username/password
   --browser=browser            browser to open SSO with (example: "firefox", "safari")
 

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -64,7 +64,7 @@ USAGE
   $ heroku auth:login
 
 OPTIONS
-  -e, --expires-in=expires-in  duration of token in seconds (default 1 year)
+  -e, --expires-in=expires-in  duration of token in seconds (default 30 days)
   -i, --interactive            login with username/password
   --browser=browser            browser to open SSO with (example: "firefox", "safari")
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
-    "@heroku-cli/command": "^8.4.1",
+    "@heroku-cli/command": "^8.5.0",
     "@oclif/command": "^1.5.11",
     "@oclif/config": "^1.12.10",
     "cli-ux": "^4.9.3",

--- a/packages/auth/src/commands/auth/login.ts
+++ b/packages/auth/src/commands/auth/login.ts
@@ -11,7 +11,7 @@ export default class Login extends Command {
     browser: flags.string({description: 'browser to open SSO with (example: "firefox", "safari")'}),
     sso: flags.boolean({hidden: true, char: 's', description: 'login for enterprise users under SSO'}),
     interactive: flags.boolean({char: 'i', description: 'login with username/password'}),
-    'expires-in': flags.integer({char: 'e', description: 'duration of token in seconds (default 1 year)'}),
+    'expires-in': flags.integer({char: 'e', description: 'duration of token in seconds (default 30 days)'}),
   }
 
   async run() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,6 +292,22 @@
     open "^6.2.0"
     uuid "^8.3.0"
 
+"@heroku-cli/command@^8.5.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@heroku-cli/command/-/command-8.5.0.tgz#1a9d977c85d5581622699d9a819d6da24a037993"
+  integrity sha512-HtjnammJPaoYkcrhmQM5sJCUueJ80KbZHUo3SldAEXmy9hefk34mk524nKS7ZlrABEiBilv4XYHCkrWCoq94uQ==
+  dependencies:
+    "@heroku-cli/color" "^1.1.14"
+    "@oclif/errors" "^1.2.2"
+    cli-ux "^4.9.3"
+    debug "^4.1.1"
+    fs-extra "^7.0.1"
+    heroku-client "^3.1.0"
+    http-call "^5.2.4"
+    netrc-parser "^3.1.6"
+    open "^6.2.0"
+    uuid "^8.3.0"
+
 "@heroku-cli/notifications@^1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@heroku-cli/notifications/-/notifications-1.2.2.tgz#46e2a8c0b678b83d46d9347dccbf3f5c31744e80"


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

This changes the `auth:login` help to say that logins expire after 30 days instead of 1 year. This matches the code changes in https://github.com/heroku/front_end_auth/pull/243 and https://github.com/heroku/heroku-cli-command/pull/81.

[GUS](https://gus.my.salesforce.com/a07AH000000BD07YAG)
