### PR TITLE
fix(pg-v5): use a different outliers query for new pg versions

### DIFF
--- a/packages/pg-v5/commands/outliers.js
+++ b/packages/pg-v5/commands/outliers.js
@@ -3,7 +3,7 @@
 const cli = require('heroku-cli-util')
 const psql = require('../lib/psql')
 
-async function ensurePGStatStatement(db) {
+async function ensurePGStatStatement (db) {
   let query = `
 SELECT exists(
   SELECT 1 FROM pg_extension e LEFT JOIN pg_namespace n ON n.oid = e.extnamespace
@@ -12,18 +12,53 @@ SELECT exists(
   let output = await psql.exec(db, query)
 
   if (!output.includes('t')) {
-    throw new Error(`pg_stat_statements extension need to be installed in the public schema first.
-You can install it by running: CREATE EXTENSION pg_stat_statements;`)
+    throw new Error(`pg_stat_statements extension need to be installed first.
+You can install it by running: CREATE EXTENSION pg_stat_statements WITH SCHEMA heroku_ext;`)
   }
 }
 
-async function run(context, heroku) {
+function outliersQuery (version, limit, truncate) {
+  let truncatedQueryString = truncate
+    ? 'CASE WHEN length(query) <= 40 THEN query ELSE substr(query, 0, 39) || \'…\' END'
+    : 'query'
+
+  if (version >= 13) {
+    return `
+SELECT
+  interval '1 millisecond' * total_exec_time AS total_exec_time,
+  to_char((total_exec_time/sum(total_exec_time) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
+  to_char(calls, 'FM999G999G999G990') AS ncalls,
+  interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time,
+  ${truncatedQueryString} AS query
+FROM pg_stat_statements
+WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
+ORDER BY total_exec_time DESC
+LIMIT ${limit}
+`
+  } else {
+    return `
+SELECT
+  interval '1 millisecond' * total_time AS total_exec_time,
+  to_char((total_time/sum(total_time) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
+  to_char(calls, 'FM999G999G999G990') AS ncalls,
+  interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time,
+  ${truncatedQueryString} AS query
+FROM pg_stat_statements
+WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
+ORDER BY total_time DESC
+LIMIT ${limit}
+`
+  }
+}
+
+async function run (context, heroku) {
   const fetcher = require('../lib/fetcher')
 
   const { app, args, flags } = context
   const { database } = args
 
   let db = await fetcher(heroku).database(app, database)
+  let version = await psql.fetchVersion(db)
 
   await ensurePGStatStatement(db)
 
@@ -31,10 +66,6 @@ async function run(context, heroku) {
     await psql.exec(db, 'SELECT pg_stat_statements_reset()')
     return
   }
-
-  let truncatedQueryString = flags.truncate
-    ? 'CASE WHEN length(query) <= 40 THEN query ELSE substr(query, 0, 39) || \'…\' END'
-    : 'query'
 
   let limit = 10
   if (context.flags.num) {
@@ -45,17 +76,7 @@ async function run(context, heroku) {
     }
   }
 
-  let query = `
-SELECT interval '1 millisecond' * total_time AS total_exec_time,
-to_char((total_time/sum(total_time) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
-to_char(calls, 'FM999G999G999G990') AS ncalls,
-interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time,
-${truncatedQueryString} AS query
-FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
-ORDER BY total_time DESC
-LIMIT ${limit}
-`
-
+  let query = outliersQuery(version, limit, flags.truncate)
   let output = await psql.exec(db, query)
   process.stdout.write(output)
 }

--- a/packages/pg-v5/lib/psql.js
+++ b/packages/pg-v5/lib/psql.js
@@ -240,6 +240,11 @@ class Tunnel {
   }
 }
 
+async function fetchVersion (db) {
+  var output = await exec(db, 'SHOW server_version', ['-X', '-q'])
+  return output.match(/[0-9]{1,}\.[0-9]{1,}/)[0]
+}
+
 async function exec (db, query, cmdArgs=[]) {
   const configs = bastion.getConfigs(db)
   const options = psqlQueryOptions(query, configs.dbEnv, cmdArgs)
@@ -266,5 +271,6 @@ async function interactive (db) {
 module.exports = {
   exec,
   execFile,
-  interactive,
+  fetchVersion,
+  interactive
 }

--- a/packages/pg-v5/test/commands/outliers.js
+++ b/packages/pg-v5/test/commands/outliers.js
@@ -5,6 +5,7 @@ const cli = require('heroku-cli-util')
 const { expect } = require('chai')
 const nock = require('nock')
 const proxyquire = require('proxyquire')
+const { stdout } = require('stdout-stderr')
 
 const db = {}
 const fetcher = () => {
@@ -13,10 +14,17 @@ const fetcher = () => {
   }
 }
 
+const EXPECTED_OUTPUT_TEXT = 'slow things'
+
 const psql = {
+  serverVersion: '11.16',
+  fetchVersion: function (db) {
+    this._fetchVersionCalled = true
+    return Promise.resolve(this.serverVersion)
+  },
   exec: function (db, query) {
     this._query = query
-    return Promise.resolve('t')
+    return Promise.resolve(EXPECTED_OUTPUT_TEXT)
   }
 }
 
@@ -29,22 +37,39 @@ describe('pg:outliers', () => {
   let api
 
   beforeEach(() => {
+    stdout.start()
     api = nock('https://api.heroku.com:443')
     cli.mockConsole()
   })
 
   afterEach(() => {
+    stdout.stop()
     nock.cleanAll()
     api.done()
   })
 
-  it('reset queries stats', () => {
-    return cmd.run({ app: 'myapp', args: {}, flags: { reset: true } })
-      .then(() => expect(psql._query.trim()).to.equal('SELECT pg_stat_statements_reset()'))
+  it('reset queries stats', async () => {
+    await cmd.run({ app: 'myapp', args: {}, flags: { reset: true } })
+
+    expect(psql._query.trim()).to.equal('SELECT pg_stat_statements_reset()')
   })
 
-  it('returns queries outliers', () => {
-    return cmd.run({ app: 'myapp', args: {}, flags: {} })
-      .then(() => expect(psql._query.trim()).to.contain('FROM pg_stat_statements'))
+  it('returns queries outliers', async () => {
+    psql.serverVersion = '11.16'
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+
+    expect(psql._fetchVersionCalled).to.eq(true)
+    expect(psql._query.trim()).to.contain('total_time AS total_exec_time')
+    expect(psql._query.trim()).to.contain('FROM pg_stat_statements')
+    expect(stdout.output).to.equal(EXPECTED_OUTPUT_TEXT)
+  })
+
+  it('uses an updated query for a newer version', async () => {
+    psql.serverVersion = '13.7'
+    await cmd.run({ app: 'myapp', args: {}, flags: {} })
+    expect(psql._fetchVersionCalled).to.eq(true)
+    expect(psql._query.trim()).to.contain('total_exec_time AS total_exec_time')
+    expect(psql._query.trim()).to.contain('FROM pg_stat_statements')
+    expect(stdout.output).to.equal(EXPECTED_OUTPUT_TEXT)
   })
 })


### PR DESCRIPTION
Postgres version 13 and newer removed the `total_time` field from `pg_stat_statements` and replaced it with `total_exec_time`. This PR updates the command to fetch the postgres server version, and use an outliers query appropriate for the version.

Testing against an older and a newer postgres database:
```
$ hdev pg:outliers HOBBY_11_URL -a jwadsworth-dev

┌─────────────────┬────────────────┬────────┬─────────────────┬─────────────────────────────────────────────────────────────────────────────────────┐
│ total_exec_time │ prop_exec_time │ ncalls │  sync_io_time   │                                        query                                        │
├─────────────────┼────────────────┼────────┼─────────────────┼─────────────────────────────────────────────────────────────────────────────────────┤
│ 00:00:00.000478 │ 76.4%          │ 2      │ 00:00:00.000016 │ SELECT                                                                             ↵│
│                 │                │        │                 │   interval $1 * total_time AS total_exec_time,                                     ↵│
│                 │                │        │                 │   to_char((total_time/sum(total_time) OVER()) * $2, $3) || $4  AS prop_exec_time,  ↵│
│                 │                │        │                 │   to_char(calls, $5) AS ncalls,                                                    ↵│
│                 │                │        │                 │   interval $6 * (blk_read_time + blk_write_time) AS sync_io_time,                  ↵│
│                 │                │        │                 │   query AS query                                                                   ↵│
│                 │                │        │                 │ FROM pg_stat_statements                                                            ↵│
│                 │                │        │                 │ WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT $7)↵│
│                 │                │        │                 │ ORDER BY total_time DESC                                                           ↵│
│                 │                │        │                 │ LIMIT $8                                                                            │
│ 00:00:00.000088 │ 14.0%          │ 5      │ 00:00:00.00001  │ SELECT exists(                                                                     ↵│
│                 │                │        │                 │   SELECT $1 FROM pg_extension e LEFT JOIN pg_namespace n ON n.oid = e.extnamespace ↵│
│                 │                │        │                 │   WHERE e.extname=$2 AND n.nspname IN ($3, $4)                                     ↵│
│                 │                │        │                 │ ) AS available                                                                      │
│ 00:00:00.000052 │ 8.4%           │ 5      │ 00:00:00        │ SHOW server_version                                                                 │
│ 00:00:00.000008 │ 1.2%           │ 1      │ 00:00:00        │ show server_version                                                                 │
└─────────────────┴────────────────┴────────┴─────────────────┴─────────────────────────────────────────────────────────────────────────────────────┘
(4 rows)

Time: 50.082 ms

$ hdev pg:outliers HOBBY_14_URL -a jwadsworth-dev

┌─────────────────┬────────────────┬────────┬────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────┐
│ total_exec_time │ prop_exec_time │ ncalls │  sync_io_time  │                                            query                                            │
├─────────────────┼────────────────┼────────┼────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────┤
│ 00:00:00.002177 │ 93.3%          │ 1      │ 00:00:00       │ SELECT                                                                                     ↵│
│                 │                │        │                │   interval $1 * total_exec_time AS total_exec_time,                                        ↵│
│                 │                │        │                │   to_char((total_exec_time/sum(total_exec_time) OVER()) * $2, $3) || $4  AS prop_exec_time,↵│
│                 │                │        │                │   to_char(calls, $5) AS ncalls,                                                            ↵│
│                 │                │        │                │   interval $6 * (blk_read_time + blk_write_time) AS sync_io_time,                          ↵│
│                 │                │        │                │   query AS query                                                                           ↵│
│                 │                │        │                │ FROM pg_stat_statements                                                                    ↵│
│                 │                │        │                │ WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT $7)        ↵│
│                 │                │        │                │ ORDER BY total_exec_time DESC                                                              ↵│
│                 │                │        │                │ LIMIT $8                                                                                    │
│ 00:00:00.000116 │ 5.0%           │ 5      │ 00:00:00.00001 │ SELECT exists(                                                                             ↵│
│                 │                │        │                │   SELECT $1 FROM pg_extension e LEFT JOIN pg_namespace n ON n.oid = e.extnamespace         ↵│
│                 │                │        │                │   WHERE e.extname=$2 AND n.nspname IN ($3, $4)                                             ↵│
│                 │                │        │                │ ) AS available                                                                              │
│ 00:00:00.00004  │ 1.7%           │ 5      │ 00:00:00       │ SHOW server_version                                                                         │
└─────────────────┴────────────────┴────────┴────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────┘
(3 rows)

Time: 47.447 ms
```
