### PR TITLE
chore: add ability to release from prerelease branches

### DIFF
--- a/scripts/publish-release
+++ b/scripts/publish-release
@@ -55,15 +55,16 @@ yarn lerna publish --yes from-package
 
 
 LAST_PUBLISHED_TAG=$(git tag --sort="-version:refname" --list --format="%(refname:strip=2)" | head -n1)
+PRERELEASE_TAG_MARKER="beta"
 
 git tag "${TAG_NAME}" -m "${TAG_NAME}"
 git push origin "${TAG_NAME}"
 
-if [[ "${CURRENT_BRANCH}" != "${MAIN_BRANCH}" ]]; then
+if [[ "${CURRENT_BRANCH}" == "${MAIN_BRANCH}" ]]; then
   RELEASE_NOTES=$(git log --graph --format="%h %s" "${LAST_PUBLISHED_TAG}...${TAG_NAME}~1")
   gh release create "${TAG_NAME}" --title="${TAG_NAME}" --notes="${RELEASE_NOTES}"
 fi
 
-if [[ "${CURRENT_BRANCH}" != *"${PRERELEASE_PREFIX}"* ]]; then
+if [[ "${CURRENT_BRANCH}" == *"${PRERELEASE_PREFIX}"* && "${TAG_NAME}" == *"${PRERELEASE_TAG_MARKER}"* ]]; then
   gh release create "${TAG_NAME}" --title="${TAG_NAME}" --prerelease # don't add release notes to a pre-release
 fi

--- a/scripts/publish-release
+++ b/scripts/publish-release
@@ -4,9 +4,10 @@ set -e -o pipefail
 
 CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 MAIN_BRANCH="master"
+PRERELEASE_PREFIX="prerelease"
 
-if [[ "${CURRENT_BRANCH}" != "${MAIN_BRANCH}" ]]; then
-  echo "scripts/publish-release must be run on the ${MAIN_BRANCH}."
+if [[ "${CURRENT_BRANCH}" != "${MAIN_BRANCH}" || "${CURRENT_BRANCH}" != *"${PRERELEASE_PREFIX}"* ]]; then
+  echo "scripts/publish-release must be run on the ${MAIN_BRANCH} or a prerelease branch."
   echo "Please checkout the ${MAIN_BRANCH} branch with:"
   echo "git checkout ${MAIN_BRANCH}"
   exit 1
@@ -27,7 +28,7 @@ if !(gh auth status --hostname "github.com" > /dev/null 2>&1); then
   exit 1
 fi
 
-git pull --rebase origin "${MAIN_BRANCH}"
+git pull --rebase origin "${CURRENT_BRANCH}"
 # The --force overrides local tags.
 # This is needed if you've published the CLI previously,
 # otherwise git will exit with an error unnecessarily.
@@ -58,6 +59,11 @@ LAST_PUBLISHED_TAG=$(git tag --sort="-version:refname" --list --format="%(refnam
 git tag "${TAG_NAME}" -m "${TAG_NAME}"
 git push origin "${TAG_NAME}"
 
-RELEASE_NOTES=$(git log --graph --format="%h %s" "${LAST_PUBLISHED_TAG}...${TAG_NAME}~1")
+if [[ "${CURRENT_BRANCH}" != "${MAIN_BRANCH}" ]]; then
+  RELEASE_NOTES=$(git log --graph --format="%h %s" "${LAST_PUBLISHED_TAG}...${TAG_NAME}~1")
+  gh release create "${TAG_NAME}" --title="${TAG_NAME}" --notes="${RELEASE_NOTES}"
+fi
 
-gh release create "${TAG_NAME}" --title="${TAG_NAME}" --notes="${RELEASE_NOTES}"
+if [[ "${CURRENT_BRANCH}" != *"${PRERELEASE_PREFIX}"* ]]; then
+  gh release create "${TAG_NAME}" --title="${TAG_NAME}" --prerelease # don't add release notes to a pre-release
+fi


### PR DESCRIPTION
This PR adds the ability to create releases and publish to NPM from branches with the word "prerelease" in the name. The purpose of this change is to enable us to create and publish prereleases ("beta" releases) prior to merging them to `master`.

[GUS ticket](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001MKX4HYAX/view)

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
