### PR TITLE
fix: debian builds to run in ci round 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           yarn: cache
       - run: yarn --frozen-lockfile --network-timeout 1000000
-      - run: yarn test
+      - run: yarn test 
 
   acceptance:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           yarn: cache
       - run: yarn --frozen-lockfile --network-timeout 1000000
-      - run: yarn test 
+      - run: yarn test
 
   acceptance:
     runs-on: ${{ matrix.os }}
@@ -49,7 +49,7 @@ jobs:
         working-directory: /
 
   pack_deb:
-#    if: github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' )
+    if: github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         working-directory: /
 
   pack_deb:
-    if: github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' )
+#    if: github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@fancy-test/nock": "^0.1.1",
-    "@oclif/dev-cli": "^1",
+    "@heroku-cli/dev-cli": "^1.26.13",
     "@oclif/plugin-help": "^2",
     "@oclif/test": "^1",
     "@types/chai": "^4",

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@fancy-test/nock": "^0.1.1",
-    "@oclif/dev-cli": "1.21.3",
+    "@heroku-cli/dev-cli": "^1.26.13",
     "@oclif/plugin-help": "2.1.6",
     "@oclif/test": "1.2.4",
     "@types/chai": "4.1.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,7 +57,7 @@
     "uuid": "3.3.2"
   },
   "devDependencies": {
-    "@oclif/dev-cli": "^1.23",
+    "@heroku-cli/dev-cli": "^1.26.13",
     "@oclif/test": "^1.2.4",
     "@types/ansi-styles": "^3.2.1",
     "@types/chai": "^4.1.7",

--- a/packages/local/package.json
+++ b/packages/local/package.json
@@ -12,7 +12,7 @@
     "tslib": "^1"
   },
   "devDependencies": {
-    "@oclif/dev-cli": "^1",
+    "@heroku-cli/dev-cli": "^1.26.13",
     "@oclif/plugin-help": "^2",
     "@oclif/test": "^1",
     "@types/chai": "^4",

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -20,7 +20,7 @@
     "tslib": "^1"
   },
   "devDependencies": {
-    "@oclif/dev-cli": "^1",
+    "@heroku-cli/dev-cli": "^1.26.13",
     "@oclif/test": "^1",
     "@types/chai": "^4",
     "@types/mocha": "^5",

--- a/packages/pipelines/package.json
+++ b/packages/pipelines/package.json
@@ -20,7 +20,7 @@
     "validator": "^13.7.0"
   },
   "devDependencies": {
-    "@oclif/dev-cli": "^1",
+    "@heroku-cli/dev-cli": "^1.26.13",
     "@oclif/plugin-help": "^2",
     "@oclif/test": "^1",
     "@types/chai": "^4",

--- a/packages/run/package.json
+++ b/packages/run/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@heroku-cli/schema": "^1.0.25",
-    "@oclif/dev-cli": "^1",
+    "@heroku-cli/dev-cli": "^1.26.13",
     "@oclif/plugin-help": "^2",
     "@oclif/test": "^1",
     "@types/chai": "^4",

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -13,7 +13,7 @@
     "tslib": "^1"
   },
   "devDependencies": {
-    "@oclif/dev-cli": "^1",
+    "@heroku-cli/dev-cli": "^1.26.13",
     "@oclif/plugin-help": "^2",
     "@oclif/test": "^1",
     "@types/chai": "^4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1188,7 +1188,7 @@
     debug "^4.1.1"
     semver "^5.6.0"
 
-"@oclif/command@^1.5.20", "@oclif/command@^1.5.4", "@oclif/command@^1.6.0", "@oclif/command@^1.8.0":
+"@oclif/command@^1.5.20", "@oclif/command@^1.5.4", "@oclif/command@^1.6.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@oclif/command/-/command-1.8.0.tgz#c1a499b10d26e9d1a611190a81005589accbb339"
   integrity sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==
@@ -1222,7 +1222,7 @@
     debug "^4.1.1"
     semver "^7.3.8"
 
-"@oclif/config@1.13.2", "@oclif/config@^1", "@oclif/config@^1.12.10", "@oclif/config@^1.12.12", "@oclif/config@^1.12.8":
+"@oclif/config@1.13.2", "@oclif/config@^1", "@oclif/config@^1.12.10", "@oclif/config@^1.12.8":
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/@oclif/config/-/config-1.13.2.tgz#c1dc25296bf06c039fd5fb0b90e4132be2213b2a"
   integrity sha512-RUOKeuAaopo3zrA5hcgE0PT2lbAUT72+eJdqTlWyI9sbPrGHZgUwV+vrL6Qal7ywWYDkL0vrKd1YS4yXtKIDKw==
@@ -1255,7 +1255,7 @@
     is-wsl "^2.1.1"
     tslib "^2.3.1"
 
-"@oclif/config@^1.15.1", "@oclif/config@^1.17.0", "@oclif/config@^1.8.7":
+"@oclif/config@^1.15.1", "@oclif/config@^1.8.7":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@oclif/config/-/config-1.17.0.tgz#ba8639118633102a7e481760c50054623d09fcab"
   integrity sha512-Lmfuf6ubjQ4ifC/9bz1fSCHc6F6E653oyaRXxg+lgT4+bYf9bk+nqrUpAbrXyABkCqgIBiFr3J4zR/kiFdE1PA==
@@ -1278,61 +1278,6 @@
     globby "^11.0.1"
     is-wsl "^2.1.1"
     tslib "^2.3.1"
-
-"@oclif/dev-cli@1.21.3":
-  version "1.21.3"
-  resolved "https://registry.yarnpkg.com/@oclif/dev-cli/-/dev-cli-1.21.3.tgz#229b69d90ef6b9b121e5b2c3a2751ad90c1a417d"
-  integrity sha512-TYhK6kz1skw28VZq6R5anSpwidZl+48jnDdKuwc3bbyaqyCqXQAnDAxliW562iDt3GkdOxpdDMza7O4qtyDSYQ==
-  dependencies:
-    "@oclif/command" "^1.5.10"
-    "@oclif/config" "^1.12.8"
-    "@oclif/errors" "^1.2.2"
-    "@oclif/plugin-help" "^2.1.6"
-    cli-ux "^5.2.0"
-    debug "^4.1.1"
-    fs-extra "^7.0.1"
-    github-slugger "^1.2.1"
-    lodash "^4.17.11"
-    normalize-package-data "^2.5.0"
-    qqjs "^0.3.10"
-    tslib "^1.9.3"
-
-"@oclif/dev-cli@^1":
-  version "1.22.2"
-  resolved "https://registry.yarnpkg.com/@oclif/dev-cli/-/dev-cli-1.22.2.tgz#e890f93d0335c0e3faaa25741999776259b2171f"
-  integrity sha512-c7633R37RxrQIpwqPKxjNRm6/jb1yuG8fd16hmNz9Nw+/MUhEtQtKHSCe9ScH8n5M06l6LEo4ldk9LEGtpaWwA==
-  dependencies:
-    "@oclif/command" "^1.5.13"
-    "@oclif/config" "^1.12.12"
-    "@oclif/errors" "^1.2.2"
-    "@oclif/plugin-help" "^2.1.6"
-    cli-ux "^5.2.1"
-    debug "^4.1.1"
-    fs-extra "^7.0.1"
-    github-slugger "^1.2.1"
-    lodash "^4.17.11"
-    normalize-package-data "^2.5.0"
-    qqjs "^0.3.10"
-    tslib "^1.9.3"
-
-"@oclif/dev-cli@^1.23":
-  version "1.26.0"
-  resolved "https://registry.npmjs.org/@oclif/dev-cli/-/dev-cli-1.26.0.tgz#e3ec294b362c010ffc8948003d3770955c7951fd"
-  integrity sha512-272udZP+bG4qahoAcpWcMTJKiA+V42kRMqQM7n4tgW35brYb2UP5kK+p08PpF8sgSfRTV8MoJVJG9ax5kY82PA==
-  dependencies:
-    "@oclif/command" "^1.8.0"
-    "@oclif/config" "^1.17.0"
-    "@oclif/errors" "^1.3.3"
-    "@oclif/plugin-help" "^3.2.0"
-    cli-ux "^5.2.1"
-    debug "^4.1.1"
-    find-yarn-workspace-root "^2.0.0"
-    fs-extra "^8.1"
-    github-slugger "^1.2.1"
-    lodash "^4.17.11"
-    normalize-package-data "^3.0.0"
-    qqjs "^0.3.10"
-    tslib "^2.0.3"
 
 "@oclif/errors@1.2.2", "@oclif/errors@^1.2.1":
   version "1.2.2"
@@ -1517,7 +1462,7 @@
     widest-line "^3.1.0"
     wrap-ansi "^6.2.0"
 
-"@oclif/plugin-help@^3", "@oclif/plugin-help@^3.2.0":
+"@oclif/plugin-help@^3":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@oclif/plugin-help/-/plugin-help-3.2.0.tgz#b2c1112f49202ebce042f86b2e42e49908172ef1"
   integrity sha512-7jxtpwVWAVbp1r46ZnTK/uF+FeZc6y4p1XcGaIUuPAp7wx6NJhIRN/iMT9UfNFX/Cz7mq+OyJz+E+i0zrik86g==
@@ -3070,7 +3015,7 @@ cli-ux@5.6.7:
     supports-hyperlinks "^2.1.0"
     tslib "^2.0.0"
 
-cli-ux@^5.2.0, cli-ux@^5.2.1, cli-ux@^5.3.1:
+cli-ux@^5.2.1, cli-ux@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/cli-ux/-/cli-ux-5.3.1.tgz#3bed8b37c44b03a5d1b9d71d39a69a919a101835"
   integrity sha512-l2MXbitx0FjtHKSbHytuxfxWv6MdWBRh23ItRJjU17cjj0dqZxfAL863tzbR1FIs7jccPllPUvn3QWK6BQg3Pg==


### PR DESCRIPTION
Remove all references to @oclif/cli-dev in the repository. 
Successful run of `pack_deb` action here: https://github.com/heroku/cli/actions/runs/3448406902/jobs/5755400031
Removed test code to run test.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
