### PR TITLE
fix(cli): use [signed-by] instead of the deprecated apt-key command for apt-based install

### DIFF
--- a/install-ubuntu.sh
+++ b/install-ubuntu.sh
@@ -21,13 +21,13 @@
       && apt-get install -y apt-transport-https)
 
   # add heroku repository to apt
-  echo "deb https://cli-assets.heroku.com/apt ./" > /etc/apt/sources.list.d/heroku.list
+  echo "deb [signed-by=/usr/share/keyrings/heroku-archive-keyring.gpg] https://cli-assets.heroku.com/apt ./" > /etc/apt/sources.list.d/heroku.list
 
   # remove toolbelt
   (dpkg -s heroku-toolbelt 1>/dev/null 2>/dev/null && (apt-get remove -y heroku-toolbelt heroku || true)) || true
 
   # install heroku's release key for package verification
-  curl https://cli-assets.heroku.com/apt/release.key | apt-key add -
+  curl https://cli-assets.heroku.com/apt/release.key | sudo gpg --dearmor -o /usr/share/keyrings/heroku-archive-keyring.gpg
 
   # update your sources
   apt-get update


### PR DESCRIPTION
### Description

`apt-key` is deprecated and will disappear in the next releases of Debian and Ubuntu as mentioned in the [man page](https://manpages.debian.org/bullseye/apt/apt-key.8.en.html).

The recommended way is now to use `signed-by` in the sources.list entry: https://wiki.debian.org/DebianRepository/UseThirdParty

This PR updates the apt-based install script to use this new method.

### Test

I've run this updated script on my machine, I know have the heroku key in `/usr/share/keyrings/heroku-archive-keyring.gpg` and install was performed as expected:

```sh
$ sh install-ubuntu.sh 
This script requires superuser access to install apt packages.
You will be prompted for your password by sudo.
[sudo] password for <user>: 
+ dpkg -s apt-transport-https
+ echo deb [signed-by=/usr/share/keyrings/heroku-archive-keyring.gpg] https://cli-assets.heroku.com/apt ./
+ dpkg -s heroku-toolbelt
+ true
+ curl https://cli-assets.heroku.com/apt/release.key
+ sudo gpg --dearmor -o /usr/share/keyrings/heroku-archive-keyring.gpg
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1753  100  1753    0     0  18849      0 --:--:-- --:--:-- --:--:-- 18849
+ apt-get update
Hit:1 http://deb.debian.org/debian bullseye InRelease
Hit:2 http://deb.debian.org/debian bullseye-updates InRelease                                                                                                   
Hit:3 http://security.debian.org/debian-security bullseye-security InRelease                                                                                    
[...]                                                                             
Get:7 https://cli-assets.heroku.com/apt ./ InRelease [2,550 B]                   
[...]
Get:11 https://cli-assets.heroku.com/apt ./ Packages [620 B]
Fetched 9,921 B in 1s (10.7 kB/s)
Reading package lists... Done
+ apt-get install -y heroku
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  heroku
0 upgraded, 1 newly installed, 0 to remove and 23 not upgraded.
Need to get 28.0 MB of archives.
After this operation, 0 B of additional disk space will be used.
Get:1 https://cli-assets.heroku.com/apt ./ heroku 7.60.2-1 [28.0 MB]
Fetched 28.0 MB in 1s (19.7 MB/s)  
Selecting previously unselected package heroku.
(Reading database ... 233783 files and directories currently installed.)
Preparing to unpack .../heroku_7.60.2-1_amd64.deb ...
Unpacking heroku (7.60.2-1) ...
Setting up heroku (7.60.2-1) ...
heroku installed to /usr/bin/heroku
 ›   Warning: Our terms of service have changed: https://dashboard.heroku.com/terms-of-service
heroku/7.60.2 linux-x64 node-v14.19.0
```