### PR TITLE
fix(ci): set AWS_EC2_METADATA_DISABLED to true

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
       HEROKU_S3_BUCKET: ${{ secrets.HEROKU_S3_BUCKET }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_EC2_METADATA_DISABLED: true
     steps:
       - uses: actions/checkout@v3
       - run: sudo mkdir -p /build
@@ -174,6 +175,7 @@ jobs:
       HEROKU_S3_BUCKET: ${{ secrets.HEROKU_S3_BUCKET }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_EC2_METADATA_DISABLED: true
     steps:
       - uses: actions/checkout@v3
       - run: |


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

[W-12049376](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001CS9owYAD/view)

Set the `AWS_EC2_METADATA_DISABLED` config to true to prevent failing aws request. See issue 5623 on aws/aws-cli.
