### PR TITLE
fix: use correct path for update hooks

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -267,7 +267,7 @@
       ],
       "update": [
         "./lib/hooks/update/plugin-migrate",
-        "./lib/hooks/update/b",
+        "./lib/hooks/update/brew",
         "./lib/hooks/update/completions",
         "./lib/hooks/update/tidy",
         "./lib/hooks/recache"


### PR DESCRIPTION
v8.2.0-beta prerelease has an error during updates. Looks for a hook that doesn't exit.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
