### PR TITLE
fix(redis-v5): Close bastion connection and io interface on Redis connection quit

### DIFF
--- a/packages/redis-v5/commands/cli.js
+++ b/packages/redis-v5/commands/cli.js
@@ -91,6 +91,7 @@ function redisCLI (uri, client) {
     client.on('error', reject)
     client.on('end', function () {
       console.log('\nDisconnected from instance.')
+      io.close()
       resolve()
     })
   })
@@ -104,6 +105,7 @@ function bastionConnect ({ uri, bastions, config, prefer_native_tls }) {
       tunnel.forwardOut('localhost', localPort, uri.hostname, uri.port, function (err, stream) {
         if (err) return reject(err)
         stream.on('close', () => tunnel.end())
+        stream.on('end', () => client.end()) 
 
         let client
         if (prefer_native_tls) {

--- a/packages/redis-v5/test/commands/cli.js
+++ b/packages/redis-v5/test/commands/cli.js
@@ -44,6 +44,7 @@ describe('heroku redis:cli', function () {
         this.connect = sinon.stub().callsFake(() => {
           this.emit('ready')
         })
+        this.end = sinon.stub()
       }
     }
 


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

Possibly a duplicate of https://github.com/heroku/cli/pull/2203. I found two issues here:

* For any connections, closing the Redis console with a `QUIT` didn't make the process exit. I believe this is because `io`/readline was still waiting for input. This PR includes a line to close it.
* For connections that go through a bastion (private Redis), the underlying TCP connection was never closed (see notes in our internal investigation notes). Looking at `ssh2` docs, I believe we were missing a `client.end()`.

With these changes:
* Writing QUIT on the Redis console closes the connection and the heroku command exits
* Pressing Ctrl+C closes the connection and the heroku command exits. No second Ctrl+C is required.
