### PR TITLE
chore(run): update example for heroku run: use a dyno type that make sense

### DIFF
--- a/packages/run-v5/commands/run.js
+++ b/packages/run-v5/commands/run.js
@@ -41,7 +41,7 @@ module.exports = {
 Running bash on app.... up, run.1
 ~ $
 
-$ heroku run -s hobby -- myscript.sh -a arg1 -s arg2
+$ heroku run -s standard-2x -- myscript.sh -a arg1 -s arg2
 Running myscript.sh -a arg1 -s arg2 on app.... up, run.1`,
   variableArgs: true,
   needsAuth: true,

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -88,7 +88,7 @@ DESCRIPTION
 
 EXAMPLES
   $ heroku run bash
-  $ heroku run -s hobby -- myscript.sh -a arg1 -s arg2
+  $ heroku run -s standard-2x -- myscript.sh -a arg1 -s arg2
 ```
 
 _See code: [src/commands/run/index.ts](https://github.com/heroku/cli/blob/v7.67.0/src/commands/run/index.ts)_

--- a/packages/run/src/commands/run/index.ts
+++ b/packages/run/src/commands/run/index.ts
@@ -14,7 +14,7 @@ export default class Run extends Command {
 
   static examples = [
     '$ heroku run bash',
-    '$ heroku run -s hobby -- myscript.sh -a arg1 -s arg2',
+    '$ heroku run -s standard-2x -- myscript.sh -a arg1 -s arg2',
   ]
 
   // This is to allow for variable length arguments


### PR DESCRIPTION
free/hobby formations can't use a different dyno size, so it's a bad example.

https://devcenter.heroku.com/articles/one-off-dynos#one-off-dyno-type

[GUS Card](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001FMbEbYAL/view)
