### PR TITLE
fix: use the spinner function from CliUx directly

### DIFF
--- a/packages/apps/src/commands/domains/add.ts
+++ b/packages/apps/src/commands/domains/add.ts
@@ -2,6 +2,7 @@ import {color} from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {CliUx} from '@oclif/core'
+import Spinner from '@oclif/core/lib/cli-ux/action/spinner'
 import {prompt} from 'inquirer'
 import * as shellescape from 'shell-escape'
 import waitForDomain from '../../lib/wait-for-domain'
@@ -75,6 +76,7 @@ export default class DomainsAdd extends Command {
   async run() {
     const {args, flags} = await this.parse(DomainsAdd)
     const {hostname} = args
+    const action = new Spinner()
 
     const domainCreatePayload: DomainCreatePayload = {
       hostname,
@@ -83,11 +85,9 @@ export default class DomainsAdd extends Command {
 
     let certs: Array<Heroku.SniEndpoint> = []
 
-    cli.action.start(`Adding ${color.green(domainCreatePayload.hostname)} to ${color.app(flags.app)}`)
+    action.start(`Adding ${color.green(domainCreatePayload.hostname)} to ${color.app(flags.app)}`)
     if (flags.cert) {
-      cli.action.stop('resolving SNI endpoint')
       domainCreatePayload.sni_endpoint = flags.cert
-      cli.action.start(`Adding ${color.green(domainCreatePayload.hostname)} to ${color.app(flags.app)}`)
     } else {
       const {body} = await this.heroku.get<Array<Heroku.SniEndpoint>>(`/apps/${flags.app}/sni-endpoints`)
 
@@ -95,14 +95,14 @@ export default class DomainsAdd extends Command {
     }
 
     if (certs.length > 1) {
-      cli.action.stop('resolving SNI endpoint')
+      action.stop('resolving SNI endpoint')
       const certSelection = await this.certSelect(certs)
 
       if (certSelection) {
         domainCreatePayload.sni_endpoint = certSelection
       }
 
-      cli.action.start(`Adding ${color.green(domainCreatePayload.hostname)} to ${color.app(flags.app)}`)
+      action.start(`Adding ${color.green(domainCreatePayload.hostname)} to ${color.app(flags.app)}`)
     }
 
     try {
@@ -129,7 +129,7 @@ export default class DomainsAdd extends Command {
     } catch (error: any) {
       cli.error(error)
     } finally {
-      cli.action.stop()
+      action.stop()
     }
   }
 }

--- a/packages/apps/src/commands/domains/clear.ts
+++ b/packages/apps/src/commands/domains/clear.ts
@@ -1,9 +1,7 @@
 import {color} from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
-import {CliUx} from '@oclif/core'
-
-const cli = CliUx.ux
+import Spinner from '@oclif/core/lib/cli-ux/action/spinner'
 
 export default class DomainsClear extends Command {
   static description = 'remove all domains from an app'
@@ -18,13 +16,15 @@ export default class DomainsClear extends Command {
 
   async run() {
     const {flags} = await this.parse(DomainsClear)
-    cli.action.start(`Removing all domains from ${color.app(flags.app)}`)
+    const action = new Spinner()
+
+    action.start(`Removing all domains from ${color.app(flags.app)}`)
     let {body: domains} = await this.heroku.get<Array<Heroku.Domain>>(`/apps/${flags.app}/domains`)
     domains = domains.filter((d: Heroku.Domain) => d.kind === 'custom')
     for (const domain of domains) {
       // eslint-disable-next-line no-await-in-loop
       await this.heroku.delete(`/apps/${flags.app}/domains/${domain.hostname}`)
     }
-    cli.action.stop()
+    action.stop()
   }
 }

--- a/packages/apps/src/commands/domains/remove.ts
+++ b/packages/apps/src/commands/domains/remove.ts
@@ -1,8 +1,6 @@
 import {color} from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
-import {CliUx} from '@oclif/core'
-
-const cli = CliUx.ux
+import Spinner from '@oclif/core/lib/cli-ux/action/spinner'
 
 export default class DomainsRemove extends Command {
   static description = 'remove a domain from an app'
@@ -19,8 +17,10 @@ export default class DomainsRemove extends Command {
 
   async run() {
     const {args, flags} = await this.parse(DomainsRemove)
-    cli.action.start(`Removing ${color.green(args.hostname)} from ${color.app(flags.app)}`)
+    const action = new Spinner()
+
+    action.start(`Removing ${color.green(args.hostname)} from ${color.app(flags.app)}`)
     await this.heroku.delete(`/apps/${flags.app}/domains/${args.hostname}`)
-    cli.action.stop()
+    action.stop()
   }
 }

--- a/packages/apps/src/commands/domains/update.ts
+++ b/packages/apps/src/commands/domains/update.ts
@@ -1,8 +1,7 @@
 import {color} from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {CliUx} from '@oclif/core'
-
-const cli = CliUx.ux
+import Spinner from '@oclif/core/lib/cli-ux/action/spinner'
 
 export default class DomainsUpdate extends Command {
   static description = 'update a domain to use a different SSL certificate on an app'
@@ -24,15 +23,17 @@ export default class DomainsUpdate extends Command {
   async run() {
     const {args, flags} = await this.parse(DomainsUpdate)
     const {hostname} = args
+    const action = new Spinner()
+
     try {
-      cli.action.start(`Updating ${color.cyan(hostname)} to use ${color.cyan(flags.cert)} certificate`)
+      action.start(`Updating ${color.cyan(hostname)} to use ${color.cyan(flags.cert)} certificate`)
       await this.heroku.patch<string>(`/apps/${flags.app}/domains/${hostname}`, {
         body: {sni_endpoint: flags.cert},
       })
     } catch (error: any) {
-      cli.error(error)
+      CliUx.ux.error(error)
     } finally {
-      cli.action.stop()
+      action.stop()
     }
   }
 }

--- a/packages/apps/src/lib/wait-for-domain.ts
+++ b/packages/apps/src/lib/wait-for-domain.ts
@@ -2,19 +2,20 @@ import {color} from '@heroku-cli/color'
 import {APIClient} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {CliUx} from '@oclif/core'
-
-const cli = CliUx.ux
+import Spinner from '@oclif/core/lib/cli-ux/action/spinner'
 
 export default async function waitForDomain(app: string, heroku: APIClient, domain: Heroku.Domain) {
-  cli.action.start(`Waiting for ${color.green(domain.hostname || 'domain')}`)
+  const action = new Spinner()
+
+  action.start(`Waiting for ${color.green(domain.hostname || 'domain')}`)
   while (domain.status === 'pending') {
     // eslint-disable-next-line no-await-in-loop
-    await cli.wait(5000)
+    await CliUx.ux.wait(5000)
     // eslint-disable-next-line no-await-in-loop
     const {body: updatedDomain} = await heroku.get<Heroku.Domain>(`/apps/${app}/domains/${domain.id}`)
     domain = updatedDomain
   }
-  cli.action.stop()
+  action.stop()
   if (domain.status === 'succeeded' || domain.status === 'none') return
   throw new Error(`The domain creation finished with status ${domain.status}`)
 }

--- a/packages/webhooks/src/commands/webhooks/add.ts
+++ b/packages/webhooks/src/commands/webhooks/add.ts
@@ -1,5 +1,6 @@
 import {flags} from '@heroku-cli/command'
 import {CliUx} from '@oclif/core'
+import Spinner from '@oclif/core/lib/cli-ux/action/spinner'
 
 import BaseCommand from '../../base'
 
@@ -24,8 +25,9 @@ export default class WebhooksAdd extends BaseCommand {
   async run() {
     const {flags} = await this.parse(WebhooksAdd)
     const {path, display} = this.webhookType(flags)
+    const action = new Spinner()
 
-    CliUx.ux.action.start(`Adding webhook to ${display}`)
+    action.start(`Adding webhook to ${display}`)
 
     const response = await this.webhooksClient.post(`${path}/webhooks`, {
       body: {
@@ -37,15 +39,13 @@ export default class WebhooksAdd extends BaseCommand {
       },
     })
 
-    CliUx.ux.action.stop('creating secret')
     const secret = response.headers && response.headers['heroku-webhook-secret'] as string
-    CliUx.ux.action.start(`Adding webhook to ${display}`)
     if (secret) {
       CliUx.ux.styledHeader('Webhooks Signing Secret')
       this.log(secret)
     } else {
       CliUx.ux.warn('no secret found')
     }
-    CliUx.ux.action.stop()
+    action.stop()
   }
 }

--- a/packages/webhooks/src/commands/webhooks/remove.ts
+++ b/packages/webhooks/src/commands/webhooks/remove.ts
@@ -1,5 +1,5 @@
 import {flags} from '@heroku-cli/command'
-import {CliUx} from '@oclif/core'
+import Spinner from '@oclif/core/lib/cli-ux/action/spinner'
 
 import BaseCommand from '../../base'
 export default class WebhooksRemove extends BaseCommand {
@@ -22,11 +22,12 @@ export default class WebhooksRemove extends BaseCommand {
   async run() {
     const {flags, args} = await this.parse(WebhooksRemove)
     const {path, display} = this.webhookType(flags)
+    const action = new Spinner()
 
-    CliUx.ux.action.start(`Removing webhook ${args.id} from ${display}`)
+    action.start(`Removing webhook ${args.id} from ${display}`)
 
     await this.webhooksClient.delete(`${path}/webhooks/${args.id}`)
 
-    CliUx.ux.action.stop()
+    action.stop()
   }
 }

--- a/packages/webhooks/src/commands/webhooks/update.ts
+++ b/packages/webhooks/src/commands/webhooks/update.ts
@@ -1,5 +1,5 @@
 import {flags} from '@heroku-cli/command'
-import {CliUx} from '@oclif/core'
+import Spinner from '@oclif/core/lib/cli-ux/action/spinner'
 
 import BaseCommand from '../../base'
 
@@ -28,8 +28,9 @@ export default class WebhooksUpdate extends BaseCommand {
   async run() {
     const {flags, args} = await this.parse(WebhooksUpdate)
     const {path, display} = this.webhookType(flags)
+    const action = new Spinner()
 
-    CliUx.ux.action.start(`Updating webhook ${args.id} for ${display}`)
+    action.start(`Updating webhook ${args.id} for ${display}`)
 
     await this.webhooksClient.patch(`${path}/webhooks/${args.id}`, {
       body: {
@@ -40,6 +41,6 @@ export default class WebhooksUpdate extends BaseCommand {
       },
     })
 
-    CliUx.ux.action.stop()
+    action.stop()
   }
 }


### PR DESCRIPTION
Re-make of #2218 (lost in a rebase)

Using the spinner function directly instead of going through CliUx.ux.action allows our tests to pass. This is a better fix than the one we had in place before.

[Apps GUS ticket](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001BL6M4YAL/view)
[Webhooks GUS ticket](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001BM3KZYA1/view)

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
