### PR TITLE
chore: eslint standardization run-v5

### DIFF
--- a/packages/run-v5/commands/console.js
+++ b/packages/run-v5/commands/console.js
@@ -11,7 +11,7 @@ async function run(context, heroku) {
     command: helpers.buildCommand(['console']),
     size: context.flags.size,
     env: context.flags.env,
-    attach: true
+    attach: true,
   }
 
   let dyno = new Dyno(opts)
@@ -24,8 +24,8 @@ module.exports = {
   needsAuth: true,
   needsApp: true,
   flags: [
-    { name: 'size', char: 's', description: 'dyno size', hasValue: true },
-    { name: 'env', char: 'e', description: "environment variables to set (use ';' to split multiple vars)", hasValue: true }
+    {name: 'size', char: 's', description: 'dyno size', hasValue: true},
+    {name: 'env', char: 'e', description: "environment variables to set (use ';' to split multiple vars)", hasValue: true},
   ],
-  run: cli.command(run)
+  run: cli.command(run),
 }

--- a/packages/run-v5/commands/logs.js
+++ b/packages/run-v5/commands/logs.js
@@ -2,16 +2,16 @@
 
 let cli = require('heroku-cli-util')
 let logDisplayer = require('../lib/log_displayer')
-const { DynoCompletion, ProcessTypeCompletion } = require('@heroku-cli/command/lib/completions')
+const {DynoCompletion, ProcessTypeCompletion} = require('@heroku-cli/command/lib/completions')
 
-async function run (context, heroku) {
+async function run(context, heroku) {
   cli.color.enabled = context.flags['force-colors'] || cli.color.enabled
   await logDisplayer(heroku, {
     app: context.app,
     dyno: context.flags.dyno || context.flags.ps,
     lines: context.flags.num || 100,
     tail: context.flags.tail,
-    source: context.flags.source
+    source: context.flags.source,
   })
 }
 
@@ -25,12 +25,12 @@ disable colors with --no-color, HEROKU_LOGS_COLOR=0, or HEROKU_COLOR=0`,
   needsAuth: true,
   needsApp: true,
   flags: [
-    { name: 'num', char: 'n', description: 'number of lines to display', hasValue: true },
-    { name: 'ps', char: 'p', description: 'hidden alias for dyno', hasValue: true, hidden: true },
-    { name: 'dyno', char: 'd', description: 'only show output from this dyno type (such as "web" or "worker")', hasValue: true, completion: DynoCompletion },
-    { name: 'source', char: 's', description: 'only show output from this source (such as "app" or "heroku")', hasValue: true, completion: ProcessTypeCompletion },
-    { name: 'tail', char: 't', description: 'continually stream logs' },
-    { name: 'force-colors', description: 'force use of colors (even on non-tty output)' }
+    {name: 'num', char: 'n', description: 'number of lines to display', hasValue: true},
+    {name: 'ps', char: 'p', description: 'hidden alias for dyno', hasValue: true, hidden: true},
+    {name: 'dyno', char: 'd', description: 'only show output from this dyno type (such as "web" or "worker")', hasValue: true, completion: DynoCompletion},
+    {name: 'source', char: 's', description: 'only show output from this source (such as "app" or "heroku")', hasValue: true, completion: ProcessTypeCompletion},
+    {name: 'tail', char: 't', description: 'continually stream logs'},
+    {name: 'force-colors', description: 'force use of colors (even on non-tty output)'},
   ],
-  run: cli.command(run)
+  run: cli.command(run),
 }

--- a/packages/run-v5/commands/rake.js
+++ b/packages/run-v5/commands/rake.js
@@ -14,17 +14,17 @@ async function run(context, heroku) {
     'exit-code': context.flags['exit-code'],
     env: context.flags.env,
     'no-tty': context.flags['no-tty'],
-    attach: true
+    attach: true,
   }
 
   let dyno = new Dyno(opts)
   try {
     await dyno.start()
-  } catch (err) {
-    if (err.exitCode) {
-      cli.error(err)
-      process.exit(err.exitCode)
-    } else throw err
+  } catch (error) {
+    if (error.exitCode) {
+      cli.error(error)
+      process.exit(error.exitCode)
+    } else throw error
   }
 }
 
@@ -35,10 +35,10 @@ module.exports = {
   needsAuth: true,
   needsApp: true,
   flags: [
-    { name: 'size', char: 's', description: 'dyno size', hasValue: true },
-    { name: 'exit-code', char: 'x', description: 'passthrough the exit code of the remote command' },
-    { name: 'env', char: 'e', description: "environment variables to set (use ';' to split multiple vars)", hasValue: true },
-    { name: 'no-tty', description: 'force the command to not run in a tty', hasValue: false }
+    {name: 'size', char: 's', description: 'dyno size', hasValue: true},
+    {name: 'exit-code', char: 'x', description: 'passthrough the exit code of the remote command'},
+    {name: 'env', char: 'e', description: "environment variables to set (use ';' to split multiple vars)", hasValue: true},
+    {name: 'no-tty', description: 'force the command to not run in a tty', hasValue: false},
   ],
-  run: cli.command(run)
+  run: cli.command(run),
 }

--- a/packages/run-v5/commands/run.js
+++ b/packages/run-v5/commands/run.js
@@ -3,10 +3,10 @@
 let cli = require('heroku-cli-util')
 let helpers = require('../lib/helpers')
 let Dyno = require('../lib/dyno')
-const { DynoSizeCompletion, ProcessTypeCompletion } = require('@heroku-cli/command/lib/completions')
+const {DynoSizeCompletion, ProcessTypeCompletion} = require('@heroku-cli/command/lib/completions')
 const debug = require('debug')('heroku:run')
 
-async function run (context, heroku) {
+async function run(context, heroku) {
   let opts = {
     heroku: heroku,
     app: context.app,
@@ -18,7 +18,7 @@ async function run (context, heroku) {
     env: context.flags.env,
     'no-tty': context.flags['no-tty'],
     attach: true,
-    listen: context.flags.listen
+    listen: context.flags.listen,
   }
   if (!opts.command) throw new Error('Usage: heroku run COMMAND\n\nExample: heroku run bash')
 
@@ -26,10 +26,10 @@ async function run (context, heroku) {
   try {
     await dyno.start()
     debug('done running')
-  } catch (err) {
-    debug(err)
-    if (err.exitCode) cli.exit(err.exitCode, err)
-    else throw err
+  } catch (error) {
+    debug(error)
+    if (error.exitCode) cli.exit(error.exitCode, error)
+    else throw error
   }
 }
 
@@ -47,13 +47,13 @@ Running myscript.sh -a arg1 -s arg2 on app.... up, run.1`,
   needsAuth: true,
   needsApp: true,
   flags: [
-    { name: 'size', char: 's', description: 'dyno size', hasValue: true, completion: DynoSizeCompletion },
-    { name: 'type', description: 'process type', hasValue: true, completion: ProcessTypeCompletion },
-    { name: 'exit-code', char: 'x', description: 'passthrough the exit code of the remote command' },
-    { name: 'env', char: 'e', description: "environment variables to set (use ';' to split multiple vars)", hasValue: true },
-    { name: 'no-tty', description: 'force the command to not run in a tty', hasValue: false },
-    { name: 'listen', description: 'listen on a local port', hasValue: false, hidden: true },
-    { name: 'no-notify', description: 'disables notification when dyno is up (alternatively use HEROKU_NOTIFICATIONS=0)', hasValue: false }
+    {name: 'size', char: 's', description: 'dyno size', hasValue: true, completion: DynoSizeCompletion},
+    {name: 'type', description: 'process type', hasValue: true, completion: ProcessTypeCompletion},
+    {name: 'exit-code', char: 'x', description: 'passthrough the exit code of the remote command'},
+    {name: 'env', char: 'e', description: "environment variables to set (use ';' to split multiple vars)", hasValue: true},
+    {name: 'no-tty', description: 'force the command to not run in a tty', hasValue: false},
+    {name: 'listen', description: 'listen on a local port', hasValue: false, hidden: true},
+    {name: 'no-notify', description: 'disables notification when dyno is up (alternatively use HEROKU_NOTIFICATIONS=0)', hasValue: false},
   ],
-  run: cli.command(run)
+  run: cli.command(run),
 }

--- a/packages/run-v5/commands/run/detached.js
+++ b/packages/run-v5/commands/run/detached.js
@@ -4,7 +4,7 @@ let cli = require('heroku-cli-util')
 let helpers = require('../../lib/helpers')
 let logDisplayer = require('../../lib/log_displayer')
 let Dyno = require('../../lib/dyno')
-const { DynoSizeCompletion, ProcessTypeCompletion } = require('@heroku-cli/command/lib/completions')
+const {DynoSizeCompletion, ProcessTypeCompletion} = require('@heroku-cli/command/lib/completions')
 
 async function run(context, heroku) {
   let opts = {
@@ -14,7 +14,7 @@ async function run(context, heroku) {
     size: context.flags.size,
     type: context.flags.type,
     env: context.flags.env,
-    attach: false
+    attach: false,
   }
   if (!opts.command) throw new Error('Usage: heroku run COMMAND\n\nExample: heroku run bash')
   let dyno = new Dyno(opts)
@@ -24,7 +24,7 @@ async function run(context, heroku) {
     await logDisplayer(heroku, {
       app: context.app,
       dyno: dyno.dyno.name,
-      tail: true
+      tail: true,
     })
   } else {
     cli.log(`Run ${cli.color.cmd('heroku logs --app ' + dyno.opts.app + ' --dyno ' + dyno.dyno.name)} to view the output.`)
@@ -42,10 +42,10 @@ Run heroku logs -a app -p run.1 to view the output.`,
   needsAuth: true,
   needsApp: true,
   flags: [
-    { name: 'size', char: 's', description: 'dyno size', hasValue: true, completion: DynoSizeCompletion },
-    { name: 'tail', char: 't', description: 'stream logs from the dyno' },
-    { name: 'type', description: 'process type', hasValue: true, completion: ProcessTypeCompletion },
-    { name: 'env', char: 'e', description: "environment variables to set (use ';' to split multiple vars)", hasValue: true }
+    {name: 'size', char: 's', description: 'dyno size', hasValue: true, completion: DynoSizeCompletion},
+    {name: 'tail', char: 't', description: 'stream logs from the dyno'},
+    {name: 'type', description: 'process type', hasValue: true, completion: ProcessTypeCompletion},
+    {name: 'env', char: 'e', description: "environment variables to set (use ';' to split multiple vars)", hasValue: true},
   ],
-  run: cli.command(run)
+  run: cli.command(run),
 }

--- a/packages/run-v5/commands/run/inside.js
+++ b/packages/run-v5/commands/run/inside.js
@@ -13,7 +13,7 @@ async function run(context, heroku) {
     command: helpers.buildCommand(context.args.slice(1)),
     'exit-code': context.flags['exit-code'],
     env: context.flags.env,
-    listen: context.flags.listen
+    listen: context.flags.listen,
   }
 
   let dyno = new Dyno(opts)
@@ -32,9 +32,9 @@ Running bash on web.1.... up
   needsAuth: true,
   needsApp: true,
   flags: [
-    { name: 'exit-code', description: 'passthrough the exit code of the remote command' },
-    { name: 'env', description: "environment variables to set (use ';' to split multiple vars)", hasValue: true },
-    { name: 'listen', description: 'listen on a local port', hasValue: false, hidden: true }
+    {name: 'exit-code', description: 'passthrough the exit code of the remote command'},
+    {name: 'env', description: "environment variables to set (use ';' to split multiple vars)", hasValue: true},
+    {name: 'listen', description: 'listen on a local port', hasValue: false, hidden: true},
   ],
-  run: cli.command(run)
+  run: cli.command(run),
 }

--- a/packages/run-v5/lib/colorize.js
+++ b/packages/run-v5/lib/colorize.js
@@ -11,10 +11,10 @@ const COLORS = [
   s => c.bold.cyan(s),
   s => c.bold.magenta(s),
   s => c.bold.yellow(s),
-  s => c.bold.blue(s)
+  s => c.bold.blue(s),
 ]
 const assignedColors = {}
-function getColorForIdentifier (i) {
+function getColorForIdentifier(i) {
   i = i.split('.')[0]
   if (assignedColors[i]) return assignedColors[i]
   assignedColors[i] = COLORS[Object.keys(assignedColors).length % COLORS.length]
@@ -43,8 +43,9 @@ const status = code => {
   if (code < 600) return c.red(code)
   return code
 }
+
 const ms = s => {
-  const ms = parseInt(s)
+  const ms = Number.parseInt(s)
   if (!ms) return s
   if (ms < 100) return c.greenBright(s)
   if (ms < 500) return c.green(s)
@@ -53,30 +54,31 @@ const ms = s => {
   return c.red(s)
 }
 
-function colorizeRouter (body) {
+function colorizeRouter(body) {
   const encodeColor = ([k, v]) => {
     switch (k) {
-      case 'at': return [k, v === 'error' ? red(v) : other(v)]
-      case 'code': return [k, red.bold(v)]
-      case 'method': return [k, method(v)]
-      case 'dyno': return [k, getColorForIdentifier(v)(v)]
-      case 'status': return [k, status(v)]
-      case 'path': return [k, path(v)]
-      case 'connect': return [k, ms(v)]
-      case 'service': return [k, ms(v)]
-      default: return [k, other(v)]
+    case 'at': return [k, v === 'error' ? red(v) : other(v)]
+    case 'code': return [k, red.bold(v)]
+    case 'method': return [k, method(v)]
+    case 'dyno': return [k, getColorForIdentifier(v)(v)]
+    case 'status': return [k, status(v)]
+    case 'path': return [k, path(v)]
+    case 'connect': return [k, ms(v)]
+    case 'service': return [k, ms(v)]
+    default: return [k, other(v)]
     }
   }
 
   try {
-    const tokens = body.split(/\s+/).map((sub) => {
+    const tokens = body.split(/\s+/).map(sub => {
       const parts = sub.split('=')
       if (parts.length === 1) {
         return parts
+      // eslint-disable-next-line no-else-return
       } else if (parts.length === 2) {
         return encodeColor(parts)
       } else {
-        return encodeColor([parts[0], parts.splice(1).join("=")])
+        return encodeColor([parts[0], parts.splice(1).join('=')])
       }
     })
 
@@ -84,25 +86,26 @@ function colorizeRouter (body) {
       if (v === undefined) {
         return other(k)
       }
+
       return other(k + '=') + v
     }).join(' ')
-  } catch (err) {
-    CliUx.ux.warn(err)
+  } catch (error) {
+    CliUx.ux.warn(error)
     return body
   }
 }
 
 const state = s => {
   switch (s) {
-    case 'down': return red(s)
-    case 'up': return c.greenBright(s)
-    case 'starting': return c.yellowBright(s)
-    case 'complete': return c.greenBright(s)
-    default: return s
+  case 'down': return red(s)
+  case 'up': return c.greenBright(s)
+  case 'starting': return c.yellowBright(s)
+  case 'complete': return c.greenBright(s)
+  default: return s
   }
 }
 
-function colorizeRun (body) {
+function colorizeRun(body) {
   try {
     if (body.match(/^Stopping all processes with SIGTERM$/)) return c.red(body)
     let starting = body.match(/^(Starting process with command )(`.+`)(by user )?(.*)?$/)
@@ -111,32 +114,35 @@ function colorizeRun (body) {
         starting[1],
         c.cmd(starting[2]),
         starting[3] || '',
-        c.green(starting[4] || '')
+        c.green(starting[4] || ''),
       ].join('')
     }
+
     let stateChange = body.match(/^(State changed from )(\w+)( to )(\w+)$/)
     if (stateChange) {
       return [
         stateChange[1],
         state(stateChange[2]),
         stateChange[3] || '',
-        state(stateChange[4] || '')
+        state(stateChange[4] || ''),
       ].join('')
     }
+
     let exited = body.match(/^(Process exited with status )(\d+)$/)
     if (exited) {
       return [
         exited[1],
-        exited[2] === '0' ? c.greenBright(exited[2]) : c.red(exited[2])
+        exited[2] === '0' ? c.greenBright(exited[2]) : c.red(exited[2]),
       ].join('')
     }
-  } catch (err) {
-    CliUx.ux.warn(err)
+  } catch (error) {
+    CliUx.ux.warn(error)
   }
+
   return body
 }
 
-function colorizeWeb (body) {
+function colorizeWeb(body) {
   try {
     if (body.match(/^Unidling$/)) return c.yellow(body)
     if (body.match(/^Restarting$/)) return c.yellow(body)
@@ -147,25 +153,28 @@ function colorizeWeb (body) {
         (starting[1]),
         c.cmd(starting[2]),
         (starting[3] || ''),
-        c.green(starting[4] || '')
+        c.green(starting[4] || ''),
       ].join('')
     }
+
     let exited = body.match(/^(Process exited with status )(\d+)$/)
     if (exited) {
       return [
         exited[1],
-        exited[2] === '0' ? c.greenBright(exited[2]) : c.red(exited[2])
+        exited[2] === '0' ? c.greenBright(exited[2]) : c.red(exited[2]),
       ].join('')
     }
+
     let stateChange = body.match(/^(State changed from )(\w+)( to )(\w+)$/)
     if (stateChange) {
       return [
         stateChange[1],
         state(stateChange[2]),
         stateChange[3],
-        state(stateChange[4])
+        state(stateChange[4]),
       ].join('')
     }
+
     let apache = body.match(/^(\d+\.\d+\.\d+\.\d+ -[^-]*- \[[^\]]+] ")(\w+)( )([^ ]+)( HTTP\/\d+\.\d+" )(\d+)( .+$)/)
     if (apache) {
       const [, ...tokens] = apache
@@ -176,87 +185,96 @@ function colorizeWeb (body) {
         path(tokens[3]),
         other(tokens[4]),
         status(tokens[5]),
-        other(tokens[6])
+        other(tokens[6]),
       ].join('')
     }
+
     let route = body.match(/^(.* ")(\w+)(.+)(HTTP\/\d+\.\d+" .*)$/)
     if (route) {
       return [
         route[1],
         method(route[2]),
         path(route[3]),
-        route[4]
+        route[4],
       ].join('')
     }
-  } catch (err) {
-    CliUx.ux.warn(err)
+  } catch (error) {
+    CliUx.ux.warn(error)
   }
+
   return body
 }
 
-function colorizeAPI (body) {
+function colorizeAPI(body) {
   if (body.match(/^Build succeeded$/)) return c.greenBright(body)
   if (body.match(/^Build failed/)) return c.red(body)
   const build = body.match(/^(Build started by user )(.+)$/)
   if (build) {
     return [
       build[1],
-      c.green(build[2])
+      c.green(build[2]),
     ].join('')
   }
+
   const deploy = body.match(/^(Deploy )([\w]+)( by user )(.+)$/)
   if (deploy) {
     return [
       deploy[1],
       c.cyan(deploy[2]),
       deploy[3],
-      c.green(deploy[4])
+      c.green(deploy[4]),
     ].join('')
   }
+
   const release = body.match(/^(Release )(v[\d]+)( created by user )(.+)$/)
   if (release) {
     return [
       release[1],
       c.magenta(release[2]),
       release[3],
-      c.green(release[4])
+      c.green(release[4]),
     ].join('')
   }
+
   let starting = body.match(/^(Starting process with command )(`.+`)(by user )?(.*)?$/)
   if (starting) {
     return [
       (starting[1]),
       c.cmd(starting[2]),
       (starting[3] || ''),
-      c.green(starting[4] || '')
+      c.green(starting[4] || ''),
     ].join('')
   }
+
   return body
 }
 
-function colorizeRedis (body) {
+function colorizeRedis(body) {
   if (body.match(/source=\w+ sample#/)) {
     body = dim(body)
   }
+
   return body
 }
 
-function colorizePG (body) {
+function colorizePG(body) {
   let create = body.match(/^(\[DATABASE].*)(CREATE TABLE)(.*)$/)
   if (create) {
     return [
       other(create[1]),
       c.magenta(create[2]),
-      c.cyan(create[3])
+      c.cyan(create[3]),
     ].join('')
   }
+
   if (body.match(/source=\w+ sample#/)) {
     body = dim(body)
   }
+
   return body
 }
 
-module.exports = function colorize (line) {
+module.exports = function colorize(line) {
   if (process.env.HEROKU_LOGS_COLOR === '0') return line
 
   let parsed = line.match(lineRegex)
@@ -265,25 +283,26 @@ module.exports = function colorize (line) {
   let identifier = parsed[2]
   let body = (parsed[4] || '').trim()
   switch (identifier) {
-    case 'api':
-      body = colorizeAPI(body)
-      break
-    case 'router':
-      body = colorizeRouter(body)
-      break
-    case 'run':
-      body = colorizeRun(body)
-      break
-    case 'web':
-      body = colorizeWeb(body)
-      break
-    case 'heroku-redis':
-      body = colorizeRedis(body)
-      break
-    case 'heroku-postgres':
-    case 'postgres':
-      body = colorizePG(body)
+  case 'api':
+    body = colorizeAPI(body)
+    break
+  case 'router':
+    body = colorizeRouter(body)
+    break
+  case 'run':
+    body = colorizeRun(body)
+    break
+  case 'web':
+    body = colorizeWeb(body)
+    break
+  case 'heroku-redis':
+    body = colorizeRedis(body)
+    break
+  case 'heroku-postgres':
+  case 'postgres':
+    body = colorizePG(body)
   }
+
   return getColorForIdentifier(identifier)(header) + ' ' + body
 }
 

--- a/packages/run-v5/lib/dyno.js
+++ b/packages/run-v5/lib/dyno.js
@@ -11,7 +11,7 @@ const http = require('https')
 const net = require('net')
 const spawn = require('child_process').spawn
 const debug = require('debug')('heroku:run')
-const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+const wait = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 /** Represents a dyno process */
 class Dyno extends Duplex {
@@ -28,7 +28,7 @@ class Dyno extends Duplex {
    * @param {Object} options.env - dyno environment variables
    * @param {boolean} options.notify - show notifications or not
   */
-  constructor (opts) {
+  constructor(opts) {
     super()
     this.cork()
     this.opts = opts
@@ -40,7 +40,7 @@ class Dyno extends Duplex {
    * Starts the dyno
    * @returns {Promise} promise resolved when dyno process is created
    */
-  start () {
+  start() {
     this._startedAt = new Date()
     const dynoStart = this._doStart()
     if (this.opts.showStatus) {
@@ -48,11 +48,11 @@ class Dyno extends Duplex {
     } else return dynoStart
   }
 
-  _doStart (retries = 2) {
+  _doStart(retries = 2) {
     let command = this.opts['exit-code'] ? `${this.opts.command}; echo "\uFFFF heroku-command-exit-status: $?"` : this.opts.command
     return this.heroku.post(this.opts.dyno ? `/apps/${this.opts.app}/dynos/${this.opts.dyno}` : `/apps/${this.opts.app}/dynos`, {
       headers: {
-        Accept: this.opts.dyno ? 'application/vnd.heroku+json; version=3.run-inside' : 'application/vnd.heroku+json; version=3'
+        Accept: this.opts.dyno ? 'application/vnd.heroku+json; version=3.run-inside' : 'application/vnd.heroku+json; version=3',
       },
       body: {
         command: command,
@@ -60,37 +60,37 @@ class Dyno extends Duplex {
         size: this.opts.size,
         type: this.opts.type,
         env: this._env(),
-        force_no_tty: this.opts['no-tty']
+        force_no_tty: this.opts['no-tty'],
+      },
+    })
+    .then(dyno => {
+      this.dyno = dyno
+      if (this.opts.attach || this.opts.dyno) {
+        if (this.dyno.name && this.opts.dyno === undefined) this.opts.dyno = this.dyno.name
+        return this.attach()
+      } else if (this.opts.showStatus) {
+        cli.action.done(this._status('done'))
       }
     })
-      .then(dyno => {
-        this.dyno = dyno
-        if (this.opts.attach || this.opts.dyno) {
-          if (this.dyno.name && this.opts.dyno === undefined) this.opts.dyno = this.dyno.name
-          return this.attach()
-        } else if (this.opts.showStatus) {
-          cli.action.done(this._status('done'))
-        }
-      })
-      .catch(err => {
+    .catch(error => {
       // Currently the runtime API sends back a 409 in the event the
       // release isn't found yet. API just forwards this response back to
       // the client, so we'll need to retry these. This usually
       // happens when you create an app and immediately try to run a
       // one-off dyno. No pause between attempts since this is
       // typically a very short-lived condition.
-        if (err.statusCode === 409 && retries > 0) {
-          return this._doStart(retries - 1)
-        } else {
-          throw err
-        }
-      })
+      if (error.statusCode === 409 && retries > 0) {
+        return this._doStart(retries - 1)
+      } else {
+        throw error
+      }
+    })
   }
 
   /**
    * Attaches stdin/stdout to dyno
    */
-  attach () {
+  attach() {
     this.pipe(process.stdout)
     this.uri = url.parse(this.dyno.attach_url)
     if (this._useSSH) {
@@ -98,16 +98,17 @@ class Dyno extends Duplex {
     } else {
       this.p = this._rendezvous()
     }
+
     return this.p.then(() => {
       this.end()
     })
   }
 
-  get _useSSH () {
+  get _useSSH() {
     return this.uri.protocol === 'http:' || this.uri.protocol === 'https:'
   }
 
-  _rendezvous () {
+  _rendezvous() {
     return new Promise((resolve, reject) => {
       this.resolve = resolve
       this.reject = reject
@@ -138,7 +139,7 @@ class Dyno extends Duplex {
     })
   }
 
-  async _ssh (retries = 20) {
+  async _ssh(retries = 20) {
     const interval = 1000
 
     try {
@@ -152,30 +153,30 @@ class Dyno extends Duplex {
         await wait(interval)
         return this._ssh()
       }
-    } catch (err) {
+    } catch (error) {
       // the API sometimes responds with a 404 when the dyno is not yet ready
-      if (err.statusCode === 404 && retries > 0) {
+      if (error.statusCode === 404 && retries > 0) {
         return this._ssh(retries - 1)
       } else {
-        throw err
+        throw error
       }
     }
   }
 
-  _connect () {
+  _connect() {
     return new Promise((resolve, reject) => {
       this.resolve = resolve
       this.reject = reject
 
       let options = this.uri
-      options.headers = {'Connection': 'Upgrade', 'Upgrade': 'tcp'}
+      options.headers = {Connection: 'Upgrade', Upgrade: 'tcp'}
       options.rejectUnauthorized = false
       let r = http.request(options)
       r.end()
 
       r.on('error', this.reject)
       r.on('upgrade', (_, remote, head) => {
-        let s = net.createServer((client) => {
+        let s = net.createServer(client => {
           client.on('end', () => {
             s.close()
             this.resolve()
@@ -188,8 +189,8 @@ class Dyno extends Duplex {
           client.setNoDelay(true)
           remote.setNoDelay(true)
 
-          remote.on('data', (data) => client.write(data))
-          client.on('data', (data) => remote.write(data))
+          remote.on('data', data => client.write(data))
+          client.on('data', data => remote.write(data))
         })
 
         s.listen(0, 'localhost', () => this._handle(s))
@@ -201,7 +202,7 @@ class Dyno extends Duplex {
     })
   }
 
-  _handle (localServer) {
+  _handle(localServer) {
     let addr = localServer.address()
     let host = addr.address
     let port = addr.port
@@ -227,6 +228,7 @@ class Dyno extends Duplex {
           params.push('-t')
         }
       }
+
       let sshProc = spawn('ssh', params, {stdio})
 
       // only receives stdout with --exit-code
@@ -235,7 +237,7 @@ class Dyno extends Duplex {
         sshProc.stdout.on('data', this._readData())
       }
 
-      sshProc.stderr.on('data', (data) => {
+      sshProc.stderr.on('data', data => {
         lastErr = data
 
         // supress host key and permission denied messages
@@ -250,40 +252,45 @@ class Dyno extends Duplex {
           if (process.env.SSH_AUTH_SOCK) {
             cli.error('Confirm that your ssh key is added to your agent by running `ssh-add`.')
           }
+
           cli.error('Check that your ssh key has been uploaded to heroku with `heroku keys:add`.')
           cli.error(`See ${cli.color.cyan('https://devcenter.heroku.com/articles/one-off-dynos#shield-private-spaces')}`)
         }
+
         // cleanup local server
         localServer.close()
       })
       this.p
-        .then(() => sshProc.kill())
-        .catch(() => sshProc.kill())
+      .then(() => sshProc.kill())
+      .catch(() => sshProc.kill())
     }
+
     this._notify()
   }
 
-  _isDebug () {
+  _isDebug() {
     let debug = process.env.HEROKU_DEBUG
     return debug && (debug === '1' || debug.toUpperCase() === 'TRUE')
   }
 
-  _env () {
+  _env() {
     let c = this.opts.env ? helpers.buildEnvFromFlag(this.opts.env) : {}
     c.TERM = process.env.TERM
     if (tty.isatty(1)) {
       c.COLUMNS = process.stdout.columns
       c.LINES = process.stdout.rows
     }
+
     return c
   }
 
-  _status (status) {
+  _status(status) {
+    // eslint-disable-next-line unicorn/explicit-length-check
     let size = this.dyno.size ? ` (${this.dyno.size})` : ''
     return `${status}, ${this.dyno.name || this.opts.dyno}${size}`
   }
 
-  _readData (c) {
+  _readData(c) {
     let firstLine = true
     return data => {
       debug('input: %o', data)
@@ -294,6 +301,7 @@ class Dyno extends Duplex {
         this._readStdin(c)
         return
       }
+
       this._notify()
 
       // carriage returns break json parsing of output
@@ -304,20 +312,22 @@ class Dyno extends Duplex {
       if (exitCode) {
         debug('got exit code: %d', exitCode[1])
         this.push(data.replace(/^\uFFFF heroku-command-exit-status: \d+$\n?/m, ''))
-        let code = parseInt(exitCode[1])
+        let code = Number.parseInt(exitCode[1])
         if (code === 0) this.resolve()
         else {
           let err = new Error(`Process exited with code ${cli.color.red(code)}`)
           err.exitCode = code
           this.reject(err)
         }
+
         return
       }
+
       this.push(data)
     }
   }
 
-  _readStdin (c) {
+  _readStdin(c) {
     this.input = c
     let stdin = process.stdin
     stdin.setEncoding('utf8')
@@ -332,7 +342,7 @@ class Dyno extends Duplex {
       let sigints = []
       stdin.on('data', function (c) {
         if (c === '\u0003') sigints.push(new Date())
-        sigints = sigints.filter(d => d > new Date() - 1000)
+        sigints = sigints.filter(d => d > Date.now() - 1000)
         if (sigints.length >= 4) {
           cli.error('forcing dyno disconnect')
           process.exit(1)
@@ -342,43 +352,46 @@ class Dyno extends Duplex {
       stdin.pipe(new Transform({
         objectMode: true,
         transform: (chunk, _, next) => c.write(chunk, next),
-        flush: done => c.write('\x04', done)
+        // eslint-disable-next-line unicorn/no-hex-escape
+        flush: done => c.write('\x04', done),
       }))
     }
+
     this.uncork()
   }
 
-  _read () {
+  _read() {
     if (this.useSSH) {
       throw new Error('Cannot read stream from ssh dyno')
     }
     // do not need to do anything to handle Readable interface
   }
 
-  _write (chunk, encoding, callback) {
+  _write(chunk, encoding, callback) {
     if (this.useSSH) {
       throw new Error('Cannot write stream to ssh dyno')
     }
+
     if (!this.input) throw new Error('no input')
     this.input.write(chunk, encoding, callback)
   }
 
-  _notify () {
+  _notify() {
     try {
       if (this._notified) return
       this._notified = true
       if (!this.opts.notify) return
       // only show notifications if dyno took longer than 20 seconds to start
-      if (new Date() - this._startedAt < 1000 * 20) return
+      if (Date.now() - this._startedAt < 1000 * 20) return
       const {notify} = require('@heroku-cli/notifications')
       notify({
         title: this.opts.app,
         subtitle: `heroku run ${this.opts.command}`,
-        message: 'dyno is up'
+        message: 'dyno is up',
         // sound: true
       })
-    } catch (err) {
-      cli.warn(err)
+    } catch (error) {
+      cli.warn(error)
     }
   }
 }

--- a/packages/run-v5/lib/helpers.js
+++ b/packages/run-v5/lib/helpers.js
@@ -2,33 +2,37 @@
 
 let cli = require('heroku-cli-util')
 
-function buildCommand (args) {
+function buildCommand(args) {
   if (args.length === 1) {
     // do not add quotes around arguments if there is only one argument
     // `heroku run "rake test"` should work like `heroku run rake test`
     return args[0]
   }
+
   let cmd = ''
   for (let arg of args) {
-    if (arg.indexOf(' ') !== -1 || arg.indexOf('"') !== -1) {
+    if (arg.includes(' ') || arg.includes('"')) {
       arg = '"' + arg.replace(/"/g, '\\"') + '"'
     }
+
     cmd = cmd + ' ' + arg
   }
+
   return cmd.trim()
 }
 
-function buildEnvFromFlag (flag) {
+function buildEnvFromFlag(flag) {
   let env = {}
   for (let v of flag.split(';')) {
     let m = v.match(/^\s*([\w.-]+)\s*=\s*(.*)?\s*$/)
     if (m) env[m[1]] = m[2]
     else cli.warn(`env flag ${v} appears invalid. Avoid using ';' in values.`)
   }
+
   return env
 }
 
 module.exports = {
   buildCommand,
-  buildEnvFromFlag
+  buildEnvFromFlag,
 }

--- a/packages/run-v5/lib/line_transform.js
+++ b/packages/run-v5/lib/line_transform.js
@@ -9,6 +9,7 @@ transform._transform = function (chunk, encoding, next) {
   if (this._lastLineData) data = this._lastLineData + data
 
   let lines = data.split('\n')
+  // eslint-disable-next-line unicorn/prefer-negative-index
   this._lastLineData = lines.splice(lines.length - 1, 1)[0]
 
   lines.forEach(this.push.bind(this))

--- a/packages/run-v5/lib/log_displayer.js
+++ b/packages/run-v5/lib/log_displayer.js
@@ -7,7 +7,7 @@ let liner = require('../lib/line_transform')
 const colorize = require('./colorize')
 const HTTP = require('http-call')
 
-function readLogs (logplexURL) {
+function readLogs(logplexURL) {
   let u = url.parse(logplexURL)
   if (u.query && u.query.includes('srv')) {
     return readLogsV1(logplexURL)
@@ -16,7 +16,7 @@ function readLogs (logplexURL) {
   }
 }
 
-async function readLogsV1 (logplexURL) {
+async function readLogsV1(logplexURL) {
   let {response} = await HTTP.stream(logplexURL)
   return new Promise(function (resolve, reject) {
     response.setEncoding('utf8')
@@ -28,7 +28,7 @@ async function readLogsV1 (logplexURL) {
   })
 }
 
-function readLogsV2 (logplexURL) {
+function readLogsV2(logplexURL) {
   return new Promise(function (resolve, reject) {
     const u = url.parse(logplexURL, true)
     const isTail = u.query.tail && u.query.tail === 'true'
@@ -37,11 +37,11 @@ function readLogsV2 (logplexURL) {
     const es = new EventSource(logplexURL, {
       proxy,
       headers: {
-        'User-Agent': userAgent
-      }
+        'User-Agent': userAgent,
+      },
     })
 
-    es.onerror = function (err) {
+    es.addEventListener('error', function (err) {
       if (err && (err.status || err.message)) {
         const msg = (isTail && (err.status === 404 || err.status === 403)) ?
           'Log stream timed out. Please try again.' :
@@ -56,17 +56,18 @@ function readLogsV2 (logplexURL) {
       }
 
       // should only land here if --tail and no error status or message
-    }
+    })
 
+    // eslint-disable-next-line unicorn/prefer-add-event-listener
     es.onmessage = function (e) {
-      e.data.trim().split(/\n+/).forEach((line) => {
+      e.data.trim().split(/\n+/).forEach(line => {
         cli.log(colorize(line))
       })
     }
   })
 }
 
-async function logDisplayer (heroku, options) {
+async function logDisplayer(heroku, options) {
   process.stdout.on('error', err => {
     if (err.code === 'EPIPE') {
       process.exit(0)
@@ -82,8 +83,8 @@ async function logDisplayer (heroku, options) {
       tail: options.tail,
       dyno: options.dyno,
       source: options.source,
-      lines: options.lines
-    }
+      lines: options.lines,
+    },
   })
   return readLogs(response.logplex_url)
 }

--- a/packages/run-v5/package.json
+++ b/packages/run-v5/package.json
@@ -22,13 +22,14 @@
     "@heroku-cli/command": "^9.0.2",
     "@heroku-cli/notifications": "^1.2.2",
     "@heroku/eventsource": "^1.0.7",
+    "@oclif/core": "^1.26.2",
     "debug": "^4.1.1",
     "fs-extra": "^7.0.1",
     "heroku-cli-util": "^8.0.11",
+    "http-call": "5.3.0",
     "shellwords": "^0.1.1"
   },
   "devDependencies": {
-    "@oclif/core": "^1.26.2",
     "@oclif/plugin-legacy": "^1.3.0",
     "chai": "^4.2.0",
     "fixture-stdout": "0.2.1",

--- a/packages/run-v5/package.json
+++ b/packages/run-v5/package.json
@@ -22,6 +22,7 @@
     "@heroku-cli/command": "^9.0.2",
     "@heroku-cli/notifications": "^1.2.2",
     "@heroku/eventsource": "^1.0.7",
+    "debug": "^4.1.1",
     "fs-extra": "^7.0.1",
     "heroku-cli-util": "^8.0.11",
     "shellwords": "^0.1.1"

--- a/packages/run-v5/package.json
+++ b/packages/run-v5/package.json
@@ -59,7 +59,9 @@
   },
   "repository": "heroku/cli",
   "scripts": {
+    "lint": "eslint . --ext .js --config ../../.eslintrc --ignore-path ../../.eslintignore",
     "postpack": "rm oclif.manifest.json",
+    "posttest": "yarn lint",
     "prepack": "oclif manifest",
     "test": "mocha",
     "test:acceptance": "yarn test --grep='@acceptance'",

--- a/packages/run-v5/test/assert_exit.js
+++ b/packages/run-v5/test/assert_exit.js
@@ -3,11 +3,11 @@
 let expect = require('chai').expect
 let cli = require('heroku-cli-util')
 
-function exit (code, gen) {
+function exit(code, gen) {
   var actual
-  return gen.catch(function (err) {
-    expect(err).to.be.an.instanceof(cli.exit.ErrorExit)
-    actual = err.code
+  return gen.catch(function (error) {
+    expect(error).to.be.an.instanceof(cli.exit.ErrorExit)
+    actual = error.code
   }).then(function () {
     expect(actual).to.be.an('number', 'Expected error.exit(i) to be called with a number')
     expect(actual).to.equal(code)

--- a/packages/run-v5/test/colorize.test.js
+++ b/packages/run-v5/test/colorize.test.js
@@ -5,6 +5,7 @@ describe('colorize', () => {
   const test = (type, input) => {
     console.log(colorize(`2018-01-01T00:00:00.00+00:00 heroku[${type}]: ${input}`))
   }
+
   it('colorizes router logs', () => {
     test('router', 'works with bare words at=info method=POST path="/record?start=123&end=321" host=cli-analytics.heroku.com request_id=0fb9c505-5d65-4e63-8fee-fa18da33ee47 fwd="50.233.199.252" dyno=web.1 connect=1ms service=14ms status=201 bytes=255 protocol=https')
     test('router', 'at=error code=H12 desc="Request timeout" method=GET path=/ host=myapp.herokuapp.com request_id=8601b555-6a83-4c12-8269-97c8e32cdb22 fwd="204.204.204.204" dyno=web.1 connect= service=30000ms status=503 bytes=0 protocol=http')

--- a/packages/run-v5/test/commands/console.js
+++ b/packages/run-v5/test/commands/console.js
@@ -1,12 +1,14 @@
 'use strict'
+/* globals afterEach beforeEach */
 
-const { expect } = require('chai')
+const {expect} = require('chai')
 const sinon = require('sinon')
 const Dyno = require('../../lib/dyno')
 const cmd = require('../../commands/console')
 
 describe('console', () => {
-  let dynoStub, dynoOpts
+  let dynoStub
+  let dynoOpts
 
   beforeEach(() => {
     dynoStub = sinon.stub(Dyno.prototype, 'start').callsFake(function () {
@@ -16,8 +18,8 @@ describe('console', () => {
   })
 
   it('runs console', () => {
-    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {} })
-      .then(() => expect(dynoOpts.command).to.equal('console'))
+    return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {}})
+    .then(() => expect(dynoOpts.command).to.equal('console'))
   })
 
   afterEach(() => {

--- a/packages/run-v5/test/commands/detached.js
+++ b/packages/run-v5/test/commands/detached.js
@@ -1,15 +1,16 @@
 'use strict'
+/* globals beforeEach */
 
 const cmd = require('../../commands/run/detached')
-const { expect } = require('chai')
+const {expect} = require('chai')
 const cli = require('heroku-cli-util')
-const { describeAcceptance } = require('../test-helper')
+const {describeAcceptance} = require('../test-helper')
 
 describeAcceptance('run:detached', () => {
   beforeEach(() => cli.mockConsole())
 
   it('runs a command', () => {
-    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey }, args: ['echo', '1', '2', '3'] })
-      .then(() => expect(cli.stdout.startsWith('Run heroku logs --app heroku-cli-ci-smoke-test-app --dyno')).to.equal(true))
+    return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: {password: global.apikey}, args: ['echo', '1', '2', '3']})
+    .then(() => expect(cli.stdout.startsWith('Run heroku logs --app heroku-cli-ci-smoke-test-app --dyno')).to.equal(true))
   })
 })

--- a/packages/run-v5/test/commands/logs.js
+++ b/packages/run-v5/test/commands/logs.js
@@ -1,15 +1,16 @@
 'use strict'
+/* globals beforeEach */
 
 const cmd = require('../../commands/logs')
 const cli = require('heroku-cli-util')
-const { expect } = require('chai')
-const { describeAcceptance } = require('../test-helper')
+const {expect} = require('chai')
+const {describeAcceptance} = require('../test-helper')
 
 describeAcceptance('logs', () => {
   beforeEach(() => cli.mockConsole())
 
   it('shows the logs', () => {
-    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey } })
-      .then(() => expect(cli.stdout.startsWith('20')).to.equal(true, 'starts with the year'))
+    return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: {password: global.apikey}})
+    .then(() => expect(cli.stdout.startsWith('20')).to.equal(true, 'starts with the year'))
   })
 })

--- a/packages/run-v5/test/commands/rake.js
+++ b/packages/run-v5/test/commands/rake.js
@@ -1,12 +1,14 @@
 'use strict'
+/* globals afterEach beforeEach */
 
-const { expect } = require('chai')
+const {expect} = require('chai')
 const sinon = require('sinon')
 const Dyno = require('../../lib/dyno')
 const cmd = require('../../commands/rake')
 
 describe('rake', () => {
-  let dynoStub, dynoOpts
+  let dynoStub
+  let dynoOpts
 
   beforeEach(() => {
     dynoStub = sinon.stub(Dyno.prototype, 'start').callsFake(function () {
@@ -16,8 +18,8 @@ describe('rake', () => {
   })
 
   it('runs rake', () => {
-    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, args: ['test'] })
-      .then(() => expect(dynoOpts.command).to.equal('rake test'))
+    return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {}, args: ['test']})
+    .then(() => expect(dynoOpts.command).to.equal('rake test'))
   })
 
   afterEach(() => {

--- a/packages/run-v5/test/commands/run.js
+++ b/packages/run-v5/test/commands/run.js
@@ -1,11 +1,12 @@
 'use strict'
+/* globals beforeEach */
 
 const cli = require('heroku-cli-util')
 const cmd = require('../../commands/run')
-const { expect } = require('chai')
+const {expect} = require('chai')
 const StdOutFixture = require('fixture-stdout')
 const assertExit = require('../assert_exit')
-const { describeAcceptance } = require('../test-helper')
+const {describeAcceptance} = require('../test-helper')
 
 describeAcceptance('run', () => {
   beforeEach(() => cli.mockConsole())
@@ -13,45 +14,53 @@ describeAcceptance('run', () => {
   it('runs a command', () => {
     let stdout = ''
     let fixture = new StdOutFixture()
-    fixture.capture(s => { stdout += s })
-    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey }, args: ['echo', '1', '2', '3'] })
-      .then(() => fixture.release())
-      .then(() => expect(stdout).to.contain('1 2 3\n'))
+    fixture.capture(s => {
+      stdout += s
+    })
+    return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: {password: global.apikey}, args: ['echo', '1', '2', '3']})
+    .then(() => fixture.release())
+    .then(() => expect(stdout).to.contain('1 2 3\n'))
   })
 
   it('runs a command with spaces', () => {
     let stdout = ''
     let fixture = new StdOutFixture()
-    fixture.capture(s => { stdout += s })
-    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey }, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo": "bar"} '] })
-      .then(() => fixture.release())
-      .then(() => expect(stdout).to.equal('{"foo": "bar"} \n'))
+    fixture.capture(s => {
+      stdout += s
+    })
+    return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: {password: global.apikey}, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo": "bar"} ']})
+    .then(() => fixture.release())
+    .then(() => expect(stdout).to.equal('{"foo": "bar"} \n'))
   })
 
   it('runs a command with quotes', () => {
     let stdout = ''
     let fixture = new StdOutFixture()
-    fixture.capture(s => { stdout += s })
-    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: { password: global.apikey }, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo":"bar"}'] })
-      .then(() => fixture.release())
-      .then(() => expect(stdout).to.equal('{"foo":"bar"}\n'))
+    fixture.capture(s => {
+      stdout += s
+    })
+    return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: {password: global.apikey}, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo":"bar"}']})
+    .then(() => fixture.release())
+    .then(() => expect(stdout).to.equal('{"foo":"bar"}\n'))
   })
 
   it('runs a command with env vars', () => {
     let stdout = ''
     let fixture = new StdOutFixture()
-    fixture.capture(s => { stdout += s })
-    return cmd.run({ app: 'heroku-cli-ci-smoke-test-app', flags: { env: 'FOO=bar' }, auth: { password: global.apikey }, args: ['env'] })
-      .then(() => fixture.release())
-      .then(() => expect(stdout).to.contain('FOO=bar'))
+    fixture.capture(s => {
+      stdout += s
+    })
+    return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {env: 'FOO=bar'}, auth: {password: global.apikey}, args: ['env']})
+    .then(() => fixture.release())
+    .then(() => expect(stdout).to.contain('FOO=bar'))
   })
 
   it('gets 127 status for invalid command', () => {
     cli.exit.mock()
     return assertExit(127, cmd.run({
       app: 'heroku-cli-ci-smoke-test-app',
-      flags: { 'exit-code': true },
-      auth: { password: global.apikey },
-      args: ['invalid-command'] }))
+      flags: {'exit-code': true},
+      auth: {password: global.apikey},
+      args: ['invalid-command']}))
   })
 })

--- a/packages/run-v5/test/lib/helpers.js
+++ b/packages/run-v5/test/lib/helpers.js
@@ -1,16 +1,15 @@
 'use strict'
-/* globals describe it */
 
 const helpers = require('../../lib/helpers')
-const { expect } = require('chai')
+const {expect} = require('chai')
 
 describe('helpers.buildCommand()', () => {
   [
-    { args: ['echo foo'], expected: 'echo foo' },
-    { args: ['echo', 'foo bar'], expected: 'echo "foo bar"' },
-    { args: ['echo', 'foo', 'bar'], expected: 'echo foo bar' },
-    { args: ['echo', '{"foo": "bar"}'], expected: 'echo "{\\"foo\\": \\"bar\\"}"' },
-    { args: ['echo', '{"foo":"bar"}'], expected: 'echo "{\\"foo\\":\\"bar\\"}"' }
+    {args: ['echo foo'], expected: 'echo foo'},
+    {args: ['echo', 'foo bar'], expected: 'echo "foo bar"'},
+    {args: ['echo', 'foo', 'bar'], expected: 'echo foo bar'},
+    {args: ['echo', '{"foo": "bar"}'], expected: 'echo "{\\"foo\\": \\"bar\\"}"'},
+    {args: ['echo', '{"foo":"bar"}'], expected: 'echo "{\\"foo\\":\\"bar\\"}"'},
   ].forEach(example => {
     it(`parses \`${example.args.join(' ')}\` as ${example.expected}`, () => {
       expect(helpers.buildCommand(example.args)).to.equal(example.expected)

--- a/packages/run-v5/test/test-helper.js
+++ b/packages/run-v5/test/test-helper.js
@@ -1,9 +1,7 @@
-
-
 function describeAcceptance(name, ...rest) {
   const describeName = `@acceptance ${name}`
 
-  let describeOrSkip = describe;
+  let describeOrSkip = describe
 
   if (process.env.CI && process.env.RUN_ACCEPTANCE_TESTS !== 'true') {
     describeOrSkip = describe.skip.bind(describe)


### PR DESCRIPTION
Fixes linting errors for the run-v5 package.

Fulfills part of the [eslint standardization GUS ticket](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001NBwHTYA1/view)

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
