### PR TITLE
chore(orgs-v5): add code coverage reports

### DIFF
--- a/packages/orgs-v5/test/commands/access/remove.js
+++ b/packages/orgs-v5/test/commands/access/remove.js
@@ -1,7 +1,10 @@
 'use strict'
 /* globals describe it beforeEach afterEach context cli nock expect */
 
+let cli = require('heroku-cli-util')
 let cmd = require('../../../commands/access/remove')[0]
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
 let stubDelete = require('../../stub/delete')
 let apiDelete
 
@@ -19,6 +22,33 @@ describe('heroku access:remove', () => {
         .then(() => expect(`Removing raulb@heroku.com access from the app myapp... done
 `).to.eq(cli.stderr))
         .then(() => apiDelete.done())
+    })
+  })
+
+  context('using old command', () => {
+    let cmd2
+    let cliErrorStub
+    let processStub
+
+    before(() => {
+      cliErrorStub = sinon.stub(cli, 'error').returns(() => {})
+      cmd2 = proxyquire(('../../../commands/access/remove'), {
+        'cli': cliErrorStub
+      })
+      processStub = sinon.stub(process, 'exit').returns(() => {})
+      cli.mockConsole()
+    })
+    after(() => {
+      cliErrorStub.restore()
+      processStub.restore()
+      nock.cleanAll()
+    })
+
+    it('errors when attempting to use old command', () => {
+      cmd2[1].run({
+        app: 'myapp'
+      })
+      expect(cliErrorStub.called).to.equal(true)
     })
   })
 })

--- a/packages/orgs-v5/test/commands/apps/leave.js
+++ b/packages/orgs-v5/test/commands/apps/leave.js
@@ -39,7 +39,7 @@ describe('heroku apps:leave', () => {
     })
   })
 
-  describe('error occurs when trying to leave the app', () => {
+  describe('when the user tries to leave the app', () => {
     before(() => {
       apiGetUserAccount = stubGet.userAccount()
       apiDeletePersonalAppCollaborator = stubDeleteError.collaboratorsPersonalAppDeleteFailure('myapp', 'raulb%40heroku.com')

--- a/packages/orgs-v5/test/commands/apps/leave.js
+++ b/packages/orgs-v5/test/commands/apps/leave.js
@@ -47,7 +47,7 @@ describe('heroku apps:leave', () => {
     })
     after(() => nock.cleanAll())
 
-    it('errors when leaving the app', () => {
+    it('shows an error if the heroku.delete() operation returns an error', () => {
       return cmd.run({ app: 'myapp' })
         .then(() => apiGetUserAccount.done())
         .then(() => apiDeletePersonalAppCollaborator.done())

--- a/packages/orgs-v5/test/commands/apps/leave.js
+++ b/packages/orgs-v5/test/commands/apps/leave.js
@@ -4,6 +4,7 @@
 let cmd = require('../../../commands/apps/leave')[0]
 let stubGet = require('../../stub/get')
 let stubDelete = require('../../stub/delete')
+let stubDeleteError = require('../../stub/delete')
 
 describe('heroku apps:leave', () => {
   let apiGetUserAccount
@@ -35,6 +36,24 @@ describe('heroku apps:leave', () => {
 `).to.eq(cli.stderr))
         .then(() => apiGetUserAccount.done())
         .then(() => apiDeletePersonalAppCollaborator.done())
+    })
+  })
+
+  describe('error occurs when trying to leave the app', () => {
+    before(() => {
+      apiGetUserAccount = stubGet.userAccount()
+      apiDeletePersonalAppCollaborator = stubDeleteError.collaboratorsPersonalAppDeleteFailure('myapp', 'raulb%40heroku.com')
+      cli.mockConsole()
+    })
+    after(() => nock.cleanAll())
+
+    it('errors when leaving the app', () => {
+      return cmd.run({ app: 'myapp' })
+        .then(() => apiGetUserAccount.done())
+        .then(() => apiDeletePersonalAppCollaborator.done())
+        .catch(function (err) {
+          expect(err).to.be.an.instanceof(Error)
+        })
     })
   })
 })

--- a/packages/orgs-v5/test/commands/orgs/open.js
+++ b/packages/orgs-v5/test/commands/orgs/open.js
@@ -1,8 +1,39 @@
-const cmd = require('../../../commands/orgs/open')
+let cli = require('heroku-cli-util')
+const sinon = require('sinon')
 const expect = require('chai').expect
+let stubGet = require('../../stub/get')
+const proxyquire = require('proxyquire')
+let cmd
+let apiGetOrgInfo
 
 describe('heroku org:open', () => {
+  beforeEach(() => {
+    apiGetOrgInfo = stubGet.teamInfo()
+    openStub = sinon.stub(cli, 'open').callsFake(() => {})
+    cmd = proxyquire('../../../commands/orgs/open', {
+      'cli': openStub
+    })
+    cli.mockConsole()
+  })
+
+  afterEach(() => {
+    openStub.restore()
+    nock.cleanAll()
+  })
+
   it('is configured for an optional team flag', function () {
     expect(cmd).to.have.own.property('wantsOrg', true)
+  })
+
+  it('erros if team flag is not passed', function () {
+    cmd.run({}).catch((err) => {
+      expect(err).to.be.instanceOf(Error)
+    })
+  })
+
+  it('if team flag is passed', function () {
+    return cmd.run({ flags: { team: 'myteam' } })
+    .then(() => apiGetOrgInfo.done())
+    .then(() => expect(openStub.called).to.equal(true))
   })
 })

--- a/packages/orgs-v5/test/commands/orgs/open.js
+++ b/packages/orgs-v5/test/commands/orgs/open.js
@@ -25,7 +25,7 @@ describe('heroku org:open', () => {
     expect(cmd).to.have.own.property('wantsOrg', true)
   })
 
-  it('erros if team flag is not passed', function () {
+  it('shows an error if team flag is not passed', function () {
     cmd.run({}).catch((err) => {
       expect(err).to.be.instanceOf(Error)
     })

--- a/packages/orgs-v5/test/commands/orgs/open.js
+++ b/packages/orgs-v5/test/commands/orgs/open.js
@@ -31,7 +31,7 @@ describe('heroku org:open', () => {
     })
   })
 
-  it('if team flag is passed', function () {
+  it('opens org in dashboard via browser if team flag is passed', function () {
     return cmd.run({ flags: { team: 'myteam' } })
     .then(() => apiGetOrgInfo.done())
     .then(() => expect(openStub.called).to.equal(true))

--- a/packages/orgs-v5/test/stub/delete.js
+++ b/packages/orgs-v5/test/stub/delete.js
@@ -14,6 +14,11 @@ function collaboratorsPersonalApp (app, email) {
     .delete(`/apps/${app}/collaborators/${email}`).reply(200, {})
 }
 
+function collaboratorsPersonalAppDeleteFailure (app, email) {
+  return nock('https://api.heroku.com:443', {})
+    .delete(`/apps/${app}/collaborators/${email}`).reply(404, {})
+}
+
 function teamInvite (email = 'foo@email.com') {
   return nock('https://api.heroku.com:443', {
     reqheaders: { Accept: 'application/vnd.heroku+json; version=3.team-invitations' }
@@ -29,6 +34,7 @@ function memberFromTeam () {
 module.exports = {
   collaboratorsteamApp,
   collaboratorsPersonalApp,
+  collaboratorsPersonalAppDeleteFailure,
   memberFromTeam,
   teamInvite
 }


### PR DESCRIPTION
## Why the change?
[GUS Card](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001NBdsYYAT/view)

As per our review of unit tests and coverage for the orgs-v5 package, this PR does the following:
- Ensures that our code coverage reports over 85% test coverage of statements ✅

## Additional Notes
- N/A

## How to verify?
1. Pull down branch
2. Run tests
3. Confirm test coverage report is visible and that it reports over 85% test coverage of statements for all files
