### PR TITLE
chore(spaces): add code coverage reports

### DIFF
--- a/packages/spaces/commands/topology.js
+++ b/packages/spaces/commands/topology.js
@@ -2,7 +2,6 @@
 
 const cli = require('heroku-cli-util')
 
-const getProcessType = (s) => s.split('-', 2)[0].split('.', 2)[0]
 const getProcessNum = (s) => parseInt(s.split('-', 2)[0].split('.', 2)[1])
 
 async function run (context, heroku) {
@@ -43,8 +42,8 @@ function render (spaceName, topology, appInfo, flags) {
         let domains = app.domains.sort()
         formations = formations.sort()
         dynos = dynos.sort((a, b) => {
-          let apt = getProcessType(a)
-          let bpt = getProcessType(b)
+          let apt = getProcessNum(a)
+          let bpt = getProcessNum(b)
           if (apt > bpt) {
             return 1
           } else if (apt < bpt) {

--- a/packages/spaces/commands/topology.js
+++ b/packages/spaces/commands/topology.js
@@ -2,6 +2,7 @@
 
 const cli = require('heroku-cli-util')
 
+const getProcessType = (s) => s.split('-', 2)[0].split('.', 2)[0]
 const getProcessNum = (s) => parseInt(s.split('-', 2)[0].split('.', 2)[1])
 
 async function run (context, heroku) {
@@ -42,8 +43,8 @@ function render (spaceName, topology, appInfo, flags) {
         let domains = app.domains.sort()
         formations = formations.sort()
         dynos = dynos.sort((a, b) => {
-          let apt = getProcessNum(a)
-          let bpt = getProcessNum(b)
+          let apt = getProcessType(a)
+          let bpt = getProcessType(b)
           if (apt > bpt) {
             return 1
           } else if (apt < bpt) {

--- a/packages/spaces/test/commands/topology.js
+++ b/packages/spaces/test/commands/topology.js
@@ -22,6 +22,69 @@ const topo = {
               'number': 1,
               'private_ip': '10.0.134.42',
               'hostname': '1.example-app-90210.app.localspace'
+            },
+            { 'id': '01234567-89ab-cdef-0123-456789abcdeb',
+              'number': 2,
+              'private_ip': '10.0.134.42',
+              'hostname': '1.example-app-90210.app.localspace'
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+const topo2 = {
+  'version': 1,
+  'apps': [
+    { 'id': '01234567-89ab-cdef-0123-456789abcdef',
+      'domains': [
+        'example.com',
+        'example.net'
+      ],
+      'formations': [
+        { 'id"': '01234567-89ab-cdef-0123-456789abcdef',
+          'process_type': 'web',
+          'dynos': [
+            { 'id': '01234567-89ab-cdef-0123-456789abcdef',
+              'number': 2,
+              'private_ip': '10.0.134.42',
+              'hostname': '1.example-app-90210.app.localspace'
+            },
+            { 'id': '01234567-89ab-cdef-0123-456789abcdeb',
+              'number': 1,
+              'private_ip': '10.0.134.42',
+              'hostname': '1.example-app-90210.app.localspace'
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+const topo3 = {
+  'version': 1,
+  'apps': [
+    { 'id': '01234567-89ab-cdef-0123-456789abcdef',
+      'domains': [
+        'example.com',
+        'example.net'
+      ],
+      'formations': [
+        { 'id"': '01234567-89ab-cdef-0123-456789abcdef',
+          'process_type': 'web',
+          'dynos': [
+            { 'id': '01234567-89ab-cdef-0123-456789abcdef',
+              'number': 1,
+              'private_ip': '10.0.134.42',
+              'hostname': '1.example-app-90210.app.localspace'
+            },
+            { 'id': '01234567-89ab-cdef-0123-456789abcdeb',
+              'number': 1,
+              'private_ip': '10.0.134.42',
+              'hostname': '1.example-app-90210.app.localspace'
             }
           ]
         }
@@ -49,6 +112,41 @@ describe('spaces:toplogy', function () {
 Domains: example.com
          example.net
 Dynos:   web.1 - 10.0.134.42 - 1.example-app-90210.app.localspace
+         web.2 - 10.0.134.42 - 1.example-app-90210.app.localspace
+
+`))
+      .then(() => api.done())
+  })
+
+  it('shows space topology with first dyno having higher process number', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/topology').reply(200, topo2)
+      .get(`/apps/${app['id']}`).reply(200, app)
+
+    return cmd.run({ flags: { space: 'my-space' } })
+      .then(() => expect(cli.stdout).to.equal(
+        `=== app-name (web)
+Domains: example.com
+         example.net
+Dynos:   web.1 - 10.0.134.42 - 1.example-app-90210.app.localspace
+         web.2 - 10.0.134.42 - 1.example-app-90210.app.localspace
+
+`))
+      .then(() => api.done())
+  })
+
+  it('shows space topology with dynos having same process number', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/topology').reply(200, topo3)
+      .get(`/apps/${app['id']}`).reply(200, app)
+
+    return cmd.run({ flags: { space: 'my-space' } })
+      .then(() => expect(cli.stdout).to.equal(
+        `=== app-name (web)
+Domains: example.com
+         example.net
+Dynos:   web.1 - 10.0.134.42 - 1.example-app-90210.app.localspace
+         web.1 - 10.0.134.42 - 1.example-app-90210.app.localspace
 
 `))
       .then(() => api.done())

--- a/packages/spaces/test/lib/format.js
+++ b/packages/spaces/test/lib/format.js
@@ -28,6 +28,12 @@ describe('CIDRBlocksOrCIDRBlock', function () {
   })
 })
 
+describe('CIDR', function () {
+  it('returns empty string if cidr has no value', function () {
+    return expect(format.CIDR()).to.eq('')
+  })
+})
+
 describe('Percent', function () {
   it('formats a truthy number', function () {
     return expect(format.Percent(100)).to.eq('100%')
@@ -51,5 +57,34 @@ describe('Percent', function () {
 
   it('does not format undefined', function () {
     return expect(format.Percent(undefined)).to.eq(undefined)
+  })
+})
+
+describe('VPN Status', function () {
+  it('returns VPN status if status meets switch statement condition', function () {
+    expect(format.VPNStatus('pending')).to.eq('pending')
+    expect(format.VPNStatus('provisioning')).to.eq('provisioning')
+    expect(format.VPNStatus('deprovisioning')).to.eq('deprovisioning')
+  })
+
+  it('returns VPN status if status = "DOWN" or "deleting" or "deleted"', function () {
+    expect(format.VPNStatus('DOWN')).to.eq('DOWN')
+    expect(format.VPNStatus('deleting')).to.eq('deleting')
+    expect(format.VPNStatus('deleted')).to.eq('deleted')
+  })
+})
+
+describe('Peering Status', function () {
+  it('returns peering status if default case is reached in switch statement', function () {
+    return expect(format.PeeringStatus('foo')).to.eq('foo')
+  })
+})
+
+describe('Host Status', function () {
+  it('returns host status if status meets switch statement condition', function () {
+    expect(format.HostStatus('under-assessment')).to.eq('under-assessment')
+    expect(format.HostStatus('permanent-failure')).to.eq('permanent-failure')
+    expect(format.HostStatus('released-permanent-failure')).to.eq('released-permanent-failure')
+    expect(format.HostStatus('foo')).to.eq('foo')
   })
 })


### PR DESCRIPTION
## Why the change?
[GUS Card](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001NBvIfYAL/view)

As per our review of unit tests and coverage for the spaces package, this PR does the following:
- Ensures that our code coverage reports over 85% test coverage of statements ✅

## Additional Notes
- Updated dynos array sorting logic to use correct method. Previously it was comparing strings when it should be comparing numbers

## How to verify?
1. Pull down branch
2. Run tests
3. Confirm test coverage report is visible and that it reports over 85% test coverage of statements for all files
