### PR TITLE
fix: update domain:add to pass required sni_endpoint param

### DIFF
--- a/packages/apps/src/commands/domains/add.ts
+++ b/packages/apps/src/commands/domains/add.ts
@@ -9,7 +9,7 @@ import waitForDomain from '../../lib/wait-for-domain'
 
 interface DomainCreatePayload {
   hostname: string;
-  sni_endpoint?: string;
+  sni_endpoint: string | null;
 }
 
 export default class DomainsAdd extends Command {
@@ -79,6 +79,7 @@ export default class DomainsAdd extends Command {
 
     const domainCreatePayload: DomainCreatePayload = {
       hostname,
+      sni_endpoint: null,
     }
 
     let certs: Array<Heroku.SniEndpoint> = []

--- a/packages/apps/test/commands/domains/add.test.ts
+++ b/packages/apps/test/commands/domains/add.test.ts
@@ -25,7 +25,7 @@ describe('domains:add', () => {
     .nock('https://api.heroku.com', api => api
     .get('/apps/myapp/features')
     .reply(200, [])
-    .post('/apps/myapp/domains', {hostname: 'example.com'})
+    .post('/apps/myapp/domains', {hostname: 'example.com', sni_endpoint: null})
     .reply(200, domainsResponse),
     )
     .command(['domains:add', 'example.com', '--app', 'myapp'])
@@ -45,7 +45,7 @@ describe('domains:add', () => {
         enabled: false,
       },
     ])
-    .post('/apps/myapp/domains', {hostname: 'example.com'})
+    .post('/apps/myapp/domains', {hostname: 'example.com', sni_endpoint: null})
     .reply(200, domainsResponse),
     )
     .command(['domains:add', 'example.com', '--app', 'myapp'])


### PR DESCRIPTION
When creating a domain via the platform api the sni_endpoint will be required:
https://devcenter.heroku.com/changelog-items/1938
