### PR TITLE
fix(ci): fix windows tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,19 +94,6 @@ jobs:
       size: xlarge
     steps:
       - checkout
-      - run:
-          name: Install latest yarn
-          command: |
-            (New-Object Net.WebClient).DownloadFile("https://yarnpkg.com/latest.msi", "$env:temp\yarn.msi")
-            cmd /c start /wait msiexec.exe /i $env:temp\yarn.msi /quiet /qn /norestart /log install.log
-      - run:
-          name: Verify yarn installation
-          command: |
-            if (!(Test-Path -Path "C:\Program Files (x86)\Yarn\bin\yarn" -PathType Leaf)) {
-              Write-Host "> Installation failed." -ForegroundColor Red
-              Write-Host "" -ForegroundColor Red
-              exit 1
-            }
       - restore_cache:
           keys:
             - node-modules-v1-win-{{ checksum "yarn.lock" }}


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
There's a yarn issue where the latest version of yarn for windows is not being published, resulting in this test failure:
https://app.circleci.com/pipelines/github/heroku/cli/1179/workflows/b638f0e8-4778-4f5a-b6dd-ec0d1e85a1c1/jobs/8444?invite=true#step-102-5

But yarn is being installed as a dependency already so this extra installation step is unnecessary.
