### PR TITLE
chore: fix snyk GH Action syntax

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -4,6 +4,8 @@ name: Snyk nightly CI check
 on:
   schedule:
     - cron: '0 0 * * *'
+
+jobs:
   snyk:
     runs-on: ubuntu-latest
     environment: Snyk


### PR DESCRIPTION
Fixing the syntax on the Snyk cron job. [Yarn 3 GUS ticket](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001JcVnJYAV/view).

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
