### PR TITLE
chore(pg-v5): add code coverage reports

### DIFF
--- a/packages/pg-v5/test/unit/commands/backups/unschedule.unit.test.js
+++ b/packages/pg-v5/test/unit/commands/backups/unschedule.unit.test.js
@@ -77,7 +77,7 @@ describe('pg:backups:unschedule error state', () => {
     pg.done()
   })
 
-  it('errors with when multiple schedules are returned from API', () => {
+  it('errors when multiple schedules are returned from API', () => {
     return cmd.run({app: 'myapp', args: {}, flags: {at: '06:00 EDT'}})
       .catch(error => expect(error.message).to.equal('Specify schedule on myapp. Existing schedules: DATABASE_URL, DATABASE_URL2'))
   })

--- a/packages/pg-v5/test/unit/commands/backups/unschedule.unit.test.js
+++ b/packages/pg-v5/test/unit/commands/backups/unschedule.unit.test.js
@@ -53,3 +53,32 @@ describe('pg:backups:unschedule', () => {
 describe('pg:backups unschedule', () => {
   shouldUnschedule(require('./helpers.js').dup('unschedule', cmd))
 })
+
+describe('pg:backups:unschedule error state', () => {
+  let pg
+  let api
+
+  beforeEach(() => {
+    api = nock('https://api.heroku.com')
+    api.get('/apps/myapp/addons').reply(200, [addon])
+    api.post('/actions/addon-attachments/resolve', {
+      app: 'myapp',
+      addon_attachment: 'DATABASE_URL',
+      addon_service: 'heroku-postgresql',
+    }).reply(200, [attachment])
+    pg = nock('https://postgres-api.heroku.com')
+    pg.get('/client/v11/databases/1/transfer-schedules').twice().reply(200, [{name: 'DATABASE_URL', uuid: '100-001'}, {name: 'DATABASE_URL2', uuid: '100-002'}])
+    cli.mockConsole()
+  })
+
+  afterEach(() => {
+    nock.cleanAll()
+    api.done()
+    pg.done()
+  })
+
+  it('errors with when multiple schedules are returned from API', () => {
+    return cmd.run({app: 'myapp', args: {}, flags: {at: '06:00 EDT'}})
+      .catch(error => expect(error.message).to.equal('Specify schedule on myapp. Existing schedules: DATABASE_URL, DATABASE_URL2'))
+  })
+})

--- a/packages/pg-v5/test/unit/commands/links/index.unit.test.js
+++ b/packages/pg-v5/test/unit/commands/links/index.unit.test.js
@@ -50,4 +50,17 @@ created_at: 100
 remote:     REDIS (redis-001)
 `))
   })
+
+  it('shows links when args are present', () => {
+    pg.get('/client/v11/databases/1/links').reply(200, [
+      {name: 'redis-link-1', created_at: '100', remote: {attachment_name: 'REDIS', name: 'redis-001'}},
+    ])
+    return cmd.run({app: 'myapp', args: {database: 'test-database'}, flags: {confirm: 'myapp'}})
+      .then(() => expect(cli.stdout).to.equal(`=== postgres-1
+
+ * redis-link-1
+created_at: 100
+remote:     REDIS (redis-001)
+`))
+  })
 })

--- a/packages/pg-v5/test/unit/commands/settings/settings.unit.test.js
+++ b/packages/pg-v5/test/unit/commands/settings/settings.unit.test.js
@@ -6,22 +6,6 @@ const {expect} = require('chai')
 const nock = require('nock')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
-// const cmd = require('../../..').commands.find(c => c.topic === 'pg' && c.command === 'copy')
-
-// const db = {
-//   id: 1,
-//   name: 'postgres-1',
-//   plan: {name: 'heroku-postgresql:standard-0'},
-// }
-// const fetcher = () => {
-//   return {
-//     addon: () => db,
-//   }
-// }
-
-// let cmd = proxyquire('../../../../commands/settings/log_statement', {
-//   '../../lib/fetcher': fetcher,
-// })
 
 const addon = {
   id: 1,
@@ -70,14 +54,18 @@ describe.only('pg:settings', () => {
   })
 
   it('shows settings', () => {
-    // cmd = require('../../../../').commands.find(c => c.topic === 'pg' && c.command === 'settings:auto-explain')
     cmd = proxyquire('../../../../commands/settings/log_statement', {
       settings: proxyquire.noCallThru().load('../../../../lib/setter', {
         './fetcher': fetcher,
       }),
     })
-    // pg.get('/postgres/v0/databases/1/config').reply(200,
-    //   {log_statement: {value: 'none'}})
+    pg.get('/postgres/v0/databases/1/config').reply(200,
+      {log_statement: {
+        value: 'log_statement',
+        values: {
+          log_statement: 'hello',
+        },
+      }})
     return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
       .then(() => expect(cli.stdout).to.equal('=== postgres-1\nlog-statement: none\n'))
   })

--- a/packages/pg-v5/test/unit/commands/settings/settings.unit.test.js
+++ b/packages/pg-v5/test/unit/commands/settings/settings.unit.test.js
@@ -1,0 +1,84 @@
+'use strict'
+/* global beforeEach afterEach */
+
+const cli = require('heroku-cli-util')
+const {expect} = require('chai')
+const nock = require('nock')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+// const cmd = require('../../..').commands.find(c => c.topic === 'pg' && c.command === 'copy')
+
+// const db = {
+//   id: 1,
+//   name: 'postgres-1',
+//   plan: {name: 'heroku-postgresql:standard-0'},
+// }
+// const fetcher = () => {
+//   return {
+//     addon: () => db,
+//   }
+// }
+
+// let cmd = proxyquire('../../../../commands/settings/log_statement', {
+//   '../../lib/fetcher': fetcher,
+// })
+
+const addon = {
+  id: 1,
+  name: 'postgres-1',
+  app: {name: 'myapp'},
+  config_vars: ['READONLY_URL', 'DATABASE_URL', 'HEROKU_POSTGRESQL_RED_URL'],
+  plan: {name: 'heroku-postgresql:standard-0'},
+}
+
+const attachment = {
+  name: 'HEROKU_POSTGRESQL_RED',
+  app: {name: 'myapp'},
+  addon,
+}
+
+const db = {
+  id: 1,
+  name: 'postgres-1',
+  plan: {name: 'heroku-postgresql:standard-0'},
+}
+const fetcher = () => {
+  return {
+    addon: () => db,
+  }
+}
+
+describe.only('pg:settings', () => {
+  let cmd
+  let api
+  let pg
+
+  beforeEach(() => {
+    api = nock('https://api.heroku.com')
+    pg = nock('https://postgres-api.heroku.com')
+    api.post('/actions/addon-attachments/resolve', {
+      addon_attachment: 'test-database',
+      addon_service: 'heroku-postgresql',
+    }).reply(200, [attachment])
+    cli.mockConsole()
+  })
+
+  afterEach(() => {
+    nock.cleanAll()
+    api.done()
+    pg.done()
+  })
+
+  it('shows settings', () => {
+    // cmd = require('../../../../').commands.find(c => c.topic === 'pg' && c.command === 'settings:auto-explain')
+    cmd = proxyquire('../../../../commands/settings/log_statement', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    // pg.get('/postgres/v0/databases/1/config').reply(200,
+    //   {log_statement: {value: 'none'}})
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('=== postgres-1\nlog-statement: none\n'))
+  })
+})

--- a/packages/pg-v5/test/unit/commands/settings/settings.unit.test.js
+++ b/packages/pg-v5/test/unit/commands/settings/settings.unit.test.js
@@ -5,7 +5,6 @@ const cli = require('heroku-cli-util')
 const {expect} = require('chai')
 const nock = require('nock')
 const proxyquire = require('proxyquire')
-const sinon = require('sinon')
 
 const addon = {
   id: 1,
@@ -52,7 +51,7 @@ const setupSettingsMockData = (cmd, settingValue = 'test_value') => {
   settingResult = settingsResult[`${cmd}`]
 }
 
-describe.only('pg:settings', () => {
+describe('pg:settings', () => {
   let cmd
   let api
   let pg
@@ -95,5 +94,255 @@ describe.only('pg:settings', () => {
     pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
     return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
       .then(() => expect(cli.stdout).to.equal(`${settingsResultName} is set to ${settingResult.value} for postgres-1.\n${settingResult.values[settingResult.value]}\n`))
+  })
+
+  it('shows settings for auto_explain with value', () => {
+    setupSettingsMockData('auto_explain')
+    cmd = proxyquire('../../../../commands/settings/auto_explain', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('auto-explain is set to test_value for postgres-1.\nExecution plans of queries will be logged for future connections.\n'))
+  })
+
+  it('shows settings for auto_explain with no value', () => {
+    setupSettingsMockData('auto_explain', '')
+    cmd = proxyquire('../../../../commands/settings/auto_explain', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('auto-explain is set to  for postgres-1.\nExecution plans of queries will not be logged for future connections.\n'))
+  })
+
+  it('shows settings for auto_explain_log_analyze with value', () => {
+    setupSettingsMockData('auto_explain.log_analyze')
+    cmd = proxyquire('../../../../commands/settings/auto_explain_log_analyze', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('auto-explain.log-analyze is set to test_value for postgres-1.\nEXPLAIN ANALYZE execution plans will be logged.\n'))
+  })
+
+  it('shows settings for auto_explain_log_analyze with no value', () => {
+    setupSettingsMockData('auto_explain.log_analyze', '')
+    cmd = proxyquire('../../../../commands/settings/auto_explain_log_analyze', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('auto-explain.log-analyze is set to  for postgres-1.\nEXPLAIN ANALYZE execution plans will not be logged.\n'))
+  })
+
+  it('shows settings for auto_explain_log_buffers with value', () => {
+    setupSettingsMockData('auto_explain.log_buffers')
+    cmd = proxyquire('../../../../commands/settings/auto_explain_log_buffers', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('auto-explain.log-buffers is set to test_value for postgres-1.\nBuffer statistics have been enabled for auto_explain.\n'))
+  })
+
+  it('shows settings for auto_explain_log_buffers with no value', () => {
+    setupSettingsMockData('auto_explain.log_buffers', '')
+    cmd = proxyquire('../../../../commands/settings/auto_explain_log_buffers', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('auto-explain.log-buffers is set to  for postgres-1.\nBuffer statistics have been disabled for auto_explain.\n'))
+  })
+
+  it('shows settings for auto_explain_log_min_duration with value', () => {
+    setupSettingsMockData('auto_explain.log_min_duration')
+    cmd = proxyquire('../../../../commands/settings/auto_explain_log_min_duration', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('auto-explain.log-min-duration is set to test_value for postgres-1.\nAll execution plans will be logged for queries taking up to test_value milliseconds or more.\n'))
+  })
+
+  it('shows settings for auto_explain_log_min_duration with no value', () => {
+    setupSettingsMockData('auto_explain.log_min_duration', -1)
+    cmd = proxyquire('../../../../commands/settings/auto_explain_log_min_duration', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('auto-explain.log-min-duration is set to -1 for postgres-1.\nExecution plan logging has been disabled.\n'))
+  })
+
+  it('shows settings for auto_explain_log_min_duration with value set to 0', () => {
+    setupSettingsMockData('auto_explain.log_min_duration', 0)
+    cmd = proxyquire('../../../../commands/settings/auto_explain_log_min_duration', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('auto-explain.log-min-duration is set to 0 for postgres-1.\nAll queries will have their execution plans logged.\n'))
+  })
+
+  it('shows settings for log_min_duration_statement with value', () => {
+    setupSettingsMockData('log_min_duration_statement')
+    cmd = proxyquire('../../../../commands/settings/log_min_duration_statement', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('log-min-duration-statement is set to test_value for postgres-1.\nThe duration of each completed statement will be logged if the statement ran for at least test_value milliseconds.\n'))
+  })
+
+  it('shows settings for log_min_duration_statement with no value', () => {
+    setupSettingsMockData('log_min_duration_statement', -1)
+    cmd = proxyquire('../../../../commands/settings/log_min_duration_statement', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('log-min-duration-statement is set to -1 for postgres-1.\nThe duration of each completed statement will not be logged.\n'))
+  })
+
+  it('shows settings for log_min_duration_statement with value set to 0', () => {
+    setupSettingsMockData('log_min_duration_statement', 0)
+    cmd = proxyquire('../../../../commands/settings/log_min_duration_statement', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('log-min-duration-statement is set to 0 for postgres-1.\nThe duration of each completed statement will be logged.\n'))
+  })
+
+  it('shows settings for auto_explain_log_nested_statements with value', () => {
+    setupSettingsMockData('auto_explain.log_nested_statements')
+    cmd = proxyquire('../../../../commands/settings/auto_explain_log_nested_statements', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('auto-explain.log-nested-statements is set to test_value for postgres-1.\nNested statements will be included in execution plan logs.\n'))
+  })
+
+  it('shows settings for auto_explain_log_nested_statements with no value', () => {
+    setupSettingsMockData('auto_explain.log_nested_statements', '')
+    cmd = proxyquire('../../../../commands/settings/auto_explain_log_nested_statements', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('auto-explain.log-nested-statements is set to  for postgres-1.\nOnly top-level execution plans will be included in logs.\n'))
+  })
+
+  it('shows settings for auto_explain_log_triggers with value', () => {
+    setupSettingsMockData('auto_explain.log_triggers')
+    cmd = proxyquire('../../../../commands/settings/auto_explain_log_triggers', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('auto-explain.log-triggers is set to test_value for postgres-1.\nTrigger execution statistics have been enabled for auto_explain.\n'))
+  })
+
+  it('shows settings for auto_explain_log_triggers with no value', () => {
+    setupSettingsMockData('auto_explain.log_triggers', '')
+    cmd = proxyquire('../../../../commands/settings/auto_explain_log_triggers', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('auto-explain.log-triggers is set to  for postgres-1.\nTrigger execution statistics have been disabled for auto_explain.\n'))
+  })
+
+  it('shows settings for auto_explain_log_verbose with value', () => {
+    setupSettingsMockData('auto_explain.log_verbose')
+    cmd = proxyquire('../../../../commands/settings/auto_explain_log_verbose', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('auto-explain.log-verbose is set to test_value for postgres-1.\nVerbose execution plan logging has been enabled for auto_explain.\n'))
+  })
+
+  it('shows settings for auto_explain_log_verbose with no value', () => {
+    setupSettingsMockData('auto_explain.log_verbose', '')
+    cmd = proxyquire('../../../../commands/settings/auto_explain_log_verbose', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('auto-explain.log-verbose is set to  for postgres-1.\nVerbose execution plan logging has been disabled for auto_explain.\n'))
+  })
+
+  it('shows settings for log_lock_waits with value', () => {
+    setupSettingsMockData('log_lock_waits')
+    cmd = proxyquire('../../../../commands/settings/log_lock_waits', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('log-lock-waits is set to test_value for postgres-1.\nWhen a deadlock is detected, a log message will be emitted in your application\'s logs.\n'))
+  })
+
+  it('shows settings for log_lock_waits with no value', () => {
+    setupSettingsMockData('log_lock_waits', '')
+    cmd = proxyquire('../../../../commands/settings/log_lock_waits', {
+      settings: proxyquire.noCallThru().load('../../../../lib/setter', {
+        './fetcher': fetcher,
+      }),
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('log-lock-waits is set to  for postgres-1.\nWhen a deadlock is detected, no log message will be emitted in your application\'s logs.\n'))
+  })
+
+  it('shows settings for settings/index', () => {
+    setupSettingsMockData('index')
+    cmd = proxyquire('../../../../commands/settings/index', {
+      '../../../../lib/fetcher': fetcher,
+    })
+    pg.get('/postgres/v0/databases/1/config').reply(200, settingsResult)
+    return cmd.run({args: {database: 'test-database', value: ''}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal('=== postgres-1\nindex: test_value\n'))
   })
 })


### PR DESCRIPTION
## Why the change?
[GUS Card](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001NBzdyYAD/view)

As per our review of unit tests and coverage for the pg-v5 package, this PR does the following:
- Ensures that our code coverage reports over 85% test coverage of statements ✅

## Additional Notes
- `nyc` is technically reading the uncovered lines found in `download.js`. What looks to be the problem is the way the code is written where the callback response is the second argument of the `https.get()` call. Within this second argument exists the logic trying to be accessed. The response callback of an argument cannot be stubbed via `sinon`. Interestingly enough, the existing test for `download.js` does in fact read the lines, however my current theory is that not being able to stub the readable stream causes the test to fail thus the lines are not counted by `nyc`'s test coverage report. Disregard this file from test coverage.
- Both `proxyquire` and `sinon` are unable to stub `bloat.js`, `blocking.js`, `vacuum_stats.js` and `locks.js`. Testing setup will need a refactor in Phase IV. Disregard these files from test coverage.

## How to verify?
1. Pull down branch
2. Run tests
3. Confirm test coverage report is visible and that it reports over 85% test coverage of statements for all files except for `download.js`, `bloat.js`, `blocking.js`, `vacuum_stats.js` and `locks.js`
