### PR TITLE
chore: move snyk to cron job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,21 +40,6 @@ jobs:
       - run: ./bin/run whoami
       - run: ./scripts/run-acceptance
 
-  snyk:
-    runs-on: ubuntu-latest
-    environment: Snyk
-    env:
-      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-      - run: yarn global add snyk
-      - run: yarn --frozen-lockfile --network-timeout 1000000
-      - run: snyk test --all-projects --fail-on=all
-      - run: snyk monitor --org=hit
-
   # dummy job needed to pass changeling compliance because it only watches one build
   done:
     runs-on: macos-latest

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,4 +1,5 @@
-name: Snyk CI check
+name: Snyk nightly CI check
+# runs nightly at midnight
 
 on:
   schedule:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,19 @@
+name: Snyk CI check
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  snyk:
+    runs-on: ubuntu-latest
+    environment: Snyk
+    env:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - run: yarn global add snyk
+      - run: yarn --frozen-lockfile --network-timeout 1000000
+      - run: snyk test --all-projects --fail-on=all
+      - run: snyk monitor --org=hit


### PR DESCRIPTION
Moving Snyk to a cron job to better enable the move to Yarn 3. [Yarn 3 GUS ticket](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001JcVnJYAV/view).

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
