### PR TITLE
chore(ci-v5): add code coverage reports

### DIFF
--- a/packages/ci-v5/lib/api.js
+++ b/packages/ci-v5/lib/api.js
@@ -1,30 +1,5 @@
-// copied from plugin-pipelines-v5
-const keyBy = require('./key-by')
-
 const V3_HEADER = 'application/vnd.heroku+json; version=3'
-const FILTERS_HEADER = `${V3_HEADER}.filters`
 const PIPELINES_HEADER = `${V3_HEADER}.pipelines`
-
-function createAppSetup(heroku, body) {
-  return heroku.post('/app-setups', {body})
-}
-
-function createCoupling(heroku, pipeline, app, stage) {
-  return postCoupling(heroku, pipeline.id, app, stage)
-}
-
-function createPipeline(heroku, name, owner) {
-  return heroku.request({
-    method: 'POST',
-    path: '/pipelines',
-    headers: {Accept: PIPELINES_HEADER},
-    body: {name, owner},
-  })
-}
-
-function deleteCoupling(heroku, id) {
-  return heroku.delete(`/pipeline-couplings/${id}`)
-}
 
 function findPipelineByName(heroku, idOrName) {
   return heroku.request({
@@ -32,10 +7,6 @@ function findPipelineByName(heroku, idOrName) {
     path: `/pipelines?eq[name]=${idOrName}`,
     headers: {Accept: PIPELINES_HEADER},
   })
-}
-
-function getCoupling(heroku, app) {
-  return heroku.get(`/apps/${app}/pipeline-couplings`)
 }
 
 function getPipeline(heroku, id) {
@@ -46,88 +17,8 @@ function getPipeline(heroku, id) {
   })
 }
 
-function getApp(heroku, app) {
-  return heroku.get(`/apps/${app}`)
-}
-
-function getTeam(heroku, teamId) {
-  return heroku.get(`/teams/${teamId}`)
-}
-
-function getAppFilter(heroku, appIds) {
-  return heroku.request({
-    method: 'POST',
-    path: '/filters/apps',
-    headers: {Accept: FILTERS_HEADER},
-    body: {in: {id: appIds}},
-  })
-}
-
-function getAccountInfo(heroku, id = '~') {
-  return heroku.get(`/users/${id}`)
-}
-
-function getAppSetup(heroku, buildId) {
-  return heroku.get(`/app-setups/${buildId}`)
-}
-
-function listPipelineApps(heroku, pipelineId) {
-  return listCouplings(heroku, pipelineId).then(couplings => {
-    const appIds = couplings.map(coupling => coupling.app.id)
-
-    return getAppFilter(heroku, appIds).then(apps => {
-      const couplingsByAppId = keyBy(couplings, coupling => coupling.app.id)
-      apps.forEach(app => {
-        app.coupling = couplingsByAppId[app.id]
-      })
-
-      return apps
-    })
-  })
-}
-
-function listCouplings(heroku, pipelineId) {
-  return heroku.get(`/pipelines/${pipelineId}/pipeline-couplings`)
-}
-
-function patchCoupling(heroku, id, stage) {
-  return heroku.patch(`/pipeline-couplings/${id}`, {body: {stage}})
-}
-
-function postCoupling(heroku, pipeline, app, stage) {
-  return heroku.post('/pipeline-couplings', {
-    body: {app, pipeline, stage},
-  })
-}
-
-function removeCoupling(heroku, app) {
-  return getCoupling(heroku, app)
-    .then(coupling => deleteCoupling(heroku, coupling.id))
-}
-
-function updateCoupling(heroku, app, stage) {
-  return getCoupling(heroku, app)
-    .then(coupling => patchCoupling(heroku, coupling.id, stage))
-}
-
 module.exports = {
-  createAppSetup,
-  createCoupling,
-  createPipeline,
-  deleteCoupling,
   findPipelineByName,
-  getAccountInfo,
-  getAppFilter,
-  getAppSetup,
-  getApp,
-  getCoupling,
   getPipeline,
-  getTeam,
-  listCouplings,
-  listPipelineApps,
-  patchCoupling,
-  postCoupling,
-  removeCoupling,
-  updateCoupling,
   V3_HEADER,
 }

--- a/packages/ci-v5/package.json
+++ b/packages/ci-v5/package.json
@@ -33,6 +33,7 @@
     "heroku-client": "^3.0.7",
     "mocha": "^5.1.1",
     "nock": "^10.0.6",
+    "nyc": "^15.1.0",
     "oclif": "3.8.1",
     "sinon": "^1.17.6",
     "std-mocks": "^1.0.1"
@@ -58,7 +59,7 @@
     "postpublish": "rm oclif.manifest.json",
     "posttest": "yarn lint",
     "prepack": "oclif manifest",
-    "test": "mocha -R tap",
+    "test": "nyc mocha -R tap",
     "version": "oclif readme && git add README.md"
   }
 }

--- a/packages/ci-v5/package.json
+++ b/packages/ci-v5/package.json
@@ -59,7 +59,7 @@
     "postpublish": "rm oclif.manifest.json",
     "posttest": "yarn lint",
     "prepack": "oclif manifest",
-    "test": "nyc mocha -R tap",
+    "test": "nyc mocha --forbid-only",
     "version": "oclif readme && git add README.md"
   }
 }

--- a/packages/ci-v5/test/unit/lib/disambiguate.unit.test.js
+++ b/packages/ci-v5/test/unit/lib/disambiguate.unit.test.js
@@ -1,0 +1,28 @@
+
+/* eslint-env mocha */
+
+const nock = require('nock')
+const expect = require('chai').expect
+const Heroku = require('heroku-client')
+const herokuAPI = require('../../../lib/heroku-api')
+const disambiguate = require('../../../lib/disambiguate')
+const pipeline = {
+  id: '123e4567-e89b-12d3-a456-426655440000',
+  name: 'my-pipeline',
+}
+
+describe('disambiguate', function () {
+  afterEach(() => nock.cleanAll())
+
+  describe('#pipeline', function () {
+    it('returns pipeline', async function () {
+      const api = nock('https://api.heroku.com')
+        .get(`/pipelines/${pipeline.id}`)
+        .reply(200, pipeline)
+
+      const response = await disambiguate(new Heroku(), pipeline.id)
+      expect(response).to.deep.eq(pipeline)
+      api.done()
+    })
+  })
+})

--- a/packages/ci-v5/test/unit/lib/disambiguate.unit.test.js
+++ b/packages/ci-v5/test/unit/lib/disambiguate.unit.test.js
@@ -24,5 +24,28 @@ describe('disambiguate', function () {
       expect(response).to.deep.eq(pipeline)
       api.done()
     })
+
+    it('erros when no pipelines are returned', async function () {
+      const api = nock('https://api.heroku.com')
+        .get('/pipelines?eq[name]=notUUID')
+        .reply(200, [])
+
+      let errorMessage
+      await disambiguate(new Heroku(), 'notUUID').catch(error => {
+        errorMessage = error.message
+      })
+      expect(errorMessage).to.equal('Pipeline not found')
+      api.done()
+    })
+
+    it('returns a single pipeline', async function () {
+      const api = nock('https://api.heroku.com')
+        .get('/pipelines?eq[name]=notUUIDpipeline')
+        .reply(200, [pipeline])
+
+      const response = await disambiguate(new Heroku(), 'notUUIDpipeline')
+      expect(response).to.deep.eq(pipeline)
+      api.done()
+    })
   })
 })

--- a/packages/ci-v5/test/unit/lib/heroku-api.unit.test.js
+++ b/packages/ci-v5/test/unit/lib/heroku-api.unit.test.js
@@ -171,4 +171,33 @@ describe('heroku-api', function () {
       api.done()
     })
   })
+
+  describe('#updateTestRun', function () {
+    it('updates test run', async function () {
+      const testRun = {id: 'uuid-999'}
+      const updatedTestRun = {test_run: {commit_message: 'updated message'}}
+
+      const api = nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.ci'}})
+        .patch(`/test-runs/${testRun.id}`, {commit_message: 'updated message'})
+        .reply(200, [updatedTestRun])
+
+      const response = await herokuAPI.updateTestRun(new Heroku(), testRun.id, {commit_message: 'updated message'})
+      expect(response).to.deep.eq([updatedTestRun])
+      api.done()
+    })
+  })
+
+  describe('#createTestRun', function () {
+    it('creates test run', async function () {
+      const testRun = {id: 'uuid-999'}
+
+      const api = nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.ci'}})
+        .post('/test-runs', testRun)
+        .reply(200, [testRun])
+
+      const response = await herokuAPI.createTestRun(new Heroku(), testRun)
+      expect(response).to.deep.eq([testRun])
+      api.done()
+    })
+  })
 })

--- a/packages/ci-v5/test/unit/lib/key-by.unit.test.js
+++ b/packages/ci-v5/test/unit/lib/key-by.unit.test.js
@@ -1,0 +1,32 @@
+
+/* eslint-env mocha */
+
+const expect = require('chai').expect
+const keyBy = require('../../../lib/key-by')
+const couplings = [
+  {
+    app: {
+      id: '01234567-89ab-cdef-0123-456789abcdef',
+    },
+    pipeline: {
+      id: '01234567-89ab-cdef-0123-456789abcdef',
+    },
+  },
+  {
+    app: {
+      id: '01234567-89ab-cdef-0123-456789abcde1',
+    },
+    pipeline: {
+      id: '01234567-89ab-cdef-0123-456789abcdef',
+    },
+  },
+]
+
+describe('key-by', function () {
+  describe('#keyByAppId', function () {
+    it('returns couplings based on app IDs', async function () {
+      const couplingsWithAppIds = keyBy(couplings, coupling => coupling.app.id)
+      expect(couplingsWithAppIds).to.have.keys(['01234567-89ab-cdef-0123-456789abcdef', '01234567-89ab-cdef-0123-456789abcde1'])
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2289,21 +2289,21 @@
 
 "@sinonjs/commons@^2.0.0":
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-2.0.0.tgz#fd4ca5b063554307e8327b4564bd56d3b73924a3"
+  resolved "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz"
   integrity sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==
   dependencies:
     type-detect "4.0.8"
 
 "@sinonjs/commons@^3.0.0":
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.0.tgz#beb434fe875d965265e04722ccfc21df7f755d72"
+  resolved "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz"
   integrity sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==
   dependencies:
     type-detect "4.0.8"
 
 "@sinonjs/fake-timers@^10.0.2":
   version "10.0.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz#d10549ed1f423d80639c528b6c7f5a1017747d0c"
+  resolved "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz"
   integrity sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==
   dependencies:
     "@sinonjs/commons" "^2.0.0"
@@ -2364,7 +2364,7 @@
 
 "@sinonjs/samsam@^8.0.0":
   version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-8.0.0.tgz#0d488c91efb3fa1442e26abea81759dfc8b5ac60"
+  resolved "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz"
   integrity sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==
   dependencies:
     "@sinonjs/commons" "^2.0.0"
@@ -2456,7 +2456,7 @@
 
 "@types/color-name@^1.1.1":
   version "1.1.1"
-  resolved "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
 "@types/debug@^4.1.2":
@@ -8505,17 +8505,6 @@ nise@^5.1.4:
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
 
-nise@^5.1.4:
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-5.1.4.tgz#491ce7e7307d4ec546f5a659b2efe94a18b4bbc0"
-  integrity sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==
-  dependencies:
-    "@sinonjs/commons" "^2.0.0"
-    "@sinonjs/fake-timers" "^10.0.2"
-    "@sinonjs/text-encoding" "^0.7.1"
-    just-extend "^4.0.2"
-    path-to-regexp "^1.7.0"
-
 nock@10.0.6, nock@^10.0.6:
   version "10.0.6"
   resolved "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz"
@@ -10006,9 +9995,9 @@ read@1, read@^1.0.7:
   dependencies:
     mute-stream "~0.0.4"
 
-readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.6.0:
+readable-stream@3, readable-stream@^3.0.0:
   version "3.6.2"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
   dependencies:
     inherits "^2.0.3"
@@ -10037,7 +10026,7 @@ readable-stream@^3.0.2, readable-stream@^3.1.1:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readable-stream@^3.4.0:
+readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -10410,7 +10399,7 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2:
 
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 safe-regex-test@^1.0.0:
@@ -10636,7 +10625,7 @@ sinon@^1.17.6:
 
 sinon@^15.0.4:
   version "15.0.4"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-15.0.4.tgz#bcca6fef19b14feccc96473f0d7adc81e0bc5268"
+  resolved "https://registry.npmjs.org/sinon/-/sinon-15.0.4.tgz"
   integrity sha512-uzmfN6zx3GQaria1kwgWGeKiXSSbShBbue6Dcj0SI8fiCNFbiUDqKl57WFlY5lyhxZVUKmXvzgG2pilRQCBwWg==
   dependencies:
     "@sinonjs/commons" "^3.0.0"
@@ -11050,7 +11039,7 @@ string_decoder@^1.1.1:
 
 string_decoder@~1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
@@ -11197,7 +11186,7 @@ supports-color@^7.0.0, supports-color@^7.1.0:
 
 supports-color@^7.2.0:
   version "7.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"


### PR DESCRIPTION
## Why the change?
[GUS Card](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001NBtQnYAL/view)

As per our review of unit tests and coverage for the ci-v5 package, this PR does the following:
- Adds `nyc` package to add code coverage reports ✅
- Ensures that our code coverage reports over 85% test coverage of statements ✅

## Additional Notes
- `disambiguate.js` had issues using `inquirer`'s `prompt` function. Given that the pipelines package already thoroughly tests an updated version of `disambiguate` (not on v5), this test/package won't be necessary in the near future. Discard this file from test coverage report.
- `api.js` copied over functions from v5 that are no longer being used. The dead code has been removed. 

## How to verify?
1. Pull down branch
2. Run tests
3. Confirm test coverage report is visible and that it reports over 85% test coverage of statements for all files with the exception of `disambiguate.js`.
