### PR TITLE
fix: safeguard against accidental releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,11 @@ jobs:
       - run: ./bin/run whoami
         # on 'main' and 'release-' branches, these tests will be run as part of the acceptance tests.
       - name: run smoke tests
-        if: github.ref_name != 'main' || !startsWith(github.head_ref, 'release-')
+        if: github.ref_name != 'main' || !startsWith(github.ref_name, 'release-')
         run: yarn lerna run test:smoke
         # only run the full suite of acceptance tests on 'main' and 'release-' branches
       - name: run acceptance tests
-        if: github.ref_name == 'main' || startsWith(github.head_ref, 'release-')
+        if: github.ref_name == 'main' || startsWith(github.ref_name, 'release-')
         run: yarn lerna run test:acceptance
 
   # dummy job needed to pass changeling compliance because it only watches one build

--- a/.github/workflows/watch-for-release.yml
+++ b/.github/workflows/watch-for-release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   start-release:
-    if: github.event.pull_request.merged == true && contains(github.head_ref, 'release-')
+    if: github.event.pull_request.merged == true && startsWith(github.ref_name, 'release-')
     uses: ./.github/workflows/full-release-pipeline.yml
     secrets: inherit
     with:


### PR DESCRIPTION
use triggering branch short name along with startsWith() instead of contains() for triggers

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
