### PR TITLE
feat(certs-v5): Add display name to certs table

### DIFF
--- a/packages/certs-v5/lib/display_table.js
+++ b/packages/certs-v5/lib/display_table.js
@@ -32,6 +32,7 @@ module.exports = function (certs) {
       ca_signed: f.ssl_cert['ca_signed?'],
       type: type(f),
       common_names: f.ssl_cert.cert_domains.join(', '),
+      display_name: f.display_name,
     }
 
     // If they're using ACM it's not really worth showing the number of associated domains since
@@ -44,8 +45,12 @@ module.exports = function (certs) {
   })
 
   let columns = [
-    {label: 'Name', key: 'name'}
+    {label: 'Name', key: 'name'},
   ]
+
+  if (certs.some(cert => cert.display_name)) {
+    columns.push({label: 'Display Name', key: 'display_name'});
+  }
 
   if (_.find(mapped, (row) => row.cname)) {
     columns = columns.concat([{label: 'Endpoint', key: 'cname', format: function (f) { return f || '(Not applicable for SNI)' }}])

--- a/packages/certs-v5/test/commands/certs/index.js
+++ b/packages/certs-v5/test/commands/certs/index.js
@@ -36,10 +36,33 @@ describe('heroku certs', function () {
         expect(cli.stderr).to.equal('')
         /* eslint-disable no-trailing-spaces */
         expect(cli.stdout).to.equal(
+          `Name        Display Name   Endpoint                  Common Name(s)  Expires               Trusted  Type      Domains
+──────────  ─────────────  ────────────────────────  ──────────────  ────────────────────  ───────  ────────  ───────
+akita-7777                 akita-7777.herokussl.com  heroku.com      2013-08-01 21:34 UTC  True     Endpoint  0
+tokyo-1050  my-tokyo-1050  tokyo-1050.herokussl.com  example.org     2013-08-01 21:34 UTC  False    Endpoint  0
+`)
+        /* eslint-enable no-trailing-spaces */
+      })
+    })
+
+    it('does not display name if there is not any', function () {
+      let mockSni = nock('https://api.heroku.com')
+        .get('/apps/example/sni-endpoints')
+        .reply(200, [])
+
+      let mockSsl = nock('https://api.heroku.com')
+        .get('/apps/example/ssl-endpoints')
+        .reply(200, [endpoint2])
+
+      return certs.run({ app: 'example' }).then(function () {
+        mockSni.done()
+        mockSsl.done()
+        expect(cli.stderr).to.equal('')
+        /* eslint-disable no-trailing-spaces */
+        expect(cli.stdout).to.equal(
           `Name        Endpoint                  Common Name(s)  Expires               Trusted  Type      Domains
 ──────────  ────────────────────────  ──────────────  ────────────────────  ───────  ────────  ───────
 akita-7777  akita-7777.herokussl.com  heroku.com      2013-08-01 21:34 UTC  True     Endpoint  0
-tokyo-1050  tokyo-1050.herokussl.com  example.org     2013-08-01 21:34 UTC  False    Endpoint  0
 `)
         /* eslint-enable no-trailing-spaces */
       })

--- a/packages/certs-v5/test/stubs/sni-endpoints.js
+++ b/packages/certs-v5/test/stubs/sni-endpoints.js
@@ -9,6 +9,7 @@ Subject:        /C=US/ST=California/L=San Francisco/O=Heroku by Salesforce/CN=se
 SSL certificate is self signed.`,
   endpoint: { 'name': 'tokyo-1050',
     'cname': 'tokyo-1050.herokussl.com',
+    'display_name': 'my-tokyo-1050',
     'ssl_cert': {
       'ca_signed?': false,
       'cert_domains': [ 'example.org' ],


### PR DESCRIPTION
As requested by Product, display the display_name attribute, if present on any cert, in the certs table.

SOC2:
https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07AH000000OuSuYAK
