### PR TITLE
fix(redis-v5): allow hobby-dev redis:cli use tls connection

### DIFF
--- a/packages/redis-v5/commands/cli.js
+++ b/packages/redis-v5/commands/cli.js
@@ -184,8 +184,9 @@ module.exports = {
 
     let redis = await api.request(`/redis/v0/databases/${addon.name}`)
     let hobby = redis.plan.indexOf('hobby') === 0
+    let prefer_native_tls = redis.prefer_native_tls
 
-    if (hobby) {
+    if (!prefer_native_tls && hobby) {
       await cli.confirmApp(context.app, context.flags.confirm, 'WARNING: Insecure action.\nAll data, including the Redis password, will not be encrypted.')
     }
 


### PR DESCRIPTION
Users of hobby-dev redis have access to native TLS functionality in versions 6 and higher. If a redis version supports native TLS, we should not warn the user that the connection is insecure.