### PR TITLE
fix: allow manual promotion with commitSHA input in GH Actions

### DIFF
--- a/.github/workflows/pack-and-release.yml
+++ b/.github/workflows/pack-and-release.yml
@@ -153,7 +153,7 @@ jobs:
           cache: yarn
       - run: yarn --frozen-lockfile --network-timeout 1000000
       - run: |
-          shortSHA="${{ inputs.commitSHA }}"
+          shortSHA=${{ inputs.commitSHA }}
           if [ -z $shortSHA ]; then
             shortSHA=`git rev-parse --short=7 HEAD`
           fi

--- a/.github/workflows/pack-and-release.yml
+++ b/.github/workflows/pack-and-release.yml
@@ -6,10 +6,14 @@ on:
         description: version to promote to latest
         type: string
         required: true
+      buildSha:
+        description: sha of version in S3
+        type: string
+        required: false
 
 jobs:
   pack_deb:
-    if: github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' )
+    if:  !${{ inputs.buildSha }} && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
     # ubuntu started using a compression method after this version that debian currently does not support
     # https://github.com/heroku/cli/pull/2245#issue-1590017122
     runs-on: ubuntu-20.04
@@ -35,7 +39,7 @@ jobs:
           path: /home/runner/work/cli/cli/packages/cli/dist
 
   pack_tarballs:
-    if: github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' )
+    if: !${{ inputs.buildSha }} && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -58,7 +62,7 @@ jobs:
 
   sign_deb:
     needs: [pack_deb]
-    if: github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' )
+    if: !${{ inputs.buildSha }} && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
     runs-on: ubuntu-latest
     environment: SignDebian
     env:
@@ -85,7 +89,7 @@ jobs:
   # TODO: the circle job ran `install_scripts` but this isn't, do we need to add that?
   upload-deb-and-tarballs:
     needs: [sign_deb, pack_tarballs]
-    if: github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' )
+    if: !${{ inputs.buildSha }} && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
     runs-on: ubuntu-latest
     environment: CLIS3BucketAndCloudfront
     env:

--- a/.github/workflows/pack-and-release.yml
+++ b/.github/workflows/pack-and-release.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   pack_deb:
-    if:  !${{ inputs.commitSHA }} && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
+    if:  ${{ inputs.commitSHA }} != '' && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
     # ubuntu started using a compression method after this version that debian currently does not support
     # https://github.com/heroku/cli/pull/2245#issue-1590017122
     runs-on: ubuntu-20.04
@@ -39,7 +39,7 @@ jobs:
           path: /home/runner/work/cli/cli/packages/cli/dist
 
   pack_tarballs:
-    if: !${{ inputs.commitSHA }} && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
+    if: ${{ inputs.commitSHA }} != '' && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -62,7 +62,7 @@ jobs:
 
   sign_deb:
     needs: [pack_deb]
-    if: !${{ inputs.commitSHA }} && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
+    if: ${{ inputs.commitSHA }} != '' && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
     runs-on: ubuntu-latest
     environment: SignDebian
     env:
@@ -89,7 +89,7 @@ jobs:
   # TODO: the circle job ran `install_scripts` but this isn't, do we need to add that?
   upload-deb-and-tarballs:
     needs: [sign_deb, pack_tarballs]
-    if: !${{ inputs.commitSHA }} && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
+    if: ${{ inputs.commitSHA }} != '' && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
     runs-on: ubuntu-latest
     environment: CLIS3BucketAndCloudfront
     env:
@@ -152,7 +152,12 @@ jobs:
           node-version: 16.x
           cache: yarn
       - run: yarn --frozen-lockfile --network-timeout 1000000
-      - run: yarn oclif promote --deb --root="./packages/cli" --version=${{ inputs.version }} --sha=`${{ inputs.commitSHA }} || git rev-parse --short=7 HEAD`
+      - run: |
+          shortSHA="${{ inputs.commitSHA }}"
+          if [ -z $shortSHA ]; then
+            shortSHA=`git rev-parse --short=7 HEAD`
+          fi
+          yarn oclif promote --deb --root="./packages/cli" --version=${{ inputs.version }} --sha=$shortSHA
 
   ## POST release jobs
   invalidate-cdn-cache:

--- a/.github/workflows/pack-and-release.yml
+++ b/.github/workflows/pack-and-release.yml
@@ -6,14 +6,14 @@ on:
         description: version to promote to latest
         type: string
         required: true
-      buildSha:
-        description: sha of version in S3
+      commitSHA:
+        description: 1st 7 chars of release commit SHA (heroku-cli-assets/versions/v:VERSION/:THIS in S3)
         type: string
         required: false
 
 jobs:
   pack_deb:
-    if:  !${{ inputs.buildSha }} && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
+    if:  !${{ inputs.commitSHA }} && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
     # ubuntu started using a compression method after this version that debian currently does not support
     # https://github.com/heroku/cli/pull/2245#issue-1590017122
     runs-on: ubuntu-20.04
@@ -39,7 +39,7 @@ jobs:
           path: /home/runner/work/cli/cli/packages/cli/dist
 
   pack_tarballs:
-    if: !${{ inputs.buildSha }} && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
+    if: !${{ inputs.commitSHA }} && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -62,7 +62,7 @@ jobs:
 
   sign_deb:
     needs: [pack_deb]
-    if: !${{ inputs.buildSha }} && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
+    if: !${{ inputs.commitSHA }} && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
     runs-on: ubuntu-latest
     environment: SignDebian
     env:
@@ -89,7 +89,7 @@ jobs:
   # TODO: the circle job ran `install_scripts` but this isn't, do we need to add that?
   upload-deb-and-tarballs:
     needs: [sign_deb, pack_tarballs]
-    if: !${{ inputs.buildSha }} && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
+    if: !${{ inputs.commitSHA }} && (github.ref == 'refs/heads/master' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v' ))
     runs-on: ubuntu-latest
     environment: CLIS3BucketAndCloudfront
     env:
@@ -152,7 +152,7 @@ jobs:
           node-version: 16.x
           cache: yarn
       - run: yarn --frozen-lockfile --network-timeout 1000000
-      - run: yarn oclif promote --deb --root="./packages/cli" --version=${{ inputs.version }} --sha=`git rev-parse --short=7 HEAD`
+      - run: yarn oclif promote --deb --root="./packages/cli" --version=${{ inputs.version }} --sha=`${{ inputs.commitSHA }} || git rev-parse --short=7 HEAD`
 
   ## POST release jobs
   invalidate-cdn-cache:


### PR DESCRIPTION
[GUS ticket](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001OgQdAYAV/view)
Work started previously here: https://github.com/heroku/cli/pull/2285

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
