### PR TITLE
fix(container-registry-v5): Increase number of retries when fetching container logs

### DIFF
--- a/packages/container-registry-v5/lib/streamer.js
+++ b/packages/container-registry-v5/lib/streamer.js
@@ -1,5 +1,5 @@
 const http = require('http-call').HTTP
-const maxRetries = 10
+const maxRetries = 30
 
 async function call (url, out, retries) {
   try {

--- a/packages/container-registry-v5/package.json
+++ b/packages/container-registry-v5/package.json
@@ -25,6 +25,7 @@
     "chai-as-promised": "^7.1.1",
     "cross-env": "^7.0.2",
     "depcheck": "^0.7.2",
+    "lolex": "^3.1.0",
     "mocha": "^5.0.4",
     "mockdate": "^2.0.2",
     "nock": "^9.2.3",

--- a/packages/container-registry-v5/test/streamer.js
+++ b/packages/container-registry-v5/test/streamer.js
@@ -1,6 +1,7 @@
 const { expect } = require('chai')
 const nock = require('nock')
 const stream = require('stream')
+let lolex = require('lolex')
 
 const streamer = require('../lib/streamer')
 
@@ -19,6 +20,17 @@ MockOut.prototype._write = function (d) {
 }
 
 describe('streaming', () => {
+  let clock;
+
+  beforeEach(function () {
+    clock = lolex.install()
+    clock.setTimeout = function (fn, timeout) { fn() }
+  })
+
+  afterEach(function () {
+    clock.uninstall()
+  })
+
   it('streams data', () => {
     const ws = new MockOut()
     const api = nock('https://streamer.test:443')
@@ -49,7 +61,7 @@ describe('streaming', () => {
     return streamer('https://streamer.test/streams/data.log', ws)
       .then(() => expect(ws.data.join('')).to.equal('My retried data'))
       .then(() => api.done())
-  }).timeout(5 * 1000 * 1.2)
+  })
 
   it('errors on too many retries', async () => {
     const ws = new MockOut()
@@ -60,7 +72,7 @@ describe('streaming', () => {
 
     await expect(streamer('https://streamer.test/streams/data.log', ws)).to.be.rejected
     await api.done()
-  }).timeout(10 * 1000 * 1.2)
+  })
 
   it('does not retry on non-404 errors', async () => {
     const ws = new MockOut()

--- a/packages/container-registry-v5/test/streamer.js
+++ b/packages/container-registry-v5/test/streamer.js
@@ -67,7 +67,7 @@ describe('streaming', () => {
     const ws = new MockOut()
     const api = nock('https://streamer.test:443')
       .get('/streams/data.log')
-      .times(10)
+      .times(30)
       .reply(404, '')
 
     await expect(streamer('https://streamer.test/streams/data.log', ws)).to.be.rejected


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
Fix for https://heroku.support/1081019

Increase the time we wait for the container logs to be available from 10 seconds to 30 seconds.