### PR TITLE
fix(docs): update cert:add / cert:update help to reflect changes to intermediate certificates

### DIFF
--- a/packages/certs-v5/commands/certs/add.js
+++ b/packages/certs-v5/commands/certs/add.js
@@ -272,8 +272,8 @@ module.exports = {
   help: 'Note: certificates with PEM encoding are also valid',
   examples: `$ heroku certs:add example.com.crt example.com.key
 
-Certificate Intermediary:
-$ heroku certs:add intermediary.crt example.com.crt example.com.key`,
+    If you require intermediate certificates, refer to this article on merging certificates to get a complete chain:
+    https://help.salesforce.com/s/articleView?id=000333504&type=1`,
   needsApp: true,
   needsAuth: true,
   run: cli.command(run)

--- a/packages/certs-v5/commands/certs/update.js
+++ b/packages/certs-v5/commands/certs/update.js
@@ -46,8 +46,8 @@ module.exports = {
   help: 'Note: certificates with PEM encoding are also valid',
   examples: `$ heroku certs:update example.com.crt example.com.key
 
-Certificate Intermediary:
-$ heroku certs:update intermediary.crt example.com.crt example.com.key`,
+    If you require intermediate certificates, refer to this article on merging certificates to get a complete chain:
+    https://help.salesforce.com/s/articleView?id=000333504&type=1`,
   needsApp: true,
   needsAuth: true,
   run: cli.command({ preauth: true }, run)


### PR DESCRIPTION
https://heroku.support/1069282

It was brought to our attention in this support ticket that our help documentation is outdated for cert:add and cert:update. Intermediate certificates are no longer allowed without bundling. 