### PR TITLE
chore(certs-v5) remove ssl-endpoint references in tests

### DIFF
--- a/packages/certs-v5/test/commands/certs/generate.js
+++ b/packages/certs-v5/test/commands/certs/generate.js
@@ -31,10 +31,6 @@ describe('heroku certs:generate', function () {
       .get('/apps/example/sni-endpoints')
       .reply(200, [endpoint])
 
-    nock('https://api.heroku.com')
-      .get('/apps/example/ssl-endpoints')
-      .reply(200, [])
-
     // stub cli here using sinon
     // if this works, remove proxyquire
     sinon.stub(cli, 'prompt')
@@ -153,10 +149,6 @@ $ heroku certs:update CERTFILE example.org.key
 
   it('# suggests next step should be certs:update when domain is known in ssl', function () {
     nock.cleanAll()
-
-    nock('https://api.heroku.com')
-      .get('/apps/example/ssl-endpoints')
-      .reply(200, [endpoint])
 
     nock('https://api.heroku.com')
       .get('/apps/example/sni-endpoints')


### PR DESCRIPTION
This removes a some unused references to ssl-endpoints.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
