### PR TITLE
chore(addons-v5): update from hobby-basic to mini plan

### DIFF
--- a/packages/addons-v5/index.js
+++ b/packages/addons-v5/index.js
@@ -9,7 +9,7 @@ exports.topic = {
 
   Add-ons are created with the \`addons:create\` command, providing a reference
   to an add-on service (such as \`heroku-postgresql\`) or a service and plan
-  (such as \`heroku-postgresql:hobby-basic\`).
+  (such as \`heroku-postgresql:mini\`).
 
   At creation, each add-on is given a globally unique name. In addition, each
   add-on has at least one attachment alias to each application which uses the
@@ -21,15 +21,15 @@ exports.topic = {
   is \`postgresql-deep-6913\` with a default attachment alias of \`DATABASE\`:
 
     $ heroku addons:create heroku-postgresql --app my-app
-    Creating postgresql-deep-6913... done, (heroku-postgresql:hobby-basic)
+    Creating postgresql-deep-6913... done, (heroku-postgresql:mini)
     Adding postgresql-deep-6913 to my-app... done
     Setting DATABASE_URL and restarting my-app... done, v5
     Database has been created and is available
 
     $ heroku addons --app my-app
-    Add-on                                     Plan                           Price
-    ─────────────────────────────────────────  ─────────────────────────────  ──────────
-    heroku-postgresql (postgresql-deep-6913)   heroku-postgresql:hobby-basic  $9/month
+    Add-on                                     Plan                    Price
+    ─────────────────────────────────────────  ──────────────────────  ────────
+    heroku-postgresql (postgresql-deep-6913)   heroku-postgresql:mini  $5/month
     └─ as DATABASE
 
   The add-on name and, in some cases, the attachment alias can be specified by
@@ -43,12 +43,12 @@ exports.topic = {
     Database has been created and is available
 
     $ heroku addons --app my-app
-    Add-on                                     Plan                           Price
-    ─────────────────────────────────────────  ─────────────────────────────  ──────────
-    heroku-postgresql (main-db)                heroku-postgresql:hobby-basic  $9/month
+    Add-on                                     Plan                    Price
+    ─────────────────────────────────────────  ──────────────────────  ────────
+    heroku-postgresql (main-db)                heroku-postgresql:mini  $5/month
     └─ as PRIMARY_DB
 
-    heroku-postgresql (postgresql-deep-6913)   heroku-postgresql:hobby-basic  $9/month
+    heroku-postgresql (postgresql-deep-6913)   heroku-postgresql:mini  $5/month
     └─ as DATABASE
 
   Attachment aliases can also be specified when making attachments:
@@ -58,13 +58,13 @@ exports.topic = {
     Setting ANOTHER_NAME vars and restarting my-app... done, v7
 
     $ heroku addons --app my-app
-    Add-on                                     Plan                           Price
-    ─────────────────────────────────────────  ─────────────────────────────  ──────────
-    heroku-postgresql (main-db)                heroku-postgresql:hobby-basic  $9/month
+    Add-on                                     Plan                    Price
+    ─────────────────────────────────────────  ──────────────────────  ────────
+    heroku-postgresql (main-db)                heroku-postgresql:mini  $5/month
     ├─ as PRIMARY_DB
     └─ as ANOTHER_NAME
 
-    heroku-postgresql (postgresql-deep-6913)   heroku-postgresql:hobby-basic  $9/month
+    heroku-postgresql (postgresql-deep-6913)   heroku-postgresql:mini  $5/month
     └─ as DATABASE
 
   For more information, read https://devcenter.heroku.com/articles/add-ons`


### PR DESCRIPTION
This updates the postgres data plan examples from a previous [PR](https://github.com/heroku/cli/pull/2041/files#diff-2c1fd3b7650cf571b1499c50bbeafe883a36e284941b4478c0344870c2486b83R12) to consistently reflect the new Mini postgres plan rolling out nov 28.
[GUS Card](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000017pSMjYAM/view)