### PR TITLE
fix: remove snyk global install and use yarn dlx instead

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -17,6 +17,5 @@ jobs:
         with:
           node-version: 16.x
       - run: yarn --frozen-lockfile --network-timeout 1000000
-      - run: yarn global add snyk
-      - run: snyk test --all-projects --fail-on=all
-      - run: snyk monitor --all-projects --org=hit
+      - run: yarn dlx snyk test --all-projects --fail-on=all
+      - run: yarn dlx snyk monitor --all-projects --org=hit


### PR DESCRIPTION
Removes the `yarn global` install of Snyk (which doesn't exist in Yarn 2 or 3) and uses `yarn dlx` to run the snyk commands instead. [Yarn 3 GUS ticket](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001JcVnJYAV/view).

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
