### PR TITLE
chore: eslint standardization redis-v5

### DIFF
--- a/packages/redis-v5/commands/credentials.js
+++ b/packages/redis-v5/commands/credentials.js
@@ -7,8 +7,8 @@ module.exports = {
   command: 'credentials',
   needsApp: true,
   needsAuth: true,
-  args: [{ name: 'database', optional: true }],
-  flags: [{ name: 'reset', description: 'reset credentials' }],
+  args: [{name: 'database', optional: true}],
+  flags: [{name: 'reset', description: 'reset credentials'}],
   description: 'display credentials information',
   run: cli.command(async (context, heroku) => {
     const api = require('../lib/shared')(context, heroku)
@@ -21,5 +21,5 @@ module.exports = {
       let redis = await api.request(`/redis/v0/databases/${addon.name}`)
       cli.log(redis.resource_url)
     }
-  })
+  }),
 }

--- a/packages/redis-v5/commands/index.js
+++ b/packages/redis-v5/commands/index.js
@@ -7,8 +7,8 @@ module.exports = {
   topic: 'redis',
   needsApp: true,
   needsAuth: true,
-  args: [{ name: 'database', optional: true }],
-  flags: [{ name: 'json', description: 'format output as JSON', hasValue: false }],
+  args: [{name: 'database', optional: true}],
+  flags: [{name: 'json', description: 'format output as JSON', hasValue: false}],
   description: 'gets information about redis',
   run: cli.command((ctx, heroku) => api(ctx, heroku).info()),
 }

--- a/packages/redis-v5/commands/info.js
+++ b/packages/redis-v5/commands/info.js
@@ -8,8 +8,8 @@ module.exports = {
   command: 'info',
   needsApp: true,
   needsAuth: true,
-  args: [{ name: 'database', optional: true }],
-  flags: [{ name: 'json', description: 'format output as JSON', hasValue: false }],
+  args: [{name: 'database', optional: true}],
+  flags: [{name: 'json', description: 'format output as JSON', hasValue: false}],
   description: 'gets information about redis',
   run: cli.command((ctx, heroku) => api(ctx, heroku).info()),
 }

--- a/packages/redis-v5/commands/keyspace-notifications.js
+++ b/packages/redis-v5/commands/keyspace-notifications.js
@@ -7,8 +7,8 @@ module.exports = {
   command: 'keyspace-notifications',
   needsApp: true,
   needsAuth: true,
-  args: [{ name: 'database', optional: true }],
-  flags: [{ name: 'config', char: 'c', description: 'set keyspace notifications configuration', hasValue: true, optional: false }],
+  args: [{name: 'database', optional: true}],
+  flags: [{name: 'config', char: 'c', description: 'set keyspace notifications configuration', hasValue: true, optional: false}],
   description: 'set the keyspace notifications configuration',
   help: `Set the configuration to enable keyspace notification events:
     K     Keyspace events, published with __keyspace@<db>__ prefix.
@@ -35,7 +35,7 @@ module.exports = {
 
     let addon = await api.getRedisAddon()
 
-    let config = await api.request(`/redis/v0/databases/${addon.name}/config`, 'PATCH', { notify_keyspace_events: context.flags.config })
+    let config = await api.request(`/redis/v0/databases/${addon.name}/config`, 'PATCH', {notify_keyspace_events: context.flags.config})
     cli.log(`Keyspace notifications for ${addon.name} (${addon.config_vars.join(', ')}) set to '${config.notify_keyspace_events.value}'.`)
-  })
+  }),
 }

--- a/packages/redis-v5/commands/maintenance.js
+++ b/packages/redis-v5/commands/maintenance.js
@@ -7,11 +7,11 @@ module.exports = {
   command: 'maintenance',
   needsApp: true,
   needsAuth: true,
-  args: [{ name: 'database', optional: true }],
+  args: [{name: 'database', optional: true}],
   flags: [
-    { name: 'window', char: 'w', description: 'set weekly UTC maintenance window', hasValue: true, optional: true },
-    { name: 'run', description: 'start maintenance', optional: true },
-    { name: 'force', char: 'f', description: 'start maintenance without entering application maintenance mode', optional: true }
+    {name: 'window', char: 'w', description: 'set weekly UTC maintenance window', hasValue: true, optional: true},
+    {name: 'run', description: 'start maintenance', optional: true},
+    {name: 'force', char: 'f', description: 'start maintenance without entering application maintenance mode', optional: true},
   ],
   description: 'manage maintenance windows',
   help: 'Set or change the maintenance window for your Redis instance',
@@ -19,16 +19,18 @@ module.exports = {
     const api = require('../lib/shared')(context, heroku)
     let addon = await api.getRedisAddon()
 
+    // eslint-disable-next-line no-eq-null, eqeqeq
     if (addon.plan.name.match(/hobby/) != null) {
       cli.exit(1, 'redis:maintenance is not available for hobby-dev instances')
     }
 
     if (context.flags.window) {
+      // eslint-disable-next-line no-eq-null, eqeqeq
       if (context.flags.window.match(/[A-Za-z]{3,10} \d\d?:[03]0/) == null) {
         cli.exit(1, 'Maintenance windows must be "Day HH:MM", where MM is 00 or 30.')
       }
 
-      let maintenance = await api.request(`/redis/v0/databases/${addon.name}/maintenance_window`, 'PUT', { description: context.flags.window })
+      let maintenance = await api.request(`/redis/v0/databases/${addon.name}/maintenance_window`, 'PUT', {description: context.flags.window})
       cli.log(`Maintenance window for ${addon.name} (${addon.config_vars.join(', ')}) set to ${maintenance.window}.`)
       cli.exit(0)
     }
@@ -46,5 +48,5 @@ module.exports = {
 
     let maintenance = await api.request(`/redis/v0/databases/${addon.name}/maintenance`, 'GET', null)
     cli.log(maintenance.message)
-  })
+  }),
 }

--- a/packages/redis-v5/commands/maxmemory.js
+++ b/packages/redis-v5/commands/maxmemory.js
@@ -7,8 +7,8 @@ module.exports = {
   command: 'maxmemory',
   needsApp: true,
   needsAuth: true,
-  args: [{ name: 'database', optional: true }],
-  flags: [{ name: 'policy', char: 'p', description: 'set policy name', hasValue: true, optional: false }],
+  args: [{name: 'database', optional: true}],
+  flags: [{name: 'policy', char: 'p', description: 'set policy name', hasValue: true, optional: false}],
   description: 'set the key eviction policy',
   help: `Set the key eviction policy when instance reaches its storage limit. Available policies for key eviction include:
 
@@ -29,8 +29,8 @@ module.exports = {
 
     let addon = await api.getRedisAddon()
 
-    let config = await api.request(`/redis/v0/databases/${addon.name}/config`, 'PATCH', { maxmemory_policy: context.flags.policy })
+    let config = await api.request(`/redis/v0/databases/${addon.name}/config`, 'PATCH', {maxmemory_policy: context.flags.policy})
     cli.log(`Maxmemory policy for ${addon.name} (${addon.config_vars.join(', ')}) set to ${config.maxmemory_policy.value}.`)
     cli.log(`${config.maxmemory_policy.value} ${config.maxmemory_policy.values[config.maxmemory_policy.value]}.`)
-  })
+  }),
 }

--- a/packages/redis-v5/commands/promote.js
+++ b/packages/redis-v5/commands/promote.js
@@ -7,7 +7,7 @@ module.exports = {
   command: 'promote',
   needsApp: true,
   needsAuth: true,
-  args: [{ name: 'database', optional: false }],
+  args: [{name: 'database', optional: false}],
   description: 'sets DATABASE as your REDIS_URL',
   run: cli.command(async (context, heroku) => {
     const api = require('../lib/shared')(context, heroku)
@@ -27,19 +27,19 @@ module.exports = {
     // current REDIS_URL but that's a bigger refactor).
     if (redis.length === 1 && redis[0].config_vars.filter(c => c.endsWith('_URL')).length === 1) {
       let attachment = redis[0]
-      await heroku.post('/addon-attachments', { body: {
-        app: { name: context.app },
-        addon: { name: attachment.name },
-        confirm: context.app
-      } })
+      await heroku.post('/addon-attachments', {body: {
+        app: {name: context.app},
+        addon: {name: attachment.name},
+        confirm: context.app,
+      }})
     }
 
     cli.log(`Promoting ${addon.name} to REDIS_URL on ${context.app}`)
-    await heroku.post('/addon-attachments', { body: {
-      app: { name: context.app },
-      addon: { name: addon.name },
+    await heroku.post('/addon-attachments', {body: {
+      app: {name: context.app},
+      addon: {name: addon.name},
       confirm: context.app,
-      name: 'REDIS'
-    } })
-  })
+      name: 'REDIS',
+    }})
+  }),
 }

--- a/packages/redis-v5/commands/stats-reset.js
+++ b/packages/redis-v5/commands/stats-reset.js
@@ -7,8 +7,8 @@ module.exports = {
   command: 'stats-reset',
   needsApp: true,
   needsAuth: true,
-  args: [{ name: 'database', optional: true }],
-  flags: [{ name: 'confirm', char: 'c', hasValue: true }],
+  args: [{name: 'database', optional: true}],
+  flags: [{name: 'confirm', char: 'c', hasValue: true}],
   description: 'reset all stats covered by RESETSTAT (https://redis.io/commands/config-resetstat)',
   run: cli.command(async (context, heroku) => {
     let api = require('../lib/shared')(context, heroku)

--- a/packages/redis-v5/commands/timeout.js
+++ b/packages/redis-v5/commands/timeout.js
@@ -6,24 +6,25 @@ module.exports = {
   command: 'timeout',
   needsApp: true,
   needsAuth: true,
-  args: [{ name: 'database', optional: true }],
-  flags: [{ name: 'seconds', char: 's', description: 'set timeout value', hasValue: true }],
+  args: [{name: 'database', optional: true}],
+  flags: [{name: 'seconds', char: 's', description: 'set timeout value', hasValue: true}],
   description: 'set the number of seconds to wait before killing idle connections',
   help: 'Sets the number of seconds to wait before killing idle connections. A value of zero means that connections will not be closed.',
   run: cli.command(async (context, heroku) => {
     if (!context.flags.seconds) {
       cli.exit(1, 'Please specify a valid timeout value.')
     }
+
     const api = require('../lib/shared')(context, heroku)
 
     let addon = await api.getRedisAddon()
 
-    let config = await api.request(`/redis/v0/databases/${addon.name}/config`, 'PATCH', { timeout: parseInt(context.flags.seconds, 10) })
+    let config = await api.request(`/redis/v0/databases/${addon.name}/config`, 'PATCH', {timeout: Number.parseInt(context.flags.seconds, 10)})
     cli.log(`Timeout for ${addon.name} (${addon.config_vars.join(', ')}) set to ${config.timeout.value} seconds.`)
     if (config.timeout.value === 0) {
       cli.log('Connections to the Redis instance can idle indefinitely.')
     } else {
       cli.log(`Connections to the Redis instance will be stopped after idling for ${config.timeout.value} seconds.`)
     }
-  })
+  }),
 }

--- a/packages/redis-v5/commands/upgrade.js
+++ b/packages/redis-v5/commands/upgrade.js
@@ -7,10 +7,10 @@ module.exports = {
   command: 'upgrade',
   needsApp: true,
   needsAuth: true,
-  args: [{ name: 'database', optional: true }],
+  args: [{name: 'database', optional: true}],
   flags: [
-    { name: 'confirm', char: 'c', hasValue: true },
-    { name: 'version', char: 'v', hasValue: true }
+    {name: 'confirm', char: 'c', hasValue: true},
+    {name: 'version', char: 'v', hasValue: true},
   ],
   description: 'perform in-place version upgrade',
   run: cli.command(async (context, heroku) => {
@@ -24,9 +24,9 @@ module.exports = {
 
     await cli.confirmApp(context.app, context.flags.confirm, `WARNING: Irreversible action.\nRedis database will be upgraded to ${cli.color.configVar(version)}. This cannot be undone.`)
     await cli.action(`Requesting upgrade of ${cli.color.addon(addon.name)} to ${version}`, async function () {
-      let res = await api.request(`/redis/v0/databases/${addon.name}/upgrade`, 'POST', { version: version })
+      let res = await api.request(`/redis/v0/databases/${addon.name}/upgrade`, 'POST', {version: version})
       cli.action.done(res.message)
     }())
-  })
+  }),
 }
 

--- a/packages/redis-v5/commands/wait.js
+++ b/packages/redis-v5/commands/wait.js
@@ -3,12 +3,12 @@
 const cli = require('heroku-cli-util')
 const wait = ms => new Promise(resolve => setTimeout(resolve, ms))
 
-async function run (context, heroku) {
+async function run(context, heroku) {
   const api = require('../lib/shared')(context, heroku)
   const addon = await api.getRedisAddon()
 
   let waitFor = async function waitFor() {
-    let interval = parseInt(context.flags['wait-interval'])
+    let interval = Number.parseInt(context.flags['wait-interval'])
     if (!interval || interval < 0) interval = 5
     let status
     let waiting = false
@@ -16,15 +16,16 @@ async function run (context, heroku) {
     while (true) {
       try {
         status = await api.request(`/redis/v0/databases/${addon.name}/wait`, 'GET')
-      } catch (err) {
-        if (err.statusCode !== 404) throw err
-        status = { 'waiting?': true }
+      } catch (error) {
+        if (error.statusCode !== 404) throw error
+        status = {'waiting?': true}
       }
 
       if (!status['waiting?']) {
         if (waiting) {
           cli.action.done(status.message)
         }
+
         return
       }
 
@@ -47,10 +48,10 @@ module.exports = {
   command: 'wait',
   needsApp: true,
   needsAuth: true,
-  args: [{ name: 'database', optional: true }],
+  args: [{name: 'database', optional: true}],
   description: 'wait for Redis instance to be available',
   flags: [
-    { name: 'wait-interval', description: 'how frequently to poll in seconds', hasValue: true },
+    {name: 'wait-interval', description: 'how frequently to poll in seconds', hasValue: true},
   ],
-  run: cli.command({ preauth: true }, run)
+  run: cli.command({preauth: true}, run),
 }

--- a/packages/redis-v5/index.js
+++ b/packages/redis-v5/index.js
@@ -15,5 +15,5 @@ exports.commands = [
 
 exports.topic = {
   name: 'redis',
-  description: 'manage heroku redis instances'
+  description: 'manage heroku redis instances',
 }

--- a/packages/redis-v5/package.json
+++ b/packages/redis-v5/package.json
@@ -44,7 +44,9 @@
   "main": "index.js",
   "repository": "heroku/cli",
   "scripts": {
+    "lint": "eslint . --ext .js --config ../../.eslintrc --ignore-path ../../.eslintignore",
     "postpublish": "rm oclif.manifest.json",
+    "posttest": "yarn lint",
     "prepack": "oclif manifest",
     "test": "nyc mocha",
     "version": "oclif readme && git add README.md"

--- a/packages/redis-v5/test/commands/cli.js
+++ b/packages/redis-v5/test/commands/cli.js
@@ -1,5 +1,5 @@
 'use strict'
-/* globals describe it beforeEach cli */
+/* globals beforeEach cli */
 
 let nock = require('nock')
 let sinon = require('sinon')
@@ -8,10 +8,13 @@ let expect = require('chai').expect
 let Duplex = require('stream').Duplex
 let EventEmitter = require('events').EventEmitter
 
-let command, net, tls, tunnel
+let command
+let net
+let tls
+let tunnel
 
 describe('heroku redis:cli', function () {
-  let command = proxyquire('../../commands/cli.js', { net: {}, tls: {}, ssh2: {} })
+  let command = proxyquire('../../commands/cli.js', {net: {}, tls: {}, ssh2: {}})
   require('../lib/shared').shouldHandleArgs(command)
 })
 
@@ -24,21 +27,24 @@ describe('heroku redis:cli', function () {
     cli.exit.mock()
 
     class Client extends Duplex {
-      _write (chunk, encoding, callback) { }
-      _read (size) { this.emit('end') }
+      _write(chunk, encoding, callback) {}
+      _read(size) {
+        this.emit('end')
+      }
     }
 
     net = {
-      connect: sinon.stub().returns(new Client())
+      connect: sinon.stub().returns(new Client()),
     }
 
     tls = {
-      connect: sinon.stub().returns(new Client())
+      connect: sinon.stub().returns(new Client()),
     }
 
     class Tunnel extends EventEmitter {
-      constructor () {
+      constructor() {
         super()
+        // eslint-disable-next-line unicorn/no-this-assignment
         tunnel = this
         this.forwardOut = sinon.stub().yields(null, new Client())
         this.connect = sinon.stub().callsFake(() => {
@@ -48,140 +54,141 @@ describe('heroku redis:cli', function () {
       }
     }
 
-    let ssh2 = { Client: Tunnel }
+    let ssh2 = {Client: Tunnel}
 
-    command = proxyquire('../../commands/cli.js', { net, tls, ssh2 })
+    command = proxyquire('../../commands/cli.js', {net, tls, ssh2})
   })
 
   it('# for hobby it uses net.connect', function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        {
-          id: addonId,
-          name: 'redis-haiku',
-          addon_service: { name: 'heroku-redis' },
-          config_vars: ['REDIS_FOO', 'REDIS_BAR'],
-          billing_entity: {
-            id: appId,
-            name: 'example'
-          }
-        }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {
+        id: addonId,
+        name: 'redis-haiku',
+        addon_service: {name: 'heroku-redis'},
+        config_vars: ['REDIS_FOO', 'REDIS_BAR'],
+        billing_entity: {
+          id: appId,
+          name: 'example',
+        },
+      },
+    ])
 
     let configVars = nock('https://api.heroku.com:443')
-      .get('/apps/example/config-vars').reply(200, { 'FOO': 'BAR' })
+    .get('/apps/example/config-vars').reply(200, {FOO: 'BAR'})
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .get('/redis/v0/databases/redis-haiku').reply(200, {
-        resource_url: 'redis://foobar:password@example.com:8649',
-        plan: 'hobby'
-      })
-    return command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => configVars.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_FOO, REDIS_BAR):\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(net.connect.called).to.equal(true))
+    .get('/redis/v0/databases/redis-haiku').reply(200, {
+      resource_url: 'redis://foobar:password@example.com:8649',
+      plan: 'hobby',
+    })
+    return command.run({app: 'example', flags: {confirm: 'example'}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => configVars.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_FOO, REDIS_BAR):\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
+    .then(() => expect(net.connect.called).to.equal(true))
   })
 
   it('# for hobby it uses TLS if prefer_native_tls', function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        {
-          id: addonId,
-          name: 'redis-haiku',
-          addon_service: { name: 'heroku-redis' },
-          config_vars: ['REDIS_FOO', 'REDIS_BAR', 'REDIS_TLS_URL'],
-          billing_entity: {
-            id: appId,
-            name: 'example'
-          }
-        }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {
+        id: addonId,
+        name: 'redis-haiku',
+        addon_service: {name: 'heroku-redis'},
+        config_vars: ['REDIS_FOO', 'REDIS_BAR', 'REDIS_TLS_URL'],
+        billing_entity: {
+          id: appId,
+          name: 'example',
+        },
+      },
+    ])
 
     let configVars = nock('https://api.heroku.com:443')
-      .get('/apps/example/config-vars').reply(200, { 'REDIS_TLS_URL': 'rediss://foobar:password@example.com:8649' })
+    .get('/apps/example/config-vars').reply(200, {REDIS_TLS_URL: 'rediss://foobar:password@example.com:8649'})
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .get('/redis/v0/databases/redis-haiku').reply(200, {
-        resource_url: 'redis://foobar:password@example.com:8649',
-        plan: 'hobby',
-        prefer_native_tls: true
-      })
-    return command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => configVars.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_FOO, REDIS_BAR, REDIS_TLS_URL):\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(tls.connect.called).to.equal(true))
+    .get('/redis/v0/databases/redis-haiku').reply(200, {
+      resource_url: 'redis://foobar:password@example.com:8649',
+      plan: 'hobby',
+      prefer_native_tls: true,
+    })
+    return command.run({app: 'example', flags: {confirm: 'example'}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => configVars.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_FOO, REDIS_BAR, REDIS_TLS_URL):\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
+    .then(() => expect(tls.connect.called).to.equal(true))
   })
 
   it('# for premium it uses tls.connect', function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        {
-          id: addonId,
-          name: 'redis-haiku',
-          addon_service: { name: 'heroku-redis' },
-          config_vars: ['REDIS_FOO', 'REDIS_BAR'],
-          billing_entity: {
-            id: appId,
-            name: 'example'
-          }
-        }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {
+        id: addonId,
+        name: 'redis-haiku',
+        addon_service: {name: 'heroku-redis'},
+        config_vars: ['REDIS_FOO', 'REDIS_BAR'],
+        billing_entity: {
+          id: appId,
+          name: 'example',
+        },
+      },
+    ])
 
     let configVars = nock('https://api.heroku.com:443')
-      .get('/apps/example/config-vars').reply(200, { 'FOO': 'BAR' })
+    .get('/apps/example/config-vars').reply(200, {FOO: 'BAR'})
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .get('/redis/v0/databases/redis-haiku').reply(200, {
-        resource_url: 'redis://foobar:password@example.com:8649',
-        plan: 'premium-0'
-      })
+    .get('/redis/v0/databases/redis-haiku').reply(200, {
+      resource_url: 'redis://foobar:password@example.com:8649',
+      plan: 'premium-0',
+    })
 
-    return command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => configVars.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_FOO, REDIS_BAR):\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(tls.connect.called).to.equal(true))
+    return command.run({app: 'example', flags: {confirm: 'example'}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => configVars.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_FOO, REDIS_BAR):\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
+    .then(() => expect(tls.connect.called).to.equal(true))
   })
 
   it('# exits with an error with shield databases', async function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        {
-          id: addonId,
-          name: 'redis-haiku',
-          addon_service: { name: 'heroku-redis' },
-          config_vars: ['REDIS_FOO', 'REDIS_BAR'],
-          billing_entity: {
-            id: appId,
-            name: 'example'
-          }
-        }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {
+        id: addonId,
+        name: 'redis-haiku',
+        addon_service: {name: 'heroku-redis'},
+        config_vars: ['REDIS_FOO', 'REDIS_BAR'],
+        billing_entity: {
+          id: appId,
+          name: 'example',
+        },
+      },
+    ])
 
     let configVars = nock('https://api.heroku.com:443')
-      .get('/apps/example/config-vars').reply(200, { 'FOO': 'BAR' })
+    .get('/apps/example/config-vars').reply(200, {FOO: 'BAR'})
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .get('/redis/v0/databases/redis-haiku').reply(200, {
-        resource_url: 'redis://foobar:password@example.com:8649',
-        plan: 'shield-9'
-      })
+    .get('/redis/v0/databases/redis-haiku').reply(200, {
+      resource_url: 'redis://foobar:password@example.com:8649',
+      plan: 'shield-9',
+    })
 
     try {
-      await command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
+      await command.run({app: 'example', flags: {confirm: 'example'}, args: {}, auth: {username: 'foobar', password: 'password'}})
       expect(true, 'cli command should fail!').to.equal(false)
-    } catch (err) {
-      expect(err).to.be.an.instanceof(cli.exit.ErrorExit)
-      expect(err.code).to.equal(1)
+    } catch (error) {
+      expect(error).to.be.an.instanceof(cli.exit.ErrorExit)
+      expect(error.code).to.equal(1)
     }
+
     await app.done()
     await redis.done()
     await configVars.done()
@@ -190,109 +197,109 @@ describe('heroku redis:cli', function () {
 
   it('# for bastion it uses tunnel.connect', function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        {
-          id: addonId,
-          name: 'redis-haiku',
-          addon_service: { name: 'heroku-redis' },
-          config_vars: ['REDIS_URL', 'REDIS_BASTIONS', 'REDIS_BASTION_KEY', 'REDIS_BASTION_REKEYS_AFTER'],
-          billing_entity: {
-            id: appId,
-            name: 'example'
-          }
-        }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {
+        id: addonId,
+        name: 'redis-haiku',
+        addon_service: {name: 'heroku-redis'},
+        config_vars: ['REDIS_URL', 'REDIS_BASTIONS', 'REDIS_BASTION_KEY', 'REDIS_BASTION_REKEYS_AFTER'],
+        billing_entity: {
+          id: appId,
+          name: 'example',
+        },
+      },
+    ])
 
     let configVars = nock('https://api.heroku.com:443')
-      .get('/apps/example/config-vars').reply(200, { 'REDIS_BASTIONS': 'example.com' })
+    .get('/apps/example/config-vars').reply(200, {REDIS_BASTIONS: 'example.com'})
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .get('/redis/v0/databases/redis-haiku').reply(200, {
-        resource_url: 'redis://foobar:password@example.com:8649',
-        plan: 'premium-0'
-      })
+    .get('/redis/v0/databases/redis-haiku').reply(200, {
+      resource_url: 'redis://foobar:password@example.com:8649',
+      plan: 'premium-0',
+    })
 
-    return command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => configVars.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_URL):\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
+    return command.run({app: 'example', flags: {confirm: 'example'}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => configVars.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_URL):\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
   })
 
   it('# for private spaces bastion with prefer_native_tls, it uses tls.connect', function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        { id: addonId,
-          name: 'redis-haiku',
-          addon_service: { name: 'heroku-redis' },
-          config_vars: ['REDIS_URL', 'REDIS_BASTIONS', 'REDIS_BASTION_KEY', 'REDIS_BASTION_REKEYS_AFTER'],
-          billing_entity: {
-            id: appId,
-            name: 'example'
-          }
-        }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {id: addonId,
+        name: 'redis-haiku',
+        addon_service: {name: 'heroku-redis'},
+        config_vars: ['REDIS_URL', 'REDIS_BASTIONS', 'REDIS_BASTION_KEY', 'REDIS_BASTION_REKEYS_AFTER'],
+        billing_entity: {
+          id: appId,
+          name: 'example',
+        },
+      },
+    ])
 
     let configVars = nock('https://api.heroku.com:443')
-      .get('/apps/example/config-vars').reply(200, { 'REDIS_BASTIONS': 'example.com' })
+    .get('/apps/example/config-vars').reply(200, {REDIS_BASTIONS: 'example.com'})
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .get('/redis/v0/databases/redis-haiku').reply(200, {
-        resource_url: 'redis://foobar:password@example.com:8649',
-        plan: 'private-7',
-        prefer_native_tls: true
-      })
+    .get('/redis/v0/databases/redis-haiku').reply(200, {
+      resource_url: 'redis://foobar:password@example.com:8649',
+      plan: 'private-7',
+      prefer_native_tls: true,
+    })
 
-    return command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => configVars.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_URL):\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
-      .then(() => expect(tls.connect.called).to.equal(true))
+    return command.run({app: 'example', flags: {confirm: 'example'}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => configVars.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal('Connecting to redis-haiku (REDIS_URL):\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
+    .then(() => expect(tls.connect.called).to.equal(true))
   })
 
   it('# selects correct connection information when multiple redises are present across multiple apps', async () => {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        {
-          id: addonId,
-          name: 'redis-haiku',
-          addon_service: { name: 'heroku-redis' },
-          config_vars: ['REDIS_URL', 'REDIS_BASTIONS', 'REDIS_BASTION_KEY', 'REDIS_BASTION_REKEYS_AFTER'],
-          billing_entity: {
-            id: appId,
-            name: 'example'
-          }
+    .get('/apps/example/addons').reply(200, [
+      {
+        id: addonId,
+        name: 'redis-haiku',
+        addon_service: {name: 'heroku-redis'},
+        config_vars: ['REDIS_URL', 'REDIS_BASTIONS', 'REDIS_BASTION_KEY', 'REDIS_BASTION_REKEYS_AFTER'],
+        billing_entity: {
+          id: appId,
+          name: 'example',
         },
-        {
-          id: 'heroku-redis-addon-id-2',
-          name: 'redis-sonnet',
-          addon_service: { name: 'heroku-redis' },
-          config_vars: ['REDIS_6_URL', 'REDIS_6_BASTIONS', 'REDIS_6_BASTION_KEY', 'REDIS_6_BASTION_REKEYS_AFTER'],
-          billing_entity: {
-            id: 'app-2-id',
-            name: 'example-app-2'
-          }
-        }
-      ])
+      },
+      {
+        id: 'heroku-redis-addon-id-2',
+        name: 'redis-sonnet',
+        addon_service: {name: 'heroku-redis'},
+        config_vars: ['REDIS_6_URL', 'REDIS_6_BASTIONS', 'REDIS_6_BASTION_KEY', 'REDIS_6_BASTION_REKEYS_AFTER'],
+        billing_entity: {
+          id: 'app-2-id',
+          name: 'example-app-2',
+        },
+      },
+    ])
 
     let configVars = nock('https://api.heroku.com:443')
-      .get('/apps/example-app-2/config-vars').reply(200, {
-        'REDIS_6_URL': 'redis-user@redis6-example.com',
-        'REDIS_6_BASTIONS': 'redis-6-bastion.example.com',
-        'REDIS_6_BASTION_KEY': 'key2'
-      })
+    .get('/apps/example-app-2/config-vars').reply(200, {
+      REDIS_6_URL: 'redis-user@redis6-example.com',
+      REDIS_6_BASTIONS: 'redis-6-bastion.example.com',
+      REDIS_6_BASTION_KEY: 'key2',
+    })
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .get('/redis/v0/databases/redis-sonnet').reply(200, {
-        resource_url: 'redis://foobar:password@redis-6.example.com:8649',
-        plan: 'private-7',
-        prefer_native_tls: true
-      })
+    .get('/redis/v0/databases/redis-sonnet').reply(200, {
+      resource_url: 'redis://foobar:password@redis-6.example.com:8649',
+      plan: 'private-7',
+      prefer_native_tls: true,
+    })
 
-    await command.run({ app: 'example', flags: { confirm: 'example' }, args: { database: 'redis-sonnet' }, auth: { username: 'foobar', password: 'password' } })
+    await command.run({app: 'example', flags: {confirm: 'example'}, args: {database: 'redis-sonnet'}, auth: {username: 'foobar', password: 'password'}})
     app.done()
     configVars.done()
     redis.done()
@@ -305,7 +312,7 @@ describe('heroku redis:cli', function () {
     expect(connectArgs[0]).to.deep.equal({
       host: 'redis-6-bastion.example.com',
       privateKey: 'key2',
-      username: 'bastion'
+      username: 'bastion',
     })
 
     const tunnelArgs = tunnel.forwardOut.args[0]
@@ -318,13 +325,13 @@ describe('heroku redis:cli', function () {
     const tlsConnectArgs = tls.connect.args[0]
     expect(tlsConnectArgs).to.have.length(1)
     const tlsConnectOptions = {
-      ...tlsConnectArgs[0]
+      ...tlsConnectArgs[0],
     }
     delete tlsConnectOptions.socket
     expect(tlsConnectOptions).to.deep.equal({
       port: 8649,
       host: 'redis-6.example.com',
-      rejectUnauthorized: false
+      rejectUnauthorized: false,
     })
   })
 })

--- a/packages/redis-v5/test/commands/credentials.js
+++ b/packages/redis-v5/test/commands/credentials.js
@@ -1,5 +1,5 @@
 'use strict'
-/* globals describe it beforeEach cli */
+/* globals beforeEach cli */
 
 let nock = require('nock')
 let expect = require('chai').expect
@@ -18,36 +18,36 @@ describe('heroku redis:credentials', function () {
 
   it('# displays the redis credentials', function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']},
+    ])
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .get('/redis/v0/databases/redis-haiku').reply(200, {
-        info: [{ name: 'Foo', values: ['Bar', 'Biz'] }],
-        resource_url: 'redis://foobar:password@hostname:8649'
-      })
+    .get('/redis/v0/databases/redis-haiku').reply(200, {
+      info: [{name: 'Foo', values: ['Bar', 'Biz']}],
+      resource_url: 'redis://foobar:password@hostname:8649',
+    })
 
-    return command.run({ app: 'example', flags: {}, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('redis://foobar:password@hostname:8649\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
+    return command.run({app: 'example', flags: {}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal('redis://foobar:password@hostname:8649\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
   })
 
   it('# resets the redis credentials', function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']},
+    ])
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .post('/redis/v0/databases/redis-haiku/credentials_rotation').reply(200, {})
+    .post('/redis/v0/databases/redis-haiku/credentials_rotation').reply(200, {})
 
-    return command.run({ app: 'example', flags: { reset: true }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('Resetting credentials for redis-haiku\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
+    return command.run({app: 'example', flags: {reset: true}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal('Resetting credentials for redis-haiku\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
   })
 })

--- a/packages/redis-v5/test/commands/info.js
+++ b/packages/redis-v5/test/commands/info.js
@@ -1,16 +1,16 @@
 'use strict'
-/* globals describe it beforeEach cli */
+/* globals beforeEach cli */
 
 let expect = require('chai').expect
 let nock = require('nock')
 
 let commands = [
-  { txt: ':info', command: require('../../commands/info') },
-  { txt: '', command: require('../../commands/index') },
+  {txt: ':info', command: require('../../commands/info')},
+  {txt: '', command: require('../../commands/index')},
 ]
 
-commands.forEach((cmd) => {
-  let { txt, command } = cmd
+commands.forEach(cmd => {
+  let {txt, command} = cmd
   describe(`heroku redis${txt}`, function () {
     beforeEach(function () {
       cli.mockConsole()
@@ -21,56 +21,56 @@ commands.forEach((cmd) => {
       let app = nock('https://api.heroku.com:443').get('/apps/example/addons').reply(200, [])
 
       return command
-        .run({ app: 'example', args: {}, flags: {} })
-        .then(() => app.done())
-        .then(() => expect(cli.stdout).to.equal(''))
-        .then(() => expect(cli.stderr).to.equal(''))
+      .run({app: 'example', args: {}, flags: {}})
+      .then(() => app.done())
+      .then(() => expect(cli.stdout).to.equal(''))
+      .then(() => expect(cli.stderr).to.equal(''))
     })
 
     it('# prints out redis info', function () {
       let app = nock('https://api.heroku.com:443')
-        .get('/apps/example/addons')
-        .reply(200, [
-          { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] },
-        ])
+      .get('/apps/example/addons')
+      .reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']},
+      ])
 
       let redis = nock('https://redis-api.heroku.com:443')
-        .get('/redis/v0/databases/redis-haiku')
-        .reply(200, { info: [{ name: 'Foo', values: ['Bar', 'Biz'] }] })
+      .get('/redis/v0/databases/redis-haiku')
+      .reply(200, {info: [{name: 'Foo', values: ['Bar', 'Biz']}]})
 
       return command
-        .run({ app: 'example', args: {}, flags: {}, auth: { username: 'foobar', password: 'password' } })
-        .then(() => app.done())
-        .then(() => redis.done())
-        .then(() =>
-          expect(cli.stdout).to.equal(
-            `=== redis-haiku (REDIS_FOO, REDIS_BAR)
+      .run({app: 'example', args: {}, flags: {}, auth: {username: 'foobar', password: 'password'}})
+      .then(() => app.done())
+      .then(() => redis.done())
+      .then(() =>
+        expect(cli.stdout).to.equal(
+          `=== redis-haiku (REDIS_FOO, REDIS_BAR)
 Foo: Bar
      Biz
 `,
-          ),
-        )
-        .then(() => expect(cli.stderr).to.equal(''))
+        ),
+      )
+      .then(() => expect(cli.stderr).to.equal(''))
     })
 
     it('# prints out JSON-formatted redis info', function () {
       let app = nock('https://api.heroku.com:443')
-        .get('/apps/example/addons')
-        .reply(200, [
-          { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] },
-        ])
+      .get('/apps/example/addons')
+      .reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']},
+      ])
 
       let redis = nock('https://redis-api.heroku.com:443')
-        .get('/redis/v0/databases/redis-haiku')
-        .reply(200, { info: [{ name: 'Foo', values: ['Bar', 'Biz'] }] })
+      .get('/redis/v0/databases/redis-haiku')
+      .reply(200, {info: [{name: 'Foo', values: ['Bar', 'Biz']}]})
 
       return command
-        .run({ app: 'example', args: {}, flags: { json: true }, auth: { username: 'foobar', password: 'password' } })
-        .then(() => app.done())
-        .then(() => redis.done())
-        .then(() =>
-          expect(cli.stdout).to.equal(
-            `[
+      .run({app: 'example', args: {}, flags: {json: true}, auth: {username: 'foobar', password: 'password'}})
+      .then(() => app.done())
+      .then(() => redis.done())
+      .then(() =>
+        expect(cli.stdout).to.equal(
+          `[
   {
     "info": [
       {
@@ -88,39 +88,39 @@ Foo: Bar
   }
 ]
 `,
-          ),
-        )
-        .then(() => expect(cli.stderr).to.equal(''))
+        ),
+      )
+      .then(() => expect(cli.stderr).to.equal(''))
     })
 
     it('# prints out redis info when not found', function () {
       let app = nock('https://api.heroku.com:443')
-        .get('/apps/example/addons')
-        .reply(200, [
-          { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] },
-        ])
+      .get('/apps/example/addons')
+      .reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']},
+      ])
 
       let redis = nock('https://redis-api.heroku.com:443').get('/redis/v0/databases/redis-haiku').reply(404, {})
 
       return command
-        .run({ app: 'example', args: {}, flags: {}, auth: { username: 'foobar', password: 'password' } })
-        .then(() => app.done())
-        .then(() => redis.done())
-        .then(() => expect(cli.stdout).to.equal(''))
-        .then(() => expect(cli.stderr).to.equal(''))
+      .run({app: 'example', args: {}, flags: {}, auth: {username: 'foobar', password: 'password'}})
+      .then(() => app.done())
+      .then(() => redis.done())
+      .then(() => expect(cli.stdout).to.equal(''))
+      .then(() => expect(cli.stderr).to.equal(''))
     })
 
     it('# prints out redis info when error', function () {
       nock('https://api.heroku.com:443')
-        .get('/apps/example/addons')
-        .reply(200, [
-          { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] },
-        ])
+      .get('/apps/example/addons')
+      .reply(200, [
+        {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']},
+      ])
 
       nock('https://redis-api.heroku.com:443').get('/redis/v0/databases/redis-haiku').reply(503, {})
 
       return expect(
-        command.run({ app: 'example', args: {}, flags: {}, auth: { username: 'foobar', password: 'password' } }),
+        command.run({app: 'example', args: {}, flags: {}, auth: {username: 'foobar', password: 'password'}}),
       ).to.be.rejectedWith(/Expected response to be successful, got 503/)
     })
   })

--- a/packages/redis-v5/test/commands/keyspace-notifications.js
+++ b/packages/redis-v5/test/commands/keyspace-notifications.js
@@ -1,5 +1,5 @@
 'use strict'
-/* globals describe it beforeEach cli */
+/* globals beforeEach cli */
 
 let expect = require('chai').expect
 let nock = require('nock')
@@ -9,7 +9,7 @@ let command = require('../../commands/keyspace-notifications')
 const unwrap = require('../unwrap')
 
 describe('heroku redis:keyspace-notifications', function () {
-  require('../lib/shared').shouldHandleArgs(command, { config: 'AKE' })
+  require('../lib/shared').shouldHandleArgs(command, {config: 'AKE'})
 })
 
 describe('heroku redis:keyspace-notifications', function () {
@@ -21,27 +21,27 @@ describe('heroku redis:keyspace-notifications', function () {
 
   it('# sets the keyspace notify events', function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']},
+    ])
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .patch('/redis/v0/databases/redis-haiku/config', { notify_keyspace_events: 'AKE' }).reply(200, {
-        notify_keyspace_events: { value: 'AKE', values: { 'AKE': '' } }
-      })
+    .patch('/redis/v0/databases/redis-haiku/config', {notify_keyspace_events: 'AKE'}).reply(200, {
+      notify_keyspace_events: {value: 'AKE', values: {AKE: ''}},
+    })
 
-    return command.run({ app: 'example', flags: { config: 'AKE' }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal(
-        `Keyspace notifications for redis-haiku (REDIS_FOO, REDIS_BAR) set to 'AKE'.\n`
-      ))
-      .then(() => expect(cli.stderr).to.equal(''))
+    return command.run({app: 'example', flags: {config: 'AKE'}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal(
+      'Keyspace notifications for redis-haiku (REDIS_FOO, REDIS_BAR) set to \'AKE\'.\n',
+    ))
+    .then(() => expect(cli.stderr).to.equal(''))
   })
 
   it('# errors on missing eviction policy', function () {
-    return expect(command.run({ app: 'example', flags: {}, args: {} })).to.be.rejectedWith(exit.ErrorExit)
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(unwrap(cli.stderr)).to.equal('Please specify a valid keyspace notification configuration.\n'))
+    return expect(command.run({app: 'example', flags: {}, args: {}})).to.be.rejectedWith(exit.ErrorExit)
+    .then(() => expect(cli.stdout).to.equal(''))
+    .then(() => expect(unwrap(cli.stderr)).to.equal('Please specify a valid keyspace notification configuration.\n'))
   })
 })

--- a/packages/redis-v5/test/commands/maintenance.js
+++ b/packages/redis-v5/test/commands/maintenance.js
@@ -1,5 +1,5 @@
 'use strict'
-/* globals describe it beforeEach cli */
+/* globals beforeEach cli */
 
 let expect = require('chai').expect
 let nock = require('nock')
@@ -21,94 +21,94 @@ describe('heroku redis:maintenance', function () {
 
   it('# shows the maintenance message', function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, plan: { name: 'premium-0' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, plan: {name: 'premium-0'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']},
+    ])
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .get('/redis/v0/databases/redis-haiku/maintenance').reply(200, { message: 'Message' })
+    .get('/redis/v0/databases/redis-haiku/maintenance').reply(200, {message: 'Message'})
 
-    return command.run({ app: 'example', args: {}, flags: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('Message\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
+    return command.run({app: 'example', args: {}, flags: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal('Message\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
   })
 
   it('# sets the maintenance window', function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, plan: { name: 'premium-0' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, plan: {name: 'premium-0'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']},
+    ])
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .put('/redis/v0/databases/redis-haiku/maintenance_window', {
-        description: 'Mon 10:00'
-      }).reply(200, { window: 'Mon 10:00' })
+    .put('/redis/v0/databases/redis-haiku/maintenance_window', {
+      description: 'Mon 10:00',
+    }).reply(200, {window: 'Mon 10:00'})
 
-    return expect(command.run({ app: 'example', args: {}, flags: { window: 'Mon 10:00' }, auth: { username: 'foobar', password: 'password' } })).to.be.rejectedWith(exit.ErrorExit)
-      .then(() => app.done())
-      .then(() => redis.done)
-      .then(() => expect(cli.stdout).to.equal('Maintenance window for redis-haiku (REDIS_FOO, REDIS_BAR) set to Mon 10:00.\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
+    return expect(command.run({app: 'example', args: {}, flags: {window: 'Mon 10:00'}, auth: {username: 'foobar', password: 'password'}})).to.be.rejectedWith(exit.ErrorExit)
+    .then(() => app.done())
+    .then(() => redis.done)
+    .then(() => expect(cli.stdout).to.equal('Maintenance window for redis-haiku (REDIS_FOO, REDIS_BAR) set to Mon 10:00.\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
   })
 
   it('# runs the maintenance', function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, plan: { name: 'premium-0' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, plan: {name: 'premium-0'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']},
+    ])
 
     let appInfo = nock('https://api.heroku.com:443')
-      .get('/apps/example').reply(200, { maintenance: true })
+    .get('/apps/example').reply(200, {maintenance: true})
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .post('/redis/v0/databases/redis-haiku/maintenance').reply(200, { message: 'Message' })
+    .post('/redis/v0/databases/redis-haiku/maintenance').reply(200, {message: 'Message'})
 
-    return expect(command.run({ app: 'example', args: {}, flags: { run: true }, auth: { username: 'foobar', password: 'password' } })).to.be.rejectedWith(exit.ErrorExit)
-      .then(() => app.done())
-      .then(() => appInfo.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('Message\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
+    return expect(command.run({app: 'example', args: {}, flags: {run: true}, auth: {username: 'foobar', password: 'password'}})).to.be.rejectedWith(exit.ErrorExit)
+    .then(() => app.done())
+    .then(() => appInfo.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal('Message\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
   })
 
   it('# run errors out when not in maintenance', function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, plan: { name: 'premium-0' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, plan: {name: 'premium-0'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']},
+    ])
 
     let appInfo = nock('https://api.heroku.com:443')
-      .get('/apps/example').reply(200, { maintenance: false })
+    .get('/apps/example').reply(200, {maintenance: false})
 
-    return expect(command.run({ app: 'example', args: {}, flags: { run: true }, auth: { username: 'foobar', password: 'password' } })).to.be.rejectedWith(exit.ErrorExit)
-      .then(() => app.done())
-      .then(() => appInfo.done())
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(unwrap(cli.stderr)).to.equal('Application must be in maintenance mode or --force flag must be used\n'))
+    return expect(command.run({app: 'example', args: {}, flags: {run: true}, auth: {username: 'foobar', password: 'password'}})).to.be.rejectedWith(exit.ErrorExit)
+    .then(() => app.done())
+    .then(() => appInfo.done())
+    .then(() => expect(cli.stdout).to.equal(''))
+    .then(() => expect(unwrap(cli.stderr)).to.equal('Application must be in maintenance mode or --force flag must be used\n'))
   })
 
   it('# errors out on hobby dynos', function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, plan: { name: 'hobby' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, plan: {name: 'hobby'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']},
+    ])
 
-    return expect(command.run({ app: 'example', args: {}, auth: { username: 'foobar', password: 'password' } })).to.be.rejected
-      .then(() => expect(unwrap(cli.stderr)).to.equal('redis:maintenance is not available for hobby-dev instances\n'))
-      .then(() => app.done())
+    return expect(command.run({app: 'example', args: {}, auth: {username: 'foobar', password: 'password'}})).to.be.rejected
+    .then(() => expect(unwrap(cli.stderr)).to.equal('redis:maintenance is not available for hobby-dev instances\n'))
+    .then(() => app.done())
   })
 
   it('# errors out on bad maintenance window', function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, plan: { name: 'premium-0' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, plan: {name: 'premium-0'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']},
+    ])
 
-    return expect(command.run({ app: 'example', args: {}, flags: { window: 'Mon 10:45' }, auth: { username: 'foobar', password: 'password' } })).to.be.rejected
-      .then(() => app.done())
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(unwrap(cli.stderr)).to.equal('Maintenance windows must be "Day HH:MM", where MM is 00 or 30.\n'))
+    return expect(command.run({app: 'example', args: {}, flags: {window: 'Mon 10:45'}, auth: {username: 'foobar', password: 'password'}})).to.be.rejected
+    .then(() => app.done())
+    .then(() => expect(cli.stdout).to.equal(''))
+    .then(() => expect(unwrap(cli.stderr)).to.equal('Maintenance windows must be "Day HH:MM", where MM is 00 or 30.\n'))
   })
 })

--- a/packages/redis-v5/test/commands/maxmemory.js
+++ b/packages/redis-v5/test/commands/maxmemory.js
@@ -1,5 +1,5 @@
 'use strict'
-/* globals describe it beforeEach cli */
+/* globals beforeEach cli */
 
 let expect = require('chai').expect
 let nock = require('nock')
@@ -9,7 +9,7 @@ let command = require('../../commands/maxmemory')
 const unwrap = require('../unwrap')
 
 describe('heroku redis:maxmemory', function () {
-  require('../lib/shared').shouldHandleArgs(command, { policy: 'noeviction' })
+  require('../lib/shared').shouldHandleArgs(command, {policy: 'noeviction'})
 })
 
 describe('heroku redis:maxmemory', function () {
@@ -21,29 +21,29 @@ describe('heroku redis:maxmemory', function () {
 
   it('# sets the key eviction policy', function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']},
+    ])
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .patch('/redis/v0/databases/redis-haiku/config', { maxmemory_policy: 'noeviction' }).reply(200, {
-        maxmemory_policy: { value: 'noeviction', values: { 'noeviction': 'return errors when memory limit is reached' } }
-      })
+    .patch('/redis/v0/databases/redis-haiku/config', {maxmemory_policy: 'noeviction'}).reply(200, {
+      maxmemory_policy: {value: 'noeviction', values: {noeviction: 'return errors when memory limit is reached'}},
+    })
 
-    return command.run({ app: 'example', flags: { policy: 'noeviction' }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal(
-        `Maxmemory policy for redis-haiku (REDIS_FOO, REDIS_BAR) set to noeviction.
+    return command.run({app: 'example', flags: {policy: 'noeviction'}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal(
+      `Maxmemory policy for redis-haiku (REDIS_FOO, REDIS_BAR) set to noeviction.
 noeviction return errors when memory limit is reached.
-`
-      ))
-      .then(() => expect(cli.stderr).to.equal(''))
+`,
+    ))
+    .then(() => expect(cli.stderr).to.equal(''))
   })
 
   it('# errors on missing eviction policy', function () {
-    return expect(command.run({ app: 'example', flags: {}, args: {} })).to.be.rejectedWith(exit.ErrorExit)
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(unwrap(cli.stderr)).to.equal('Please specify a valid maxmemory eviction policy.\n'))
+    return expect(command.run({app: 'example', flags: {}, args: {}})).to.be.rejectedWith(exit.ErrorExit)
+    .then(() => expect(cli.stdout).to.equal(''))
+    .then(() => expect(unwrap(cli.stderr)).to.equal('Please specify a valid maxmemory eviction policy.\n'))
   })
 })

--- a/packages/redis-v5/test/commands/promote.js
+++ b/packages/redis-v5/test/commands/promote.js
@@ -1,5 +1,5 @@
 'use strict'
-/* globals describe it beforeEach cli */
+/* globals beforeEach cli */
 
 let nock = require('nock')
 let expect = require('chai').expect
@@ -18,62 +18,62 @@ describe('heroku redis:promote', function () {
 
   it('# promotes', function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        { name: 'redis-silver-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_URL', 'HEROKU_REDIS_SILVER_URL'] },
-        { name: 'redis-gold-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['HEROKU_REDIS_GOLD_URL'] }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {name: 'redis-silver-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_URL', 'HEROKU_REDIS_SILVER_URL']},
+      {name: 'redis-gold-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['HEROKU_REDIS_GOLD_URL']},
+    ])
 
     let attach = nock('https://api.heroku.com:443')
-      .post('/addon-attachments', {
-        'app': { 'name': 'example' },
-        'addon': { 'name': 'redis-gold-haiku' },
-        'confirm': 'example',
-        'name': 'REDIS'
-      }).reply(200, {})
+    .post('/addon-attachments', {
+      app: {name: 'example'},
+      addon: {name: 'redis-gold-haiku'},
+      confirm: 'example',
+      name: 'REDIS',
+    }).reply(200, {})
 
-    return command.run({ app: 'example', flags: {}, args: { database: 'redis-gold-haiku' }, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => attach.done())
-      .then(() => expect(cli.stdout).to.equal('Promoting redis-gold-haiku to REDIS_URL on example\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
+    return command.run({app: 'example', flags: {}, args: {database: 'redis-gold-haiku'}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => attach.done())
+    .then(() => expect(cli.stdout).to.equal('Promoting redis-gold-haiku to REDIS_URL on example\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
   })
 
   it('# promotes and replaces attachment of existing REDIS_URL if necessary', function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        {
-          name: 'redis-silver-haiku',
-          addon_service: { name: 'heroku-redis' },
-          config_vars: [
-            'REDIS_URL',
-            'REDIS_BASTIONS',
-            'REDIS_BASTION_KEY',
-            'REDIS_BASTION_REKEYS_AFTER'
-          ]
-        },
-        { name: 'redis-gold-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['HEROKU_REDIS_GOLD_URL'] }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {
+        name: 'redis-silver-haiku',
+        addon_service: {name: 'heroku-redis'},
+        config_vars: [
+          'REDIS_URL',
+          'REDIS_BASTIONS',
+          'REDIS_BASTION_KEY',
+          'REDIS_BASTION_REKEYS_AFTER',
+        ],
+      },
+      {name: 'redis-gold-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['HEROKU_REDIS_GOLD_URL']},
+    ])
 
     let attachRedisUrl = nock('https://api.heroku.com:443')
-      .post('/addon-attachments', {
-        'app': { 'name': 'example' },
-        'addon': { 'name': 'redis-silver-haiku' },
-        'confirm': 'example'
-      }).reply(200, {})
+    .post('/addon-attachments', {
+      app: {name: 'example'},
+      addon: {name: 'redis-silver-haiku'},
+      confirm: 'example',
+    }).reply(200, {})
 
     let attach = nock('https://api.heroku.com:443')
-      .post('/addon-attachments', {
-        'app': { 'name': 'example' },
-        'addon': { 'name': 'redis-gold-haiku' },
-        'confirm': 'example',
-        'name': 'REDIS'
-      }).reply(200, {})
+    .post('/addon-attachments', {
+      app: {name: 'example'},
+      addon: {name: 'redis-gold-haiku'},
+      confirm: 'example',
+      name: 'REDIS',
+    }).reply(200, {})
 
-    return command.run({ app: 'example', flags: {}, args: { database: 'redis-gold-haiku' }, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => attachRedisUrl.done())
-      .then(() => attach.done())
-      .then(() => expect(cli.stdout).to.equal('Promoting redis-gold-haiku to REDIS_URL on example\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
+    return command.run({app: 'example', flags: {}, args: {database: 'redis-gold-haiku'}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => attachRedisUrl.done())
+    .then(() => attach.done())
+    .then(() => expect(cli.stdout).to.equal('Promoting redis-gold-haiku to REDIS_URL on example\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
   })
 })

--- a/packages/redis-v5/test/commands/stats-reset.js
+++ b/packages/redis-v5/test/commands/stats-reset.js
@@ -1,5 +1,5 @@
 'use strict'
-/* globals describe it beforeEach cli */
+/* globals beforeEach cli */
 
 let expect = require('chai').expect
 let nock = require('nock')
@@ -16,19 +16,19 @@ describe('heroku redis:stats-reset', () => {
 
   it('# resets the stats of the addon', () => {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_URL'] }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_URL']},
+    ])
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .post('/redis/v0/databases/redis-haiku/stats/reset').reply(200, {
-        message: 'Stats reset successful.'
-      })
+    .post('/redis/v0/databases/redis-haiku/stats/reset').reply(200, {
+      message: 'Stats reset successful.',
+    })
 
-    return command.run({ app: 'example', flags: { confirm: 'example' }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal('Stats reset successful.\n'))
-      .then(() => expect(cli.stderr).to.equal(''))
+    return command.run({app: 'example', flags: {confirm: 'example'}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal('Stats reset successful.\n'))
+    .then(() => expect(cli.stderr).to.equal(''))
   })
 })

--- a/packages/redis-v5/test/commands/timeout.js
+++ b/packages/redis-v5/test/commands/timeout.js
@@ -1,5 +1,5 @@
 'use strict'
-/* globals describe it beforeEach cli */
+/* globals beforeEach cli */
 
 let expect = require('chai').expect
 let nock = require('nock')
@@ -9,7 +9,7 @@ let command = require('../../commands/timeout')
 const unwrap = require('../unwrap')
 
 describe('heroku redis:timeout', function () {
-  require('../lib/shared').shouldHandleArgs(command, { seconds: '5' })
+  require('../lib/shared').shouldHandleArgs(command, {seconds: '5'})
 })
 
 describe('heroku redis:timeout', function () {
@@ -21,49 +21,49 @@ describe('heroku redis:timeout', function () {
 
   it('# sets the timout', function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']},
+    ])
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .patch('/redis/v0/databases/redis-haiku/config', { timeout: 5 }).reply(200, {
-        timeout: { value: 5 }
-      })
+    .patch('/redis/v0/databases/redis-haiku/config', {timeout: 5}).reply(200, {
+      timeout: {value: 5},
+    })
 
-    return command.run({ app: 'example', flags: { seconds: '5' }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal(
-        `Timeout for redis-haiku (REDIS_FOO, REDIS_BAR) set to 5 seconds.
+    return command.run({app: 'example', flags: {seconds: '5'}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal(
+      `Timeout for redis-haiku (REDIS_FOO, REDIS_BAR) set to 5 seconds.
 Connections to the Redis instance will be stopped after idling for 5 seconds.
 `))
-      .then(() => expect(cli.stderr).to.equal(''))
+    .then(() => expect(cli.stderr).to.equal(''))
   })
 
   it('# sets the timout to zero', function () {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO', 'REDIS_BAR'] }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO', 'REDIS_BAR']},
+    ])
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .patch('/redis/v0/databases/redis-haiku/config', { timeout: 0 }).reply(200, {
-        timeout: { value: 0 }
-      })
+    .patch('/redis/v0/databases/redis-haiku/config', {timeout: 0}).reply(200, {
+      timeout: {value: 0},
+    })
 
-    return command.run({ app: 'example', flags: { seconds: '0' }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal(
-        `Timeout for redis-haiku (REDIS_FOO, REDIS_BAR) set to 0 seconds.
+    return command.run({app: 'example', flags: {seconds: '0'}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal(
+      `Timeout for redis-haiku (REDIS_FOO, REDIS_BAR) set to 0 seconds.
 Connections to the Redis instance can idle indefinitely.
 `))
-      .then(() => expect(cli.stderr).to.equal(''))
+    .then(() => expect(cli.stderr).to.equal(''))
   })
 
   it('# errors on missing timeout', function () {
-    return expect(command.run({ app: 'example', flags: {}, args: {} })).to.be.rejectedWith(exit.ErrorExit)
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(unwrap(cli.stderr)).to.equal('Please specify a valid timeout value.\n'))
+    return expect(command.run({app: 'example', flags: {}, args: {}})).to.be.rejectedWith(exit.ErrorExit)
+    .then(() => expect(cli.stdout).to.equal(''))
+    .then(() => expect(unwrap(cli.stderr)).to.equal('Please specify a valid timeout value.\n'))
   })
 })

--- a/packages/redis-v5/test/commands/upgrade.js
+++ b/packages/redis-v5/test/commands/upgrade.js
@@ -1,5 +1,5 @@
 'use strict'
-/* globals describe it beforeEach cli */
+/* globals beforeEach cli */
 
 let expect = require('chai').expect
 let nock = require('nock')
@@ -17,24 +17,24 @@ describe('heroku redis:upgrade', () => {
 
   it('# upgrades the redis version', () => {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_URL'] }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_URL']},
+    ])
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .post('/redis/v0/databases/redis-haiku/upgrade', { version: '6.2' }).reply(200, {
-        message: 'Upgrading version now!'
-      })
+    .post('/redis/v0/databases/redis-haiku/upgrade', {version: '6.2'}).reply(200, {
+      message: 'Upgrading version now!',
+    })
 
-    return command.run({ app: 'example', flags: { confirm: 'example', version: '6.2' }, args: {}, auth: { username: 'foobar', password: 'password' } })
-      .then(() => app.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stderr).to.equal('Requesting upgrade of redis-haiku to 6.2... Upgrading version now!\n'))
+    return command.run({app: 'example', flags: {confirm: 'example', version: '6.2'}, args: {}, auth: {username: 'foobar', password: 'password'}})
+    .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stderr).to.equal('Requesting upgrade of redis-haiku to 6.2... Upgrading version now!\n'))
   })
 
   it('# errors on missing version', function () {
-    return expect(command.run({ app: 'example', flags: {}, args: {} })).to.be.rejectedWith(exit.ErrorExit)
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(unwrap(cli.stderr)).to.equal('Please specify a valid version.\n'))
+    return expect(command.run({app: 'example', flags: {}, args: {}})).to.be.rejectedWith(exit.ErrorExit)
+    .then(() => expect(cli.stdout).to.equal(''))
+    .then(() => expect(unwrap(cli.stderr)).to.equal('Please specify a valid version.\n'))
   })
 })

--- a/packages/redis-v5/test/commands/wait.js
+++ b/packages/redis-v5/test/commands/wait.js
@@ -1,5 +1,5 @@
 'use strict'
-/* globals describe it before after cli */
+/* globals beforeEach */
 
 const cli = require('heroku-cli-util')
 let nock = require('nock')
@@ -16,35 +16,35 @@ describe('heroku redis:wait ', () => {
 
   it('# returns when waiting? is false', () => {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_URL'] }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_URL']},
+    ])
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .get('/redis/v0/databases/redis-haiku/wait').reply(200, { 'waiting?': false })
+    .get('/redis/v0/databases/redis-haiku/wait').reply(200, {'waiting?': false})
 
-    return cmd.run({ app: 'example', flags: {}, args: {} })
-      .then(() => app.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal(''))
+    return cmd.run({app: 'example', flags: {}, args: {}})
+    .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal(''))
+    .then(() => expect(cli.stderr).to.equal(''))
   })
 
   it('# waits for version upgrade', () => {
     let app = nock('https://api.heroku.com:443')
-      .get('/apps/example/addons').reply(200, [
-        { name: 'redis-haiku', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_URL'] }
-      ])
+    .get('/apps/example/addons').reply(200, [
+      {name: 'redis-haiku', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_URL']},
+    ])
 
     let redis = nock('https://redis-api.heroku.com:443')
-      .get('/redis/v0/databases/redis-haiku/wait').reply(200, { 'waiting?': true, 'message': 'upgrading version' })
-      .get('/redis/v0/databases/redis-haiku/wait').reply(200, { 'waiting?': false, 'message': 'available' })
+    .get('/redis/v0/databases/redis-haiku/wait').reply(200, {'waiting?': true, message: 'upgrading version'})
+    .get('/redis/v0/databases/redis-haiku/wait').reply(200, {'waiting?': false, message: 'available'})
 
-    return cmd.run({ app: 'example', flags: {}, args: {} })
-      .then(() => app.done())
-      .then(() => redis.done())
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal(`Waiting for database redis-haiku... upgrading version
+    return cmd.run({app: 'example', flags: {}, args: {}})
+    .then(() => app.done())
+    .then(() => redis.done())
+    .then(() => expect(cli.stdout).to.equal(''))
+    .then(() => expect(cli.stderr).to.equal(`Waiting for database redis-haiku... upgrading version
 Waiting for database redis-haiku... available
 `))
   })

--- a/packages/redis-v5/test/lib/shared.js
+++ b/packages/redis-v5/test/lib/shared.js
@@ -1,5 +1,5 @@
 'use strict'
-/* globals describe it beforeEach cli */
+/* globals beforeEach cli */
 
 let expect = require('chai').expect
 let nock = require('nock')
@@ -18,23 +18,23 @@ exports.shouldHandleArgs = function (command, flags) {
 
     it('# shows an error if an app has no addons', function () {
       let app = nock('https://api.heroku.com:443')
-        .get('/apps/example/addons').reply(200, [])
-      return expect(command.run({ app: 'example', flags: flags, args: {} })).to.be.rejectedWith(exit.ErrorExit)
-        .then(() => app.done())
-        .then(() => expect(cli.stdout).to.equal(''))
-        .then(() => expect(unwrap(cli.stderr)).to.equal('No Redis instances found.\n'))
+      .get('/apps/example/addons').reply(200, [])
+      return expect(command.run({app: 'example', flags: flags, args: {}})).to.be.rejectedWith(exit.ErrorExit)
+      .then(() => app.done())
+      .then(() => expect(cli.stdout).to.equal(''))
+      .then(() => expect(unwrap(cli.stderr)).to.equal('No Redis instances found.\n'))
     })
 
     it('# shows an error if the addon is ambiguous', function () {
       let app = nock('https://api.heroku.com:443')
-        .get('/apps/example/addons').reply(200, [
-          { name: 'redis-haiku-a', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_FOO'] },
-          { name: 'redis-haiku-b', addon_service: { name: 'heroku-redis' }, config_vars: ['REDIS_BAR'] }
-        ])
-      return expect(command.run({ app: 'example', flags: flags, args: {} })).to.be.rejectedWith(exit.ErrorExit)
-        .then(() => app.done())
-        .then(() => expect(cli.stdout).to.equal(''))
-        .then(() => expect(unwrap(cli.stderr)).to.equal('Please specify a single instance. Found: redis-haiku-a, redis-haiku-b\n'))
+      .get('/apps/example/addons').reply(200, [
+        {name: 'redis-haiku-a', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_FOO']},
+        {name: 'redis-haiku-b', addon_service: {name: 'heroku-redis'}, config_vars: ['REDIS_BAR']},
+      ])
+      return expect(command.run({app: 'example', flags: flags, args: {}})).to.be.rejectedWith(exit.ErrorExit)
+      .then(() => app.done())
+      .then(() => expect(cli.stdout).to.equal(''))
+      .then(() => expect(unwrap(cli.stderr)).to.equal('Please specify a single instance. Found: redis-haiku-a, redis-haiku-b\n'))
     })
   })
 }

--- a/packages/redis-v5/test/unwrap.js
+++ b/packages/redis-v5/test/unwrap.js
@@ -1,6 +1,6 @@
 'use strict'
 
-function unwrap (str) {
+function unwrap(str) {
   let sanitize = str.replace(/\n ([▸!]) {3}/g, '')
   sanitize = sanitize.replace(/ ([▸!]) {4}/g, '')
 


### PR DESCRIPTION
Fixes linting errors for the redis-v5 package.

Fulfills part of the [eslint standardization GUS ticket](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001NBwHTYA1/view)

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
