### PR TITLE
fix: trigger for release CD

### DIFF
--- a/.github/workflows/publish-pack-upload.yml
+++ b/.github/workflows/publish-pack-upload.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       isPreRelease:
-        description: is release not for prod?
+        description: is release for beta/rc/dev?
         type: boolean
         required: false
         default: false
@@ -41,7 +41,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [[ ${{ inputs.isPreRelease }} ]]; then
+          if ${{ inputs.isPreRelease }}
+          then
             bash scripts/publish-prerelease
           else
             bash scripts/publish-release

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -3,7 +3,7 @@ name: Trigger Release
 on:
   pull_request:
     branches:
-      - main
+      - release-*
     types: [ closed ]
   push:
     branches:

--- a/packages/cli/src/analytics.ts
+++ b/packages/cli/src/analytics.ts
@@ -2,7 +2,6 @@ import {vars} from '@heroku-cli/command'
 import {Interfaces} from '@oclif/core'
 import netrc from 'netrc-parser'
 import * as path from 'path'
-
 import deps from './deps'
 
 const debug = require('debug')('heroku:analytics')


### PR DESCRIPTION
trigger released based on branch being merged in, not in to.
fix bash logic for determining which release script to run
whitespace in package for release

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
