### PR TITLE
test: experiment to determine failing `gh create release`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [16.x]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -18,7 +18,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: yarn
       - run: yarn --frozen-lockfile --network-timeout 1000000
-      - run: yarn test
+      - run: ./scripts/publish-release-test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   integration:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,11 @@ on:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: pub-hk-ubuntu-22.04-small
     permissions: write-all
     strategy:
       matrix:
         node-version: [16.x]
-        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -27,60 +26,60 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  integration:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        node-version: [16.x]
-        os: [ubuntu-latest, macos-latest]
-    environment: AcceptanceTests
-    env:
-      HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-      ENABLE_NET_CONNECT: true
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: yarn
-      - run: yarn --frozen-lockfile --network-timeout 1000000
-      - run: yarn lerna run test:integration
-
-  acceptance:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        node-version: [16.x]
-        os: [ubuntu-latest]
-    environment: AcceptanceTests
-    env:
-      HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-      ENABLE_NET_CONNECT: true
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: yarn
-      - run: yarn --frozen-lockfile --network-timeout 1000000
-      - name: Build packages
-        run: yarn lerna run prepack
-      - run: ./bin/run whoami
-        # on 'main' and 'release-' branches, these tests will be run as part of the acceptance tests.
-      - name: run smoke tests
-        if: github.ref_name != 'main' || !startsWith(github.head_ref, 'release-')
-        run: yarn lerna run test:smoke
-        # only run the full suite of acceptance tests on 'main' and 'release-' branches
-      - name: run acceptance tests
-        if: github.ref_name == 'main' || startsWith(github.head_ref, 'release-')
-        run: yarn lerna run test:acceptance
+#  integration:
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      matrix:
+#        node-version: [16.x]
+#        os: [ubuntu-latest, macos-latest]
+#    environment: AcceptanceTests
+#    env:
+#      HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+#      ENABLE_NET_CONNECT: true
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Use Node.js ${{ matrix.node-version }}
+#        uses: actions/setup-node@v3
+#        with:
+#          node-version: ${{ matrix.node-version }}
+#          cache: yarn
+#      - run: yarn --frozen-lockfile --network-timeout 1000000
+#      - run: yarn lerna run test:integration
+#
+#  acceptance:
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      matrix:
+#        node-version: [16.x]
+#        os: [ubuntu-latest]
+#    environment: AcceptanceTests
+#    env:
+#      HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+#      ENABLE_NET_CONNECT: true
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Use Node.js ${{ matrix.node-version }}
+#        uses: actions/setup-node@v3
+#        with:
+#          node-version: ${{ matrix.node-version }}
+#          cache: yarn
+#      - run: yarn --frozen-lockfile --network-timeout 1000000
+#      - name: Build packages
+#        run: yarn lerna run prepack
+#      - run: ./bin/run whoami
+#        # on 'main' and 'release-' branches, these tests will be run as part of the acceptance tests.
+#      - name: run smoke tests
+#        if: github.ref_name != 'main' || !startsWith(github.head_ref, 'release-')
+#        run: yarn lerna run test:smoke
+#        # only run the full suite of acceptance tests on 'main' and 'release-' branches
+#      - name: run acceptance tests
+#        if: github.ref_name == 'main' || startsWith(github.head_ref, 'release-')
+#        run: yarn lerna run test:acceptance
 
   # dummy job needed to pass changeling compliance because it only watches one build
   done:
     runs-on: macos-latest
-    needs: [test, integration, acceptance]
+    needs: [test]
     steps:
       - run: echo done
         working-directory: /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    permissions: write-all
     strategy:
       matrix:
         node-version: [16.x]
@@ -19,7 +20,6 @@ jobs:
           cache: yarn
       - run: yarn --frozen-lockfile --network-timeout 1000000
       - run: ./scripts/publish-release-test
-        permissions: write-all
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
-      - run: yarn --frozen-lockfile --network-timeout 1000000
-      - run: ./scripts/publish-release-test
+#      - run: yarn --frozen-lockfile --network-timeout 1000000
+      - run: |
+          GH_DEBUG=*
+          gh auth status --hostname "github.com"
+          gh release create v8.1.6 --title=v8.1.6 --generate-notes --notes-start-tag=v8.1.4 --draft
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           cache: yarn
       - run: yarn --frozen-lockfile --network-timeout 1000000
       - run: ./scripts/publish-release-test
+        permissions: write-all
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
 #          GH_DEBUG=*
 #          gh auth status --hostname "github.com"
 #          gh release create v8.1.6 --title=v8.1.6 --generate-notes --notes-start-tag=v8.1.4 --draft
-      - run: ./scripts/publish-release-test
+      - run: |
+          git update-index --chmod=+x ./scripts/publish-release-test
+          ./scripts/publish-release-test
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
 jobs:
   test:
     runs-on: pub-hk-ubuntu-22.04-small
-    permissions: write-all
     strategy:
       matrix:
         node-version: [16.x]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,11 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: yarn
 #      - run: yarn --frozen-lockfile --network-timeout 1000000
-      - run: |
-          GH_DEBUG=*
-          gh auth status --hostname "github.com"
-          gh release create v8.1.6 --title=v8.1.6 --generate-notes --notes-start-tag=v8.1.4 --draft
+#      - run: |
+#          GH_DEBUG=*
+#          gh auth status --hostname "github.com"
+#          gh release create v8.1.6 --title=v8.1.6 --generate-notes --notes-start-tag=v8.1.4 --draft
+      - run: ./scripts/publish-release-test
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/publish-release-test
+++ b/scripts/publish-release-test
@@ -2,7 +2,7 @@
 
 set -e -o pipefail
 
-echo "${GITHUB_TOKEN}" | gh auth login --with-token
 GH_DEBUG=*
+echo "${GITHUB_TOKEN}" | gh auth login --with-token
 gh auth status --hostname "github.com"
 gh release create v8.1.6 --title=v8.1.6 --generate-notes --notes-start-tag=v8.1.4 --draft

--- a/scripts/publish-release-test
+++ b/scripts/publish-release-test
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+echo "${GITHUB_TOKEN}" | gh auth login --with-token
+gh release create v8.1.6 --title=v8.1.6 --generate-notes --notes-start-tag=v8.1.4 --draft

--- a/scripts/publish-release-test
+++ b/scripts/publish-release-test
@@ -3,4 +3,5 @@
 set -e -o pipefail
 
 echo "${GITHUB_TOKEN}" | gh auth login --with-token
+GH_DEBUG=*
 gh release create v8.1.6 --title=v8.1.6 --generate-notes --notes-start-tag=v8.1.4 --draft

--- a/scripts/publish-release-test
+++ b/scripts/publish-release-test
@@ -4,4 +4,5 @@ set -e -o pipefail
 
 echo "${GITHUB_TOKEN}" | gh auth login --with-token
 GH_DEBUG=*
+gh auth status --hostname "github.com"
 gh release create v8.1.6 --title=v8.1.6 --generate-notes --notes-start-tag=v8.1.4 --draft


### PR DESCRIPTION
Not intended to be merged.
Attempt to debug `gh release create` failures.
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
