### PR TITLE
feat(installer): allow standalone installation ignoring correct PATH

### DIFF
--- a/install-standalone.sh
+++ b/install-standalone.sh
@@ -17,8 +17,12 @@
 
   echoerr() { echo "\$@" 1>&2; }
 
-  if [[ ! ":\$PATH:" == *":/usr/local/bin:"* ]]; then
-    echoerr "Your path is missing /usr/local/bin, you need to add this to use this installer."
+  if [ -z "$HEROKU_NO_PATH_CHECK" ] && [[ ! ":\$PATH:" == *":/usr/local/bin:"* ]]; then
+    echoerr
+    echoerr "Your PATH appears to be missing /usr/local/bin, so the CLI may not run."
+    echoerr "To install it regardless, set HEROKU_NO_PATH_CHECK and re-run the installer:"
+    echoerr
+    echoerr "    export HEROKU_NO_PATH_CHECK=1"
     exit 1
   fi
 


### PR DESCRIPTION
`PATH` sometimes doesn't appear to be set correctly when running the installer under certain circumstances. In my case, running the `curl | sh` as suggested in the CLI docs doesn't work, and I had to edit out the checks from the script.

This PR allows users to export `HEROKU_NO_PATH_CHECK` to ignore this and install the CLI anyway, and provides instructions to the user in case they want to do this.