### PR TITLE
fix: workflow syntax doesn't allow description key in job

### DIFF
--- a/.github/workflows/start-gh-release.yml
+++ b/.github/workflows/start-gh-release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   get-source-branch-name:
-    description: GHA does not provide short name for branch being merged in. This shortens it so we can validate it with startsWith()
+    # GHA does not provide short name for branch being merged in. This shortens it so we can validate it with startsWith()
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
