### PR TITLE
fix(run-v5) Add Debug ssh flags

### DIFF
--- a/packages/run-v5/lib/dyno.js
+++ b/packages/run-v5/lib/dyno.js
@@ -214,6 +214,11 @@ class Dyno extends Duplex {
     } else {
       let params = [host, '-p', port, '-oStrictHostKeyChecking=no', '-oUserKnownHostsFile=/dev/null', '-oServerAliveInterval=20']
 
+      // Debug SSH
+      if (this._isDebug()) {
+        params.push('-vvv')
+      }
+
       const stdio = [0, 1, 'pipe']
       if (this.opts['exit-code']) {
         stdio[1] = 'pipe'

--- a/packages/run/src/lib/dyno.ts
+++ b/packages/run/src/lib/dyno.ts
@@ -274,6 +274,11 @@ export default class Dyno extends Duplex {
     } else {
       const params = [host, '-p', port.toString(), '-oStrictHostKeyChecking=no', '-oUserKnownHostsFile=/dev/null', '-oServerAliveInterval=20']
 
+      // Debug SSH
+      if (this._isDebug()) {
+        params.push('-vvv')
+      }
+
       const stdio: Array<(number | 'pipe')> = [0, 1, 'pipe']
       if (this.opts['exit-code']) {
         stdio[1] = 'pipe'


### PR DESCRIPTION
Right now it is hard to debug SSH connection issues on heroku run.

This will output the ssh debug information if we run the command in debug mode

GUS: [W-9537346
](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000PxaKYAS/view)