### PR TITLE
chore(ci): replace circle env vars with gha env vars in release scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
   #         name: signed-deb
   #         path: /home/runner/work/cli/cli/packages/cli/dist
 
+  # TODO: the circle job ran `install_scripts` but this isn't, do we need to add that?
   release-deb-and-tarballs:
     needs: [test, acceptance, pack_tarballs]
     if: github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' )

--- a/scripts/postrelease/change_management
+++ b/scripts/postrelease/change_management
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 
-if (!process.env.CIRCLE_TAG) {
+if (!(process.env.GITHUB_REF_TYPE === 'tag' && process.env.GITHUB_REF_NAME.startsWith('v'))) {
   console.log('Not on stable release, skipping change management trigger')
   process.exit(0)
 }
 
 const REQUEST_PROMISE = require('promise-request-retry')
 
-// Set these in CircleCI in the heroku/cli project
+// Set these in Github Actions in the heroku/cli project
 //
 const TPS_API_APP_ID = process.env.TPS_API_APP_ID
 const TPS_API_RELEASE_ACTOR_EMAIL = process.env.TPS_API_RELEASE_ACTOR_EMAIL
@@ -15,9 +15,9 @@ const TPS_API_STAGE = process.env.TPS_API_STAGE || 'production'
 const TPS_API_TOKEN_PARAM = process.env.TPS_API_TOKEN_PARAM
 const TPS_API_URL_PARAM = process.env.TPS_API_URL_PARAM
 
-// This is set by CircleCI automagically
-//
-const RELEASE_COMMIT_SHA = process.env.CIRCLE_SHA1
+// This is set by GitHub Actions automagically
+// https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+const RELEASE_COMMIT_SHA = process.env.GITHUB_SHA
 
 if (TPS_API_APP_ID &&
   TPS_API_RELEASE_ACTOR_EMAIL &&

--- a/scripts/postrelease/install_scripts
+++ b/scripts/postrelease/install_scripts
@@ -2,7 +2,7 @@
 
 set -ex
 
-if [[ ! -z "${CIRCLE_TAG}" ]]; then
+if [[ "$GITHUB_REF_TYPE" == "tag" && "$GITHUB_REF_NAME" = v* ]]; then
   echo "Pushing install scripts to s3..."
   aws s3 cp --content-type text/plain --cache-control "max-age: 604800" ./install-standalone.sh "s3://${HEROKU_S3_BUCKET}/install-standalone.sh"
   aws s3 cp --content-type text/plain --cache-control "max-age: 604800" ./install-standalone.sh "s3://${HEROKU_S3_BUCKET}/install.sh"

--- a/scripts/postrelease/invalidate_cdn_cache
+++ b/scripts/postrelease/invalidate_cdn_cache
@@ -2,9 +2,9 @@
 
 set -ex
 
-if [[ ! -z "${CIRCLE_TAG}" ]]; then
+if [[ "$GITHUB_REF_TYPE" == "tag" && "$GITHUB_REF_NAME" = v* ]]; then
   aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DISTRIBUTION" --paths "/*"
-elif [[ "$CIRCLE_BRANCH" == "master" ]]; then
+elif [[ "$GITHUB_REF_NAME" == "master" ]]; then
   aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DISTRIBUTION" --paths "/channels/beta/*"
 else
   echo "Not on stable or beta release, skipping invalidate cdn cache"

--- a/scripts/release/homebrew.js
+++ b/scripts/release/homebrew.js
@@ -52,7 +52,7 @@ async function getDownloadInfoForNodeVersion (version) {
   }
 }
 
-if (!process.env.CIRCLE_TAG) {
+if (!(process.env.GITHUB_REF_TYPE === 'tag' && process.env.GITHUB_REF_NAME.startsWith('v'))) {
   console.log('Not on stable release; skipping releasing homebrew')
   process.exit(0)
 }

--- a/scripts/utils/_github_setup
+++ b/scripts/utils/_github_setup
@@ -2,8 +2,8 @@
 
 set -e
 
-if [[ "${CIRCLECI:-}" != "true" ]]; then
-  echo "skipping github setup since not on circle"
+if [[ "${CI:-}" != "true" ]]; then
+  echo "skipping github setup since not on CI"
   exit
 fi
 

--- a/scripts/utils/_update_channel.js
+++ b/scripts/utils/_update_channel.js
@@ -5,9 +5,9 @@ const path = require('path')
 module.exports = () => {
   const pjsonPath = path.join(__dirname, '..', '..', 'packages', 'cli', 'package.json')
   const pjson = require(pjsonPath)
-  if (process.env.CIRCLE_TAG && process.env.CIRCLE_TAG.startsWith('v')) {
+  if (process.env.GITHUB_REF_TYPE === 'tag' && process.env.GITHUB_REF_NAME.startsWith('v')) {
     pjson.version = pjson.version.split('-')[0]
-  } else if (process.env.CIRCLE_BRANCH === 'master') {
+  } else if (process.env.GITHUB_REF_NAME === 'master') {
     pjson.version = pjson.version.split('-')[0] + '-beta'
   } else {
     pjson.version = pjson.version.split('-')[0] + '-dev'


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

[W-12049376](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001CS9owYAD/view)

Replace circle env vars in the release scripts with their gha equivalents.
