### PR TITLE
fix: add yarn.lock update in create release pr

### DIFF
--- a/scripts/create-release-pr
+++ b/scripts/create-release-pr
@@ -55,4 +55,4 @@ git add . -u
 echo "Creating git commit and pushing to GitHub..."
 git commit -m "v${PACKAGE_VERSION}"
 git push origin "${BRANCH_NAME}"
-#gh pr create --title="release v${PACKAGE_VERSION}" --body "release v${PACKAGE_VERSION}"
+gh pr create --title="release v${PACKAGE_VERSION}" --body "release v${PACKAGE_VERSION}"

--- a/scripts/create-release-pr
+++ b/scripts/create-release-pr
@@ -45,13 +45,13 @@ yarn lerna version \
   --no-push \
   --no-git-tag-version \
   --yes
-git add . -u
 PACKAGE_VERSION=`node -e "console.log(require('./lerna.json').version)"`
 echo "Done creating new CLI package(s) versions"
 
 echo "Updating yarn.lock with new package versions"
 yarn
 
+git add . -u
 echo "Creating git commit and pushing to GitHub..."
 git commit -m "v${PACKAGE_VERSION}"
 git push origin "${BRANCH_NAME}"

--- a/scripts/create-release-pr
+++ b/scripts/create-release-pr
@@ -55,4 +55,4 @@ yarn
 echo "Creating git commit and pushing to GitHub..."
 git commit -m "v${PACKAGE_VERSION}"
 git push origin "${BRANCH_NAME}"
-gh pr create --title="release v${PACKAGE_VERSION}" --body "release v${PACKAGE_VERSION}"
+#gh pr create --title="release v${PACKAGE_VERSION}" --body "release v${PACKAGE_VERSION}"


### PR DESCRIPTION
Move `git add` to after yarn.lock update in create release pr
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
