### PR TITLE
feat(pipelines): Exit with non-zero status on failed promotion

### DIFF
--- a/packages/pipelines/src/commands/pipelines/promote.ts
+++ b/packages/pipelines/src/commands/pipelines/promote.ts
@@ -237,6 +237,8 @@ export default class Promote extends Command {
       promotionTargets = await streamReleaseCommand(this.heroku, promotionTargets, promotion)
     } catch (error) {
       cli.error(error)
+
+      cli.exit(1)
     }
 
     const appsByID = keyBy(allApps, 'id')
@@ -257,6 +259,8 @@ export default class Promote extends Command {
       cli.log('\nPromotion successful')
     } else {
       cli.warn('\nPromotion to some apps failed')
+
+      cli.exit(1)
     }
 
     cli.styledObject(styledTargets)


### PR DESCRIPTION
This change adds a non-zero exit from the `pipelines:promote` command if
it fails. This would allow a chain of commands to stop in the event of a
failed promotion, improving the experience of a deploy script.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
