### PR TITLE
feat(redis-v5): add redis:stats-reset command

### DIFF
--- a/packages/redis-v5/commands/stats-reset.js
+++ b/packages/redis-v5/commands/stats-reset.js
@@ -1,0 +1,21 @@
+'use strict'
+
+let cli = require('heroku-cli-util')
+
+module.exports = {
+  topic: 'redis',
+  command: 'stats-reset',
+  needsApp: true,
+  needsAuth: true,
+  args: [{ name: 'database', optional: true }],
+  flags: [{ name: 'confirm', char: 'c', hasValue: true }],
+  description: 'reset all stats covered by RESETSTAT (https://redis.io/commands/config-resetstat)',
+  run: cli.command(async (context, heroku) => {
+    let api = require('../lib/shared')(context, heroku)
+    let addon = await api.getRedisAddon()
+
+    await cli.confirmApp(context.app, context.flags.confirm, `WARNING: Irreversible action.\nAll stats covered by RESETSTAT will be reset on ${cli.color.addon(addon.name)}.`)
+    let res = await api.request(`/redis/v0/databases/${addon.name}/stats/reset`, 'POST')
+    cli.log(res.message)
+  }),
+}

--- a/packages/redis-v5/index.js
+++ b/packages/redis-v5/index.js
@@ -8,7 +8,8 @@ exports.commands = [
   require('./commands/timeout'),
   require('./commands/maxmemory'),
   require('./commands/maintenance'),
-  require('./commands/keyspace-notifications')
+  require('./commands/keyspace-notifications'),
+  require('./commands/stats-reset'),
 ]
 
 exports.topic = {

--- a/packages/redis-v5/test/commands/stats-reset.js
+++ b/packages/redis-v5/test/commands/stats-reset.js
@@ -1,0 +1,34 @@
+'use strict'
+/* globals describe it beforeEach cli */
+
+let expect = require('chai').expect
+let nock = require('nock')
+let exit = require('heroku-cli-util').exit
+
+let command = require('../../commands/stats-reset')
+
+describe('heroku redis:stats-reset', () => {
+  beforeEach(() => {
+    cli.mockConsole()
+    nock.cleanAll()
+    exit.mock()
+  })
+
+  it('# resets the stats of the addon', () => {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_URL'] }
+      ])
+
+    let redis = nock('https://redis-api.heroku.com:443')
+      .post('/redis/v0/databases/redis-haiku/stats/reset').reply(200, {
+        message: 'Stats reset successful.'
+      })
+
+    return command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
+      .then(() => app.done())
+      .then(() => redis.done())
+      .then(() => expect(cli.stdout).to.equal('Stats reset successful.\n'))
+      .then(() => expect(cli.stderr).to.equal(''))
+  })
+})


### PR DESCRIPTION
This commit adds a command to reset statistics for a specific Heroku
Redis add-on, covering the stats outlined in
https://redis.io/commands/config-resetstat.

This is irreversible, so by default this requires confirmation, and
otherwise uses a `--confirm` flag to override it.

Ref: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000OiyXYAS/view
