### PR TITLE
fix: add missing circle ci apt packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,8 +220,11 @@ jobs:
     steps:
       - checkout
       - run: *yarn_setup
-      - run: *yarn_install
       - restore_cache: *yarn_restore_cache
+      - run: *yarn_install
+      - run: |
+          apt-get update
+          apt-get install -y nsis p7zip-full
       - run: |
           mkdir -p /build
           cp yarn.lock packages/cli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,13 +338,14 @@ jobs:
       - run:
           name: Publish Install Scripts
           command: /cli/scripts/postrelease/install_scripts
-  trigger_macos:
-    <<: *defaults
-    steps:
-      - add_ssh_keys
-      - checkout
-      - run: yarn --frozen-lockfile
-      - run: ./scripts/release/macos_installer_trigger
+  ## Job not currently being used
+  # trigger_macos:
+  #   <<: *defaults
+  #   steps:
+  #     - add_ssh_keys
+  #     - checkout
+  #     - run: yarn --frozen-lockfile
+  #     - run: ./scripts/release/macos_installer_trigger
   release-homebrew:
     <<: *defaults
     steps:
@@ -419,7 +420,7 @@ workflows:
               only: /^v.*/
             branches:
               only:
-                - fix-ci-apt-pkgs
+                - master
           requires: &pack-requires
             - node14-test
             - node12-test
@@ -457,18 +458,16 @@ workflows:
             - heroku-cli-s3
           requires:
             - release-deb-and-tarballs
-      # - release-homebrew:
-      #     filters: &tags_only
-      #       tags: *version_tags
-      #       branches: &never_run_on_branches
-      #         ignore: /.*/
-      #     context:
-      #       - heroku-cli-s3
-      #     requires:
-      #       - release-deb-and-tarballs
-      # - change-management: &change_management
-      #     filters: *tags_only
-      #     context:
-      #       - heroku-cli-tps
-      #     requires:
-      #       - release-deb-and-tarballs
+      - release-homebrew:
+          filters: &tags_only
+            tags: *version_tags
+            branches: &never_run_on_branches
+              ignore: /.*/
+          requires:
+            - release-deb-and-tarballs
+      - change-management: &change_management
+          filters: *tags_only
+          context:
+            - heroku-cli-tps
+          requires:
+            - release-deb-and-tarballs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
             - node-modules-v1-win-{{ checksum "yarn.lock" }}
       - run:
           name: Install dependencies
-          command: yarn install --frozen-lockfile
+          command: yarn install --frozen-lockfile --prefer-offline
       - save_cache:
           paths:
             - ./node_modules
@@ -320,6 +320,9 @@ jobs:
       - run: *yarn_install
       - attach_workspace:
           at: /cli/packages/cli
+      - run: |
+          apt-get update
+          apt-get install -y awscli
       - run:
           name: packages/cli yarn install
           command: |
@@ -359,7 +362,9 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run: yarn --frozen-lockfile
+      - run: |
+          apt-get update
+          apt-get install -y awscli
       - run: ./scripts/postrelease/invalidate_cdn_cache
   change-management:
     <<: *defaults
@@ -439,19 +444,19 @@ workflows:
             - pack-windows
             - pack-tarballs
             - sign-deb
-      # - release-deb-and-tarballs:
-      #     filters: *master_dev_and_version_tags
-      #     context:
-      #       - heroku-cli-s3
-      #     requires:
-      #       - sign-deb
-      #       - pack-tarballs
-      # - invalidate-cdn-cache:
-      #     filters: *master_dev_and_version_tags
-      #     context:
-      #       - heroku-cli-s3
-      #     requires:
-      #       - release-deb-and-tarballs
+      - release-deb-and-tarballs:
+          filters: *master_dev_and_version_tags
+          context:
+            - heroku-cli-s3
+          requires:
+            - sign-deb
+            - pack-tarballs
+      - invalidate-cdn-cache:
+          filters: *master_dev_and_version_tags
+          context:
+            - heroku-cli-s3
+          requires:
+            - release-deb-and-tarballs
       # - release-homebrew:
       #     filters: &tags_only
       #       tags: *version_tags
@@ -460,7 +465,7 @@ workflows:
       #     context:
       #       - heroku-cli-s3
       #     requires:
-      #       - invalidate-cdn-cache
+      #       - release-deb-and-tarballs
       # - change-management: &change_management
       #     filters: *tags_only
       #     context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,6 +242,9 @@ jobs:
       - restore_cache: *yarn_restore_cache
       - run: *yarn_install
       - run: |
+          apt-get update
+          apt-get install -y p7zip-full
+      - run: |
           mkdir -p /build
           cp yarn.lock packages/cli
           cd packages/cli
@@ -260,6 +263,9 @@ jobs:
       - run: *yarn_setup
       - restore_cache: *yarn_restore_cache
       - run: *yarn_install
+      - run: |
+          apt-get update
+          apt-get install -y apt-utils
       - run: |
           mkdir -p /build
           cp yarn.lock packages/cli
@@ -405,7 +411,7 @@ workflows:
               only: /^v.*/
             branches:
               only:
-                - master
+                - fix-ci-apt-pkgs
           requires: &pack-requires
             - node14-test
             - node12-test
@@ -430,31 +436,31 @@ workflows:
             - pack-windows
             - pack-tarballs
             - sign-deb
-      - release-deb-and-tarballs:
-          filters: *master_dev_and_version_tags
-          context:
-            - heroku-cli-s3
-          requires:
-            - sign-deb
-            - pack-tarballs
-      - invalidate-cdn-cache:
-          filters: *master_dev_and_version_tags
-          context:
-            - heroku-cli-s3
-          requires:
-            - release-deb-and-tarballs
-      - release-homebrew:
-          filters: &tags_only
-            tags: *version_tags
-            branches: &never_run_on_branches
-              ignore: /.*/
-          context:
-            - heroku-cli-s3
-          requires:
-            - invalidate-cdn-cache
-      - change-management: &change_management
-          filters: *tags_only
-          context:
-            - heroku-cli-tps
-          requires:
-            - release-deb-and-tarballs
+      # - release-deb-and-tarballs:
+      #     filters: *master_dev_and_version_tags
+      #     context:
+      #       - heroku-cli-s3
+      #     requires:
+      #       - sign-deb
+      #       - pack-tarballs
+      # - invalidate-cdn-cache:
+      #     filters: *master_dev_and_version_tags
+      #     context:
+      #       - heroku-cli-s3
+      #     requires:
+      #       - release-deb-and-tarballs
+      # - release-homebrew:
+      #     filters: &tags_only
+      #       tags: *version_tags
+      #       branches: &never_run_on_branches
+      #         ignore: /.*/
+      #     context:
+      #       - heroku-cli-s3
+      #     requires:
+      #       - invalidate-cdn-cache
+      # - change-management: &change_management
+      #     filters: *tags_only
+      #     context:
+      #       - heroku-cli-tps
+      #     requires:
+      #       - release-deb-and-tarballs

--- a/scripts/sign/deb
+++ b/scripts/sign/deb
@@ -4,8 +4,8 @@ set -e -o pipefail
 # This will sign files after `oclif-dev pack:deb`, this script should be ran from
 # the `dist/deb` folder
 echo "$HEROKU_DEB_SECRET_KEY" | base64 -d 2> /dev/null | gpg --import --batch --passphrase "$HEROKU_DEB_SIGNING_PASSWORD" 2> /dev/null
-gpg --digest-algo SHA512 --clearsign --batch --passphrase "$HEROKU_DEB_SIGNING_PASSWORD" -u $HEROKU_DEB_KEY_ID -o InRelease Release 2> /dev/null
-gpg --digest-algo SHA512 -abs --batch --passphrase "$HEROKU_DEB_SIGNING_PASSWORD" -u $HEROKU_DEB_KEY_ID -o Release.gpg Release 2> /dev/null
+gpg --digest-algo SHA512 --clearsign --pinentry-mode loopback --passphrase "$HEROKU_DEB_SIGNING_PASSWORD" -u $HEROKU_DEB_KEY_ID -o InRelease Release 2> /dev/null
+gpg --digest-algo SHA512 -abs --pinentry-mode loopback --passphrase "$HEROKU_DEB_SIGNING_PASSWORD" -u $HEROKU_DEB_KEY_ID -o Release.gpg Release 2> /dev/null
 echo "Signed debian packages successfully"
 echo "sha256 sums:"
 sha256sum *Release*


### PR DESCRIPTION
We removed the custom ci docker image in #1968 but need this few packages in certain jobs