### PR TITLE
fix: enable GH releases in CD

### DIFF
--- a/.github/workflows/publish-pack-upload.yml
+++ b/.github/workflows/publish-pack-upload.yml
@@ -21,6 +21,7 @@ jobs:
   publish-npm-and-github:
     runs-on: pub-hk-ubuntu-22.04-small
     permissions:
+      # give secrets.GITHUB_TOKEN ability to push/tag/release
       contents: write
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish-pack-upload.yml
+++ b/.github/workflows/publish-pack-upload.yml
@@ -20,6 +20,8 @@ on:
 jobs:
   publish-npm-and-github:
     runs-on: pub-hk-ubuntu-22.04-small
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 16.x
@@ -29,13 +31,14 @@ jobs:
           cache: yarn
       - run: yarn --frozen-lockfile --network-timeout 1000000
       - name: set NPM auth
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_PUBLISH_KEY }}" > ~/.npmrc
+      - name: set git user
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_PUBLISH_KEY }}" > ~/.npmrc
           git config user.name "GitHub Actions Bot"
           git config user.email "heroku-front-end+npm-releases@salesforce.com"
-      - name: Publish to NPM
-#        env:
-#          GITHUB_TOKEN: '!!!NEED THIS!!! ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}'
+      - name: Publish to NPM & GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ ${{ inputs.isPreRelease }} ]]; then
             bash scripts/publish-prerelease

--- a/scripts/publish-prerelease
+++ b/scripts/publish-prerelease
@@ -19,11 +19,11 @@ fi
 
 ## hostname is necessary just in case you are logged into the CLI
 ## GitHub enterprise instance
-#if !(gh auth status --hostname "github.com" > /dev/null 2>&1); then
-#  echo "Not logged into github".
-#  echo "Please run: gh auth login"
-#  exit 1
-#fi
+if !(gh auth status --hostname "github.com" > /dev/null 2>&1); then
+  echo "Not logged into github".
+  echo "Please run: gh auth login"
+  exit 1
+fi
 
 git pull --rebase origin "${CURRENT_BRANCH}"
 # The --force overrides local tags.
@@ -60,4 +60,4 @@ yarn lerna publish --dist-tag beta --yes from-package
 git tag "${TAG_NAME}" -m "${TAG_NAME}"
 git push origin "${TAG_NAME}"
 
-#gh release create "${TAG_NAME}" --title="${TAG_NAME}" --prerelease
+gh release create "${TAG_NAME}" --title="${TAG_NAME}" --prerelease

--- a/scripts/publish-release
+++ b/scripts/publish-release
@@ -10,20 +10,20 @@ if [[ "${CURRENT_BRANCH}" != *"${RELEASE_PREFIX}"*  ]]; then
   exit 1
 fi
 
-#if !(command -v gh > /dev/null); then
-#  echo "GitHub CLI is required for this release script."
-#  echo "Please install GitHub CLI and try again:"
-#  echo "https://github.com/cli/cli#installation"
-#  exit 1
-#fi
+if !(command -v gh > /dev/null); then
+  echo "GitHub CLI is required for this release script."
+  echo "Please install GitHub CLI and try again:"
+  echo "https://github.com/cli/cli#installation"
+  exit 1
+fi
 
-## hostname is necessary just in case you are logged into the CLI
-## GitHub enterprise instance
-#if !(gh auth status --hostname "github.com" > /dev/null 2>&1); then
-#  echo "Not logged into github".
-#  echo "Please run: gh auth login"
-#  exit 1
-#fi
+# hostname is necessary just in case you are logged into the CLI
+# GitHub enterprise instance
+if !(gh auth status --hostname "github.com" > /dev/null 2>&1); then
+  echo "Not logged into github".
+  echo "Please run: gh auth login"
+  exit 1
+fi
 
 git pull --rebase origin "${CURRENT_BRANCH}"
 # The --force overrides local tags.
@@ -51,11 +51,10 @@ echo "publishing packages to npm..."
 yarn lerna publish --yes from-package
 
 
-#LAST_PUBLISHED_TAG=$(git tag --sort="-version:refname" --list --format="%(refname:strip=2)" | head -n1)
+LAST_PUBLISHED_TAG=$(git tag --sort="-version:refname" --list --format="%(refname:strip=2)" | head -n1)
 
 git tag "${TAG_NAME}" -m "${TAG_NAME}"
 git push origin "${TAG_NAME}"
 
-# temporary disable while waiting on service account approval
-#RELEASE_NOTES=$(git log --graph --format="%h %s" "${LAST_PUBLISHED_TAG}...${TAG_NAME}~1")
-#gh release create "${TAG_NAME}" --title="${TAG_NAME}" --notes="${RELEASE_NOTES}"
+RELEASE_NOTES=$(git log --graph --format="%h %s" "${LAST_PUBLISHED_TAG}...${TAG_NAME}~1")
+gh release create "${TAG_NAME}" --title="${TAG_NAME}" --notes="${RELEASE_NOTES}"


### PR DESCRIPTION
The final piece of https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001NBcPzYAL/view
Uncomment existing GH release code from scripts.
Give automatically created GHA GITHUB_TOKEN permission to push/tag/release and use.
https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
