### PR TITLE
fix: correctly use git log range for release notes.

### DIFF
--- a/scripts/publish-release
+++ b/scripts/publish-release
@@ -51,5 +51,5 @@ SORTED_TAGS=$(git tag --sort="-version:refname" --list --format="%(refname:strip
 FILTERED_TAGS=$(echo ${SORTED_TAGS} | grep 'v[0-9.]*' | grep -v '-')
 LAST_PUBLISHED_TAG=$(echo ${FILTERED_TAGS} | head -n1)
 
-RELEASE_NOTES=$(git log --graph --format="%h %s" "${LAST_PUBLISHED_TAG}...${TAG_NAME}~1")
+RELEASE_NOTES=$(git log --graph --format="%h %s" "${LAST_PUBLISHED_TAG}..${TAG_NAME}~1")
 gh release create "${TAG_NAME}" --title="${TAG_NAME}" --notes="${RELEASE_NOTES}"


### PR DESCRIPTION
Depending on git history, we could show older commits in change log.
[Explanation of ".." vs "..." in git log range](https://stackoverflow.com/questions/18595305/git-log-outputs-in-a-specific-revision-range/18595347#18595347) 
Examples: 
`git log --graph --format="%h %s" "v8.1.3...v8.1.4~1` 
yields 
```
* 31cc2895a fix: enable GH releases in CD (#2361)
* 289c8ec82 chore: set up integration, smoke, and acceptance test runs (#2354)
* 8923de7a1 fix: bugs from CD refactor (#2352)
* 8e386785c chore: add acceptance test for orgs-v5 (#2351)
* 4ccc6bf42 v8.1.3 (#2335)
* b516b331d chore: eslint standardization run-v5 (#2332)
* 6a2bae6ae chore: eslint standardization spaces (#2333)
* 32a562d51 fix: add working directory for install scripts step (#2323)
* 6eacdb4e3 v8.1.2 (#2334)
* 0999b1f2a chore: eslint standardization redis-v5 (#2331)
* ad87a9b69 chore: eslint standardization pg v5 (#2329)
* 1485f272c chore(pipelines): add code coverage reports (#2316)
* 61f79bc9e v8.1.1 (#2330)
* c5fb9d539 chore: update version of @oclif/plugin-plugins (#2328)
* a02268a2e v8.1.0 (#2327)
* fe98aecae feat(pg-v5): Adding pg:settings for auto_explain (#2310)
* 2b22b168e chore: eslint standardization clean-up (#2325)
* dd85b41fb chore(spaces): add code coverage reports (#2322)
* d24ff80b1 chore: eslint standardization orgs-v5 (#2314)
```
which includes down to v8.1.0. 

`git log --graph --format="%h %s" "v8.1.3..v8.1.4~1`
which only includes what we are interested in
```
* 31cc2895a fix: enable GH releases in CD (#2361)
* 289c8ec82 chore: set up integration, smoke, and acceptance test runs (#2354)
* 8923de7a1 fix: bugs from CD refactor (#2352)
* 8e386785c chore: add acceptance test for orgs-v5 (#2351)
```


<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
