### PR TITLE
fix(pg-v5): Fix databasename for URLs with query element and be more consistent

### DIFF
--- a/packages/pg-v5/commands/copy.js
+++ b/packages/pg-v5/commands/copy.js
@@ -1,9 +1,9 @@
 'use strict'
 
+const util = require('../lib/util')
 const cli = require('heroku-cli-util')
 
 async function run(context, heroku) {
-  const url = require('url')
   const host = require('../lib/host')
   const pgbackups = require('../lib/pgbackups')(context, heroku)
   const fetcher = require('../lib/fetcher')(heroku)
@@ -21,13 +21,12 @@ async function run(context, heroku) {
   let resolve = async function (db) {
     if (db.match(/^postgres:\/\//)) {
       // For the case an input is URL format
-      let uri = url.parse(db)
-      let dbname = uri.path ? uri.path.slice(1) : ''
-      let host = `${uri.hostname}:${uri.port || 5432}`
+      let conn = util.parsePostgresConnectionString(db)
+      let host = `${conn.host}:${conn.port}`
       return {
-        name: dbname ? `database ${dbname} on ${host}` : `database on ${host}`,
+        name: conn.database ? `database ${conn.database} on ${host}` : `database on ${host}`,
         url: db,
-        confirm: dbname || uri.host
+        confirm: conn.database || conn.host
       }
     } else {
       // Other case (need to resolve attachment)

--- a/packages/pg-v5/lib/util.js
+++ b/packages/pg-v5/lib/util.js
@@ -102,17 +102,17 @@ exports.getConnectionDetails = function (attachment, config) {
 
   // build the default payload for non-bastion dbs
   debug(`Using "${connstringVar}" to connect to your database…`)
-  const target = url.parse(config[connstringVar])
-  let [user, password] = target.auth.split(':')
+
+  let conn = exports.parsePostgresConnectionString(config[connstringVar])
 
   let payload = {
-    user,
-    password,
-    database: target.path.split('/', 2)[1],
-    host: target.hostname,
-    port: target.port,
+    user: conn.user,
+    password: conn.password,
+    database: conn.database,
+    host: conn.hostname,
+    port: conn.port,
     attachment,
-    url: target
+    url: conn
   }
 
   // If bastion creds exist, graft it into the payload
@@ -159,8 +159,8 @@ exports.databaseNameFromUrl = (uri, config) => {
   let name = names.pop()
   while (names.length > 0 && name === 'DATABASE_URL') name = names.pop()
   if (name) return cli.color.configVar(name.replace(/_URL$/, ''))
-  uri = url.parse(uri)
-  return `${uri.hostname}:${uri.port || 5432}${uri.path}`
+  let conn = exports.parsePostgresConnectionString(uri)
+  return `${conn.host}:${conn.port}${conn.pathname}`
 }
 
 exports.parsePostgresConnectionString = (db) => {

--- a/packages/pg-v5/test/lib/fetcher.js
+++ b/packages/pg-v5/test/lib/fetcher.js
@@ -9,6 +9,7 @@ const fetcher = proxyquire('../../lib/fetcher', { '@heroku-cli/plugin-addons': {
 const Heroku = require('heroku-client')
 const sinon = require('sinon')
 const url = require('url')
+const util = require('../../lib/util')
 
 beforeEach(function () {
   const getConfig = require('../../lib/config')
@@ -214,9 +215,9 @@ describe('fetcher', () => {
             password: 'pgpass',
             database: 'pgdb',
             host: 'pghost.com',
-            port: null,
+            port: 5432,
             attachment: attachments[0],
-            url: url.parse('postgres://pguser:pgpass@pghost.com/pgdb')
+            url: util.parsePostgresConnectionString('postgres://pguser:pgpass@pghost.com/pgdb')
           }))
       })
 
@@ -250,9 +251,9 @@ describe('fetcher', () => {
             password: 'pgpass',
             database: 'pgdb',
             host: 'pghost.com',
-            port: null,
+            port: 5432,
             attachment: attachments[0],
-            url: url.parse('postgres://pguser:pgpass@pghost.com/pgdb')
+            url: util.parsePostgresConnectionString('postgres://pguser:pgpass@pghost.com/pgdb')
           }))
       })
 
@@ -286,9 +287,9 @@ describe('fetcher', () => {
             password: 'pgpass',
             database: 'pgdb',
             host: 'pghost.com',
-            port: null,
+            port: 5432,
             attachment: attachments[0],
-            url: url.parse('postgres://pguser:pgpass@pghost.com/pgdb')
+            url: util.parsePostgresConnectionString('postgres://pguser:pgpass@pghost.com/pgdb')
           }))
       })
 
@@ -322,9 +323,9 @@ describe('fetcher', () => {
             password: 'pgpass',
             database: 'pgdb',
             host: 'pghost.com',
-            port: null,
+            port: 5432,
             attachment: attachments[0],
-            url: url.parse('postgres://pguser:pgpass@pghost.com/pgdb')
+            url: util.parsePostgresConnectionString('postgres://pguser:pgpass@pghost.com/pgdb')
           }))
       })
 


### PR DESCRIPTION
For operations such as pg:psql, we have been assuming that the URL parsed `path` method is enough to find the database name. This is incorrect when we pass parameters such as `sslmode`. In general, this problem has been solved with `parsePostgresConnectionString` but not everything uses it.

This fix removes any custom parsing we are doing of URLs and moves to using this function everywhere to avoid inconsistency.

* util.databaseNameFromUrl
* util.getConnectionDetails
* the pg:copy resolver

Without this, `pg:psql` was failing on verify-full URL's but with this patch, it works fine.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
