### PR TITLE
fix: add version to homebrew template and set version_scheme

### DIFF
--- a/scripts/release/homebrew.js
+++ b/scripts/release/homebrew.js
@@ -68,6 +68,7 @@ async function updateHerokuFormula (brewDir) {
       .replace('__CLI_DOWNLOAD_URL_M1__', `${urlPrefix}/${fileNameM1}`)
       .replace('__CLI_SHA256__', sha256Intel)
       .replace('__CLI_SHA256_M1__', sha256M1)
+      .replace('__CLI_VERSION__', VERSION)
 
   fs.writeFileSync(formulaPath, templateReplaced)
 

--- a/scripts/release/homebrew/templates/heroku.rb
+++ b/scripts/release/homebrew/templates/heroku.rb
@@ -7,6 +7,8 @@ class Heroku < Formula
   homepage "https://cli.heroku.com"
   url "__CLI_DOWNLOAD_URL__"
   sha256 "__CLI_SHA256__"
+  version "__CLI_VERSION__"
+  version_scheme 1
 
   on_macos do
     if Hardware::CPU.arm?


### PR DESCRIPTION
For a description of the issue (and notes on how to fix), see https://github.com/heroku/homebrew-brew/issues/30

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
