### PR TITLE
build(ci): set HEROKU_AUTHOR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
   pack_deb:
     if: github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' )
     runs-on: ubuntu-latest
+    env:
+      HEROKU_AUTHOR: 'Heroku'
     steps:
       - uses: actions/checkout@v3
       - name: Install system deps


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

This PR attempts to fix https://github.com/heroku/cli/issues/2138 by setting `HEROKU_AUTHOR` in the `pack_deb` step. I believe this changes how oclif/dev-cli works ([ref](https://github.com/oclif/dev-cli/blob/ef2ec22438e87fb7107b4c49d2c47584a2222817/src/commands/pack/deb.ts#L49)) thus resulting in `Origin` being altered. Alternatively could update the author in the `package.json` instead.