### PR TITLE
fix(pg-v5): add an environment variable for which addon service to resolve

### DIFF
--- a/packages/pg-v5/lib/fetcher.js
+++ b/packages/pg-v5/lib/fetcher.js
@@ -15,7 +15,9 @@ module.exports = heroku => {
 
       debug(`fetching ${db} on ${app}`)
 
-      return resolve.appAttachment(heroku, app, db, { addon_service: 'heroku-postgresql', namespace: namespace })
+      let addonService = process.env.HEROKU_POSTGRESQL_ADDON_NAME || 'heroku-postgresql'
+      debug(`addon service: ${addonService}`)
+      return resolve.appAttachment(heroku, app, db, { addon_service: addonService, namespace: namespace })
         .then(attached => ({ matches: [attached] }))
         .catch(function (err) {
           if (err.statusCode === 422 && err.body && err.body.id === 'multiple_matches' && err.matches) {

--- a/packages/pg-v5/test/lib/fetcher.js
+++ b/packages/pg-v5/test/lib/fetcher.js
@@ -31,11 +31,21 @@ describe('fetcher', () => {
 
   afterEach(() => {
     api.done()
+    delete process.env.HEROKU_POSTGRESQL_ADDON_NAME
   })
 
   describe('addon', () => {
     it('returns addon attached to app', () => {
       stub.withArgs(sinon.match.any, 'myapp', 'DATABASE_URL', { addon_service: 'heroku-postgresql', namespace: null }).returns(Promise.resolve({ addon: { name: 'postgres-1' } }))
+      return fetcher(new Heroku()).addon('myapp', 'DATABASE_URL')
+        .then(addon => {
+          expect(addon.name).to.equal('postgres-1')
+        })
+    })
+
+    it('returns addon attached to app in another shogun', () => {
+      stub.withArgs(sinon.match.any, 'myapp', 'DATABASE_URL', { addon_service: 'heroku-postgresql-meta', namespace: null }).returns(Promise.resolve({ addon: { name: 'postgres-1' } }))
+      process.env.HEROKU_POSTGRESQL_ADDON_NAME = 'heroku-postgresql-meta'
       return fetcher(new Heroku()).addon('myapp', 'DATABASE_URL')
         .then(addon => {
           expect(addon.name).to.equal('postgres-1')


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

Now that the data team uses multiple control plane not all commands can correctly resolve the add-on.

Before:
```
HEROKU_POSTGRESQL_HOST="control-plane2.heroku.com" HEROKU_POSTGRESQL_ADDON_NAME=heroku-postgresql-meta heroku pg:ps -a shogun
 ▸    Ambiguous identifier; multiple matching add-ons found: DOD_HVAS_DATABASE, ARCHIVE_DATABASE.
```

After:
```
HEROKU_POSTGRESQL_HOST="control-plane2.heroku.com" HEROKU_POSTGRESQL_ADDON_NAME=heroku-postgresql-meta ./bin/run pg:ps -a shogun
  pid  |        state        |             source             |    username    |   running_for    |       transaction_start       | waiting |
<redacted>
```
