### PR TITLE
fix: output linux artifacts that debian can decompress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,9 @@ jobs:
 
   pack_deb:
     if: github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' )
-    runs-on: ubuntu-latest
+    # ubuntu started using a compression method after this version that debian currently does not support
+    # https://github.com/heroku/cli/pull/2245#issue-1590017122
+    runs-on: ubuntu-20.04
     env:
       HEROKU_AUTHOR: 'Heroku'
     steps:


### PR DESCRIPTION
Issue: https://github.com/heroku/cli/issues/2240#issuecomment-1435325995
Initial solution here: https://github.com/heroku/cli/pull/2245
Downgrade ubuntu from latest to one that uses a compression method debian supports

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
