### PR TITLE
fix(redis-v5): update cli process termination redis:cli

### DIFF
--- a/packages/redis-v5/commands/cli.js
+++ b/packages/redis-v5/commands/cli.js
@@ -92,6 +92,7 @@ function redisCLI (uri, client) {
     client.on('end', function () {
       console.log('\nDisconnected from instance.')
       resolve()
+      cli.exit()
     })
   })
 }


### PR DESCRIPTION
[Ticket addressed](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001J2c07YAB/view)

**Problem:** Once the tunneling connection is made to a private space app (ex: private-7), disconnecting the connection is successful, however the cli continues to hang.

**Solution:** The termination of a connection is acknowledged, but it's outputted in a promise which highlights the problem. While the promise is settled, it doesn't stop the execution of code which is why the cli hangs. Using `cli.exit()` after settling the promise allows us to terminate further execution of code preventing the cli from hanging.

**Verify:**
1. Pull down repo and navigate to the root directory of `cli` 
2. Find an app in a private space with a `private-...` redis plan. (or I can add you to a team with an existing app)
3. Make sure the problem still exists by running `heroku redis:cli <your redis plan name> -a <your app name>`
    - When the redis connection is made, type `quit`
    - The console should say `Disconnected from instance.` but the cli should just hang after that until you `Ctrl+C`.
4. Try updated cli fix by running `./bin/run redis:cli <your redis plan name> -a <your app name>`
    - When the redis connection is made, type `quit`
    - The console should say `Disconnected from instance.` and exit out back to your terminal prompt rather than hanging