### PR TITLE
fix (pg-v5): Look for pg_stat_statements in heroku_ext

### DIFF
--- a/packages/pg-v5/commands/outliers.js
+++ b/packages/pg-v5/commands/outliers.js
@@ -7,7 +7,7 @@ async function ensurePGStatStatement(db) {
   let query = `
 SELECT exists(
   SELECT 1 FROM pg_extension e LEFT JOIN pg_namespace n ON n.oid = e.extnamespace
-  WHERE e.extname='pg_stat_statements' AND n.nspname = 'public'
+  WHERE e.extname='pg_stat_statements' AND n.nspname IN ('public', 'heroku_ext')
 ) AS available`
   let output = await psql.exec(db, query)
 


### PR DESCRIPTION
Following https://devcenter.heroku.com/changelog-items/2446

We need to also include `heroku_ext` here.

Testing on a new db:


```
ds9aic4ustc1f=> SELECT exists(
  SELECT 1 FROM pg_extension e LEFT JOIN pg_namespace n ON n.oid = e.extnamespace
  WHERE e.extname='pg_stat_statements' AND n.nspname = 'public'
);
 exists 
--------
 f
(1 row)

ds9aic4ustc1f=> SELECT exists(
  SELECT 1 FROM pg_extension e LEFT JOIN pg_namespace n ON n.oid = e.extnamespace
  WHERE e.extname='pg_stat_statements' AND n.nspname = 'heroku_ext'
);
 exists 
--------
 t
(1 row)

ds9aic4ustc1f=> SELECT exists(
  SELECT 1 FROM pg_extension e LEFT JOIN pg_namespace n ON n.oid = e.extnamespace
  WHERE e.extname='pg_stat_statements' AND n.nspname IN ('heroku_ext', 'public')
);
 exists 
--------
 t
(1 row)
```

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
