### PR TITLE
chore(installer): Remove `apt-transport-https` installation from Ubuntu install script

### DIFF
--- a/install-ubuntu.sh
+++ b/install-ubuntu.sh
@@ -14,12 +14,6 @@
     $SUDO sh <<SCRIPT
   set -ex
 
-  # if apt-transport-https is not installed, clear out old sources, update, then install apt-transport-https
-  dpkg -s apt-transport-https 1>/dev/null 2>/dev/null || \
-    (echo "" > /etc/apt/sources.list.d/heroku.list \
-      && apt-get update \
-      && apt-get install -y apt-transport-https)
-
   # add heroku repository to apt
   echo "deb https://cli-assets.heroku.com/apt ./" > /etc/apt/sources.list.d/heroku.list
 


### PR DESCRIPTION
As HTTPS transport has been available by default in `apt` since 1.5, `apt-transport-https` has become a dummy transitional package whose installation isn't needed on any of the supported Ubuntu releases (oldest supported release, Focal, is using `apt` 1.6).

This commit removes `apt-transport-https` installation from Ubuntu install script to prevent installation of unnecessary package.

See [`apt-transport-https` manpages](https://manpages.ubuntu.com/manpages/bionic/en/man1/apt-transport-https.1.html) for details.