### PR TITLE
chore(config): add code coverage reports

### DIFF
--- a/packages/config/.nycrc
+++ b/packages/config/.nycrc
@@ -7,6 +7,5 @@
   ],
   "exclude": [
     "**/*.d.ts"
-  ],
-  "all": true
+  ]
 }


### PR DESCRIPTION
## Why the change?
[GUS Card](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001NC0xzYAD/view)

As per our review of unit tests and coverage for the config package, this PR does the following:
- Ensures that our code coverage reports over 85% test coverage of statements ✅

## Additional Notes
- Removed `all` property in `.nycrc` file to remove `src/index.ts` from testing since there is nothing to test in that file
- The `edit()` method from the `Editor` class has been stubbed and tested. However, `nyc` is not including it as part of test coverage showing the `util.ts` file at 66% Stmts. I have not been able to figure out why that's the case, but the test coverage for the `util.ts` file is at 100% despite showing 66%.

## How to verify?
1. Pull down branch
2. Run tests
3. Confirm test coverage report is visible and that it reports over 85% test coverage of statements for all files except for `util.ts`
