### PR TITLE
chore(cli): update subdomain examples

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -273,9 +273,9 @@ DESCRIPTION
 
 EXAMPLES
   $ heroku open -a myapp
-  # opens https://myapp.herokuapp.com
+  # opens https://myapp-xxxxxxxxxxxx.herokuapp.com
   $ heroku open -a myapp /foo
-  # opens https://myapp.herokuapp.com/foo
+  # opens https://myapp-xxxxxxxxxxxx.herokuapp.com/foo
 ```
 
 ## `heroku apps:rename NEWNAME`
@@ -296,7 +296,7 @@ DESCRIPTION
 
 EXAMPLES
   $ heroku apps:rename --app oldname newname
-  https://newname.herokuapp.com/ | https://git.heroku.com/newname.git
+  https://newname-xxxxxxxxxxxx.herokuapp.com/ | https://git.heroku.com/newname.git
   Git remote heroku updated
 ```
 

--- a/docs/domains.md
+++ b/docs/domains.md
@@ -40,7 +40,7 @@ DESCRIPTION
 EXAMPLES
   $ heroku domains
   === example Heroku Domain
-  example.herokuapp.com
+  example-xxxxxxxxxxxx.herokuapp.com
   === example Custom Domains
   Domain Name      DNS Record Type  DNS Target
   www.example.com  CNAME            www.example.herokudns.com

--- a/packages/apps-v5/README.md
+++ b/packages/apps-v5/README.md
@@ -273,9 +273,9 @@ DESCRIPTION
 
 EXAMPLES
   $ heroku open -a myapp
-  # opens https://myapp.herokuapp.com
+  # opens https://myapp-xxxxxxxxxxxx.herokuapp.com
   $ heroku open -a myapp /foo
-  # opens https://myapp.herokuapp.com/foo
+  # opens https://myapp-xxxxxxxxxxxx.herokuapp.com/foo
 ```
 
 ## `heroku apps:rename NEWNAME`
@@ -296,7 +296,7 @@ DESCRIPTION
 
 EXAMPLES
   $ heroku apps:rename --app oldname newname
-  https://newname.herokuapp.com/ | https://git.heroku.com/newname.git
+  https://newname-xxxxxxxxxxxx.herokuapp.com/ | https://git.heroku.com/newname.git
   Git remote heroku updated
 ```
 

--- a/packages/apps-v5/src/commands/apps/rename.js
+++ b/packages/apps-v5/src/commands/apps/rename.js
@@ -43,7 +43,7 @@ let cmd = {
   description: 'rename an app',
   help: 'This will locally update the git remote if it is set to the old app.',
   examples: `$ heroku apps:rename --app oldname newname
-https://newname.herokuapp.com/ | https://git.heroku.com/newname.git
+https://newname-xxxxxxxxxxxx.herokuapp.com/ | https://git.heroku.com/newname.git
 Git remote heroku updated`,
   needsAuth: true,
   needsApp: true,

--- a/packages/apps/README.md
+++ b/packages/apps/README.md
@@ -64,7 +64,7 @@ DESCRIPTION
 EXAMPLES
   $ heroku domains
   === example Heroku Domain
-  example.herokuapp.com
+  example-xxxxxxxxxxxx.herokuapp.com
   === example Custom Domains
   Domain Name      DNS Record Type  DNS Target
   www.example.com  CNAME            www.example.herokudns.com

--- a/packages/apps/src/commands/domains/index.ts
+++ b/packages/apps/src/commands/domains/index.ts
@@ -17,7 +17,7 @@ export default class DomainsIndex extends Command {
   static examples = [
     `$ heroku domains
 === example Heroku Domain
-example.herokuapp.com
+example-xxxxxxxxxxxx.herokuapp.com
 
 === example Custom Domains
 Domain Name      DNS Record Type  DNS Target


### PR DESCRIPTION
## Why the change?
[GUS Card](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001Nh75OYAR/view)

We are currently updating our future app subdomains to prevent potential attack vectors. While there are no technical changes required in the Heroku CLI for updating the subdomains for newly created apps, this PR does the following:
- Updates subdomains copy in examples to maintain product consistency ✅


## Additional Notes
- N/A

## How to verify?
1. Get copy approval from @SandyPantsLai
