### PR TITLE
chore(container-registry-v5): add code coverage reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "private": true,
   "scripts": {
     "build": "lerna run prepack",
-    "test": "yarn lerna run --scope @heroku-cli/plugin-container-registry-v5 test",
+    "test": "lerna run test --concurrency 4",
     "version": "cp packages/cli/CHANGELOG.md CHANGELOG.md && git add CHANGELOG.md",
     "cleanNodeModules": "rm -rf ./packages/*/node_modules && rm -rf ./node_modules"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "private": true,
   "scripts": {
     "build": "lerna run prepack",
-    "test": "lerna run test --concurrency 4",
+    "test": "yarn lerna run --scope @heroku-cli/plugin-container-registry-v5 test",
     "version": "cp packages/cli/CHANGELOG.md CHANGELOG.md && git add CHANGELOG.md",
     "cleanNodeModules": "rm -rf ./packages/*/node_modules && rm -rf ./node_modules"
   },

--- a/packages/container-registry-v5/lib/sanbashi.js
+++ b/packages/container-registry-v5/lib/sanbashi.js
@@ -58,6 +58,7 @@ Sanbashi.chooseJobs = async function (jobs) {
   // eslint-disable-next-line guard-for-in
   for (let processType in jobs) {
     let group = jobs[processType]
+    console.log('group:', group)
     if (group.length > 1) {
       let prompt = {
         type: 'list',
@@ -66,7 +67,9 @@ Sanbashi.chooseJobs = async function (jobs) {
         message: `Found multiple Dockerfiles with process type ${processType}. Please choose one to build and push `,
       }
       let answer = await Inquirer.prompt(prompt)
+      console.log('answer:', answer)
       chosenJobs.push(group.find(o => o.dockerfile === answer[processType]))
+      console.log('chosenJobs:', chosenJobs)
     } else {
       chosenJobs.push(group[0])
     }

--- a/packages/container-registry-v5/lib/sanbashi.js
+++ b/packages/container-registry-v5/lib/sanbashi.js
@@ -67,9 +67,7 @@ Sanbashi.chooseJobs = async function (jobs) {
         message: `Found multiple Dockerfiles with process type ${processType}. Please choose one to build and push `,
       }
       let answer = await Inquirer.prompt(prompt)
-      console.log('answer:', answer)
       chosenJobs.push(group.find(o => o.dockerfile === answer[processType]))
-      console.log('chosenJobs:', chosenJobs)
     } else {
       chosenJobs.push(group[0])
     }

--- a/packages/container-registry-v5/test/commands/index.js
+++ b/packages/container-registry-v5/test/commands/index.js
@@ -1,0 +1,24 @@
+'use strict'
+/* globals beforeEach afterEach */
+
+const cli = require('heroku-cli-util')
+var pkg = require('../../package.json')
+const cmdIndex = require('../../commands/index')(pkg)
+const {expect} = require('chai')
+const sinon = require('sinon')
+
+describe('container run', () => {
+  let showVersionStub
+
+  beforeEach(() => {
+    cli.mockConsole()
+    showVersionStub = sinon.stub(console, 'log')
+  })
+
+  afterEach(() => showVersionStub.restore())
+
+  it('shows package version', () => {
+    cmdIndex.run()
+    expect(showVersionStub.called).to.equal(true)
+  })
+})

--- a/packages/container-registry-v5/test/sanbashi.test.js
+++ b/packages/container-registry-v5/test/sanbashi.test.js
@@ -7,6 +7,14 @@ let Inquirer = require('inquirer')
 let childProcess = require('child_process')
 let EventEmitter = require('events').EventEmitter
 
+const eventMock = () => {
+  let eventEmitter = new EventEmitter()
+  process.nextTick(function () {
+    eventEmitter.emit('exit', 0)
+  })
+  return eventEmitter
+}
+
 describe('Sanbashi', () => {
   describe('.getDockerfiles', () => {
     it('can recurse the directory', () => {
@@ -116,13 +124,7 @@ describe('Sanbashi', () => {
     let eventStub
 
     beforeEach(() => {
-      eventStub = Sinon.stub(childProcess, 'spawn').callsFake(() => {
-        let eventEmitter = new EventEmitter()
-        process.nextTick(function () {
-          eventEmitter.emit('exit', 0)
-        })
-        return eventEmitter
-      })
+      eventStub = Sinon.stub(childProcess, 'spawn').callsFake(eventMock)
     })
 
     it('successfully pushes image to Sanbashi cmd', async () => {
@@ -141,13 +143,7 @@ describe('Sanbashi', () => {
     let eventStub
 
     beforeEach(() => {
-      eventStub = Sinon.stub(childProcess, 'spawn').callsFake(() => {
-        let eventEmitter = new EventEmitter()
-        process.nextTick(function () {
-          eventEmitter.emit('exit', 0)
-        })
-        return eventEmitter
-      })
+      eventStub = Sinon.stub(childProcess, 'spawn').callsFake(eventMock)
     })
 
     it('successfully pulls image to execute with Sanbashi cmd', async () => {
@@ -166,13 +162,7 @@ describe('Sanbashi', () => {
     let eventStub
 
     beforeEach(() => {
-      eventStub = Sinon.stub(childProcess, 'spawn').callsFake(() => {
-        let eventEmitter = new EventEmitter()
-        process.nextTick(function () {
-          eventEmitter.emit('exit', 0)
-        })
-        return eventEmitter
-      })
+      eventStub = Sinon.stub(childProcess, 'spawn').callsFake(eventMock)
     })
 
     it('successfully runs image to execute with Sanbashi cmd', async () => {

--- a/packages/container-registry-v5/test/sanbashi.test.js
+++ b/packages/container-registry-v5/test/sanbashi.test.js
@@ -100,14 +100,14 @@ describe('Sanbashi', () => {
       }
     })
   })
-  describe('.chooseJobs', () => {
+  describe('.chooseJobs multiple entries', () => {
     let promptStub
     beforeEach(() => {
       promptStub = Sinon.stub(Inquirer, 'prompt').returns({web: 'Nested/Dockerfile.web'})
     })
 
     it('prompts user when multiple entries exists', async () => {
-      const dockerfiles = [Path.join('.', 'Nested', 'Dockerfile.web'), Path.join('.', 'Nested', 'Dockerfile.web')]
+      const dockerfiles = [Path.join('.', 'Nested', 'Dockerfile.web'), Path.join('.', 'Dockerfile.web')]
       const jobs = Sanbashi.getJobs('rootfulroot', dockerfiles)
       let chosenJob = await Sanbashi.chooseJobs(jobs)
       expect(chosenJob[0]).to.have.property('dockerfile', dockerfiles[0])

--- a/packages/container-registry-v5/test/sanbashi.test.js
+++ b/packages/container-registry-v5/test/sanbashi.test.js
@@ -102,15 +102,15 @@ describe('Sanbashi', () => {
   })
   describe('.chooseJobs multiple entries', () => {
     let promptStub
+    const dockerfilePath = Path.join('.', 'Nested', 'Dockerfile.web')
     beforeEach(() => {
-      promptStub = Sinon.stub(Inquirer, 'prompt').returns({web: 'Nested/Dockerfile.web'})
+      promptStub = Sinon.stub(Inquirer, 'prompt').returns({web: dockerfilePath})
     })
 
     it('prompts user when multiple entries exists', async () => {
       const dockerfiles = [Path.join('.', 'Nested', 'Dockerfile.web'), Path.join('.', 'Dockerfile.web')]
       const jobs = Sanbashi.getJobs('rootfulroot', dockerfiles)
       let chosenJob = await Sanbashi.chooseJobs(jobs)
-      console.log('test chosenJob[0]:', chosenJob)
       expect(chosenJob[0]).to.have.property('dockerfile', dockerfiles[0])
       expect(chosenJob).to.have.property('length', 1)
     })

--- a/packages/container-registry-v5/test/sanbashi.test.js
+++ b/packages/container-registry-v5/test/sanbashi.test.js
@@ -110,6 +110,7 @@ describe('Sanbashi', () => {
       const dockerfiles = [Path.join('.', 'Nested', 'Dockerfile.web'), Path.join('.', 'Dockerfile.web')]
       const jobs = Sanbashi.getJobs('rootfulroot', dockerfiles)
       let chosenJob = await Sanbashi.chooseJobs(jobs)
+      console.log('test chosenJob[0]:', chosenJob)
       expect(chosenJob[0]).to.have.property('dockerfile', dockerfiles[0])
       expect(chosenJob).to.have.property('length', 1)
     })


### PR DESCRIPTION
## Why the change?
[GUS Card](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001NBwPvYAL/view)

As per our review of unit tests and coverage for the container-registry-v5 package, this PR does the following:
- Ensures that our code coverage reports over 85% test coverage of statements ✅

## Additional Notes
- N/A

## How to verify?
1. Pull down branch
2. Run tests
3. Confirm test coverage report is visible and that it reports over 85% test coverage of statements for all files
