### PR TITLE
fix: Revert previous change to run pack_deb and pack_tarballs in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
         working-directory: /
 
   pack_deb:
+    if: github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' )
     runs-on: ubuntu-latest
     env:
       HEROKU_AUTHOR: 'Heroku'
@@ -68,12 +69,12 @@ jobs:
       - name: Building deb
         run: ./scripts/pack/deb
       - uses: actions/upload-artifact@v3
-        if: github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' )
         with:
           name: packed-deb
           path: /home/runner/work/cli/cli/packages/cli/dist
 
   pack_tarballs:
+    if: github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -90,7 +91,6 @@ jobs:
       - name: Building tarballs
         run: ./scripts/pack/tarballs
       - uses: actions/upload-artifact@v3
-        if: github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' )
         with:
           name: packed-tarballs
           path: /home/runner/work/cli/cli/packages/cli/dist


### PR DESCRIPTION
Revert previous change to run `pack_deb` and `pack_tarballs` in PRs. They will never pass on release branches because they attempt to install packages we are attempting to release. 

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
