### PR TITLE
chore(addons-v5): add code coverage reports

### DIFF
--- a/packages/addons-v5/test/commands/addons/docs.js
+++ b/packages/addons-v5/test/commands/addons/docs.js
@@ -1,7 +1,12 @@
 'use strict'
 /* globals describe beforeEach it commands cli expect nock */
 
+let cli = require('heroku-cli-util')
+let proxyquire = require('proxyquire')
+const sinon = require('sinon')
+let openStub = sinon.stub(cli, 'open').callsFake(() => {})
 let cmd = commands.find((c) => c.topic === 'addons' && c.command === 'docs')
+let docs
 
 describe('addons:docs', function () {
   beforeEach(() => cli.mockConsole())
@@ -14,6 +19,20 @@ describe('addons:docs', function () {
     return cmd.run({ args: { addon: 'slowdb' }, flags: { 'show-url': true } })
       .then(() => expect(cli.stdout).to.equal('https://devcenter.heroku.com/articles/slowdb\n'))
       .then(() => expect(cli.stderr).to.equal(''))
+      .then(() => api.done())
+  })
+
+  it('opens an addon by name with no url flag passed', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/addon-services/slowdb')
+      .reply(200, { name: 'slowdb' })
+
+    docs = proxyquire('../../../commands/addons/docs', {
+      'heroku-cli-util': openStub
+    })
+
+    return docs.run({ args: { addon: 'slowdb' }, flags: {} })
+      .then(() => expect(cli.stdout).to.equal('Opening https://devcenter.heroku.com/articles/slowdb...\n'))
       .then(() => api.done())
   })
 

--- a/packages/addons-v5/test/commands/addons/open.js
+++ b/packages/addons-v5/test/commands/addons/open.js
@@ -13,7 +13,7 @@ describe('addons:open', function () {
       process.env.HEROKU_SUDO = true
     })
 
-    it('with sudo && sso.method is true', function () {
+    it('uses file path via sso to open url', function () {
       let api = nock('https://api.heroku.com:443')
 
       api.get('/apps/myapp/addons/db2/sso')
@@ -24,7 +24,7 @@ describe('addons:open', function () {
         .then(() => api.done())
     })
 
-    it('with sudo && sso.method is false', function () {
+    it('writes sudo template to file and opens url', function () {
       let api = nock('https://api.heroku.com:443')
 
       api.get('/apps/myapp/addons/db2/sso')

--- a/packages/addons-v5/test/commands/addons/open.js
+++ b/packages/addons-v5/test/commands/addons/open.js
@@ -8,6 +8,34 @@ let cmd = commands.find((c) => c.topic === 'addons' && c.command === 'open')
 describe('addons:open', function () {
   beforeEach(() => cli.mockConsole())
 
+  describe('testing sudo', function () {
+    beforeEach(() => {
+      process.env.HEROKU_SUDO = true
+    })
+
+    it('with sudo && sso.method is true', function () {
+      let api = nock('https://api.heroku.com:443')
+
+      api.get('/apps/myapp/addons/db2/sso')
+        .reply(200, { action: 'exampleURL', method: 'get' })
+
+      return cmd.run({ app: 'myapp', args: { addon: 'db2' }, flags: { 'show-url': true } })
+        .then(() => expect(cli.stdout).to.equal('Opening exampleURL...\n'))
+        .then(() => api.done())
+    })
+
+    it('with sudo && sso.method is false', function () {
+      let api = nock('https://api.heroku.com:443')
+
+      api.get('/apps/myapp/addons/db2/sso')
+        .reply(200, { action: 'exampleURL' })
+
+      return cmd.run({ app: 'myapp', args: { addon: 'db2' }, flags: { 'show-url': true } })
+        .then(() => expect(cli.stdout).to.equal('Opening file:///var/folders/xs/t_c4cq1j2gsf8mctmkyggsrw0000gp/T/heroku-sso.html...\n'))
+        .then(() => api.done())
+    })
+  })
+
   it('only prints the URL when --show-url passed', function () {
     let api = nock('https://api.heroku.com:443')
 

--- a/packages/addons-v5/test/commands/addons/open.js
+++ b/packages/addons-v5/test/commands/addons/open.js
@@ -31,7 +31,7 @@ describe('addons:open', function () {
         .reply(200, { action: 'exampleURL' })
 
       return cmd.run({ app: 'myapp', args: { addon: 'db2' }, flags: { 'show-url': true } })
-        .then(() => expect(cli.stdout).to.equal('Opening file:///var/folders/xs/t_c4cq1j2gsf8mctmkyggsrw0000gp/T/heroku-sso.html...\n'))
+        .then(() => expect(cli.stdout).to.contain('Opening file://'))
         .then(() => api.done())
     })
   })


### PR DESCRIPTION
## Why the change?
[GUS Card](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001NBKJnYAP/view)

As per our review of unit tests and coverage for the apps-v5 package, this PR does the following:
- Ensures that our code coverage reports over 85% test coverage of statements ✅

## Additional Notes
- N/A

## How to verify?
1. Pull down branch
2. Run tests
3. Confirm test coverage report is visible and that it reports over 85% test coverage of statements for all files
