### PR TITLE
feat(pg-v5): Add pg:settings:track-functions

### DIFF
--- a/packages/pg-v5/commands/settings/track_functions.js
+++ b/packages/pg-v5/commands/settings/track_functions.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const cli = require('heroku-cli-util')
+const settings = require('../../lib/setter')
+
+function explain (setting) {
+  return setting.values[setting.value]
+}
+
+module.exports = {
+  topic: 'pg',
+  command: 'settings:track-functions',
+  description: `track_functions controls tracking of function call counts and time used. Default is none.`,
+  help: `Valid values for VALUE:
+none - No functions are tracked
+pl   - Only procedural language functions are tracked
+all  - All functions, including SQL and C language functions, are tracked. Simple SQL-language that are inlined are not tracked`,
+  needsApp: true,
+  needsAuth: true,
+  args: [{ name: 'value', optional: true }, { name: 'database', optional: true }],
+  run: cli.command({ preauth: true }, settings.generate('track_functions', settings.enum, explain))
+}

--- a/packages/pg-v5/index.js
+++ b/packages/pg-v5/index.js
@@ -50,6 +50,7 @@ exports.commands = flatten([
   require('./commands/settings/log_lock_waits'),
   require('./commands/settings/log_min_duration_statement'),
   require('./commands/settings/log_statement'),
+  require('./commands/settings/track_functions'),
   require('./commands/unfollow'),
   require('./commands/upgrade'),
   require('./commands/vacuum_stats'),


### PR DESCRIPTION
This commit adds the front end to a newly exposed setting for Heroku
Postgres, allowing users to change the value for the GUC
`track_functions`. This allows users to gather statistics for different
types of function invocations, if they so choose.

Ref: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000U0wTYAS/view
