### PR TITLE
chore(snyk): move yarn install first and add --all-products to monitor command

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
-      - run: yarn global add snyk
       - run: yarn --frozen-lockfile --network-timeout 1000000
+      - run: yarn global add snyk
       - run: snyk test --all-projects --fail-on=all
-      - run: snyk monitor --org=hit
+      - run: snyk monitor --all-projects --org=hit


### PR DESCRIPTION
Moves the yarn install command first and adds `--all-projects` to the monitor command. [Yarn 3 GUS ticket](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001JcVnJYAV/view).

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
