### PR TITLE
fix: use correct cwd for execa during install scripts upload

### DIFF
--- a/.github/workflows/pack-and-release.yml
+++ b/.github/workflows/pack-and-release.yml
@@ -166,7 +166,6 @@ jobs:
           fi
           yarn oclif promote --deb --xz --root="./packages/cli" --indexes --version=${{ inputs.version }} --sha=$shortSHA --channel=${{ inputs.channel }}
       - name: promote Linux install scripts
-        working-directory: /home/runner/work/cli/cli/
         continue-on-error: true
         run: node ./scripts/postrelease/install_scripts.js
 

--- a/scripts/postrelease/install_scripts.js
+++ b/scripts/postrelease/install_scripts.js
@@ -3,15 +3,21 @@
 const execa = require('execa')
 const getHerokuS3Bucket = require('../utils/getHerokuS3Bucket')
 const qq = require('qqjs')
+const path = require('path')
+
+const opts = {
+  cwd: path.join(__dirname, '..', '..'),
+  stdio: 'inherit'
+}
 
 qq.config.silent = false
 qq.run(async () => {
   const {GITHUB_REF_TYPE, GITHUB_REF_NAME} = process.env
   if (GITHUB_REF_TYPE === 'tag' && GITHUB_REF_NAME.startsWith('v')) {
     const HEROKU_S3_BUCKET = getHerokuS3Bucket()
-    await execa(`aws s3 cp --content-type text/plain --cache-control "max-age: 604800" ./install-standalone.sh "s3://${HEROKU_S3_BUCKET}/install-standalone.sh"`)
-    await execa(`aws s3 cp --content-type text/plain --cache-control "max-age: 604800" ./install-standalone.sh "s3://${HEROKU_S3_BUCKET}/install.sh"`)
-    await execa(`aws s3 cp --content-type text/plain --cache-control "max-age: 604800" ./install-ubuntu.sh "s3://${HEROKU_S3_BUCKET}/install-ubuntu.sh"`)
+    await execa(`aws s3 cp --content-type text/plain --cache-control "max-age: 604800" ./install-standalone.sh "s3://${HEROKU_S3_BUCKET}/install-standalone.sh"`, opts)
+    await execa(`aws s3 cp --content-type text/plain --cache-control "max-age: 604800" ./install-standalone.sh "s3://${HEROKU_S3_BUCKET}/install.sh"`, opts)
+    await execa(`aws s3 cp --content-type text/plain --cache-control "max-age: 604800" ./install-ubuntu.sh "s3://${HEROKU_S3_BUCKET}/install-ubuntu.sh"`, opts)
   } else {
     console.log('Not on stable release, skipping updating install scripts')
   }


### PR DESCRIPTION
Continuation of https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001KPfC4YAL/view
Make certain execa is executed from the correct directory

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
