### PR TITLE
fix: Use older ubuntu runner to use older deb compression defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
   pack_deb:
     if: github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       HEROKU_AUTHOR: 'Heroku'
     steps:


### PR DESCRIPTION
ubuntu-latest points to Ubuntu 22.04 as of this commit, which may use zstd by default for compressing all or a part of deb packages in `dpkg --build` or `dpkg-deb --build`. Debian 11 cannot use zstd, as filed in #2240. So, revert to building on an older Debian/Ubuntu base to maintain compatibility with Debian 11 since it is still supported.

See https://github.com/heroku/cli/issues/2240#issuecomment-1435325995 for more info.
