### PR TITLE
refactor: add per hour and max price per month to pricing displays

### DIFF
--- a/packages/addons-v5/commands/addons/index.js
+++ b/packages/addons-v5/commands/addons/index.js
@@ -6,6 +6,7 @@ async function run(ctx, api) {
   const util = require('../../lib/util')
   const table = util.table
   const style = util.style
+  const formatHourlyPrice = util.formatHourlyPrice
   const formatPrice = util.formatPrice
   const formatState = util.formatState
   const grandfatheredPrice = util.grandfatheredPrice
@@ -125,6 +126,14 @@ async function run(ctx, api) {
         label: 'Price',
         format: function (price) {
           if (typeof price === 'undefined') return style('dim', '?')
+          return formatHourlyPrice(price)
+        },
+      },
+      {
+        key: 'plan.maxPrice',
+        label: 'Max Price',
+        format: function (price) {
+          if (typeof price === 'undefined') return style('dim', '?')
           return formatPrice(price)
         },
       },
@@ -223,10 +232,17 @@ async function run(ctx, api) {
         label: 'Price',
         format: function (addon) {
           if (addon.app.name === app) {
-            return formatPrice(addon.plan.price)
+            return formatHourlyPrice(addon.plan.price)
           }
 
           return style('dim', printf('(billed to %s app)', style('app', addon.app.name)))
+        },
+      }, {
+        label: 'Max Price',
+        format: function (addon) {
+          if (addon.app.name === app) {
+            return formatPrice(addon.plan.price)
+          }
         },
       }, {
         label: 'State',

--- a/packages/addons-v5/commands/addons/index.js
+++ b/packages/addons-v5/commands/addons/index.js
@@ -231,7 +231,7 @@ async function run(ctx, api) {
         label: 'Price',
         format: function (addon) {
           if (addon.app.name === app) {
-            return formatPrice(addon.plan.price, true)
+            return formatPrice({price: addon.plan.price, hourly: true})
           }
 
           return style('dim', printf('(billed to %s app)', style('app', addon.app.name)))
@@ -240,7 +240,7 @@ async function run(ctx, api) {
         label: 'Max Price',
         format: function (addon) {
           if (addon.app.name === app) {
-            return formatPrice(addon.plan.price, false)
+            return formatPrice({price: addon.plan.price, hourly: false})
           }
         },
       }, {

--- a/packages/addons-v5/commands/addons/index.js
+++ b/packages/addons-v5/commands/addons/index.js
@@ -6,7 +6,6 @@ async function run(ctx, api) {
   const util = require('../../lib/util')
   const table = util.table
   const style = util.style
-  const formatHourlyPrice = util.formatHourlyPrice
   const formatPrice = util.formatPrice
   const formatState = util.formatState
   const grandfatheredPrice = util.grandfatheredPrice
@@ -126,15 +125,15 @@ async function run(ctx, api) {
         label: 'Price',
         format: function (price) {
           if (typeof price === 'undefined') return style('dim', '?')
-          return formatHourlyPrice(price)
+          return formatPrice({price, hourly: true})
         },
       },
       {
-        key: 'plan.maxPrice',
+        key: 'plan.price',
         label: 'Max Price',
         format: function (price) {
           if (typeof price === 'undefined') return style('dim', '?')
-          return formatPrice(price)
+          return formatPrice({price, hourly: false})
         },
       },
       {
@@ -232,7 +231,7 @@ async function run(ctx, api) {
         label: 'Price',
         format: function (addon) {
           if (addon.app.name === app) {
-            return formatHourlyPrice(addon.plan.price)
+            return formatPrice(addon.plan.price, true)
           }
 
           return style('dim', printf('(billed to %s app)', style('app', addon.app.name)))
@@ -241,7 +240,7 @@ async function run(ctx, api) {
         label: 'Max Price',
         format: function (addon) {
           if (addon.app.name === app) {
-            return formatPrice(addon.plan.price)
+            return formatPrice(addon.plan.price, false)
           }
         },
       }, {

--- a/packages/addons-v5/commands/addons/index.js
+++ b/packages/addons-v5/commands/addons/index.js
@@ -242,6 +242,8 @@ async function run(ctx, api) {
           if (addon.app.name === app) {
             return formatPrice({price: addon.plan.price, hourly: false})
           }
+
+          return style('dim', printf('(billed to %s app)', style('app', addon.app.name)))
         },
       }, {
         label: 'State',

--- a/packages/addons-v5/commands/addons/info.js
+++ b/packages/addons-v5/commands/addons/info.js
@@ -22,7 +22,8 @@ let run = cli.command({preauth: true}, function (ctx, api) {
     cli.styledHeader(style('addon', addon.name))
     cli.styledHash({
       Plan: addon.plan.name,
-      Price: formatPrice(addon.plan.price),
+      Price: formatPrice({price: addon.plan.price, hourly: true}),
+      'Max Price': formatPrice({price: addon.plan.price, hourly: false}),
       Attachments: addon.attachments.map(function (att) {
         return [
           style('app', att.app.name),

--- a/packages/addons-v5/commands/addons/plans.js
+++ b/packages/addons-v5/commands/addons/plans.js
@@ -17,7 +17,12 @@ async function run(context, heroku) {
         {key: 'default', label: '', format: d => d ? 'default' : ''},
         {key: 'name', label: 'slug'},
         {key: 'human_name', label: 'name'},
-        {key: 'price', format: util.formatPrice},
+        {key: 'price', format: function (price) {
+          return util.formatPrice({price, hourly: true})
+        }},
+        {key: 'price', label: 'max price', format: function (price) {
+          return util.formatPrice({price, hourly: false})
+        }},
       ],
     })
   }

--- a/packages/addons-v5/commands/addons/upgrade.js
+++ b/packages/addons-v5/commands/addons/upgrade.js
@@ -96,7 +96,7 @@ async function run(c, h) {
         'X-Heroku-Legacy-Provider-Messages': 'true',
       },
     }).catch(error => handlePlanChangeAPIError(error))
-    cli.action.done(`done, ${cli.color.green(util.formatPrice(addon.plan.price))}`)
+    cli.action.done(`done${addon.plan.price ? `, ${util.formatPriceText(addon.plan.price)}` : ''}`)
     if (addon.provision_message) cli.log(addon.provision_message)
   })())
 }

--- a/packages/addons-v5/lib/create_addon.js
+++ b/packages/addons-v5/lib/create_addon.js
@@ -34,7 +34,7 @@ module.exports = async function (heroku, app, plan, confirm, wait, options) {
           'x-heroku-legacy-provider-messages': 'true',
         },
       }).then(function (addon) {
-        cli.action.done(cli.color.green(util.formatPrice(addon.plan.price)))
+        cli.action.done(cli.color.green(util.formatPriceText(addon.plan.price)))
         return addon
       }),
     )

--- a/packages/addons-v5/lib/util.js
+++ b/packages/addons-v5/lib/util.js
@@ -33,23 +33,23 @@ module.exports = {
   // This function assumes that price.cents will reflect price per month.
   // If the API returns any unit other than month
   // this function will need to be updated.
-  formatHourlyPrice: function (price) {
-    if (!price) return
-    if (price.contract) return 'contract'
-    if (price.cents === 0) return 'free'
+  // formatHourlyPrice: function (priceCents) {
+  //   // we are using a standardized 720 hours/month
+  //   // let priceHourly = Number(Math.round(Number.parseFloat((price.cents / 100) / 720) + 'e2') + 'e-2')
+  //   // const decimals = priceHourly.toString().includes('.') ? 2 : 0
+  //   // return `~$${priceHourly.toFixed(decimals)}/hour`
+  //   const priceHourly = ((priceCents / 100) / 720).toPrecision(4)
+  //   return `~$${priceHourly}/hour`
+  // },
 
-    // we are using a standardized 720 hours/month
-    let priceHourly = Number(Math.round(Number.parseFloat((price.cents / 100) / 720) + 'e2') + 'e-2')
-    const decimals = priceHourly.toString().includes('.') ? 2 : 0
-    return `~$${priceHourly.toFixed(decimals)}/hour`
-  },
-
-  formatPrice: function (price) {
+  formatPrice: function ({price, hourly}) {
     const printf = require('printf')
 
     if (!price) return
     if (price.contract) return 'contract'
     if (price.cents === 0) return 'free'
+
+    if (hourly) return `~$${((price.cents / 100) / 720).toPrecision(4)}/hour`
 
     let fmt = price.cents % 100 === 0 ? '$%.0f/%s' : '$%.02f/%s'
     return printf(fmt, price.cents / 100, price.unit)

--- a/packages/addons-v5/lib/util.js
+++ b/packages/addons-v5/lib/util.js
@@ -31,14 +31,14 @@ module.exports = {
   },
 
   formatPrice: function (price) {
-    const printf = require('printf')
-
     if (!price) return
     if (price.contract) return 'contract'
     if (price.cents === 0) return 'free'
 
-    let fmt = price.cents % 100 === 0 ? '$%.0f/%s' : '$%.02f/%s'
-    return printf(fmt, price.cents / 100, price.unit)
+    let priceHourly = Number(Math.round(Number.parseFloat((price.cents / 100) / 720) + 'e2') + 'e-2')
+    const decimals = priceHourly % 100 === 0 ? 0 : 2
+    const formattedPrice = `~$${priceHourly.toFixed(decimals)}/hour`
+    return formattedPrice
   },
 
   trapConfirmationRequired: async function (app, confirm, fn) {

--- a/packages/addons-v5/lib/util.js
+++ b/packages/addons-v5/lib/util.js
@@ -49,7 +49,7 @@ module.exports = {
     if (price.contract) return 'contract'
     if (price.cents === 0) return 'free'
 
-    if (hourly) return `~$${((price.cents / 100) / 720).toPrecision(4)}/hour`
+    if (hourly) return `~$${((price.cents / 100) / 720).toFixed(3)}/hour`
 
     let fmt = price.cents % 100 === 0 ? '$%.0f/%s' : '$%.02f/%s'
     return printf(fmt, price.cents / 100, price.unit)

--- a/packages/addons-v5/lib/util.js
+++ b/packages/addons-v5/lib/util.js
@@ -30,15 +30,29 @@ module.exports = {
     })
   },
 
-  formatPrice: function (price) {
+  // This function assumes that price.cents will reflect price per month.
+  // If the API returns any unit other than month
+  // this function will need to be updated.
+  formatHourlyPrice: function (price) {
     if (!price) return
     if (price.contract) return 'contract'
     if (price.cents === 0) return 'free'
 
+    // we are using a standardized 720 hours/month
     let priceHourly = Number(Math.round(Number.parseFloat((price.cents / 100) / 720) + 'e2') + 'e-2')
-    const decimals = priceHourly % 100 === 0 ? 0 : 2
-    const formattedPrice = `~$${priceHourly.toFixed(decimals)}/hour`
-    return formattedPrice
+    const decimals = priceHourly.toString().includes('.') ? 2 : 0
+    return `~$${priceHourly.toFixed(decimals)}/hour`
+  },
+
+  formatPrice: function (price) {
+    const printf = require('printf')
+
+    if (!price) return
+    if (price.contract) return 'contract'
+    if (price.cents === 0) return 'free'
+
+    let fmt = price.cents % 100 === 0 ? '$%.0f/%s' : '$%.02f/%s'
+    return printf(fmt, price.cents / 100, price.unit)
   },
 
   trapConfirmationRequired: async function (app, confirm, fn) {

--- a/packages/addons-v5/lib/util.js
+++ b/packages/addons-v5/lib/util.js
@@ -33,15 +33,6 @@ module.exports = {
   // This function assumes that price.cents will reflect price per month.
   // If the API returns any unit other than month
   // this function will need to be updated.
-  // formatHourlyPrice: function (priceCents) {
-  //   // we are using a standardized 720 hours/month
-  //   // let priceHourly = Number(Math.round(Number.parseFloat((price.cents / 100) / 720) + 'e2') + 'e-2')
-  //   // const decimals = priceHourly.toString().includes('.') ? 2 : 0
-  //   // return `~$${priceHourly.toFixed(decimals)}/hour`
-  //   const priceHourly = ((priceCents / 100) / 720).toPrecision(4)
-  //   return `~$${priceHourly}/hour`
-  // },
-
   formatPrice: function ({price, hourly}) {
     const printf = require('printf')
 
@@ -49,6 +40,7 @@ module.exports = {
     if (price.contract) return 'contract'
     if (price.cents === 0) return 'free'
 
+    // we are using a standardized 720 hours/month
     if (hourly) return `~$${((price.cents / 100) / 720).toFixed(3)}/hour`
 
     let fmt = price.cents % 100 === 0 ? '$%.0f/%s' : '$%.02f/%s'
@@ -62,6 +54,14 @@ module.exports = {
         return cli.confirmApp(app, confirm, error.body.message)
           .then(() => fn(app))
       })
+  },
+
+  formatPriceText: function (price) {
+    const priceHourly = this.formatPrice({price, hourly: true})
+    const priceMonthly = this.formatPrice({price, hourly: false})
+    if (!priceHourly) return ''
+    if (priceHourly === 'free' || priceHourly === 'contract') return `${cli.color.green(priceHourly)}`
+    return `${cli.color.green(priceHourly)} (max ${priceMonthly})`
   },
 
   formatState: function (state) {

--- a/packages/addons-v5/test/unit/commands/addons.--all.unit.test.js
+++ b/packages/addons-v5/test/unit/commands/addons.--all.unit.test.js
@@ -26,6 +26,7 @@ describe('addons --all', function () {
 
     it('prints add-ons in a table', function () {
       return cmd.run({flags: {}}).then(function () {
+        console.log(`\n \n ${cli.stdout} \n \n`)
         util.expectOutput(cli.stdout,
           `Owning App    Add-on     Plan                    Price      State
 ────────────  ─────────  ──────────────────────  ─────────  ────────

--- a/packages/addons-v5/test/unit/commands/addons.--all.unit.test.js
+++ b/packages/addons-v5/test/unit/commands/addons.--all.unit.test.js
@@ -26,13 +26,12 @@ describe('addons --all', function () {
 
     it('prints add-ons in a table', function () {
       return cmd.run({flags: {}}).then(function () {
-        console.log(`\n \n ${cli.stdout} \n \n`)
         util.expectOutput(cli.stdout,
-          `Owning App    Add-on     Plan                    Price      State
-────────────  ─────────  ──────────────────────  ─────────  ────────
-acme-inc-api  api-redis  heroku-redis:premium-2  $60/month  created
-acme-inc-www  www-db     heroku-postgresql:mini  $5/month   created
-acme-inc-www  www-redis  heroku-redis:premium-2  $60/month  creating`)
+          `Owning App    Add-on     Plan                    Price         Max Price  State
+────────────  ─────────  ──────────────────────  ────────────  ─────────  ────────
+acme-inc-api  api-redis  heroku-redis:premium-2  ~$0.083/hour  $60/month  created
+acme-inc-www  www-db     heroku-postgresql:mini  ~$0.007/hour  $5/month   created
+acme-inc-www  www-redis  heroku-redis:premium-2  ~$0.083/hour  $60/month  creating`)
       })
     })
 
@@ -68,9 +67,9 @@ acme-inc-www  www-redis  heroku-redis:premium-2  $60/month  creating`)
     it('prints add-ons in a table with the grandfathered price', function () {
       return cmd.run({flags: {}}).then(function () {
         util.expectOutput(cli.stdout,
-          `Owning App    Add-on  Plan                          Price       State
-────────────  ──────  ────────────────────────────  ──────────  ───────
-acme-inc-dwh  dwh-db  heroku-postgresql:standard-2  $100/month  created`)
+          `Owning App    Add-on  Plan                          Price         Max Price   State
+────────────  ──────  ────────────────────────────  ────────────  ──────────  ───────
+acme-inc-dwh  dwh-db  heroku-postgresql:standard-2  ~$0.139/hour  $100/month  created`)
       })
     })
   })
@@ -90,9 +89,9 @@ acme-inc-dwh  dwh-db  heroku-postgresql:standard-2  $100/month  created`)
     it('prints add-ons in a table with contract', function () {
       return cmd.run({flags: {}}).then(function () {
         util.expectOutput(cli.stdout,
-          `Owning App    Add-on  Plan                          Price     State
-────────────  ──────  ────────────────────────────  ────────  ───────
-acme-inc-dwh  dwh-db  heroku-postgresql:standard-2  contract  created`)
+          `Owning App    Add-on  Plan                          Price     Max Price  State
+────────────  ──────  ────────────────────────────  ────────  ─────────  ───────
+acme-inc-dwh  dwh-db  heroku-postgresql:standard-2  contract  contract   created`)
       })
     })
   })

--- a/packages/addons-v5/test/unit/commands/addons.--app.unit.test.js
+++ b/packages/addons-v5/test/unit/commands/addons.--app.unit.test.js
@@ -91,9 +91,9 @@ The table above shows add-ons and the attachments to the current app (acme-inc-w
 
       return run('acme-inc-dwh', function () {
         util.expectOutput(cli.stdout, `
-Add-on                               Plan  Price                         State
-───────────────────────────────────  ────  ────────────────────────────  ───────
-heroku-postgresql (www-db)           mini  (billed to acme-inc-www app)  created
+Add-on                               Plan  Price                         Max Price                     State
+───────────────────────────────────  ────  ────────────────────────────  ────────────────────────────  ───────
+heroku-postgresql (www-db)           mini  (billed to acme-inc-www app)  (billed to acme-inc-www app)  created
  ├─ as WWW_DB
  └─ as DATABASE on acme-inc-www app
 
@@ -296,9 +296,9 @@ The table above shows add-ons and the attachments to the current app (acme-inc-d
 
     return run('acme-inc-api', function () {
       util.expectOutput(cli.stdout, `
-Add-on         Plan  Price                         State
-─────────────  ────  ────────────────────────────  ─────
-? (www-db)     ?     (billed to acme-inc-www app)
+Add-on         Plan  Price                         Max Price                     State
+─────────────  ────  ────────────────────────────  ────────────────────────────  ─────
+? (www-db)     ?     (billed to acme-inc-www app)  (billed to acme-inc-www app)
  └─ as WWW_DB
 
 The table above shows add-ons and the attachments to the current app (acme-inc-api) or other apps.

--- a/packages/addons-v5/test/unit/commands/addons.--app.unit.test.js
+++ b/packages/addons-v5/test/unit/commands/addons.--app.unit.test.js
@@ -52,12 +52,12 @@ describe('addons --app', function () {
 
       return run('acme-inc-www', function () {
         util.expectOutput(cli.stdout, `
-Add-on                      Plan       Price      State
-──────────────────────────  ─────────  ─────────  ────────
-heroku-postgresql (www-db)  mini       $5/month   created
+Add-on                      Plan       Price        Max Price      State
+──────────────────────────  ─────────  ───────────  ─────────  ────────
+heroku-postgresql (www-db)  mini       ~$0.01/hour  $5/month   created
  └─ as DATABASE
 
-heroku-redis (www-redis)    premium-2  $60/month  creating
+heroku-redis (www-redis)    premium-2  ~$0.08/hour  $60/month  creating
  └─ as REDIS
 
 The table above shows add-ons and the attachments to the current app (acme-inc-www) or other apps.
@@ -72,9 +72,9 @@ The table above shows add-ons and the attachments to the current app (acme-inc-w
       ])
       return run('acme-inc-www', function () {
         util.expectOutput(cli.stdout, `
-Add-on                             Plan  Price     State
-─────────────────────────────────  ────  ────────  ───────
-heroku-postgresql (www-db)         mini  $5/month  created
+Add-on                             Plan  Price        Max Price     State
+─────────────────────────────────  ────  ───────────  ─────────  ───────
+heroku-postgresql (www-db)         mini  ~$0.01/hour  $5/month  created
  ├─ as DATABASE
  └─ as WWW_DB on acme-inc-dwh app
 
@@ -281,9 +281,10 @@ The table above shows add-ons and the attachments to the current app (acme-inc-d
     it('prints add-ons in a table with contract', function () {
       return run('acme-inc-dwh', function () {
         util.expectOutput(cli.stdout,
-          `Add-on                      Plan        Price     State
-──────────────────────────  ──────────  ────────  ───────
-heroku-postgresql (dwh-db)  standard-2  contract  created
+          `
+Add-on                      Plan        Price     Max Price  State
+──────────────────────────  ──────────  ────────  ─────────  ───────
+heroku-postgresql (dwh-db)  standard-2  contract  contract   created
  └─ as DATABASE
 The table above shows add-ons and the attachments to the current app (acme-inc-dwh) or other apps.`)
       })

--- a/packages/addons-v5/test/unit/commands/addons.--app.unit.test.js
+++ b/packages/addons-v5/test/unit/commands/addons.--app.unit.test.js
@@ -52,12 +52,12 @@ describe('addons --app', function () {
 
       return run('acme-inc-www', function () {
         util.expectOutput(cli.stdout, `
-Add-on                      Plan       Price        Max Price      State
-──────────────────────────  ─────────  ───────────  ─────────  ────────
-heroku-postgresql (www-db)  mini       ~$0.01/hour  $5/month   created
+Add-on                      Plan       Price         Max Price  State
+──────────────────────────  ─────────  ────────────  ─────────  ────────
+heroku-postgresql (www-db)  mini       ~$0.007/hour  $5/month   created
  └─ as DATABASE
 
-heroku-redis (www-redis)    premium-2  ~$0.08/hour  $60/month  creating
+heroku-redis (www-redis)    premium-2  ~$0.083/hour  $60/month  creating
  └─ as REDIS
 
 The table above shows add-ons and the attachments to the current app (acme-inc-www) or other apps.
@@ -72,9 +72,9 @@ The table above shows add-ons and the attachments to the current app (acme-inc-w
       ])
       return run('acme-inc-www', function () {
         util.expectOutput(cli.stdout, `
-Add-on                             Plan  Price        Max Price     State
-─────────────────────────────────  ────  ───────────  ─────────  ───────
-heroku-postgresql (www-db)         mini  ~$0.01/hour  $5/month  created
+Add-on                             Plan  Price         Max Price  State
+─────────────────────────────────  ────  ────────────  ─────────  ───────
+heroku-postgresql (www-db)         mini  ~$0.007/hour  $5/month   created
  ├─ as DATABASE
  └─ as WWW_DB on acme-inc-dwh app
 
@@ -257,9 +257,9 @@ The table above shows add-ons and the attachments to the current app (acme-inc-d
     it('prints add-ons in a table with the grandfathered price', function () {
       return run('acme-inc-dwh', function () {
         util.expectOutput(cli.stdout,
-          `Add-on                      Plan        Price       State
-──────────────────────────  ──────────  ──────────  ───────
-heroku-postgresql (dwh-db)  standard-2  $100/month  created
+          `Add-on                      Plan        Price         Max Price   State
+──────────────────────────  ──────────  ────────────  ──────────  ───────
+heroku-postgresql (dwh-db)  standard-2  ~$0.139/hour  $100/month  created
  └─ as DATABASE
 The table above shows add-ons and the attachments to the current app (acme-inc-dwh) or other apps.`)
       })

--- a/packages/addons-v5/test/unit/commands/addons/create.unit.test.js
+++ b/packages/addons-v5/test/unit/commands/addons/create.unit.test.js
@@ -85,7 +85,7 @@ describe('addons:create', () => {
         args: ['heroku-postgresql:standard-0', '--rollback', '--follow', 'otherdb', '--foo'],
         flags: {as: 'mydb'},
       })
-        .then(() => expect(cli.stderr).to.equal('Creating heroku-postgresql:standard-0 on myapp... $100/month\n'))
+        .then(() => expect(cli.stderr).to.equal('Creating heroku-postgresql:standard-0 on myapp... ~$0.139/hour (max $100/month)\n'))
         .then(() => expect(cli.stdout).to.equal(`provision message
 Created db3-swiftly-123 as DATABASE_URL
 Use heroku addons:docs heroku-db3 to view documentation
@@ -132,7 +132,7 @@ Use heroku addons:docs heroku-db3 to view documentation
           args: ['heroku-postgresql:standard-0'],
           flags: {as: 'mydb'},
         })
-          .then(() => expect(cli.stderr).to.equal('Creating heroku-postgresql:standard-0 on myapp... $100/month\n'))
+          .then(() => expect(cli.stderr).to.equal('Creating heroku-postgresql:standard-0 on myapp... ~$0.139/hour (max $100/month)\n'))
           .then(() => expect(cli.stdout).to.equal(`provision message
 db3-swiftly-123 is being created in the background. The app will restart when complete...
 Use heroku addons:info db3-swiftly-123 to check creation progress
@@ -162,7 +162,7 @@ Use heroku addons:docs heroku-db3 to view documentation
           args: ['heroku-postgresql:standard-0'],
           flags: {as: 'mydb'},
         })
-          .then(() => expect(cli.stderr).to.equal('Creating heroku-postgresql:standard-0 on myapp... $100/month\n'))
+          .then(() => expect(cli.stderr).to.equal('Creating heroku-postgresql:standard-0 on myapp... ~$0.139/hour (max $100/month)\n'))
           .then(() => expect(cli.stdout).to.equal(`db3-swiftly-123 is being created in the background. The app will restart when complete...
 Use heroku addons:info db3-swiftly-123 to check creation progress
 Use heroku addons:docs heroku-db3 to view documentation
@@ -191,7 +191,7 @@ Use heroku addons:docs heroku-db3 to view documentation
           args: ['heroku-postgresql:standard-0'],
           flags: {as: 'mydb'},
         })
-          .then(() => expect(cli.stderr).to.equal('Creating heroku-postgresql:standard-0 on myapp... $100/month\n'))
+          .then(() => expect(cli.stderr).to.equal('Creating heroku-postgresql:standard-0 on myapp... ~$0.139/hour (max $100/month)\n'))
           .then(() => expect(cli.stdout).to.equal(`provision message
 db3-swiftly-123 is being created in the background. The app will restart when complete...
 Use heroku addons:info db3-swiftly-123 to check creation progress
@@ -246,7 +246,7 @@ Use heroku addons:docs heroku-db3 to view documentation
           .then(() => provisionedResponse.done())
           .then(() => expect(notifySpy.called).to.equal(true))
           .then(() => expect(notifySpy.calledOnce).to.equal(true))
-          .then(() => expect(cli.stderr).to.equal('Creating heroku-postgresql:standard-0 on myapp... $100/month\nCreating db3-swiftly-123... done\n'))
+          .then(() => expect(cli.stderr).to.equal('Creating heroku-postgresql:standard-0 on myapp... ~$0.139/hour (max $100/month)\nCreating db3-swiftly-123... done\n'))
           .then(() => expect(cli.stdout).to.equal(`provision message
 Waiting for db3-swiftly-123...
 Created db3-swiftly-123 as DATABASE_URL
@@ -352,7 +352,7 @@ Use heroku addons:docs heroku-db3 to view documentation
         app: 'myapp',
         args: ['heroku-postgresql:standard-0', '--rollback', '--follow', 'otherdb', '--foo'],
         flags: {as: 'mydb', confirm: 'myapp'},
-      }).then(() => expect(cli.stderr).to.equal('Creating heroku-postgresql:standard-0 on myapp... !\nCreating heroku-postgresql:standard-0 on myapp... $100/month\n'))
+      }).then(() => expect(cli.stderr).to.equal('Creating heroku-postgresql:standard-0 on myapp... !\nCreating heroku-postgresql:standard-0 on myapp... ~$0.139/hour (max $100/month)\n'))
         .then(() => expect(cli.stdout).to.equal(`provision message
 Created db3-swiftly-123 as DATABASE_URL
 Use heroku addons:docs heroku-db3 to view documentation
@@ -399,7 +399,7 @@ Use heroku addons:docs heroku-db3 to view documentation
         args: ['heroku-postgresql:standard-0'],
         flags: {as: 'mydb'},
       })
-        .then(() => expect(cli.stderr).to.equal('Creating heroku-postgresql:standard-0 on myapp... $100/month\n'))
+        .then(() => expect(cli.stderr).to.equal('Creating heroku-postgresql:standard-0 on myapp... ~$0.139/hour (max $100/month)\n'))
         .then(() => expect(cli.stdout).to.equal(`provision message
 Created db3-swiftly-123
 Use heroku addons:docs heroku-db3 to view documentation

--- a/packages/addons-v5/test/unit/commands/addons/info.unit.test.js
+++ b/packages/addons-v5/test/unit/commands/addons/info.unit.test.js
@@ -34,6 +34,7 @@ describe('addons:info', function () {
 
     it('prints add-ons in a table', function () {
       return cmd.run({flags: {}, args: {addon: 'www-db'}}).then(function () {
+        console.log(`\n \n ${cli.stdout} \n \n`)
         util.expectOutput(cli.stdout,
           `=== www-db
 Attachments:  acme-inc-www::DATABASE

--- a/packages/addons-v5/test/unit/commands/addons/info.unit.test.js
+++ b/packages/addons-v5/test/unit/commands/addons/info.unit.test.js
@@ -34,14 +34,14 @@ describe('addons:info', function () {
 
     it('prints add-ons in a table', function () {
       return cmd.run({flags: {}, args: {addon: 'www-db'}}).then(function () {
-        console.log(`\n \n ${cli.stdout} \n \n`)
         util.expectOutput(cli.stdout,
           `=== www-db
 Attachments:  acme-inc-www::DATABASE
 Installed at: Invalid Date
+Max Price:    $5/month
 Owning app:   acme-inc-www
 Plan:         heroku-postgresql:mini
-Price:        $5/month
+Price:        ~$0.007/hour
 State:        created
 `)
       })
@@ -71,9 +71,10 @@ State:        created
           `=== www-db
 Attachments:  acme-inc-www::DATABASE
 Installed at: Invalid Date
+Max Price:    $5/month
 Owning app:   acme-inc-www
 Plan:         heroku-postgresql:mini
-Price:        $5/month
+Price:        ~$0.007/hour
 State:        created
 `)
       })
@@ -109,9 +110,10 @@ State:        created
           `=== www-db
 Attachments:  acme-inc-www::DATABASE
 Installed at: Invalid Date
+Max Price:    $5/month
 Owning app:   acme-inc-www
 Plan:         heroku-postgresql:mini
-Price:        $5/month
+Price:        ~$0.007/hour
 State:        created
 `)
       })
@@ -144,9 +146,10 @@ State:        created
           `=== dwh-db
 Attachments:  acme-inc-dwh::DATABASE
 Installed at: Invalid Date
+Max Price:    $100/month
 Owning app:   acme-inc-dwh
 Plan:         heroku-postgresql:standard-2
-Price:        $100/month
+Price:        ~$0.139/hour
 State:        created
 `)
       })
@@ -179,6 +182,7 @@ State:        created
           `=== dwh-db
 Attachments:  acme-inc-dwh::DATABASE
 Installed at: Invalid Date
+Max Price:    contract
 Owning app:   acme-inc-dwh
 Plan:         heroku-postgresql:standard-2
 Price:        contract

--- a/packages/addons-v5/test/unit/commands/addons/plans.unit.test.js
+++ b/packages/addons-v5/test/unit/commands/addons/plans.unit.test.js
@@ -16,16 +16,13 @@ describe('addons:plans', function () {
         {name: 'fourth', human_name: 'Fourth', price: {cents: 0, unit: 'month', contract: true}, default: false},
       ])
     return cmd.run({args: {service: 'daservice'}, flags: {}})
-      .then(() => {
-        console.log(`\n \n ${cli.stdout} \n \n`)
-        expect(cli.stdout).to.equal(`         slug    name    price
-───────  ──────  ──────  ──────────
-default  first   First   free
-         second  Second  $20/month
-         third   Third   $100/month
-         fourth  Fourth  contract
-`)
-      })
+      .then(() => expect(cli.stdout).to.equal(`         slug    name    price         max price
+───────  ──────  ──────  ────────────  ──────────
+default  first   First   free          free
+         second  Second  ~$0.028/hour  $20/month
+         third   Third   ~$0.139/hour  $100/month
+         fourth  Fourth  contract      contract
+`))
       .then(() => api.done())
   })
 })

--- a/packages/addons-v5/test/unit/commands/addons/plans.unit.test.js
+++ b/packages/addons-v5/test/unit/commands/addons/plans.unit.test.js
@@ -16,13 +16,16 @@ describe('addons:plans', function () {
         {name: 'fourth', human_name: 'Fourth', price: {cents: 0, unit: 'month', contract: true}, default: false},
       ])
     return cmd.run({args: {service: 'daservice'}, flags: {}})
-      .then(() => expect(cli.stdout).to.equal(`         slug    name    price
+      .then(() => {
+        console.log(`\n \n ${cli.stdout} \n \n`)
+        expect(cli.stdout).to.equal(`         slug    name    price
 ───────  ──────  ──────  ──────────
 default  first   First   free
          second  Second  $20/month
          third   Third   $100/month
          fourth  Fourth  contract
-`))
+`)
+      })
       .then(() => api.done())
   })
 })

--- a/packages/addons-v5/test/unit/commands/addons/upgrade.unit.test.js
+++ b/packages/addons-v5/test/unit/commands/addons/upgrade.unit.test.js
@@ -26,6 +26,32 @@ describe('addons:upgrade', () => {
       .then(() => api.done())
   })
 
+  it('displays hourly and monthly price when upgrading an add-on', () => {
+    let addon = {name: 'kafka-swiftly-123', addon_service: {name: 'heroku-kafka'}, app: {name: 'myapp'}, plan: {name: 'premium-0'}}
+
+    let api = nock('https://api.heroku.com:443')
+      .post('/actions/addons/resolve', {app: 'myapp', addon: 'heroku-kafka'}).reply(200, [addon])
+      .patch('/apps/myapp/addons/kafka-swiftly-123', {plan: {name: 'heroku-kafka:standard'}})
+      .reply(200, {plan: {price: {cents: 2500, unit: 'month'}}, provision_message: 'provision msg'})
+    return cmd.run({app: 'myapp', args: {addon: 'heroku-kafka', plan: 'heroku-kafka:standard'}})
+      .then(() => expect(cli.stdout).to.equal('provision msg\n'))
+      .then(() => expect(cli.stderr).to.equal('Changing kafka-swiftly-123 on myapp from premium-0 to heroku-kafka:standard... done, ~$0.035/hour (max $25/month)\n'))
+      .then(() => api.done())
+  })
+
+  it('does not display a price when upgrading an add-on and no price is returned from the api', () => {
+    let addon = {name: 'kafka-swiftly-123', addon_service: {name: 'heroku-kafka'}, app: {name: 'myapp'}, plan: {name: 'premium-0'}}
+
+    let api = nock('https://api.heroku.com:443')
+      .post('/actions/addons/resolve', {app: 'myapp', addon: 'heroku-kafka'}).reply(200, [addon])
+      .patch('/apps/myapp/addons/kafka-swiftly-123', {plan: {name: 'heroku-kafka:hobby'}})
+      .reply(200, {plan: {}, provision_message: 'provision msg'})
+    return cmd.run({app: 'myapp', args: {addon: 'heroku-kafka', plan: 'heroku-kafka:hobby'}})
+      .then(() => expect(cli.stdout).to.equal('provision msg\n'))
+      .then(() => expect(cli.stderr).to.equal('Changing kafka-swiftly-123 on myapp from premium-0 to heroku-kafka:hobby... done\n'))
+      .then(() => api.done())
+  })
+
   it('upgrades to a contract add-on', () => {
     let addon = {name: 'connect-swiftly-123', addon_service: {name: 'heroku-connect'}, app: {name: 'myapp'}, plan: {name: 'free'}}
 

--- a/packages/addons-v5/test/unit/lib/util.unit.test.js
+++ b/packages/addons-v5/test/unit/lib/util.unit.test.js
@@ -6,21 +6,36 @@ let expect = require('chai').expect
 describe('util.formatPrice', function () {
   it('formats as "free" when cents is 0', function () {
     expect(util.formatPrice({cents: 0})).to.eq('free')
+    expect(util.formatHourlyPrice({cents: 0})).to.eq('free')
   })
 
   it('formats as "contract" when price.contract is truthy', function () {
     expect(util.formatPrice({cents: 0, contract: true})).to.eq('contract')
-  })
-
-  it('formats as dollars with cents when the calculated price is not whole dollars', function () {
-    expect(util.formatPrice({cents: 1200})).to.eq('~$0.02/hour')
-  })
-
-  it('formats as dollars without cents when the calculated price is whole dollars', function () {
-    expect(util.formatPrice({cents: 720000})).to.eq('~$10/hour')
+    expect(util.formatHourlyPrice({cents: 0, contract: true}))
   })
 
   it('returns undefined when no pricing information given', function () {
     expect(util.formatPrice(null)).to.eq()
+    expect(util.formatHourlyPrice(null)).to.eq()
+  })
+
+  describe('when displaying hourly price', function () {
+    it('formats as dollars with cents when the calculated price is not whole dollars', function () {
+      expect(util.formatHourlyPrice({cents: 1200})).to.eq('~$0.02/hour')
+    })
+
+    it('formats as dollars without cents when the calculated price is whole dollars', function () {
+      expect(util.formatHourlyPrice({cents: 720000})).to.eq('~$10/hour')
+    })
+  })
+
+  describe('when displaying monthly price', function () {
+    it('formats as dollars with cents when the calculated price is not whole dollars', function () {
+      expect(util.formatPrice({cents: 1200, unit: 'month'})).to.eq('$12/month')
+    })
+
+    it('formats as dollars without cents when the calculated price is whole dollars', function () {
+      expect(util.formatPrice({cents: 720000, unit: 'month'})).to.eq('$7200/month')
+    })
   })
 })

--- a/packages/addons-v5/test/unit/lib/util.unit.test.js
+++ b/packages/addons-v5/test/unit/lib/util.unit.test.js
@@ -5,37 +5,32 @@ let expect = require('chai').expect
 
 describe('util.formatPrice', function () {
   it('formats as "free" when cents is 0', function () {
-    expect(util.formatPrice({cents: 0})).to.eq('free')
-    expect(util.formatHourlyPrice({cents: 0})).to.eq('free')
+    expect(util.formatPrice({price: {cents: 0}, hourly: false})).to.eq('free')
+    expect(util.formatPrice({price: {cents: 0}, hourly: true})).to.eq('free')
   })
 
   it('formats as "contract" when price.contract is truthy', function () {
-    expect(util.formatPrice({cents: 0, contract: true})).to.eq('contract')
-    expect(util.formatHourlyPrice({cents: 0, contract: true}))
+    expect(util.formatPrice({price: {cents: 0, contract: true}, hourly: false})).to.eq('contract')
+    expect(util.formatPrice({price: {cents: 0, contract: true}, hourly: true}))
   })
 
   it('returns undefined when no pricing information given', function () {
-    expect(util.formatPrice(null)).to.eq()
-    expect(util.formatHourlyPrice(null)).to.eq()
+    expect(util.formatPrice({price: null})).to.eq()
   })
 
   describe('when displaying hourly price', function () {
-    it('formats as dollars with cents when the calculated price is not whole dollars', function () {
-      expect(util.formatHourlyPrice({cents: 1200})).to.eq('~$0.02/hour')
-    })
-
-    it('formats as dollars without cents when the calculated price is whole dollars', function () {
-      expect(util.formatHourlyPrice({cents: 720000})).to.eq('~$10/hour')
+    it('formats as dollars with cents with 3 decimals', function () {
+      expect(util.formatPrice({price: {cents: 1200}, hourly: true})).to.eq('~$0.017/hour')
     })
   })
 
   describe('when displaying monthly price', function () {
     it('formats as dollars with cents when the calculated price is not whole dollars', function () {
-      expect(util.formatPrice({cents: 1200, unit: 'month'})).to.eq('$12/month')
+      expect(util.formatPrice({price: {cents: 1200, unit: 'month'}, hourly: false})).to.eq('$12/month')
     })
 
     it('formats as dollars without cents when the calculated price is whole dollars', function () {
-      expect(util.formatPrice({cents: 720000, unit: 'month'})).to.eq('$7200/month')
+      expect(util.formatPrice({price: {cents: 720000, unit: 'month'}, hourly: false})).to.eq('$7200/month')
     })
   })
 })

--- a/packages/addons-v5/test/unit/lib/util.unit.test.js
+++ b/packages/addons-v5/test/unit/lib/util.unit.test.js
@@ -5,19 +5,19 @@ let expect = require('chai').expect
 
 describe('util.formatPrice', function () {
   it('formats as "free" when cents is 0', function () {
-    expect(util.formatPrice({cents: 0, unit: 'does not matter'})).to.eq('free')
+    expect(util.formatPrice({cents: 0})).to.eq('free')
   })
 
-  it('formats cents per unit', function () {
-    expect(util.formatPrice({cents: 100, unit: 'UNIT'})).to.eq('$1/UNIT')
+  it('formats as "contract" when price.contract is truthy', function () {
+    expect(util.formatPrice({cents: 0, contract: true})).to.eq('contract')
   })
 
-  it('formats as dollars with cents when not whole dollars', function () {
-    expect(util.formatPrice({cents: 1201, unit: 'month'})).to.eq('$12.01/month')
+  it('formats as dollars with cents when the calculated price is not whole dollars', function () {
+    expect(util.formatPrice({cents: 1200})).to.eq('~$0.02/hour')
   })
 
-  it('formats as dollars without cents when whole dollars', function () {
-    expect(util.formatPrice({cents: 1200, unit: 'month'})).to.eq('$12/month')
+  it('formats as dollars without cents when the calculated price is whole dollars', function () {
+    expect(util.formatPrice({cents: 720000})).to.eq('~$10/hour')
   })
 
   it('returns undefined when no pricing information given', function () {

--- a/packages/apps-v5/src/commands/ps/type.js
+++ b/packages/apps-v5/src/commands/ps/type.js
@@ -3,7 +3,7 @@
 let cli = require('heroku-cli-util')
 const {sortBy, compact} = require('lodash')
 
-const costs = {Free: 0, Eco: 0, Hobby: 7, Basic: 7, 'Standard-1X': 25, 'Standard-2X': 50, 'Performance-M': 250, Performance: 500, 'Performance-L': 500, '1X': 36, '2X': 72, PX: 576}
+const costsHourly = {Eco: 0, Hobby: '0.01', Basic: '0.01', 'Standard-1X': '0.03', 'Standard-2X': '0.06', 'Performance-M': '0.34', 'Performance-L': '0.69'}
 
 let emptyFormationErr = app => {
   return new Error(`No process types on ${app}.
@@ -69,7 +69,7 @@ Types: ${cli.color.yellow(formation.map(f => f.type).join(', '))}`)
       type: cli.color.green(d.type),
       size: cli.color.cyan(d.size),
       qty: cli.color.yellow(d.quantity.toString()),
-      'cost/mo': costs[d.size] ? '$' + (costs[d.size] * d.quantity).toString() : '',
+      'cost/hr': costsHourly[d.size] ? '~$' + (costsHourly[d.size] * d.quantity).toString() : '',
     }))
 
     if (formation.length === 0) throw emptyFormationErr()
@@ -80,7 +80,7 @@ Types: ${cli.color.yellow(formation.map(f => f.type).join(', '))}`)
         {key: 'type'},
         {key: 'size'},
         {key: 'qty'},
-        {key: 'cost/mo'},
+        {key: 'cost/hr'},
       ],
     })
 

--- a/packages/apps-v5/src/commands/ps/type.js
+++ b/packages/apps-v5/src/commands/ps/type.js
@@ -3,7 +3,7 @@
 let cli = require('heroku-cli-util')
 const {sortBy, compact} = require('lodash')
 
-const costsHourly = {Eco: 0, Hobby: '0.01', Basic: '0.01', 'Standard-1X': '0.03', 'Standard-2X': '0.06', 'Performance-M': '0.34', 'Performance-L': '0.69'}
+const costMonthly = {Free: 0, Eco: 0, Hobby: 7, Basic: 7, 'Standard-1X': 25, 'Standard-2X': 50, 'Performance-M': 250, Performance: 500, 'Performance-L': 500, '1X': 36, '2X': 72, PX: 576}
 
 let emptyFormationErr = app => {
   return new Error(`No process types on ${app}.
@@ -15,7 +15,7 @@ async function run(context, heroku) {
   let app = context.app
 
   let parse = async function (args) {
-    if (args.length === 0) return []
+    if (!args || args.length === 0) return []
     let formation = await heroku.get(`/apps/${app}/formation`)
     if (args.find(a => a.match(/=/))) {
       return compact(args.map(arg => {
@@ -32,6 +32,10 @@ Types: ${cli.color.yellow(formation.map(f => f.type).join(', '))}`)
     }
 
     return formation.map(p => ({type: p.type, size: args[0]}))
+  }
+
+  const calculateHourly = function (size) {
+    return costMonthly[size] / 720
   }
 
   let displayFormation = async function () {
@@ -69,7 +73,8 @@ Types: ${cli.color.yellow(formation.map(f => f.type).join(', '))}`)
       type: cli.color.green(d.type),
       size: cli.color.cyan(d.size),
       qty: cli.color.yellow(d.quantity.toString()),
-      'cost/hr': costsHourly[d.size] ? '~$' + (costsHourly[d.size] * d.quantity).toString() : '',
+      'cost/hour': calculateHourly(d.size) ? '~$' + (calculateHourly(d.size) * d.quantity).toPrecision(4).toString() : '',
+      'max cost/month': costMonthly[d.size] ? '$' + (costMonthly[d.size] * d.quantity).toString() : '',
     }))
 
     if (formation.length === 0) throw emptyFormationErr()
@@ -80,7 +85,8 @@ Types: ${cli.color.yellow(formation.map(f => f.type).join(', '))}`)
         {key: 'type'},
         {key: 'size'},
         {key: 'qty'},
-        {key: 'cost/hr'},
+        {key: 'cost/hour'},
+        {key: 'max cost/month'},
       ],
     })
 

--- a/packages/apps-v5/src/commands/ps/type.js
+++ b/packages/apps-v5/src/commands/ps/type.js
@@ -73,7 +73,7 @@ Types: ${cli.color.yellow(formation.map(f => f.type).join(', '))}`)
       type: cli.color.green(d.type),
       size: cli.color.cyan(d.size),
       qty: cli.color.yellow(d.quantity.toString()),
-      'cost/hour': calculateHourly(d.size) ? '~$' + (calculateHourly(d.size) * d.quantity).toPrecision(4).toString() : '',
+      'cost/hour': calculateHourly(d.size) ? '~$' + (calculateHourly(d.size) * d.quantity).toFixed(3).toString() : '',
       'max cost/month': costMonthly[d.size] ? '$' + (costMonthly[d.size] * d.quantity).toString() : '',
     }))
 

--- a/packages/apps-v5/test/unit/commands/ps/type.unit.test.js
+++ b/packages/apps-v5/test/unit/commands/ps/type.unit.test.js
@@ -17,6 +17,28 @@ describe('ps:type', function () {
     nock.cleanAll()
   })
 
+  it('displays cost/hour and max cost/month for all individually-priced dyno sizes', function () {
+    let api = nock('https://api.heroku.com')
+      .get('/apps/myapp')
+      .reply(200, app())
+      .get('/apps/myapp/formation')
+      .reply(200, [
+        {type: 'web', quantity: 1, size: 'Eco'},
+        {type: 'web', quantity: 1, size: 'Basic'},
+        {type: 'web', quantity: 1, size: 'Standard-1X'},
+        {type: 'web', quantity: 1, size: 'Standard-2X'},
+        {type: 'web', quantity: 1, size: 'Performance-M'},
+        {type: 'web', quantity: 1, size: 'Performance-L'},
+      ])
+
+    return cmd.run({app: 'myapp'})
+      .then(() => {
+        console.log(`\n \n ${cli.stdout} \n \n`)
+        expect(cli.stdout).to.eq('')
+      })
+      .then(() => api.done())
+  })
+
   it('switches to hobby dynos', function () {
     let api = nock('https://api.heroku.com')
       .get('/apps/myapp')
@@ -29,8 +51,9 @@ describe('ps:type', function () {
       .reply(200, [{type: 'web', quantity: 1, size: 'Basic'}, {type: 'worker', quantity: 2, size: 'Basic'}])
 
     return cmd.run({app: 'myapp', args: ['basic']})
-      .then(() => expect(cli.stdout).to.eq(`=== Dyno Types
-type    size   qty  cost/hr
+      .then(() => expect(cli.stdout).to.eq(`
+=== Dyno Types
+type    size   qty  cost/hour
 ──────  ─────  ───  ───────
 web     Basic  1    ~$0.01
 worker  Basic  2    ~$0.02

--- a/packages/apps-v5/test/unit/commands/ps/type.unit.test.js
+++ b/packages/apps-v5/test/unit/commands/ps/type.unit.test.js
@@ -33,8 +33,27 @@ describe('ps:type', function () {
 
     return cmd.run({app: 'myapp'})
       .then(() => {
-        console.log(`\n \n ${cli.stdout} \n \n`)
-        expect(cli.stdout).to.eq('')
+        expect(cli.stdout).to.eq(`=== Dyno Types
+type  size           qty  cost/hour  max cost/month
+────  ─────────────  ───  ─────────  ──────────────
+web   Eco            1
+web   Basic          1    ~$0.010    $7
+web   Standard-1X    1    ~$0.035    $25
+web   Standard-2X    1    ~$0.069    $50
+web   Performance-M  1    ~$0.347    $250
+web   Performance-L  1    ~$0.694    $500
+=== Dyno Totals
+type           total
+─────────────  ─────
+Eco            1
+Basic          1
+Standard-1X    1
+Standard-2X    1
+Performance-M  1
+Performance-L  1
+
+$5 (flat monthly fee, shared across all Eco dynos)
+`)
       })
       .then(() => api.done())
   })
@@ -51,12 +70,11 @@ describe('ps:type', function () {
       .reply(200, [{type: 'web', quantity: 1, size: 'Basic'}, {type: 'worker', quantity: 2, size: 'Basic'}])
 
     return cmd.run({app: 'myapp', args: ['basic']})
-      .then(() => expect(cli.stdout).to.eq(`
-=== Dyno Types
-type    size   qty  cost/hour
-──────  ─────  ───  ───────
-web     Basic  1    ~$0.01
-worker  Basic  2    ~$0.02
+      .then(() => expect(cli.stdout).to.eq(`=== Dyno Types
+type    size   qty  cost/hour  max cost/month
+──────  ─────  ───  ─────────  ──────────────
+web     Basic  1    ~$0.010    $7
+worker  Basic  2    ~$0.019    $14
 === Dyno Totals
 type   total
 ─────  ─────
@@ -79,10 +97,10 @@ Basic  3
 
     return cmd.run({app: 'myapp', args: ['web=standard-1x', 'worker=standard-2x']})
       .then(() => expect(cli.stdout).to.eq(`=== Dyno Types
-type    size         qty  cost/hr
-──────  ───────────  ───  ───────
-web     Standard-1X  1    ~$0.03
-worker  Standard-2X  2    ~$0.12
+type    size         qty  cost/hour  max cost/month
+──────  ───────────  ───  ─────────  ──────────────
+web     Standard-1X  1    ~$0.035    $25
+worker  Standard-2X  2    ~$0.139    $100
 === Dyno Totals
 type         total
 ───────────  ─────
@@ -102,8 +120,8 @@ Standard-2X  2
 
     return cmd.run({app: 'myapp', args: []})
       .then(() => expect(cli.stdout).to.eq(`=== Dyno Types
-type  size      qty  cost/hr
-────  ────────  ───  ───────
+type  size      qty  cost/hour  max cost/month
+────  ────────  ───  ─────────  ──────────────
 web   Shield-M  0
 web   Shield-L  0
 === Dyno Totals

--- a/packages/apps-v5/test/unit/commands/ps/type.unit.test.js
+++ b/packages/apps-v5/test/unit/commands/ps/type.unit.test.js
@@ -30,10 +30,10 @@ describe('ps:type', function () {
 
     return cmd.run({app: 'myapp', args: ['basic']})
       .then(() => expect(cli.stdout).to.eq(`=== Dyno Types
-type    size   qty  cost/mo
+type    size   qty  cost/hr
 ──────  ─────  ───  ───────
-web     Basic  1    $7
-worker  Basic  2    $14
+web     Basic  1    ~$0.01
+worker  Basic  2    ~$0.02
 === Dyno Totals
 type   total
 ─────  ─────
@@ -56,10 +56,10 @@ Basic  3
 
     return cmd.run({app: 'myapp', args: ['web=standard-1x', 'worker=standard-2x']})
       .then(() => expect(cli.stdout).to.eq(`=== Dyno Types
-type    size         qty  cost/mo
+type    size         qty  cost/hr
 ──────  ───────────  ───  ───────
-web     Standard-1X  1    $25
-worker  Standard-2X  2    $100
+web     Standard-1X  1    ~$0.03
+worker  Standard-2X  2    ~$0.12
 === Dyno Totals
 type         total
 ───────────  ─────
@@ -79,7 +79,7 @@ Standard-2X  2
 
     return cmd.run({app: 'myapp', args: []})
       .then(() => expect(cli.stdout).to.eq(`=== Dyno Types
-type  size      qty  cost/mo
+type  size      qty  cost/hr
 ────  ────────  ───  ───────
 web   Shield-M  0
 web   Shield-L  0

--- a/packages/spaces/commands/create.js
+++ b/packages/spaces/commands/create.js
@@ -8,10 +8,12 @@ const {RegionCompletion} = require('@heroku-cli/command/lib/completions')
 
 async function run(context, heroku) {
   let space = context.flags.space || context.args.space
-  let dollarAmount = '$1000'
+  let dollarAmountMonthly = '$1200'
+  let dollarAmountHourly = '$1.67'
   let spaceType = 'Standard'
   if (context.flags.shield) {
-    dollarAmount = '$3000'
+    dollarAmountMonthly = '$3600'
+    dollarAmountHourly = '$5'
     spaceType = 'Shield'
   }
 
@@ -36,7 +38,8 @@ async function run(context, heroku) {
   })
 
   space = await cli.action(`Creating space ${cli.color.green(space)} in team ${cli.color.cyan(team)}`, request)
-  cli.warn(`${cli.color.bold('Spend Alert.')} Each Heroku ${spaceType} Private Space costs ${dollarAmount} in Add-on Credits/month (pro-rated to the second).`)
+  cli.warn(`${cli.color.bold('Spend Alert.')} During the limited GA period, each Heroku ${spaceType} Private Space costs ${dollarAmountHourly}/hour (max ${dollarAmountMonthly}/month), pro-rated to the second.`)
+  // cli.warn(`${cli.color.bold('Spend Alert.')} Each Heroku ${spaceType} Private Space costs ${dollarAmount} in Add-on Credits/month (pro-rated to the second).`)
   cli.warn('Use spaces:wait to track allocation.')
   cli.styledHeader(space.name)
   cli.styledObject({

--- a/packages/spaces/test/unit/commands/create.unit.test.js
+++ b/packages/spaces/test/unit/commands/create.unit.test.js
@@ -55,7 +55,8 @@ Created at: ${now.toISOString()}
     return cmd.run({flags: {team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two'}})
       .then(() => {
         console.log(`\n \n ${cli.stderr} \n \n`)
-        expect(cli.stderr).to.include('Spend Alert. During the limited GA period, each Heroku Standard Private\n ▸    Space costs $1.67/hour (max $1200/month), pro-rated to the second.')
+        expect(cli.stderr).to.include('Spend Alert. During the limited GA period, each Heroku Standard Private')
+        expect(cli.stderr).to.include('Space costs $1.67/hour (max $1200/month), pro-rated to the second.')
       })
       .then(() => api.done())
   })
@@ -99,8 +100,8 @@ Created at: ${now.toISOString()}
         {shield: true, name: 'my-space', team: {name: 'my-team'}, region: {name: 'my-region'}, features: ['one', 'two'], state: 'enabled', created_at: now, cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20'},
       )
     return cmd.run({flags: {team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two', shield: true}, log_drain_url: 'https://logs.cheetah.com'})
-      .then(() => expect(cli.stderr).to.include(
-        'Spend Alert. During the limited GA period, each Heroku Shield Private\n ▸    Space costs $5/hour (max $3600/month), pro-rated to the second.'))
+      .then(() => expect(cli.stderr).to.include('Spend Alert. During the limited GA period, each Heroku Shield Private'))
+      .then(() => expect(cli.stderr).to.include('Space costs $5/hour (max $3600/month), pro-rated to the second.'))
       .then(() => api.done())
   })
 

--- a/packages/spaces/test/unit/commands/create.unit.test.js
+++ b/packages/spaces/test/unit/commands/create.unit.test.js
@@ -55,7 +55,7 @@ Created at: ${now.toISOString()}
     return cmd.run({flags: {team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two'}})
       .then(() => {
         console.log(`\n \n ${cli.stderr} \n \n`)
-        expect(cli.stderr).to.include('Each Heroku Standard Private Space costs $1000')
+        expect(cli.stderr).to.include('Spend Alert. During the limited GA period, each Heroku Standard Private\n ▸    Space costs $1.67/hour (max $1200/month), pro-rated to the second.')
       })
       .then(() => api.done())
   })
@@ -100,7 +100,7 @@ Created at: ${now.toISOString()}
       )
     return cmd.run({flags: {team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two', shield: true}, log_drain_url: 'https://logs.cheetah.com'})
       .then(() => expect(cli.stderr).to.include(
-        'Each Heroku Shield Private Space costs $3000'))
+        'Spend Alert. During the limited GA period, each Heroku Shield Private\n ▸    Space costs $5/hour (max $3600/month), pro-rated to the second.'))
       .then(() => api.done())
   })
 

--- a/packages/spaces/test/unit/commands/create.unit.test.js
+++ b/packages/spaces/test/unit/commands/create.unit.test.js
@@ -53,8 +53,10 @@ Created at: ${now.toISOString()}
         {shield: false, name: 'my-space', team: {name: 'my-team'}, region: {name: 'my-region'}, features: ['one', 'two'], state: 'enabled', created_at: now, cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20'},
       )
     return cmd.run({flags: {team: 'my-team', space: 'my-space', region: 'my-region', features: 'one, two'}})
-      .then(() => expect(cli.stderr).to.include(
-        'Each Heroku Standard Private Space costs $1000'))
+      .then(() => {
+        console.log(`\n \n ${cli.stderr} \n \n`)
+        expect(cli.stderr).to.include('Each Heroku Standard Private Space costs $1000')
+      })
       .then(() => api.done())
   })
 


### PR DESCRIPTION
## Description
This PR adds price per hour and monthly max price to all of the CLI's pricing displays. The commands affected are:
ps:type
spaces:create
addons
addons:info
addons:plans
addons:upgrade
addons:create

## Details
- Hourly price is reported using three decimal places
- In the addons-v5 plugin, we get pricing data from the API. in the apps-v5 and spaces packages that information is hard-coded.

## Testing
I tested pricing displays using our unit tests and test data. In several cases I added new unit tests to ensure that the displays and any pricing display logic was tested thoroughly.

## Screenshots
`ps:type`
<details>
<img src=https://github.com/heroku/cli/assets/12739849/8c917e45-a30e-4c30-a6c6-db83ace058ad) />
</details>

`spaces:create`
<details>
<img src=https://github.com/heroku/cli/assets/12739849/04155c25-1458-4d53-9008-f3cae80c218a) />
</details>

`addons`
<details>
<img src=https://github.com/heroku/cli/assets/12739849/e3e0ec70-62ee-4568-b639-a4c60679ec61 />
</details>

`addons:info`
<details>
<img src=https://github.com/heroku/cli/assets/12739849/2f6cd09c-96d5-44c5-8d32-b42a535d081c />
</details>

`addons:plans`
<details>
<img src=https://github.com/heroku/cli/assets/12739849/056df70a-aeec-4151-aaff-5722471e4060 />
</details>

`addons:update` & `addons:create`
With standard pricing
<details>
<img src=https://github.com/heroku/cli/assets/12739849/4ab8fcc3-697f-4b96-bd69-5ce62e89000f />
</details>

With no price information returned from the API
<details>
<img src=https://github.com/heroku/cli/assets/12739849/3d86471f-2c40-4b7b-ac58-f83c68e2ce56 />
</details>

With contract pricing
<details>
<img src=https://github.com/heroku/cli/assets/12739849/e71868de-0b4c-4fa4-b518-aa84b4a6a341 />
</details>

With price set to zero
<details>
<img src=https://github.com/heroku/cli/assets/12739849/13982534-7187-45bc-9b27-a020d7ea2844 />
</details>

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
