### PR TITLE
chore(status): add code coverage reports

### DIFF
--- a/packages/status/.gitignore
+++ b/packages/status/.gitignore
@@ -4,5 +4,6 @@
 /lib
 /node_modules
 /tmp
+/.nyc_output
 lib
 node_modules

--- a/packages/status/package.json
+++ b/packages/status/package.json
@@ -32,6 +32,7 @@
     "globby": "^9.0.0",
     "mocha": "^5.1.1",
     "nock": "^10.0.6",
+    "nyc": "^15.1.0",
     "oclif": "3.8.1",
     "ts-node": "^10.9.1",
     "typescript": "4.8.4"
@@ -65,7 +66,7 @@
     "prepack": "yarn run build && oclif manifest",
     "preversion": "yarn run postpublish",
     "pretest": "tsc -p test --noEmit",
-    "test": "mocha --forbid-only \"test/**/*.test.ts\"",
+    "test": "nyc mocha --forbid-only \"test/**/*.test.ts\"",
     "posttest": "yarn lint",
     "version": "oclif readme && git add README.md"
   }


### PR DESCRIPTION
## Why the change?
[GUS Card](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001NBtC8YAL/view)

As per our review of unit tests and coverage for the status package, this PR does the following:
- Adds `nyc` package to add code coverage reports ✅
- Ensures that our code coverage reports over 85% test coverage of statements ✅

## Additional Notes
- N/A

## How to verify?
1. Pull down branch
2. Run tests
3. Confirm test coverage report is visible and that it reports over 85% test coverage of statements for all files
