### PR TITLE
feat(pg-v5): accept a list of extensions to pre-install for pg:backups:restore and pg:reset

### DIFF
--- a/packages/pg-v5/commands/backups/restore.js
+++ b/packages/pg-v5/commands/backups/restore.js
@@ -25,6 +25,11 @@ async function run(context, heroku) {
 
   let backupURL
   let backupName = args.backup
+  let extensions = context.flags.extensions
+  if (extensions) {
+    extensions = extensions.split(',').map(ext => ext.trim().toLowerCase()).sort()
+  }
+
 
   if (backupName && backupName.match(/^https?:\/\//)) {
     backupURL = dropboxURL(backupName)
@@ -54,7 +59,7 @@ async function run(context, heroku) {
   let restore
   await cli.action(`Starting restore of ${cli.color.cyan(backupName)} to ${cli.color.addon(db.name)}`, async function () {
     restore = await heroku.post(`/client/v11/databases/${db.id}/restores`, {
-      body: { backup_url: backupURL, extensions: flags.extensions },
+      body: { backup_url: backupURL, extensions: extensions },
       host: host(db)
     })
   }())

--- a/packages/pg-v5/commands/backups/restore.js
+++ b/packages/pg-v5/commands/backups/restore.js
@@ -54,7 +54,7 @@ async function run(context, heroku) {
   let restore
   await cli.action(`Starting restore of ${cli.color.cyan(backupName)} to ${cli.color.addon(db.name)}`, async function () {
     restore = await heroku.post(`/client/v11/databases/${db.id}/restores`, {
-      body: { backup_url: backupURL },
+      body: { backup_url: backupURL, extensions: flags.extensions },
       host: host(db)
     })
   }())
@@ -80,6 +80,7 @@ module.exports = {
   ],
   flags: [
     { name: 'wait-interval', hasValue: true },
+    { name: 'extensions', char: 'e', hasValue: true, description: 'comma-separated list of extensions to pre-install in the public schema' },
     { name: 'verbose', char: 'v' },
     { name: 'confirm', char: 'c', hasValue: true }
   ],

--- a/packages/pg-v5/commands/reset.js
+++ b/packages/pg-v5/commands/reset.js
@@ -7,13 +7,20 @@ async function run(context, heroku) {
   const fetcher = require('../lib/fetcher')(heroku)
   let { app, args, flags } = context
   let db = await fetcher.addon(app, args.database)
+  let extensions = flags.extensions
+  if (extensions) {
+    extensions = extensions.split(',').map(ext => ext.trim().toLowerCase()).sort()
+  }
 
   await cli.confirmApp(app, flags.confirm, `WARNING: Destructive action
 ${cli.color.addon(db.name)} will lose all of its data
 `)
 
   await cli.action(`Resetting ${cli.color.addon(db.name)}`, async function () {
-    await heroku.put(`/client/v11/databases/${db.id}/reset`, { host: host(db) })
+    await heroku.put(`/client/v11/databases/${db.id}/reset`, {
+      body: { extensions: extensions },
+      host: host(db)
+    })
   }())
 }
 
@@ -24,6 +31,9 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   args: [{ name: 'database', optional: true }],
-  flags: [{ name: 'confirm', char: 'c', hasValue: true }],
+  flags: [
+    { name: 'extensions', char: 'e', hasValue: true, description: 'comma-separated list of extensions to pre-install in the public schema' },
+    { name: 'confirm', char: 'c', hasValue: true }
+  ],
   run: cli.command({ preauth: true }, run)
 }

--- a/packages/pg-v5/test/commands/backups/restore.js
+++ b/packages/pg-v5/test/commands/backups/restore.js
@@ -140,6 +140,34 @@ Stop a running restore with heroku pg:backups:cancel.
         .then(() => expect(cli.stderr).to.equal(`Starting restore of https://www.dropbox.com to postgres-1... done\n${restoringText()}`))
     })
   })
+
+  context('with extensions', () => {
+    beforeEach(() => {
+      pg.get('/client/v11/apps/myapp/transfers').reply(200, [
+        { num: 5, from_type: 'pg_dump', to_type: 'gof3r', succeeded: true, to_url: 'https://myurl' }
+      ])
+      pg.post('/client/v11/databases/1/restores', { backup_url: 'https://myurl', extensions: 'uuid-ossp,postgis' }).reply(200, {
+        num: 5,
+        from_name: 'DATABASE',
+        uuid: '100-001'
+      })
+      pg.get('/client/v11/apps/myapp/transfers/100-001').reply(200, {
+        finished_at: '101',
+        succeeded: true
+      })
+    })
+
+    it('restores a db with pre-installed extensions', () => {
+      return cmdRun({ app: 'myapp', args: {}, flags: { confirm: 'myapp', extensions: 'uuid-ossp,postgis' } })
+        .then(() => expect(cli.stdout).to.equal(`
+Use Ctrl-C at any time to stop monitoring progress; the backup will continue restoring.
+Use heroku pg:backups to check progress.
+Stop a running restore with heroku pg:backups:cancel.
+
+`))
+        .then(() => expect(cli.stderr).to.equal(`Starting restore of b005 to postgres-1... done\n${restoringText()}`))
+    })
+  })
 }
 
 describe('pg:backups:restore', () => {

--- a/packages/pg-v5/test/commands/backups/restore.js
+++ b/packages/pg-v5/test/commands/backups/restore.js
@@ -146,7 +146,7 @@ Stop a running restore with heroku pg:backups:cancel.
       pg.get('/client/v11/apps/myapp/transfers').reply(200, [
         { num: 5, from_type: 'pg_dump', to_type: 'gof3r', succeeded: true, to_url: 'https://myurl' }
       ])
-      pg.post('/client/v11/databases/1/restores', { backup_url: 'https://myurl', extensions: 'uuid-ossp,postgis' }).reply(200, {
+      pg.post('/client/v11/databases/1/restores', { backup_url: 'https://myurl', extensions: ['postgis', 'uuid-ossp'] }).reply(200, {
         num: 5,
         from_name: 'DATABASE',
         uuid: '100-001'
@@ -158,7 +158,7 @@ Stop a running restore with heroku pg:backups:cancel.
     })
 
     it('restores a db with pre-installed extensions', () => {
-      return cmdRun({ app: 'myapp', args: {}, flags: { confirm: 'myapp', extensions: 'uuid-ossp,postgis' } })
+      return cmdRun({ app: 'myapp', args: {}, flags: { confirm: 'myapp', extensions: 'uuid-ossp, Postgis' } })
         .then(() => expect(cli.stdout).to.equal(`
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue restoring.
 Use heroku pg:backups to check progress.

--- a/packages/pg-v5/test/commands/reset.js
+++ b/packages/pg-v5/test/commands/reset.js
@@ -41,4 +41,17 @@ describe('pg:reset', () => {
     return cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp' } })
       .then(() => expect(cli.stderr).to.equal('Resetting postgres-1... done\n'))
   })
+
+  context('with extensions', () => {
+    beforeEach(() => {
+      pg.put('/client/v11/databases/1/reset', { extensions: ['postgis', 'uuid-ossp'] }).reply(200, {
+        message: 'Reset successful.',
+      })
+    })
+
+    it('resets a db with pre-installed extensions', () => {
+      return cmd.run({ app: 'myapp', args: {}, flags: { confirm: 'myapp', extensions: 'uuid-ossp, Postgis' } })
+        .then(() => expect(cli.stderr).to.equal('Resetting postgres-1... done\n'))
+    })
+  })
 })


### PR DESCRIPTION
This adds support for a new flag on the `pg:backups:restore` and `pg:reset` commands to specify a list of extensions to pre-install before restoring the backup.