### PR TITLE
feat(apps-v5): add execution plane to dyno list as extended attribute

### DIFF
--- a/packages/apps-v5/src/commands/ps/index.js
+++ b/packages/apps-v5/src/commands/ps/index.js
@@ -17,6 +17,7 @@ function printExtended (dynos) {
       { key: 'name', label: 'Process' },
       { key: 'state', label: 'State', format: (state, row) => `${state} ${time.ago(new Date(row.updated_at))}` },
       { key: 'extended.region', label: 'Region' },
+      { key: 'extended.execution_plane', label: 'Execution Plane' },
       { key: 'extended.instance', label: 'Instance' },
       { key: 'extended.ip', label: 'IP' },
       { key: 'extended.port', label: 'Port' },

--- a/packages/apps-v5/test/commands/ps/index.js
+++ b/packages/apps-v5/test/commands/ps/index.js
@@ -138,15 +138,15 @@ web.1: up ${hourAgoStr} (~ 1h ago)
       .reply(200, { name: 'myapp' })
       .get('/apps/myapp/dynos?extended=true')
       .reply(200, [
-        { id: 100, command: 'npm start', size: 'Free', name: 'web.1', type: 'web', updated_at: hourAgo, state: 'up', extended: { region: 'us', instance: 'instance', ip: '10.0.0.1', port: 8000, az: 'us-east', route: 'da route' } },
-        { id: 101, command: 'bash', size: 'Free', name: 'run.1', type: 'run', updated_at: hourAgo, state: 'up', extended: { region: 'us', instance: 'instance', ip: '10.0.0.2', port: 8000, az: 'us-east', route: 'da route' } }
+        { id: 100, command: 'npm start', size: 'Free', name: 'web.1', type: 'web', updated_at: hourAgo, state: 'up', extended: { region: 'us', execution_plane: 'execution_plane', instance: 'instance', ip: '10.0.0.1', port: 8000, az: 'us-east', route: 'da route' } },
+        { id: 101, command: 'bash', size: 'Free', name: 'run.1', type: 'run', updated_at: hourAgo, state: 'up', extended: { region: 'us', execution_plane: 'execution_plane', instance: 'instance', ip: '10.0.0.2', port: 8000, az: 'us-east', route: 'da route' } }
       ])
 
     return cmd.run({ app: 'myapp', args: [], flags: { extended: true } })
-      .then(() => expect(cli.stdout).to.equal(`ID   Process  State                                    Region  Instance  IP        Port  AZ       Release  Command    Route     Size
-───  ───────  ───────────────────────────────────────  ──────  ────────  ────────  ────  ───────  ───────  ─────────  ────────  ────
-101  run.1    up ${hourAgoStr} (~ 1h ago)  us      instance  10.0.0.2  8000  us-east           bash       da route  Free
-100  web.1    up ${hourAgoStr} (~ 1h ago)  us      instance  10.0.0.1  8000  us-east           npm start  da route  Free
+      .then(() => expect(cli.stdout).to.equal(`ID   Process  State                                    Region  Execution Plane  Instance  IP        Port  AZ       Release  Command    Route     Size
+───  ───────  ───────────────────────────────────────  ──────  ───────────────  ────────  ────────  ────  ───────  ───────  ─────────  ────────  ────
+101  run.1    up ${hourAgoStr} (~ 1h ago)  us      execution_plane  instance  10.0.0.2  8000  us-east           bash       da route  Free
+100  web.1    up ${hourAgoStr} (~ 1h ago)  us      execution_plane  instance  10.0.0.1  8000  us-east           npm start  da route  Free
 `))
       .then(() => expect(cli.stderr, 'to be empty'))
       .then(() => api.done())
@@ -160,15 +160,15 @@ web.1: up ${hourAgoStr} (~ 1h ago)
       .reply(200, { space: { shield: true } })
       .get('/apps/myapp/dynos?extended=true')
       .reply(200, [
-        { id: 100, command: 'npm start', size: 'Private-M', name: 'web.1', type: 'web', updated_at: hourAgo, state: 'up', extended: { region: 'us', instance: 'instance', ip: '10.0.0.1', port: 8000, az: 'us-east', route: 'da route' } },
-        { id: 101, command: 'bash', size: 'Private-L', name: 'run.1', type: 'run', updated_at: hourAgo, state: 'up', extended: { region: 'us', instance: 'instance', ip: '10.0.0.2', port: 8000, az: 'us-east', route: 'da route' } }
+        { id: 100, command: 'npm start', size: 'Private-M', name: 'web.1', type: 'web', updated_at: hourAgo, state: 'up', extended: { region: 'us', execution_plane: 'execution_plane', instance: 'instance', ip: '10.0.0.1', port: 8000, az: 'us-east', route: 'da route' } },
+        { id: 101, command: 'bash', size: 'Private-L', name: 'run.1', type: 'run', updated_at: hourAgo, state: 'up', extended: { region: 'us', execution_plane: 'execution_plane', instance: 'instance', ip: '10.0.0.2', port: 8000, az: 'us-east', route: 'da route' } }
       ])
 
     return cmd.run({ app: 'myapp', args: [], flags: { extended: true } })
-      .then(() => expect(cli.stdout).to.equal(`ID   Process  State                                    Region  Instance  IP        Port  AZ       Release  Command    Route     Size
-───  ───────  ───────────────────────────────────────  ──────  ────────  ────────  ────  ───────  ───────  ─────────  ────────  ────────
-101  run.1    up ${hourAgoStr} (~ 1h ago)  us      instance  10.0.0.2  8000  us-east           bash       da route  Shield-L
-100  web.1    up ${hourAgoStr} (~ 1h ago)  us      instance  10.0.0.1  8000  us-east           npm start  da route  Shield-M
+      .then(() => expect(cli.stdout).to.equal(`ID   Process  State                                    Region  Execution Plane  Instance  IP        Port  AZ       Release  Command    Route     Size
+───  ───────  ───────────────────────────────────────  ──────  ───────────────  ────────  ────────  ────  ───────  ───────  ─────────  ────────  ────────
+101  run.1    up ${hourAgoStr} (~ 1h ago)  us      execution_plane  instance  10.0.0.2  8000  us-east           bash       da route  Shield-L
+100  web.1    up ${hourAgoStr} (~ 1h ago)  us      execution_plane  instance  10.0.0.1  8000  us-east           npm start  da route  Shield-M
 `))
       .then(() => expect(cli.stderr, 'to be empty'))
       .then(() => api.done())


### PR DESCRIPTION
I'm adding support for a new extended attribute to the API which
includes the execution plane a dyno is currently or intended to be run
on.