### PR TITLE
fix(cli): use uuid rather than addon name for pg:credentials

### DIFF
--- a/packages/pg-v5/commands/credentials.js
+++ b/packages/pg-v5/commands/credentials.js
@@ -26,11 +26,11 @@ async function run(context, heroku) {
       return util.presentCredentialAttachments(app, credAttachments, credentials, cred)
     }
 
-    credentials = await heroku.get(`/postgres/v0/databases/${addon.name}/credentials`,
+    credentials = await heroku.get(`/postgres/v0/databases/${addon.id}/credentials`,
       {host: host(addon)})
     let isDefaultCredential = cred => cred.name !== 'default'
     credentials = sortBy(credentials, isDefaultCredential, 'name')
-    attachments = await heroku.get(`/addons/${addon.name}/addon-attachments`)
+    attachments = await heroku.get(`/addons/${addon.id}/addon-attachments`)
 
     cli.warn(`${cli.color.cmd('pg:credentials')} has recently changed. Please use ${cli.color.cmd('pg:credentials:url')} for the previous output.`)
     cli.table(credentials, {

--- a/packages/pg-v5/test/unit/commands/credentials.unit.test.js
+++ b/packages/pg-v5/test/unit/commands/credentials.unit.test.js
@@ -103,8 +103,8 @@ describe('pg:credentials', () => {
         namespace: 'credential:ransom',
       },
     ]
-    api.get('/addons/postgres-1/addon-attachments').reply(200, attachments)
-    pg.get('/postgres/v0/databases/postgres-1/credentials').reply(200, credentials)
+    api.get('/addons/1/addon-attachments').reply(200, attachments)
+    pg.get('/postgres/v0/databases/1/credentials').reply(200, credentials)
 
     let displayed = `Credential                                                                     State
 ─────────────────────────────────────────────────────────────────────────────  ────────
@@ -179,8 +179,8 @@ ransom                                                                         a
         namespace: 'credential:ransom',
       },
     ]
-    api.get('/addons/postgres-1/addon-attachments').reply(200, attachments)
-    pg.get('/postgres/v0/databases/postgres-1/credentials').reply(200, credentials)
+    api.get('/addons/1/addon-attachments').reply(200, attachments)
+    pg.get('/postgres/v0/databases/1/credentials').reply(200, credentials)
 
     let displayed = `Credential                                            State
 ────────────────────────────────────────────────────  ────────


### PR DESCRIPTION
Fix for https://heroku.support/1140923

We are currently using the addon name to query the API for postgres credentials. This breaks after addons are renamed using `addons:rename`. This PR updates the command to use a uuid, a method we largely switched to in 2017. A few commands have yet to be updated, including this one.  

We are waiting on Data to implement support for UUID, until then this PR can not be tested -> https://salesforce-internal.slack.com/archives/C02LKCXMAEM/p1661381725900759