### PR TITLE
chore(local): add code coverage reports

### DIFF
--- a/packages/local/package.json
+++ b/packages/local/package.json
@@ -22,7 +22,8 @@
     "oclif": "3.8.1",
     "ts-node": "^10",
     "tslib": "^1.9.3",
-    "typescript": "4.8.4"
+    "typescript": "4.8.4",
+    "sinon": "^6.3.5"
   },
   "engines": {
     "node": ">=14"

--- a/packages/local/src/fork-foreman.ts
+++ b/packages/local/src/fork-foreman.ts
@@ -10,22 +10,11 @@ function getForemanScriptPath() {
   const withJsExtension = path.join(__dirname, file + '.js')
   const withTsExtension = path.join(__dirname, file + '.ts')
 
-  console.log('withJsExtension:', withJsExtension)
-  console.log('withTsExtension:', withTsExtension)
-
-  const hasJsExtension = fs.existsSync(withJsExtension)
-  const hasTsExtension = fs.existsSync(withTsExtension)
-
-  console.log('hasJsExtension', hasJsExtension)
-  console.log('hasTsExtension', hasTsExtension)
-
   if (fs.existsSync(withJsExtension)) {
-    // console.log('withJsExtension:', withJsExtension)
     return withJsExtension
   }
 
   if (fs.existsSync(withTsExtension)) {
-    // console.log('withTsExtension:', withTsExtension)
     return withTsExtension
   }
 

--- a/packages/local/src/fork-foreman.ts
+++ b/packages/local/src/fork-foreman.ts
@@ -10,11 +10,22 @@ function getForemanScriptPath() {
   const withJsExtension = path.join(__dirname, file + '.js')
   const withTsExtension = path.join(__dirname, file + '.ts')
 
+  console.log('withJsExtension:', withJsExtension)
+  console.log('withTsExtension:', withTsExtension)
+
+  const hasJsExtension = fs.existsSync(withJsExtension)
+  const hasTsExtension = fs.existsSync(withTsExtension)
+
+  console.log('hasJsExtension', hasJsExtension)
+  console.log('hasTsExtension', hasTsExtension)
+
   if (fs.existsSync(withJsExtension)) {
+    // console.log('withJsExtension:', withJsExtension)
     return withJsExtension
   }
 
   if (fs.existsSync(withTsExtension)) {
+    // console.log('withTsExtension:', withTsExtension)
     return withTsExtension
   }
 

--- a/packages/local/test/unit/commands/local/version.unit.test.ts
+++ b/packages/local/test/unit/commands/local/version.unit.test.ts
@@ -5,7 +5,6 @@ import * as fs from 'fs'
 const sinon = require('sinon')
 
 let existsSyncSpy: any
-let existsSyncStub: any
 
 describe('local:version', () => {
   test
@@ -26,37 +25,11 @@ describe('local:version', () => {
       // existsSync is called multiple times in the stack before
       // the expected arguments are passed. This checks that the
       // correct arguments are passed
-      const withJsExtension = existsSyncSpy.getCall(11).args[0]
-      const withTsExtension = existsSyncSpy.getCall(12).args[0]
+      const withJsExtension = existsSyncSpy.getCall(31).args[0]
+      const withTsExtension = existsSyncSpy.getCall(32).args[0]
       expect(withJsExtension).to.include('local/src/run-foreman.js')
       expect(withTsExtension).to.include('local/src/run-foreman.ts')
     })
-
-  // test
-  //   // .stderr()
-  //   // .do(() => {
-  //   //   existsSyncStub = sinon.stub(fs, 'existsSync').returns(false)
-  //   // })
-  //   .stub(fs, 'existsSync', () => false)
-  //   .command(['local:version'])
-  //   .catch(error => {
-  //     expect(error.message).to.equal('Path to file not found')
-  //   })
-  //   .it('is errors with no file path found')
-
-  // test
-  //   .do(() => {
-  //     existsSyncStub = sinon.stub(fs, 'existsSync')
-  //   })
-  //   .command(['local:version'])
-  //   .it('selects correct extensions', () => {
-  //     // existsSync is called multiple times in the stack before
-  //     // the expected arguments are passed. This checks that the
-  //     // correct arguments are passed
-
-  //     existsSyncStub.onCall(11).return(false)
-  //     existsSyncStub.onCall(12).return(false)
-  //   })
 
   test
     .command(['local:version', 'extra'])

--- a/packages/local/test/unit/commands/local/version.unit.test.ts
+++ b/packages/local/test/unit/commands/local/version.unit.test.ts
@@ -2,9 +2,12 @@ import {expect, test} from '@oclif/test'
 
 import * as foreman from '../../../../src/fork-foreman'
 import * as fs from 'fs'
-const sinon = require('sinon')
+import * as path from 'path'
 
+const sinon = require('sinon')
 let existsSyncSpy: any
+const jsExtensionPath = path.join('local', 'src', 'run-foreman.js')
+const tsExtensionPath = path.join('local', 'src', 'run-foreman.ts')
 
 describe('local:version', () => {
   test
@@ -27,8 +30,8 @@ describe('local:version', () => {
       // correct arguments are passed
       const withJsExtension = existsSyncSpy.getCall(31).args[0]
       const withTsExtension = existsSyncSpy.getCall(32).args[0]
-      expect(withJsExtension).to.include('local/src/run-foreman.js')
-      expect(withTsExtension).to.include('local/src/run-foreman.ts')
+      expect(withJsExtension).to.include(jsExtensionPath)
+      expect(withTsExtension).to.include(tsExtensionPath)
     })
 
   test

--- a/packages/local/test/unit/commands/local/version.unit.test.ts
+++ b/packages/local/test/unit/commands/local/version.unit.test.ts
@@ -1,6 +1,11 @@
 import {expect, test} from '@oclif/test'
 
 import * as foreman from '../../../../src/fork-foreman'
+import * as fs from 'fs'
+const sinon = require('sinon')
+
+let existsSyncSpy: any
+let existsSyncStub: any
 
 describe('local:version', () => {
   test
@@ -11,6 +16,47 @@ describe('local:version', () => {
     })
     .command(['local:version'])
     .it('is passes the --version flag to foreman')
+
+  test
+    .do(() => {
+      existsSyncSpy = sinon.spy(fs, 'existsSync')
+    })
+    .command(['local:version'])
+    .it('selects correct extensions', () => {
+      // existsSync is called multiple times in the stack before
+      // the expected arguments are passed. This checks that the
+      // correct arguments are passed
+      const withJsExtension = existsSyncSpy.getCall(11).args[0]
+      const withTsExtension = existsSyncSpy.getCall(12).args[0]
+      expect(withJsExtension).to.include('local/src/run-foreman.js')
+      expect(withTsExtension).to.include('local/src/run-foreman.ts')
+    })
+
+  // test
+  //   // .stderr()
+  //   // .do(() => {
+  //   //   existsSyncStub = sinon.stub(fs, 'existsSync').returns(false)
+  //   // })
+  //   .stub(fs, 'existsSync', () => false)
+  //   .command(['local:version'])
+  //   .catch(error => {
+  //     expect(error.message).to.equal('Path to file not found')
+  //   })
+  //   .it('is errors with no file path found')
+
+  // test
+  //   .do(() => {
+  //     existsSyncStub = sinon.stub(fs, 'existsSync')
+  //   })
+  //   .command(['local:version'])
+  //   .it('selects correct extensions', () => {
+  //     // existsSync is called multiple times in the stack before
+  //     // the expected arguments are passed. This checks that the
+  //     // correct arguments are passed
+
+  //     existsSyncStub.onCall(11).return(false)
+  //     existsSyncStub.onCall(12).return(false)
+  //   })
 
   test
     .command(['local:version', 'extra'])


### PR DESCRIPTION
## Why the change?
[GUS Card](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001NBiF1YAL/view)

As per our review of unit tests and coverage for the local package, this PR does the following:
- Ensures that our code coverage reports over 85% test coverage of statements ✅

## Additional Notes
- `fork-foreman.ts` will need a refactor. Additional tests have been added, but discard it in the `nyc` coverage report

## How to verify?
1. Pull down branch
2. Run tests
3. Confirm test coverage report is visible and that it reports over 85% test coverage of statements for all files except for `fork-foreman.ts`
