### PR TITLE
ci: restore aws credentials to invalidate-cdn-cache job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,6 +452,8 @@ workflows:
             - pack-tarballs
       - invalidate-cdn-cache:
           filters: *master_dev_and_version_tags
+          context:
+            - heroku-cli-s3
           requires:
             - release-deb-and-tarballs
       - release-homebrew:


### PR DESCRIPTION
This was removed due to comment shuffling in
https://github.com/heroku/cli/pull/1797, but the S3 credentials are
necessary to purge the cloudfront CDN's cache
