### PR TITLE
feat(addons-v5): handle asynchronous deprovisioning state

### DIFF
--- a/packages/addons-v5/commands/addons/destroy.js
+++ b/packages/addons-v5/commands/addons/destroy.js
@@ -1,40 +1,53 @@
+/* eslint-disable no-await-in-loop */
+
 'use strict'
 
 const cli = require('heroku-cli-util')
+const {notify} = require('../../lib/notify')
 
 async function run(context, heroku) {
+  const destroyAddon = require('../../lib/destroy_addon')
   const resolve = require('../../lib/resolve')
   const {groupBy, toPairs} = require('lodash')
+  const force = context.flags.force || process.env.HEROKU_FORCE === '1'
+  const wait = context.flags.wait || false
 
-  let force = context.flags.force || process.env.HEROKU_FORCE === '1'
   if (context.args.length === 0) throw new Error('Missing add-on name')
 
   let addons = await Promise.all(
     context.args.map(name => resolve.addon(heroku, context.app, name)),
   )
-  for (let addon of addons) {
-    // prevent deletion of app when context.app is set but the addon is attached to a different app
-    let app = addon.app.name
+
+  for (const addon of addons) {
+    // prevent deletion of add-on when context.app is set but the addon is attached to a different app
+    const app = addon.app.name
     if (context.app && app !== context.app) throw new Error(`${cli.color.addon(addon.name)} is on ${cli.color.app(app)} not ${cli.color.app(context.app)}`)
   }
 
   for (let app of toPairs(groupBy(addons, 'app.name'))) {
     addons = app[1]
     app = app[0]
+
     await cli.confirmApp(app, context.flags.confirm)
-    for (let addon of addons) {
-      let msg = `Destroying ${cli.color.addon(addon.name)} on ${cli.color.app(addon.app.name)}`
-      await cli.action(msg, heroku.request({
-        method: 'DELETE',
-        path: `/apps/${addon.app.id}/addons/${addon.id}`,
-        headers: {'Accept-Expansion': 'plan'},
-        body: {force},
-      }))
+
+    for (const addon of addons) {
+      try {
+        await destroyAddon(heroku, addon, force, wait)
+        if (wait) {
+          notify(`heroku addons:destroy ${addon.name}`, 'Add-on successfully deprovisioned')
+        }
+      } catch (error) {
+        if (wait) {
+          notify(`heroku addons:destroy ${addon.name}`, 'Add-on failed to deprovision', false)
+        }
+
+        throw error
+      }
     }
   }
 }
 
-let cmd = {
+const cmd = {
   topic: 'addons',
   description: 'permanently destroy an add-on resource',
   usage: 'addons:destroy [ADDON]... [flags]',
@@ -43,6 +56,7 @@ let cmd = {
   flags: [
     {name: 'force', char: 'f', description: 'allow destruction even if connected to other apps'},
     {name: 'confirm', char: 'c', hasValue: true},
+    {name: 'wait', description: 'watch add-on destruction status and exit when complete'},
   ],
   variableArgs: true,
   run: cli.command({preauth: true}, run),

--- a/packages/addons-v5/commands/addons/info.js
+++ b/packages/addons-v5/commands/addons/info.js
@@ -1,17 +1,17 @@
 'use strict'
 
-let cli = require('heroku-cli-util')
+const cli = require('heroku-cli-util')
 
-let grandfatheredPrice = require('../../lib/util').grandfatheredPrice
-let formatPrice = require('../../lib/util').formatPrice
-let formatState = require('../../lib/util').formatState
-let style = require('../../lib/util').style
+const grandfatheredPrice = require('../../lib/util').grandfatheredPrice
+const formatPrice = require('../../lib/util').formatPrice
+const formatState = require('../../lib/util').formatState
+const style = require('../../lib/util').style
 
-let run = cli.command({preauth: true}, function (ctx, api) {
+const run = cli.command({preauth: true}, function (ctx, api) {
   const resolve = require('../../lib/resolve')
   return (async function () {
-    let addon = await resolve.addon(api, ctx.app, ctx.args.addon)
-    let attachments = await api.request({
+    const addon = await resolve.addon(api, ctx.app, ctx.args.addon)
+    const attachments = await api.request({
       method: 'GET',
       path: `/addons/${addon.id}/addon-attachments`,
     })
@@ -37,7 +37,8 @@ let run = cli.command({preauth: true}, function (ctx, api) {
   })()
 })
 
-let topic = 'addons'
+const topic = 'addons'
+
 module.exports = {
   topic: topic,
   command: 'info',

--- a/packages/addons-v5/commands/addons/wait.js
+++ b/packages/addons-v5/commands/addons/wait.js
@@ -1,8 +1,10 @@
+/* eslint-disable no-await-in-loop */
+
 'use strict'
 
 const cli = require('heroku-cli-util')
 const {notify} = require('../../lib/notify')
-const waitForAddonProvisioning = require('../../lib/addons_wait')
+const {waitForAddonProvisioning, waitForAddonDeprovisioning} = require('../../lib/addons_wait')
 
 async function run(ctx, api) {
   const resolve = require('../../lib/resolve')
@@ -10,39 +12,48 @@ async function run(ctx, api) {
   let addons
   if (ctx.args.addon) {
     addons = [await resolve.addon(api, ctx.app, ctx.args.addon)]
+  } else if (ctx.app) {
+    addons = await api.get(`/apps/${ctx.app}/addons`)
   } else {
-    if (ctx.app) { // eslint-disable-line no-lonely-if
-      addons = await api.get(`/apps/${ctx.app}/addons`)
-    } else {
-      addons = await api.get('/addons')
-    }
+    addons = await api.get('/addons')
   }
 
-  addons = addons.filter(addon => addon.state === 'provisioning')
+  addons = addons.filter(addon => addon.state === 'provisioning' || addon.state === 'deprovisioning')
 
-  let interval = Number.parseInt(ctx.flags['wait-interval'])
+  let interval = Number.parseInt(ctx.flags['wait-interval'], 10)
   if (!interval || interval < 0) {
     interval = 5
   }
 
   for (let addon of addons) {
     const startTime = new Date()
-    try {
-      addon = await waitForAddonProvisioning(api, addon, interval)
-    } catch (error) {
-      notify(`heroku addons:wait ${addon.name}`, 'Add-on failed to provision', false)
-      throw error
-    }
 
-    let configVars = (addon.config_vars || [])
-    if (configVars.length > 0) {
-      configVars = configVars.map(c => cli.color.configVar(c)).join(', ')
-      cli.log(`Created ${cli.color.addon(addon.name)} as ${configVars}`)
-    }
+    if (addon.state === 'provisioning') {
+      try {
+        addon = await waitForAddonProvisioning(api, addon, interval)
+      } catch (error) {
+        notify(`heroku addons:wait ${addon.name}`, 'Add-on failed to provision', false)
+        throw error
+      }
 
-    // only show notification if addon took longer than 5 seconds to provision
-    if (Date.now() - startTime >= 1000 * 5) {
-      notify(`heroku addons:wait ${addon.name}`, 'Add-on successfully provisioned')
+      let configVars = (addon.config_vars || [])
+
+      if (configVars.length > 0) {
+        configVars = configVars.map(c => cli.color.configVar(c)).join(', ')
+        cli.log(`Created ${cli.color.addon(addon.name)} as ${configVars}`)
+      }
+
+      // only show notification if addon took longer than 5 seconds to provision
+      if (Date.now() - startTime >= 1000 * 5) {
+        notify(`heroku addons:wait ${addon.name}`, 'Add-on successfully provisioned')
+      }
+    } else if (addon.state === 'deprovisioning') {
+      addon = await waitForAddonDeprovisioning(api, addon, interval)
+
+      // only show notification if addon took longer than 5 seconds to deprovision
+      if (Date.now() - startTime >= 1000 * 5) {
+        notify(`heroku addons:wait ${addon.name}`, 'Add-on successfully deprovisioned')
+      }
     }
   }
 }

--- a/packages/addons-v5/commands/addons/wait.js
+++ b/packages/addons-v5/commands/addons/wait.js
@@ -25,34 +25,36 @@ async function run(ctx, api) {
     interval = 5
   }
 
-  for (let addon of addons) {
+  for (const addon of addons) {
     const startTime = new Date()
+    const addonName = addon.name
 
     if (addon.state === 'provisioning') {
+      let addonResponse
       try {
-        addon = await waitForAddonProvisioning(api, addon, interval)
+        addonResponse = await waitForAddonProvisioning(api, addon, interval)
       } catch (error) {
-        notify(`heroku addons:wait ${addon.name}`, 'Add-on failed to provision', false)
+        notify(`heroku addons:wait ${addonName}`, 'Add-on failed to provision', false)
         throw error
       }
 
-      let configVars = (addon.config_vars || [])
+      const configVars = (addonResponse.config_vars || [])
 
       if (configVars.length > 0) {
-        configVars = configVars.map(c => cli.color.configVar(c)).join(', ')
-        cli.log(`Created ${cli.color.addon(addon.name)} as ${configVars}`)
+        const decoratedConfigVars = configVars.map(c => cli.color.configVar(c)).join(', ')
+        cli.log(`Created ${cli.color.addon(addonName)} as ${decoratedConfigVars}`)
       }
 
       // only show notification if addon took longer than 5 seconds to provision
       if (Date.now() - startTime >= 1000 * 5) {
-        notify(`heroku addons:wait ${addon.name}`, 'Add-on successfully provisioned')
+        notify(`heroku addons:wait ${addonName}`, 'Add-on successfully provisioned')
       }
     } else if (addon.state === 'deprovisioning') {
-      addon = await waitForAddonDeprovisioning(api, addon, interval)
+      await waitForAddonDeprovisioning(api, addon, interval)
 
       // only show notification if addon took longer than 5 seconds to deprovision
       if (Date.now() - startTime >= 1000 * 5) {
-        notify(`heroku addons:wait ${addon.name}`, 'Add-on successfully deprovisioned')
+        notify(`heroku addons:wait ${addonName}`, 'Add-on successfully deprovisioned')
       }
     }
   }

--- a/packages/addons-v5/index.js
+++ b/packages/addons-v5/index.js
@@ -89,3 +89,4 @@ exports.commands = _.flatten([
 
 exports.resolve = require('./lib/resolve')
 exports.createAddon = require('./lib/create_addon')
+exports.destroyAddon = require('./lib/destroy_addon')

--- a/packages/addons-v5/lib/addons_wait.js
+++ b/packages/addons-v5/lib/addons_wait.js
@@ -1,26 +1,60 @@
+/* eslint-disable no-await-in-loop */
+
 'use strict'
 
 const cli = require('heroku-cli-util')
 
-module.exports = async function (api, addon, interval) {
-  const app = addon.app.name
-  const addonName = addon.name
+module.exports = {
+  waitForAddonProvisioning: async function (api, addon, interval) {
+    const app = addon.app.name
+    const addonName = addon.name
 
-  await cli.action(`Creating ${cli.color.addon(addon.name)}`, (async function () {
-    while (addon.state === 'provisioning') {
-      await new Promise(resolve => setTimeout(resolve, interval * 1000))
+    await cli.action(`Creating ${cli.color.addon(addon.name)}`, (async function () {
+      while (addon.state === 'provisioning') {
+        // eslint-disable-next-line no-promise-executor-return
+        await new Promise(resolve => setTimeout(resolve, interval * 1000))
 
-      addon = await api.request({
-        method: 'GET',
-        path: `/apps/${app}/addons/${addonName}`,
-        headers: {'Accept-Expansion': 'addon_service,plan'},
-      })
-    }
+        addon = await api.request({
+          method: 'GET',
+          path: `/apps/${app}/addons/${addonName}`,
+          headers: {'Accept-Expansion': 'addon_service,plan'},
+        })
+      }
 
-    if (addon.state === 'deprovisioned') {
-      throw new Error(`The add-on was unable to be created, with status ${addon.state}`)
-    }
-  })())
+      if (addon.state === 'deprovisioned') {
+        throw new Error(`The add-on was unable to be created, with status ${addon.state}`)
+      }
+    })())
 
-  return addon
+    return addon
+  },
+
+  waitForAddonDeprovisioning: async function (api, addon, interval) {
+    const app = addon.app.name
+    const addonName = addon.name
+
+    await cli.action(`Destroying ${cli.color.addon(addon.name)}`, (async function () {
+      while (addon.state === 'deprovisioning') {
+        // eslint-disable-next-line no-promise-executor-return
+        await new Promise(resolve => setTimeout(resolve, interval * 1000))
+
+        await api.request({
+          method: 'GET',
+          path: `/apps/${app}/addons/${addonName}`,
+          headers: {'Accept-Expansion': 'addon_service,plan'},
+        }).then(addonInfo => {
+          addon = addonInfo
+        }).catch(function (error) {
+          // Not ideal, but API deletes the record returning a 404 when deprovisioned.
+          if (error.statusCode === 404) {
+            addon.state = 'deprovisioned'
+          } else {
+            throw error
+          }
+        })
+      }
+    })())
+
+    return addon
+  },
 }

--- a/packages/addons-v5/lib/addons_wait.js
+++ b/packages/addons-v5/lib/addons_wait.js
@@ -8,33 +8,35 @@ module.exports = {
   waitForAddonProvisioning: async function (api, addon, interval) {
     const app = addon.app.name
     const addonName = addon.name
+    let addonResponse = {...addon}
 
-    await cli.action(`Creating ${cli.color.addon(addon.name)}`, (async function () {
-      while (addon.state === 'provisioning') {
+    await cli.action(`Creating ${cli.color.addon(addonName)}`, (async function () {
+      while (addonResponse.state === 'provisioning') {
         // eslint-disable-next-line no-promise-executor-return
         await new Promise(resolve => setTimeout(resolve, interval * 1000))
 
-        addon = await api.request({
+        addonResponse = await api.request({
           method: 'GET',
           path: `/apps/${app}/addons/${addonName}`,
           headers: {'Accept-Expansion': 'addon_service,plan'},
         })
       }
 
-      if (addon.state === 'deprovisioned') {
-        throw new Error(`The add-on was unable to be created, with status ${addon.state}`)
+      if (addonResponse.state === 'deprovisioned') {
+        throw new Error(`The add-on was unable to be created, with status ${addonResponse.state}`)
       }
     })())
 
-    return addon
+    return addonResponse
   },
 
   waitForAddonDeprovisioning: async function (api, addon, interval) {
     const app = addon.app.name
     const addonName = addon.name
+    let addonResponse = {...addon}
 
-    await cli.action(`Destroying ${cli.color.addon(addon.name)}`, (async function () {
-      while (addon.state === 'deprovisioning') {
+    await cli.action(`Destroying ${cli.color.addon(addonName)}`, (async function () {
+      while (addonResponse.state === 'deprovisioning') {
         // eslint-disable-next-line no-promise-executor-return
         await new Promise(resolve => setTimeout(resolve, interval * 1000))
 
@@ -42,12 +44,12 @@ module.exports = {
           method: 'GET',
           path: `/apps/${app}/addons/${addonName}`,
           headers: {'Accept-Expansion': 'addon_service,plan'},
-        }).then(addonInfo => {
-          addon = addonInfo
+        }).then(response => {
+          addonResponse = response
         }).catch(function (error) {
           // Not ideal, but API deletes the record returning a 404 when deprovisioned.
           if (error.statusCode === 404) {
-            addon.state = 'deprovisioned'
+            addonResponse.state = 'deprovisioned'
           } else {
             throw error
           }
@@ -55,6 +57,6 @@ module.exports = {
       }
     })())
 
-    return addon
+    return addonResponse
   },
 }

--- a/packages/addons-v5/lib/create_addon.js
+++ b/packages/addons-v5/lib/create_addon.js
@@ -15,7 +15,7 @@ function formatConfigVarsMessage(addon) {
 
 module.exports = async function (heroku, app, plan, confirm, wait, options) {
   const util = require('./util')
-  const waitForAddonProvisioning = require('./addons_wait')
+  const {waitForAddonProvisioning} = require('./addons_wait')
 
   function createAddonRequest(confirm) {
     let body = {

--- a/packages/addons-v5/lib/destroy_addon.js
+++ b/packages/addons-v5/lib/destroy_addon.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const cli = require('heroku-cli-util')
+
+module.exports = async function (heroku, addon, force, wait) {
+  const {waitForAddonDeprovisioning} = require('./addons_wait')
+
+  function destroyAddonRequest(force) {
+    return cli.action(
+      `Destroying ${cli.color.addon(addon.name)} on ${cli.color.app(addon.app.name)}`,
+      heroku.delete(`/apps/${addon.app.id}/addons/${addon.id}`, {
+        headers: {'Accept-Expansion': 'plan'},
+        body: {force},
+      }).then(function (addon) {
+        if (addon.state === 'deprovisioning') {
+          cli.action.done(cli.color.yellow('pending'))
+        }
+
+        return addon
+      }).catch(error => {
+        if (error.body && error.body.message) {
+          throw new Error(`The add-on was unable to be destroyed: ${error.body.message}.`)
+        } else {
+          throw new Error(`The add-on was unable to be destroyed: ${error}.`)
+        }
+      }),
+    )
+  }
+
+  addon = await destroyAddonRequest(force)
+
+  if (addon.state === 'deprovisioning') {
+    if (wait) {
+      cli.log(`Waiting for ${cli.color.addon(addon.name)}...`)
+      const deprovision_response = await waitForAddonDeprovisioning(heroku, addon, 5)
+      addon = deprovision_response
+    } else {
+      cli.log(`${cli.color.addon(addon.name)} is being destroyed in the background. The app will restart when complete...`)
+      cli.log(`Use ${cli.color.cmd('heroku addons:info ' + addon.name)} to check destruction progress`)
+    }
+  } else if (addon.state !== 'deprovisioned') {
+    throw new Error(`The add-on was unable to be destroyed, with status ${addon.state}.`)
+  }
+
+  return addon
+}

--- a/packages/addons-v5/lib/util.js
+++ b/packages/addons-v5/lib/util.js
@@ -72,6 +72,9 @@ module.exports = {
     case 'provisioning':
       state = 'creating'
       break
+    case 'deprovisioning':
+      state = 'destroying'
+      break
     case 'deprovisioned':
       state = 'errored'
       break

--- a/packages/addons-v5/package.json
+++ b/packages/addons-v5/package.json
@@ -31,7 +31,8 @@
     "nyc": "^15.1.0",
     "oclif": "3.11.3",
     "proxyquire": "^2.1.0",
-    "sinon": "^6.3.5"
+    "sinon": "^6.3.5",
+    "theredoc": "^1.0.0"
   },
   "files": [
     "oclif.manifest.json",

--- a/packages/addons-v5/test/fixtures.js
+++ b/packages/addons-v5/test/fixtures.js
@@ -105,6 +105,17 @@ fixtures.addons = {
       cents: 500,
     },
   },
+  'www-db-2': {
+    app: fixtures.apps.api,
+    id: 'b68d8f51-6577-4a46-a617-c5f36f1bb032',
+    name: 'www-db-2',
+    addon_service: fixtures.services['heroku-postgresql'],
+    plan: fixtures.plans['heroku-postgresql:mini'],
+    state: 'deprovisioned',
+    billed_price: {
+      cents: 500,
+    },
+  },
   'www-redis': {
     app: fixtures.apps.www,
     id: '8a836ecc-4c88-11e5-ba7e-2cf0ee2c94de',
@@ -112,6 +123,17 @@ fixtures.addons = {
     addon_service: fixtures.services['heroku-redis'],
     plan: fixtures.plans['heroku-redis:premium-2'],
     state: 'provisioning',
+    billed_price: {
+      cents: 6000,
+    },
+  },
+  'www-redis-2': {
+    app: fixtures.apps.www,
+    id: 'bc28b002-44da-4b8b-9dba-f0ef236a5759',
+    name: 'www-redis-2',
+    addon_service: fixtures.services['heroku-redis'],
+    plan: fixtures.plans['heroku-redis:premium-2'],
+    state: 'deprovisioning',
     billed_price: {
       cents: 6000,
     },

--- a/packages/addons-v5/test/unit/commands/addons/destroy.unit.test.js
+++ b/packages/addons-v5/test/unit/commands/addons/destroy.unit.test.js
@@ -1,40 +1,155 @@
+/* eslint-disable max-nested-callbacks */
+/* globals commands context beforeEach afterEach cli nock */
+
 'use strict'
-/* globals commands beforeEach afterEach cli nock */
 
 const cmd = commands.find(c => c.topic === 'addons' && c.command === 'destroy')
 const {expect} = require('chai')
+const lolex = require('lolex')
+const sinon = require('sinon')
+const theredoc = require('theredoc')
 
 describe('addons:destroy', () => {
   beforeEach(() => cli.mockConsole())
   afterEach(() => nock.cleanAll())
 
-  it('destroys an add-on', () => {
-    let addon = {id: 201, name: 'db3-swiftly-123', addon_service: {name: 'heroku-db3'}, app: {name: 'myapp', id: 101}}
+  context('when an add-on implements sync deprovisioning', () => {
+    it('destroys the add-on synchronously', () => {
+      const addon = {
+        id: 201,
+        name: 'db3-swiftly-123',
+        addon_service: {name: 'heroku-db3'},
+        app: {name: 'myapp', id: 101},
+        state: 'provisioned',
+      }
+      const api = nock('https://api.heroku.com:443')
+        .post('/actions/addons/resolve', {app: 'myapp', addon: 'heroku-db3'}).reply(200, [addon])
+        .delete('/apps/101/addons/201', {force: false})
+        .reply(200, {...addon, state: 'deprovisioned'})
 
-    let api = nock('https://api.heroku.com:443')
-      .post('/actions/addons/resolve', {app: 'myapp', addon: 'heroku-db3'}).reply(200, [addon])
-      .delete('/apps/101/addons/201', {force: false})
-      .reply(200, {plan: {price: {cents: 0}}, provision_message: 'provision msg'})
+      return cmd.run({app: 'myapp', args: ['heroku-db3'], flags: {confirm: 'myapp'}})
+        .then(() => expect(cli.stdout).to.equal(''))
+        .then(() => expect(cli.stderr).to.equal('Destroying db3-swiftly-123 on myapp... done\n'))
+        .then(() => api.done())
+    })
+  })
 
-    return cmd.run({app: 'myapp', args: ['heroku-db3'], flags: {confirm: 'myapp'}})
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('Destroying db3-swiftly-123 on myapp... done\n'))
-      .then(() => api.done())
+  context('when an add-on implements async deprovisioning', () => {
+    it('destroys the add-on asynchronously', () => {
+      const addon = {
+        id: 201,
+        name: 'db4-swiftly-123',
+        addon_service: {name: 'heroku-db4'},
+        app: {name: 'myapp', id: 101},
+        state: 'provisioned',
+      }
+      const api = nock('https://api.heroku.com:443')
+        .post('/actions/addons/resolve', {app: 'myapp', addon: 'heroku-db4'})
+        .reply(200, [addon])
+        .delete('/apps/101/addons/201', {force: false})
+        .reply(202, {...addon, state: 'deprovisioning'})
+
+      return cmd.run({app: 'myapp', args: ['heroku-db4'], flags: {confirm: 'myapp'}})
+        .then(() => expect(cli.stdout).to.equal(theredoc`
+          db4-swiftly-123 is being destroyed in the background. The app will restart when complete...
+          Use heroku addons:info db4-swiftly-123 to check destruction progress\n
+        `))
+        .then(() => expect(cli.stderr).to.equal('Destroying db4-swiftly-123 on myapp... pending\n'))
+        .then(() => api.done())
+    })
+
+    context('--wait', () => {
+      let clock
+      let sandbox
+
+      beforeEach(() => {
+        sandbox = sinon.createSandbox()
+        clock = lolex.install()
+        clock.setTimeout = function (fn) {
+          fn()
+        }
+      })
+
+      afterEach(function () {
+        clock.uninstall()
+        sandbox.restore()
+      })
+
+      it('waits for response and notifies', () => {
+        const addon = {
+          id: 201,
+          name: 'db5-swiftly-123',
+          addon_service: {name: 'heroku-db5'},
+          app: {name: 'myapp', id: 101},
+          state: 'provisioned',
+        }
+        const notifySpy = sandbox.spy(require('@heroku-cli/notifications'), 'notify')
+        const api = nock('https://api.heroku.com:443')
+          .post('/actions/addons/resolve', {app: 'myapp', addon: 'heroku-db5'})
+          .reply(200, [addon])
+          .delete('/apps/101/addons/201', {force: false})
+          .reply(202, {...addon, state: 'deprovisioning'})
+          .get('/apps/myapp/addons/db5-swiftly-123')
+          .reply(200, {...addon, state: 'deprovisioning'})
+          .get('/apps/myapp/addons/db5-swiftly-123')
+          .reply(404, {id: 'not_found', message: 'Not found'}) // when it has been deprovisioned
+
+        return cmd.run({app: 'myapp', args: ['heroku-db5'], flags: {confirm: 'myapp', wait: true}})
+          .then(() => api.done())
+          .then(() => expect(notifySpy.called).to.equal(true))
+          .then(() => expect(notifySpy.calledOnce).to.equal(true))
+          .then(() => expect(cli.stderr).to.equal(theredoc`
+            Destroying db5-swiftly-123 on myapp... pending
+            Destroying db5-swiftly-123... done\n
+          `))
+          .then(() => expect(cli.stdout).to.equal('Waiting for db5-swiftly-123...\n'))
+      })
+    })
   })
 
   it('fails when addon app is not the app specified', () => {
-    let addon = {id: 201, name: 'db4-swiftly-123', addon_service: {name: 'heroku-db4'}, app: {name: 'myotherapp', id: 101}}
+    const addon_in_other_app = {
+      id: 201,
+      name: 'db6-swiftly-123',
+      addon_service: {name: 'heroku-db6'},
+      app: {name: 'myotherapp', id: 102},
+      state: 'provisioned',
+    }
+    const api = nock('https://api.heroku.com:443')
+      .post('/actions/addons/resolve', {app: 'myapp', addon: 'heroku-db6'})
+      .reply(200, [addon_in_other_app])
 
-    let api = nock('https://api.heroku.com:443')
-      .post('/actions/addons/resolve', {app: 'myapp', addon: 'heroku-db4'}).reply(200, [addon])
-
-    return cmd.run({app: 'myapp', args: ['heroku-db4'], flags: {confirm: 'myapp'}})
+    return cmd.run({app: 'myapp', args: ['heroku-db6'], flags: {confirm: 'myapp'}})
       .then(() => {
         throw new Error('unreachable')
       })
       .catch(error => {
         api.done()
-        expect(error.message).to.equal('db4-swiftly-123 is on myotherapp not myapp')
+        expect(error.message).to.equal('db6-swiftly-123 is on myotherapp not myapp')
+      })
+  })
+
+  it('shows that it failed to deprovision when there are errors returned', function () {
+    const addon = {
+      id: 201,
+      name: 'db7-swiftly-123',
+      addon_service: {name: 'heroku-db7'},
+      app: {name: 'myapp', id: 101},
+      state: 'suspended',
+    }
+    const api = nock('https://api.heroku.com:443')
+      .post('/actions/addons/resolve', {app: 'myapp', addon: 'heroku-db7'})
+      .reply(200, [addon])
+      .delete('/apps/101/addons/201', {force: false})
+      .reply(403, {id: 'forbidden', message: 'Cannot delete a suspended addon'})
+
+    return cmd.run({app: 'myapp', args: ['heroku-db7'], flags: {confirm: 'myapp'}})
+      .then(() => {
+        throw new Error('unreachable')
+      })
+      .catch(error => {
+        api.done()
+        expect(error.message).to.equal('The add-on was unable to be destroyed: Cannot delete a suspended addon.')
       })
   })
 })

--- a/packages/addons-v5/test/unit/commands/addons/info.unit.test.js
+++ b/packages/addons-v5/test/unit/commands/addons/info.unit.test.js
@@ -215,9 +215,10 @@ describe('addons:info', function () {
           === www-redis
           Attachments:  acme-inc-www::REDIS
           Installed at: Invalid Date
+          Max Price:    $60/month
           Owning app:   acme-inc-www
           Plan:         heroku-redis:premium-2
-          Price:        $60/month
+          Price:        ~$0.083/hour
           State:        creating\n
         `)
       })
@@ -247,9 +248,10 @@ describe('addons:info', function () {
           === www-redis-2
           Attachments:  acme-inc-www::REDIS
           Installed at: Invalid Date
+          Max Price:    $60/month
           Owning app:   acme-inc-www
           Plan:         heroku-redis:premium-2
-          Price:        $60/month
+          Price:        ~$0.083/hour
           State:        destroying\n
         `)
       })

--- a/packages/addons-v5/test/unit/commands/addons/info.unit.test.js
+++ b/packages/addons-v5/test/unit/commands/addons/info.unit.test.js
@@ -1,12 +1,14 @@
-'use strict'
 /* globals context beforeEach */
 
-let fixtures = require('../../../fixtures')
-let util = require('../../../util')
-let cli = require('heroku-cli-util')
-let nock = require('nock')
-let cmd = require('../../../../commands/addons/info')
-let cache = require('../../../../lib/resolve').addon.cache
+'use strict'
+
+const fixtures = require('../../../fixtures')
+const util = require('../../../util')
+const cli = require('heroku-cli-util')
+const nock = require('nock')
+const cmd = require('../../../../commands/addons/info')
+const cache = require('../../../../lib/resolve').addon.cache
+const theredoc = require('theredoc')
 
 describe('addons:info', function () {
   beforeEach(function () {
@@ -21,9 +23,7 @@ describe('addons:info', function () {
         .post('/actions/addons/resolve', {app: null, addon: 'www-db'})
         .reply(200, [fixtures.addons['www-db']])
 
-      nock('https://api.heroku.com', {reqheaders: {
-        'Accept-Expansion': 'addon_service,plan',
-      }})
+      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
         .get(`/addons/${fixtures.addons['www-db'].id}`)
         .reply(200, fixtures.addons['www-db'])
 
@@ -34,16 +34,16 @@ describe('addons:info', function () {
 
     it('prints add-ons in a table', function () {
       return cmd.run({flags: {}, args: {addon: 'www-db'}}).then(function () {
-        util.expectOutput(cli.stdout,
-          `=== www-db
-Attachments:  acme-inc-www::DATABASE
-Installed at: Invalid Date
-Max Price:    $5/month
-Owning app:   acme-inc-www
-Plan:         heroku-postgresql:mini
-Price:        ~$0.007/hour
-State:        created
-`)
+        util.expectOutput(cli.stdout, theredoc`
+          === www-db
+          Attachments:  acme-inc-www::DATABASE
+          Installed at: Invalid Date
+          Max Price:    $5/month
+          Owning app:   acme-inc-www
+          Plan:         heroku-postgresql:mini
+          Price:        ~$0.007/hour
+          State:        created\n
+        `)
       })
     })
   })
@@ -67,16 +67,16 @@ State:        created
 
     it('prints add-ons in a table', function () {
       return cmd.run({flags: {}, args: {addon: 'www-db'}, app: 'example'}).then(function () {
-        util.expectOutput(cli.stdout,
-          `=== www-db
-Attachments:  acme-inc-www::DATABASE
-Installed at: Invalid Date
-Max Price:    $5/month
-Owning app:   acme-inc-www
-Plan:         heroku-postgresql:mini
-Price:        ~$0.007/hour
-State:        created
-`)
+        util.expectOutput(cli.stdout, theredoc`
+          === www-db
+          Attachments:  acme-inc-www::DATABASE
+          Installed at: Invalid Date
+          Max Price:    $5/month
+          Owning app:   acme-inc-www
+          Plan:         heroku-postgresql:mini
+          Price:        ~$0.007/hour
+          State:        created\n
+        `)
       })
     })
   })
@@ -90,15 +90,15 @@ State:        created
       nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
         .get('/apps/example/addons/www-db')
         .reply(404)
+
       nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
         .get('/addons/www-db')
         .reply(200, fixtures.addons['www-db'])
 
-      nock('https://api.heroku.com', {reqheaders: {
-        'Accept-Expansion': 'addon_service,plan',
-      }})
+      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
         .get(`/addons/${fixtures.addons['www-db'].id}`)
         .reply(200, fixtures.addons['www-db'])
+
       nock('https://api.heroku.com')
         .get(`/addons/${fixtures.addons['www-db'].id}/addon-attachments`)
         .reply(200, [fixtures.attachments['acme-inc-www::DATABASE']])
@@ -106,16 +106,16 @@ State:        created
 
     it('prints add-ons in a table', function () {
       return cmd.run({flags: {}, args: {addon: 'www-db'}, app: 'example'}).then(function () {
-        util.expectOutput(cli.stdout,
-          `=== www-db
-Attachments:  acme-inc-www::DATABASE
-Installed at: Invalid Date
-Max Price:    $5/month
-Owning app:   acme-inc-www
-Plan:         heroku-postgresql:mini
-Price:        ~$0.007/hour
-State:        created
-`)
+        util.expectOutput(cli.stdout, theredoc`
+          === www-db
+          Attachments:  acme-inc-www::DATABASE
+          Installed at: Invalid Date
+          Max Price:    $5/month
+          Owning app:   acme-inc-www
+          Plan:         heroku-postgresql:mini
+          Price:        ~$0.007/hour
+          State:        created\n
+        `)
       })
     })
   })
@@ -142,16 +142,16 @@ State:        created
 
     it('prints add-ons in a table with grandfathered price', function () {
       return cmd.run({flags: {}, args: {addon: 'dwh-db'}}).then(function () {
-        util.expectOutput(cli.stdout,
-          `=== dwh-db
-Attachments:  acme-inc-dwh::DATABASE
-Installed at: Invalid Date
-Max Price:    $100/month
-Owning app:   acme-inc-dwh
-Plan:         heroku-postgresql:standard-2
-Price:        ~$0.139/hour
-State:        created
-`)
+        util.expectOutput(cli.stdout, theredoc`
+          === dwh-db
+          Attachments:  acme-inc-dwh::DATABASE
+          Installed at: Invalid Date
+          Max Price:    $100/month
+          Owning app:   acme-inc-dwh
+          Plan:         heroku-postgresql:standard-2
+          Price:        ~$0.139/hour
+          State:        created\n
+        `)
       })
     })
   })
@@ -178,16 +178,80 @@ State:        created
 
     it('prints add-ons in a table with contract', function () {
       return cmd.run({flags: {}, args: {addon: 'dwh-db'}}).then(function () {
-        util.expectOutput(cli.stdout,
-          `=== dwh-db
-Attachments:  acme-inc-dwh::DATABASE
-Installed at: Invalid Date
-Max Price:    contract
-Owning app:   acme-inc-dwh
-Plan:         heroku-postgresql:standard-2
-Price:        contract
-State:        created
-`)
+        util.expectOutput(cli.stdout, theredoc`
+          === dwh-db
+          Attachments:  acme-inc-dwh::DATABASE
+          Installed at: Invalid Date
+          Max Price:    contract
+          Owning app:   acme-inc-dwh
+          Plan:         heroku-postgresql:standard-2
+          Price:        contract
+          State:        created\n
+        `)
+      })
+    })
+  })
+
+  context('provisioning add-on', function () {
+    beforeEach(function () {
+      const provisioningAddon = fixtures.addons['www-redis']
+
+      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
+        .post('/actions/addons/resolve', {app: null, addon: 'www-redis'})
+        .reply(200, [provisioningAddon])
+
+      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
+        .get(`/addons/${provisioningAddon.id}`)
+        .reply(200, provisioningAddon)
+
+      nock('https://api.heroku.com')
+        .get(`/addons/${provisioningAddon.id}/addon-attachments`)
+        .reply(200, [fixtures.attachments['acme-inc-www::REDIS']])
+    })
+
+    it('prints add-ons in a table with humanized state', function () {
+      return cmd.run({flags: {}, args: {addon: 'www-redis'}}).then(function () {
+        util.expectOutput(cli.stdout, theredoc`
+          === www-redis
+          Attachments:  acme-inc-www::REDIS
+          Installed at: Invalid Date
+          Owning app:   acme-inc-www
+          Plan:         heroku-redis:premium-2
+          Price:        $60/month
+          State:        creating\n
+        `)
+      })
+    })
+  })
+
+  context('deprovisioning add-on', function () {
+    beforeEach(function () {
+      const deprovisioningAddon = fixtures.addons['www-redis-2']
+
+      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
+        .post('/actions/addons/resolve', {app: null, addon: 'www-redis-2'})
+        .reply(200, [deprovisioningAddon])
+
+      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
+        .get(`/addons/${deprovisioningAddon.id}`)
+        .reply(200, deprovisioningAddon)
+
+      nock('https://api.heroku.com')
+        .get(`/addons/${deprovisioningAddon.id}/addon-attachments`)
+        .reply(200, [fixtures.attachments['acme-inc-www::REDIS']])
+    })
+
+    it('prints add-ons in a table with humanized state', function () {
+      return cmd.run({flags: {}, args: {addon: 'www-redis-2'}}).then(function () {
+        util.expectOutput(cli.stdout, theredoc`
+          === www-redis-2
+          Attachments:  acme-inc-www::REDIS
+          Installed at: Invalid Date
+          Owning app:   acme-inc-www
+          Plan:         heroku-redis:premium-2
+          Price:        $60/month
+          State:        destroying\n
+        `)
       })
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -555,6 +555,7 @@ __metadata:
     printf: 0.6.1
     proxyquire: ^2.1.0
     sinon: ^6.3.5
+    theredoc: ^1.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
As part of the effort to EOL Legacy Add-on Partner API, Heroku Ecosystem recently added to Platform API a new feature that allows add-on providers to perform an asynchronous deprovisioning operation on add-on resources.

When an async deprovision is performed the add-on resource is kept on `deprovisioning` state until the add-on provider finishes the process and the resource is deleted.

This work updates addons-v5 project commands to account for such scenario:
- Command `destroy` now accepts an additional `--wait` flag (in the same spirit that `create` accepts it for asynchronous provisioning) and shows specific messages when an asynchronous deprovision is underway.
- Command `wait` is updated to handle asynchronous provisioning or deprovisioning.
- Command `info` was updated to correctly show a humanized add-on state for add-ons being asynchronously deprovisioned.

Unit tests for all these commands were updated, adding new tests for the behavior added and patching the tests were changes needed to be introduced for existing commands.

Some chores were done to remove linter warnings and improve readability only on modified files. There's still a lot of warnings to fix on other project files, but they weren't done here because it would've made this PR more complex to review.

### SOC2 Compliance
[GUS Card](https://gus.lightning.force.com/a07EE00001TOv8NYAT)