### PR TITLE
chore(buildpacks): add code coverage reports

### DIFF
--- a/packages/buildpacks/.nycrc
+++ b/packages/buildpacks/.nycrc
@@ -7,6 +7,5 @@
   ],
   "exclude": [
     "**/*.d.ts"
-  ],
-  "all": true
+  ]
 }


### PR DESCRIPTION
## Why the change?
[GUS Card](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001NBlbaYAD/view)

As per our review of unit tests and coverage for the buildpacks package, this PR does the following:
- Ensures that our code coverage reports over 85% test coverage of statements ✅

## Additional Notes
- Removed `all` property in `.nycrc` file to remove `src/index.ts` from testing since there is nothing to test in that file

## How to verify?
1. Pull down branch
2. Run tests
3. Confirm test coverage report is visible and that it reports over 85% test coverage of statements for all files
