### PR TITLE
FEAT(packages/pg-v5): Allow additional psql args

### DIFF
--- a/packages/pg-v5/lib/psql.js
+++ b/packages/pg-v5/lib/psql.js
@@ -8,10 +8,10 @@ const finished = util.promisify(Stream.finished)
 const bastion = require('./bastion')
 const debug = require('./debug')
 
-function psqlQueryOptions (query, dbEnv) {
+function psqlQueryOptions (query, dbEnv, cmdArgs=[]) {
   debug('Running query: %s', query.trim())
 
-  const psqlArgs = ['-c', query, '--set', 'sslmode=require']
+  const psqlArgs = ['-c', query, '--set', 'sslmode=require'].concat(cmdArgs)
 
   const childProcessOptions = {
     encoding: 'utf8',
@@ -240,9 +240,9 @@ class Tunnel {
   }
 }
 
-async function exec (db, query) {
+async function exec (db, query, cmdArgs=[]) {
   const configs = bastion.getConfigs(db)
-  const options = psqlQueryOptions(query, configs.dbEnv)
+  const options = psqlQueryOptions(query, configs.dbEnv, cmdArgs)
 
   return runWithTunnel(db, configs.dbTunnelConfig, options)
 }

--- a/packages/pg-v5/lib/psql.js
+++ b/packages/pg-v5/lib/psql.js
@@ -243,7 +243,6 @@ class Tunnel {
 async function exec (db, query, cmdArgs=[]) {
   const configs = bastion.getConfigs(db)
   const options = psqlQueryOptions(query, configs.dbEnv, cmdArgs)
-
   return runWithTunnel(db, configs.dbTunnelConfig, options)
 }
 

--- a/packages/pg-v5/test/lib/psql.js
+++ b/packages/pg-v5/test/lib/psql.js
@@ -219,7 +219,7 @@ describe('psql', () => {
           fakePsqlProcess.start()
           return fakePsqlProcess
         })
-        const promise = psql.exec(bastionDb, 'SELECT NOW();', 1000)
+        const promise = psql.exec(bastionDb, 'SELECT NOW();')
         await fakePsqlProcess.waitForStart()
         mock.verify()
         expect(tunnelStub.withArgs(tunnelConf).calledOnce).to.equal(true)
@@ -248,7 +248,7 @@ describe('psql', () => {
           return fakePsqlProcess
         })
 
-        const promise = psql.exec(bastionDb, 'SELECT NOW();', 1000)
+        const promise = psql.exec(bastionDb, 'SELECT NOW();')
         await fakePsqlProcess.waitForStart()
         mock.verify()
         expect(tunnelStub.withArgs(tunnelConf).calledOnce).to.equal(true)
@@ -279,7 +279,7 @@ describe('psql', () => {
           return fakePsqlProcess
         })
 
-        const execPromise = psql.exec(bastionDb, 'SELECT NOW();', 1000)
+        const execPromise = psql.exec(bastionDb, 'SELECT NOW();')
         await fakePsqlProcess.waitForStart()
         mock.verify()
         expect(tunnelStub.withArgs(tunnelConf).calledOnce).to.equal(true)
@@ -348,7 +348,7 @@ describe('psql', () => {
         return fakePsqlProcess
       })
 
-      const promise = psql.execFile(bastionDb, 'test.sql', 1000)
+      const promise = psql.execFile(bastionDb, 'test.sql')
       await fakePsqlProcess.waitForStart()
       mock.verify()
       expect(tunnelStub.withArgs(tunnelConf).calledOnce).to.equal(true)


### PR DESCRIPTION
This PR adds an optional arg to `psql.exec` so that the user can specify additional arguments to the psql process.

I am specifically interested in this for providing the `-q` and `-t` args in order to have more consistent query output, but I'm sure it is useful in other ways.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
