### PR TITLE
chore(pipelines): add code coverage reports

### DIFF
--- a/packages/pipelines/src/setup/poll-app-setups.ts
+++ b/packages/pipelines/src/setup/poll-app-setups.ts
@@ -1,6 +1,8 @@
 import * as api from '../api'
+import {CliUx} from '@oclif/core'
+import color from '@heroku-cli/color'
 
-const cli = require('heroku-cli-util')
+const cli = CliUx.ux
 
 function wait(ms: any) {
   return new Promise((resolve: (value?: any) => void) => setTimeout(resolve, ms))
@@ -13,12 +15,12 @@ function pollAppSetup(heroku: any, appSetup: any): any {
     }
 
     if (setup.status === 'failed') {
-      throw new Error(`Couldn't create application ${cli.color.app(setup.app.name)}: ${setup.failure_message}`)
+      throw new Error(`Couldn't create application ${color.app(setup.app.name)}: ${setup.failure_message}`)
     }
 
     return wait(1000).then(() => pollAppSetup(heroku, appSetup))
   }).catch((error: any) => {
-    return cli.exit(1, error)
+    return cli.error(error, {exit: 1})
   })
 }
 

--- a/packages/pipelines/test/commands/pipelines/connect.test.ts
+++ b/packages/pipelines/test/commands/pipelines/connect.test.ts
@@ -56,4 +56,21 @@ describe('pipelines:connect', () => {
       expect(ctx.stdout).to.equal('')
     })
   })
+
+  describe('with an account connected to Github experiencing request failures', () => {
+    test
+    .nock('https://api.github.com', github => {
+      const repo = {
+        id: 1235,
+        default_branch: 'main',
+        name: 'my-org/my-repo',
+      }
+      github.get(`/repos/${repo.name}`).reply(401, {})
+    })
+    .command(['pipelines:connect', 'my-pipeline', '--repo=my-org/my-repo'])
+    .catch(error => {
+      expect(error.message).to.contain('Could not access the my-org/my-repo repo')
+    })
+    .it('shows an error if github request fails')
+  })
 })

--- a/packages/pipelines/test/commands/pipelines/connect.test.ts
+++ b/packages/pipelines/test/commands/pipelines/connect.test.ts
@@ -59,6 +59,14 @@ describe('pipelines:connect', () => {
 
   describe('with an account connected to Github experiencing request failures', () => {
     test
+    .nock('https://kolkrabbi.heroku.com', kolkrabbi => {
+      const kolkrabbiAccount = {
+        github: {
+          token: '123-abc',
+        },
+      }
+      kolkrabbi.get('/account/github/token').reply(200, kolkrabbiAccount)
+    })
     .nock('https://api.github.com', github => {
       const repo = {
         id: 1235,

--- a/packages/pipelines/test/commands/pipelines/setup.test.ts
+++ b/packages/pipelines/test/commands/pipelines/setup.test.ts
@@ -2,6 +2,7 @@ import {CliUx} from '@oclif/core'
 import color from '@heroku-cli/color'
 import {expect, test} from '@oclif/test'
 import sinon from 'sinon'
+import pollAppSetups from '../../../src/setup/poll-app-setups'
 
 const cli = CliUx.ux
 
@@ -252,6 +253,61 @@ describe('pipelines:setup', () => {
           expect(error.message).to.contain(`Couldn't create application ${color.app('my-pipeline')}: status failed`)
         })
         .it('shows error if getAppSetup returns body with setup.status === failed')
+      })
+
+      context('when pollAppSetup status times out', function () {
+        const team = 'test-org'
+        const confirmStub = sinon.stub()
+
+        test
+        .do(() => {
+          confirmStub.resolves(true)
+        })
+        .nock('https://api.heroku.com', api => {
+          api.post('/pipelines').reply(201, pipeline)
+
+          const couplings = [
+            {id: 1, stage: 'production', app: prodApp},
+            {id: 2, stage: 'staging', app: stagingApp},
+          ]
+
+          couplings.forEach(function (coupling) {
+            api
+            .post('/app-setups', {
+              source_blob: {url: archiveURL},
+              app: {name: coupling.app.name, organization: team},
+              pipeline_coupling: {stage: coupling.stage, pipeline: pipeline.id},
+            })
+            .reply(201, {id: coupling.id, app: coupling.app})
+
+            api.get(`/app-setups/${coupling.id}`).reply(200, {status: 'timedout'})
+            api.get(`/app-setups/${coupling.id}`).reply(200, {status: 'failed', app: {name: 'my-pipeline'}, failure_message: 'timedout'})
+          })
+
+          api.get('/teams/test-org').reply(200, {id: '89-0123-456'})
+        })
+        .nock('https://api.github.com', github => github.get(`/repos/${repo.name}`).reply(200, repo))
+        .nock('https://kolkrabbi.heroku.com', kolkrabbi => {
+          kolkrabbi
+          .get('/account/github/token')
+          .reply(200, kolkrabbiAccount)
+          .get(`/github/repos/${repo.name}/tarball/${repo.default_branch}`)
+          .reply(200, {
+            archive_link: archiveURL,
+          })
+          .post(`/pipelines/${pipeline.id}/repository`)
+          .reply(201, {})
+        })
+        .stub(cli, 'confirm', () => confirmStub)
+        .stub(cli, 'open', () => () => Promise.resolve())
+        .stub(pollAppSetups, 'wait', () => {
+          pollAppSetups('foo', 'bar')
+        })
+        .command(['pipelines:setup', 'my-pipeline', 'my-org/my-repo', '--team', team])
+        .catch(error => {
+          expect(error.message).to.contain('timedout')
+        })
+        .it('shows error if getAppSetup times out')
       })
     })
   })

--- a/packages/pipelines/test/commands/pipelines/setup.test.ts
+++ b/packages/pipelines/test/commands/pipelines/setup.test.ts
@@ -1,4 +1,5 @@
 import {CliUx} from '@oclif/core'
+import color from '@heroku-cli/color'
 import {expect, test} from '@oclif/test'
 import sinon from 'sinon'
 
@@ -200,6 +201,57 @@ describe('pipelines:setup', () => {
         .stub(cli, 'open', () => () => Promise.resolve())
         .command(['pipelines:setup', '--team', team])
         .it('creates apps in a team with CI enabled')
+      })
+
+      context('when pollAppSetup status fails', function () {
+        const team = 'test-org'
+        const confirmStub = sinon.stub()
+
+        test
+        .do(() => {
+          confirmStub.resolves(true)
+        })
+        .nock('https://api.heroku.com', api => {
+          api.post('/pipelines').reply(201, pipeline)
+
+          const couplings = [
+            {id: 1, stage: 'production', app: prodApp},
+            {id: 2, stage: 'staging', app: stagingApp},
+          ]
+
+          couplings.forEach(function (coupling) {
+            api
+            .post('/app-setups', {
+              source_blob: {url: archiveURL},
+              app: {name: coupling.app.name, organization: team},
+              pipeline_coupling: {stage: coupling.stage, pipeline: pipeline.id},
+            })
+            .reply(201, {id: coupling.id, app: coupling.app})
+
+            api.get(`/app-setups/${coupling.id}`).reply(200, {status: 'failed', app: {name: 'my-pipeline'}, failure_message: 'status failed'})
+          })
+
+          api.get('/teams/test-org').reply(200, {id: '89-0123-456'})
+        })
+        .nock('https://api.github.com', github => github.get(`/repos/${repo.name}`).reply(200, repo))
+        .nock('https://kolkrabbi.heroku.com', kolkrabbi => {
+          kolkrabbi
+          .get('/account/github/token')
+          .reply(200, kolkrabbiAccount)
+          .get(`/github/repos/${repo.name}/tarball/${repo.default_branch}`)
+          .reply(200, {
+            archive_link: archiveURL,
+          })
+          .post(`/pipelines/${pipeline.id}/repository`)
+          .reply(201, {})
+        })
+        .stub(cli, 'confirm', () => confirmStub)
+        .stub(cli, 'open', () => () => Promise.resolve()) // eslint-disable-line unicorn/consistent-function-scoping
+        .command(['pipelines:setup', 'my-pipeline', 'my-org/my-repo', '--team', team])
+        .catch(error => {
+          expect(error.message).to.contain(`Couldn't create application ${color.app('my-pipeline')}: status failed`)
+        })
+        .it('shows error if getAppSetup returns body with setup.status === failed')
       })
     })
   })


### PR DESCRIPTION
## Why the change?
[GUS Card](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001NBlbhYAD/view)

As per our review of unit tests and coverage for the pipelines package, this PR does the following:
- Ensures that our code coverage reports over 85% test coverage of statements ✅

## Additional Notes
- Updated `cli.exit()` from `heroku-cli-util` with `cli.error()` from `oclif/core`

## How to verify?
1. Pull down branch
2. Run tests
3. Confirm test coverage report is visible and that it reports over 85% test coverage of statements for all files
