### PR TITLE
feat(redis-v5): add redis:upgrade command

### DIFF
--- a/packages/redis-v5/README.md
+++ b/packages/redis-v5/README.md
@@ -31,6 +31,7 @@ To publish new versions, see
 * [`heroku redis:promote DATABASE`](#heroku-redispromote-database)
 * [`heroku redis:stats-reset [DATABASE]`](#heroku-redisstats-reset-database)
 * [`heroku redis:timeout [DATABASE]`](#heroku-redistimeout-database)
+* [`heroku redis:upgrade [DATABASE]`](#heroku-redisupgrade-database)
 * [`heroku redis:wait [DATABASE]`](#heroku-rediswait-database)
 
 ## `heroku redis [DATABASE]`
@@ -209,6 +210,21 @@ OPTIONS
 DESCRIPTION
   Sets the number of seconds to wait before killing idle connections. A value of zero means that connections will not be 
   closed.
+```
+
+## `heroku redis:upgrade [DATABASE]`
+
+perform in-place version upgrade
+
+```
+USAGE
+  $ heroku redis:upgrade [DATABASE]
+
+OPTIONS
+  -a, --app=app          (required) app to run command against
+  -c, --confirm=confirm
+  -r, --remote=remote    git remote of app to use
+  -v, --version=version
 ```
 
 ## `heroku redis:wait [DATABASE]`

--- a/packages/redis-v5/commands/upgrade.js
+++ b/packages/redis-v5/commands/upgrade.js
@@ -23,7 +23,7 @@ module.exports = {
     let version = context.flags.version
 
     await cli.confirmApp(context.app, context.flags.confirm, `WARNING: Irreversible action.\nRedis database will be upgraded to ${cli.color.configVar(version)}. This cannot be undone.`)
-    await cli.action(`Starting upgrade of ${cli.color.addon(addon.name)} to ${version}`, async function () {
+    await cli.action(`Requesting upgrade of ${cli.color.addon(addon.name)} to ${version}`, async function () {
       await api.request(`/redis/v0/databases/${addon.name}/upgrade`, 'POST', { version: version })
       cli.action.done(`upgrade has started!`)
     }())

--- a/packages/redis-v5/commands/upgrade.js
+++ b/packages/redis-v5/commands/upgrade.js
@@ -1,0 +1,32 @@
+'use strict'
+
+let cli = require('heroku-cli-util')
+
+module.exports = {
+  topic: 'redis',
+  command: 'upgrade',
+  needsApp: true,
+  needsAuth: true,
+  args: [{ name: 'database', optional: true }],
+  flags: [
+    { name: 'confirm', char: 'c', hasValue: true },
+    { name: 'version', char: 'v', hasValue: true }
+  ],
+  description: 'perform in-place version upgrade',
+  run: cli.command(async (context, heroku) => {
+    if (!context.flags.version) {
+      cli.exit(1, 'Please specify a valid version.')
+    }
+
+    let api = require('../lib/shared')(context, heroku)
+    let addon = await api.getRedisAddon()
+    let version = context.flags.version
+
+    await cli.confirmApp(context.app, context.flags.confirm, `WARNING: Irreversible action.\nRedis database will be upgraded to ${cli.color.configVar(version)}. This cannot be undone.`)
+    await cli.action(`Starting upgrade of ${cli.color.addon(addon.name)} to ${version}`, async function () {
+      await api.request(`/redis/v0/databases/${addon.name}/upgrade`, 'POST', { version: version })
+      cli.action.done(`upgrade has started!`)
+    }())
+  })
+}
+

--- a/packages/redis-v5/index.js
+++ b/packages/redis-v5/index.js
@@ -10,6 +10,7 @@ exports.commands = [
   require('./commands/maintenance'),
   require('./commands/keyspace-notifications'),
   require('./commands/stats-reset'),
+  require('./commands/upgrade'),
 ]
 
 exports.topic = {

--- a/packages/redis-v5/test/commands/upgrade.js
+++ b/packages/redis-v5/test/commands/upgrade.js
@@ -29,7 +29,7 @@ describe('heroku redis:upgrade', () => {
     return command.run({ app: 'example', flags: { confirm: 'example', version: '6.2' }, args: {}, auth: { username: 'foobar', password: 'password' } })
       .then(() => app.done())
       .then(() => redis.done())
-      .then(() => expect(cli.stderr).to.equal('Starting upgrade of redis-haiku to 6.2... upgrade has started!\n'))
+      .then(() => expect(cli.stderr).to.equal('Requesting upgrade of redis-haiku to 6.2... upgrade has started!\n'))
   })
 
   it('# errors on missing version', function () {

--- a/packages/redis-v5/test/commands/upgrade.js
+++ b/packages/redis-v5/test/commands/upgrade.js
@@ -1,0 +1,40 @@
+'use strict'
+/* globals describe it beforeEach cli */
+
+let expect = require('chai').expect
+let nock = require('nock')
+let exit = require('heroku-cli-util').exit
+
+let command = require('../../commands/upgrade')
+
+describe('heroku redis:upgrade', () => {
+  beforeEach(() => {
+    cli.mockConsole()
+    nock.cleanAll()
+    exit.mock()
+  })
+
+  it('# upgrades the redis version', () => {
+    let app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons').reply(200, [
+        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_URL'] }
+      ])
+
+    let redis = nock('https://redis-api.heroku.com:443')
+      .post('/redis/v0/databases/redis-haiku/upgrade', { version: '6.2' }).reply(200, {
+        message: 'Upgrading version now!'
+      })
+
+    return command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
+      .then(() => app.done())
+      .then(() => redis.done())
+      .then(() => expect(cli.stdout).to.equal('Upgrading version now!\n'))
+      .then(() => expect(cli.stderr).to.equal(''))
+  })
+
+  it('# errors on missing version', function () {
+    return expect(command.run({ app: 'example', flags: {}, args: {} })).to.be.rejectedWith(exit.ErrorExit)
+      .then(() => expect(cli.stdout).to.equal(''))
+      .then(() => expect(unwrap(cli.stderr)).to.equal('Please specify a valid version.\n'))
+  })
+})

--- a/packages/redis-v5/test/commands/upgrade.js
+++ b/packages/redis-v5/test/commands/upgrade.js
@@ -29,7 +29,6 @@ describe('heroku redis:upgrade', () => {
     return command.run({ app: 'example', flags: { confirm: 'example', version: '6.2' }, args: {}, auth: { username: 'foobar', password: 'password' } })
       .then(() => app.done())
       .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('Upgrading version now!\n'))
       .then(() => expect(cli.stderr).to.equal(''))
   })
 

--- a/packages/redis-v5/test/commands/upgrade.js
+++ b/packages/redis-v5/test/commands/upgrade.js
@@ -6,6 +6,7 @@ let nock = require('nock')
 let exit = require('heroku-cli-util').exit
 
 let command = require('../../commands/upgrade')
+const unwrap = require('../unwrap')
 
 describe('heroku redis:upgrade', () => {
   beforeEach(() => {
@@ -25,7 +26,7 @@ describe('heroku redis:upgrade', () => {
         message: 'Upgrading version now!'
       })
 
-    return command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
+    return command.run({ app: 'example', flags: { confirm: 'example', version: '6.2' }, args: {}, auth: { username: 'foobar', password: 'password' } })
       .then(() => app.done())
       .then(() => redis.done())
       .then(() => expect(cli.stdout).to.equal('Upgrading version now!\n'))

--- a/packages/redis-v5/test/commands/upgrade.js
+++ b/packages/redis-v5/test/commands/upgrade.js
@@ -29,7 +29,7 @@ describe('heroku redis:upgrade', () => {
     return command.run({ app: 'example', flags: { confirm: 'example', version: '6.2' }, args: {}, auth: { username: 'foobar', password: 'password' } })
       .then(() => app.done())
       .then(() => redis.done())
-      .then(() => expect(cli.stderr).to.equal(''))
+      .then(() => expect(cli.stderr).to.equal('Starting upgrade of redis-haiku to 6.2... upgrade has started!\n'))
   })
 
   it('# errors on missing version', function () {


### PR DESCRIPTION
This PR adds a new `redis:upgrade` command that permit users to perform in-place upgrades of their Heroku Redis add-on.
