### PR TITLE
fix: update create-release-pr to work with yarn3

### DIFF
--- a/scripts/create-release-pr
+++ b/scripts/create-release-pr
@@ -49,6 +49,9 @@ git add . -u
 PACKAGE_VERSION=`node -e "console.log(require('./lerna.json').version)"`
 echo "Done creating new CLI package(s) versions"
 
+echo "Updating yarn.lock with new package versions"
+yarn
+
 echo "Creating git commit and pushing to GitHub..."
 git commit -m "v${PACKAGE_VERSION}"
 git push origin "${BRANCH_NAME}"


### PR DESCRIPTION
https://gus.lightning.force.com/lightning/r/a07EE00001V8EeJYAV/view

Update yarn.lock in create-release-pr script for packages in this monorepo outside of packages/cli, ie: "@heroku-cli/plugin-certs-v5": "^NEW_VERSION"

Outcome without this fix: https://github.com/heroku/cli/actions/runs/5825041518/job/15795614844?pr=2431

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
