### PR TITLE
feature: new workflow to promote a version pushed to S3

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,0 +1,28 @@
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: version to promote to latest
+        type: string
+        required: true
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    environment: CLIS3BucketAndCloudfront
+    env:
+      CLOUDFRONT_DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION }}
+      HEROKU_S3_BUCKET: ${{ secrets.HEROKU_S3_BUCKET }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_EC2_METADATA_DISABLED: true
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: yarn
+      - run: yarn --frozen-lockfile --network-timeout 1000000
+      - run: cd packages/cli
+      - run: oclif promote --deb --version=${{inputs.tag}}

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -25,4 +25,4 @@ jobs:
           cache: yarn
       - run: yarn --frozen-lockfile --network-timeout 1000000
       - run: cd packages/cli
-      - run: oclif promote --deb --version=${{ inputs.tag }}
+      - run: oclif promote --deb --version=${{ inputs.version }}

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -25,4 +25,4 @@ jobs:
           cache: yarn
       - run: yarn --frozen-lockfile --network-timeout 1000000
       - run: cd packages/cli
-      - run: oclif promote --deb --version=${{inputs.tag}}
+      - run: oclif promote --deb --version=${{ inputs.tag }}


### PR DESCRIPTION
CLI release process is still in need of refactoring after oclif core upgrades. This is a temporary solution to promote builds pushed to NPM and S3 from current CI.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
