### PR TITLE
chore Update heroku-20 to heroku-22

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -77,7 +77,7 @@ OPTIONS
 
 EXAMPLES
   $ heroku apps:create
-  Creating app... done, stack is heroku-20
+  Creating app... done, stack is heroku-22
   https://floating-dragon-42.heroku.com/ | https://git.heroku.com/floating-dragon-42.git
 
   # or just
@@ -353,8 +353,8 @@ OPTIONS
   -r, --remote=remote  git remote of app to use
 
 EXAMPLES
-  $ heroku stack:set heroku-20 -a myapp
-  Setting stack to heroku-20... done
+  $ heroku stack:set heroku-22 -a myapp
+  Setting stack to heroku-22... done
   You will need to redeploy myapp for the change to take effect.
   Run git push heroku main to trigger a new build on myapp.
 ```

--- a/packages/apps-v5/README.md
+++ b/packages/apps-v5/README.md
@@ -120,7 +120,7 @@ OPTIONS
 
 EXAMPLES
   $ heroku apps:create
-  Creating app... done, stack is heroku-20
+  Creating app... done, stack is heroku-22
   https://floating-dragon-42.heroku.com/ | https://git.heroku.com/floating-dragon-42.git
 
   # or just
@@ -309,8 +309,8 @@ OPTIONS
   -r, --remote=remote  git remote of app to use
 
 EXAMPLES
-  $ heroku stack:set heroku-20 -a myapp
-  Setting stack to heroku-20... done
+  $ heroku stack:set heroku-22 -a myapp
+  Setting stack to heroku-22... done
   You will need to redeploy myapp for the change to take effect.
   Run git push heroku main to trigger a new build on myapp.
 ```

--- a/packages/apps-v5/src/commands/apps/create.js
+++ b/packages/apps-v5/src/commands/apps/create.js
@@ -151,7 +151,7 @@ function run (context, heroku) {
 let cmd = {
   description: 'creates a new app',
   examples: `$ heroku apps:create
-Creating app... done, stack is heroku-20
+Creating app... done, stack is heroku-22
 https://floating-dragon-42.heroku.com/ | https://git.heroku.com/floating-dragon-42.git
 
 # or just

--- a/packages/apps-v5/src/commands/apps/stacks/set.js
+++ b/packages/apps-v5/src/commands/apps/stacks/set.js
@@ -27,8 +27,8 @@ let cmd = {
   needsApp: true,
   needsAuth: true,
   description: 'set the stack of an app',
-  examples: `$ heroku stack:set heroku-20 -a myapp
-Setting stack to heroku-20... done
+  examples: `$ heroku stack:set heroku-22 -a myapp
+Setting stack to heroku-22... done
 You will need to redeploy myapp for the change to take effect.
 Run git push heroku main to trigger a new build on myapp.`,
   args: [{ name: 'stack' }],

--- a/packages/apps-v5/test/commands/apps/info.js
+++ b/packages/apps-v5/test/commands/apps/info.js
@@ -24,7 +24,7 @@ let app = {
 }
 
 let appStackChange = Object.assign({}, app, {
-  build_stack: { name: 'heroku-20' }
+  build_stack: { name: 'heroku-22' }
 })
 
 let appExtended = Object.assign({}, app, {
@@ -356,7 +356,7 @@ Region:           eu
 Repo Size:        1000 B
 Slug Size:        1000 B
 Space:            myspace
-Stack:            cedar-14 (next build will use heroku-20)
+Stack:            cedar-14 (next build will use heroku-22)
 Web URL:          https://myapp.herokuapp.com
 `))
       .then(() => appApi.done())

--- a/packages/apps-v5/test/commands/apps/stack/set.js
+++ b/packages/apps-v5/test/commands/apps/stack/set.js
@@ -12,17 +12,17 @@ const pendingUpgradeApp = {
     name: 'heroku-16'
   },
   build_stack: {
-    name: 'heroku-20'
+    name: 'heroku-22'
   }
 }
 
 const completedUpgradeApp = {
   name: 'myapp',
   stack: {
-    name: 'heroku-20'
+    name: 'heroku-22'
   },
   build_stack: {
-    name: 'heroku-20'
+    name: 'heroku-22'
   }
 }
 
@@ -31,11 +31,11 @@ describe('stack:set', function () {
 
   it('sets the stack', function () {
     let api = nock('https://api.heroku.com:443')
-      .patch('/apps/myapp', { build_stack: 'heroku-20' })
+      .patch('/apps/myapp', { build_stack: 'heroku-22' })
       .reply(200, pendingUpgradeApp)
 
-    return cmd.run({ app: 'myapp', args: { stack: 'heroku-20' }, flags: {} })
-      .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-20... done\n'))
+    return cmd.run({ app: 'myapp', args: { stack: 'heroku-22' }, flags: {} })
+      .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-22... done\n'))
       .then(() => expect(cli.stdout).to.equal(`You will need to redeploy myapp for the change to take effect.
 Run git push heroku main to trigger a new build on myapp.
 `))
@@ -44,11 +44,11 @@ Run git push heroku main to trigger a new build on myapp.
 
   it('sets the stack on a different remote', function () {
     let api = nock('https://api.heroku.com:443')
-      .patch('/apps/myapp', { build_stack: 'heroku-20' })
+      .patch('/apps/myapp', { build_stack: 'heroku-22' })
       .reply(200, pendingUpgradeApp)
 
-    return cmd.run({ app: 'myapp', args: { stack: 'heroku-20' }, flags: { remote: 'staging' } })
-      .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-20... done\n'))
+    return cmd.run({ app: 'myapp', args: { stack: 'heroku-22' }, flags: { remote: 'staging' } })
+      .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-22... done\n'))
       .then(() => expect(cli.stdout).to.equal(`You will need to redeploy myapp for the change to take effect.
 Run git push staging main to trigger a new build on myapp.
 `))
@@ -57,11 +57,11 @@ Run git push staging main to trigger a new build on myapp.
 
   it('does not show the redeploy message if the stack was immediately updated by API', function () {
     let api = nock('https://api.heroku.com:443')
-      .patch('/apps/myapp', { build_stack: 'heroku-20' })
+      .patch('/apps/myapp', { build_stack: 'heroku-22' })
       .reply(200, completedUpgradeApp)
 
-    return cmd.run({ app: 'myapp', args: { stack: 'heroku-20' }, flags: {} })
-      .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-20... done\n'))
+    return cmd.run({ app: 'myapp', args: { stack: 'heroku-22' }, flags: {} })
+      .then(() => expect(cli.stderr).to.equal('Setting stack to heroku-22... done\n'))
       .then(() => expect(cli.stdout).to.equal(''))
       .then(() => api.done())
   })


### PR DESCRIPTION
The Heroku CLI's help text refers to Heroku-20 in a few of the examples. eg:


```
$ heroku stack:set heroku-20 -a myapp

Setting stack to heroku-20... done

You will need to redeploy myapp for the change to take effect.

Run git push heroku main to trigger a new build on myapp.

```


This updates it to use Heroku-22 instead.


See:

https://github.com/heroku/cli/search?q=heroku-20

GUS-W-10349673

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
