### PR TITLE
fix(cli): fix rollbar exitCode returning undefined

### DIFF
--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -10,6 +10,11 @@ const globalTelemetry = require('../lib/global_telemetry')
 
 process.once('beforeExit', async code => {
   // capture as successful exit
+  if (global.cliTelemetry.isVersionOrHelp) {
+    const cmdStartTime = global.cliTelemetry.commandRunDuration
+    global.cliTelemetry.commandRunDuration = globalTelemetry.computeDuration(cmdStartTime)
+  }
+
   global.cliTelemetry.exitCode = code
   global.cliTelemetry.cliRunDuration = globalTelemetry.computeDuration(cliStartTime)
   const telemetryData = global.cliTelemetry

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -261,7 +261,8 @@
     "hooks": {
       "init": [
         "./lib/hooks/init/version",
-        "./lib/hooks/init/terms-of-service"
+        "./lib/hooks/init/terms-of-service",
+        "./lib/hooks/init/performance_analytics"
       ],
       "prerun": [
         "./lib/hooks/prerun/analytics"

--- a/packages/cli/src/global_telemetry.ts
+++ b/packages/cli/src/global_telemetry.ts
@@ -66,7 +66,8 @@ interface Telemetry {
       prerun: boolean,
       postrun: boolean,
       command_not_found: boolean,
-    }
+    },
+    isVersionOrHelp: boolean
 }
 
 export interface TelemetryGlobal extends NodeJS.Global {
@@ -84,20 +85,45 @@ export function initializeInstrumentation() {
 export function setupTelemetry(config: any, opts: any) {
   const now = new Date()
   const cmdStartTime = now.getTime()
-  return {
-    command: opts.Command.id,
-    os: config.platform,
-    version: config.version,
-    exitCode: 0,
-    exitState: 'successful',
-    cliRunDuration: 0,
-    commandRunDuration: cmdStartTime,
-    lifecycleHookCompletion: {
-      init: true,
-      prerun: true,
-      postrun: false,
-      command_not_found: false,
-    },
+  const isHelpOrVersionCmd = (opts.id === 'version' || opts.id === '--help')
+  const isRegularCmd = Boolean(opts.Command)
+
+  if (isHelpOrVersionCmd) {
+    return {
+      command: opts.id,
+      os: config.platform,
+      version: config.version,
+      exitCode: 0,
+      exitState: 'successful',
+      cliRunDuration: 0,
+      commandRunDuration: cmdStartTime,
+      lifecycleHookCompletion: {
+        init: true,
+        prerun: false,
+        postrun: false,
+        command_not_found: false,
+      },
+      isVersionOrHelp: true,
+    }
+  }
+
+  if (isRegularCmd) {
+    return {
+      command: opts.Command.id,
+      os: config.platform,
+      version: config.version,
+      exitCode: 0,
+      exitState: 'successful',
+      cliRunDuration: 0,
+      commandRunDuration: cmdStartTime,
+      lifecycleHookCompletion: {
+        init: true,
+        prerun: true,
+        postrun: false,
+        command_not_found: false,
+      },
+      isVersionOrHelp: false,
+    }
   }
 }
 
@@ -124,6 +150,7 @@ export function reportCmdNotFound(config: any) {
       postrun: false,
       command_not_found: true,
     },
+    isVersionOrHelp: false,
   }
 }
 

--- a/packages/cli/src/hooks/init/performance_analytics.ts
+++ b/packages/cli/src/hooks/init/performance_analytics.ts
@@ -1,0 +1,11 @@
+import {Hook} from '@oclif/core'
+
+import * as telemetry from '../../global_telemetry'
+
+declare const global: telemetry.TelemetryGlobal
+
+const performance_analytics: Hook<'init'> = async function (options) {
+  global.cliTelemetry = telemetry.setupTelemetry(this.config, options)
+}
+
+export default performance_analytics

--- a/packages/cli/test/unit/global_telemetry.unit.test.ts
+++ b/packages/cli/test/unit/global_telemetry.unit.test.ts
@@ -1,122 +1,122 @@
-// import 'dotenv/config'
-// import {expect} from '@oclif/test'
-// import * as telemetry from '../../src/global_telemetry'
-// import {identity} from 'lodash'
-// import * as os from 'os'
-// const {version} = require('../../../../packages/cli/package.json')
-// const nock = require('nock')
-// const isDev = process.env.IS_DEV_ENVIRONMENT === 'true'
+import 'dotenv/config'
+import {expect} from '@oclif/test'
+import * as telemetry from '../../src/global_telemetry'
+import {identity} from 'lodash'
+import * as os from 'os'
+const {version} = require('../../../../packages/cli/package.json')
+const nock = require('nock')
+const isDev = process.env.IS_DEV_ENVIRONMENT === 'true'
 
-// nock.disableNetConnect()
+nock.disableNetConnect()
 
-// describe('telemetry', async () => {
-//   afterEach(() => {
-//     nock.cleanAll()
-//   })
+describe('telemetry', async () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
 
-//   const now = new Date()
-//   const mockCmdStartTime = now.getTime()
-//   const mockOs = os.platform()
-//   const mockConfig = {
-//     platform: mockOs,
-//     version,
-//   }
-//   const mockOpts = {
-//     Command: {
-//       id: 'pipelines:open',
-//     },
-//   }
-//   const mockTelemetryObject = {
-//     command: 'pipelines:open',
-//     os: mockOs,
-//     version,
-//     exitCode: 0,
-//     exitState: 'successful',
-//     cliRunDuration: 0,
-//     commandRunDuration: mockCmdStartTime,
-//     lifecycleHookCompletion: {
-//       init: true,
-//       prerun: true,
-//       postrun: false,
-//       command_not_found: false,
-//     },
-//     isVersionOrHelp: false,
-//   }
+  const now = new Date()
+  const mockCmdStartTime = now.getTime()
+  const mockOs = os.platform()
+  const mockConfig = {
+    platform: mockOs,
+    version,
+  }
+  const mockOpts = {
+    Command: {
+      id: 'pipelines:open',
+    },
+  }
+  const mockTelemetryObject = {
+    command: 'pipelines:open',
+    os: mockOs,
+    version,
+    exitCode: 0,
+    exitState: 'successful',
+    cliRunDuration: 0,
+    commandRunDuration: mockCmdStartTime,
+    lifecycleHookCompletion: {
+      init: true,
+      prerun: true,
+      postrun: false,
+      command_not_found: false,
+    },
+    isVersionOrHelp: false,
+  }
 
-//   const setupTelemetryTest = (config: any, opts: any) => {
-//     const result = telemetry.setupTelemetry(config, opts)
-//     expect(result!.command).to.equal(mockTelemetryObject.command)
-//     expect(result!.os).to.equal(mockTelemetryObject.os)
-//     expect(result!.version).to.equal(mockTelemetryObject.version)
-//     expect(result!.exitCode).to.equal(mockTelemetryObject.exitCode)
-//     expect(result!.exitState).to.equal(mockTelemetryObject.exitState)
-//     expect(result!.cliRunDuration).to.equal(mockTelemetryObject.cliRunDuration)
-//     expect(result!.commandRunDuration).to.greaterThan(mockTelemetryObject.commandRunDuration)
-//     expect(result!.lifecycleHookCompletion.init).to.equal(mockTelemetryObject.lifecycleHookCompletion.init)
-//     expect(result!.lifecycleHookCompletion.prerun).to.equal(mockTelemetryObject.lifecycleHookCompletion.prerun)
-//     expect(result!.lifecycleHookCompletion.postrun).to.equal(mockTelemetryObject.lifecycleHookCompletion.postrun)
-//     expect(result!.lifecycleHookCompletion.command_not_found).to.equal(mockTelemetryObject.lifecycleHookCompletion.command_not_found)
-//   }
+  const setupTelemetryTest = (config: any, opts: any) => {
+    const result = telemetry.setupTelemetry(config, opts)
+    expect(result!.command).to.equal(mockTelemetryObject.command)
+    expect(result!.os).to.equal(mockTelemetryObject.os)
+    expect(result!.version).to.equal(mockTelemetryObject.version)
+    expect(result!.exitCode).to.equal(mockTelemetryObject.exitCode)
+    expect(result!.exitState).to.equal(mockTelemetryObject.exitState)
+    expect(result!.cliRunDuration).to.equal(mockTelemetryObject.cliRunDuration)
+    expect(result!.commandRunDuration).to.greaterThan(mockTelemetryObject.commandRunDuration)
+    expect(result!.lifecycleHookCompletion.init).to.equal(mockTelemetryObject.lifecycleHookCompletion.init)
+    expect(result!.lifecycleHookCompletion.prerun).to.equal(mockTelemetryObject.lifecycleHookCompletion.prerun)
+    expect(result!.lifecycleHookCompletion.postrun).to.equal(mockTelemetryObject.lifecycleHookCompletion.postrun)
+    expect(result!.lifecycleHookCompletion.command_not_found).to.equal(mockTelemetryObject.lifecycleHookCompletion.command_not_found)
+  }
 
-//   const computeDurationTest = (cmdStartTime: any) => {
-//     const timeDurationResult = telemetry.computeDuration(cmdStartTime)
-//     expect(timeDurationResult).to.greaterThan(1)
-//   }
+  const computeDurationTest = (cmdStartTime: any) => {
+    const timeDurationResult = telemetry.computeDuration(cmdStartTime)
+    expect(timeDurationResult).to.greaterThan(1)
+  }
 
-//   const reportCmdNotFoundTest = (config: any) => {
-//     mockTelemetryObject.command = 'invalid_command'
-//     mockTelemetryObject.exitState = 'command_not_found'
-//     mockTelemetryObject.commandRunDuration = 0
-//     mockTelemetryObject.lifecycleHookCompletion.prerun = false
-//     mockTelemetryObject.lifecycleHookCompletion.postrun = false
-//     mockTelemetryObject.lifecycleHookCompletion.command_not_found = true
+  const reportCmdNotFoundTest = (config: any) => {
+    mockTelemetryObject.command = 'invalid_command'
+    mockTelemetryObject.exitState = 'command_not_found'
+    mockTelemetryObject.commandRunDuration = 0
+    mockTelemetryObject.lifecycleHookCompletion.prerun = false
+    mockTelemetryObject.lifecycleHookCompletion.postrun = false
+    mockTelemetryObject.lifecycleHookCompletion.command_not_found = true
 
-//     const result = telemetry.reportCmdNotFound(config)
-//     expect(result.command).to.equal(mockTelemetryObject.command)
-//     expect(result.os).to.equal(mockTelemetryObject.os)
-//     expect(result.version).to.equal(mockTelemetryObject.version)
-//     expect(result.exitCode).to.equal(mockTelemetryObject.exitCode)
-//     expect(result.exitState).to.equal(mockTelemetryObject.exitState)
-//     expect(result.cliRunDuration).to.equal(mockTelemetryObject.cliRunDuration)
-//     expect(result.commandRunDuration).to.equal(mockTelemetryObject.commandRunDuration)
-//     expect(result.lifecycleHookCompletion.init).to.equal(mockTelemetryObject.lifecycleHookCompletion.init)
-//     expect(result.lifecycleHookCompletion.prerun).to.equal(mockTelemetryObject.lifecycleHookCompletion.prerun)
-//     expect(result.lifecycleHookCompletion.postrun).to.equal(mockTelemetryObject.lifecycleHookCompletion.postrun)
-//     expect(result.lifecycleHookCompletion.command_not_found).to.equal(mockTelemetryObject.lifecycleHookCompletion.command_not_found)
-//   }
+    const result = telemetry.reportCmdNotFound(config)
+    expect(result.command).to.equal(mockTelemetryObject.command)
+    expect(result.os).to.equal(mockTelemetryObject.os)
+    expect(result.version).to.equal(mockTelemetryObject.version)
+    expect(result.exitCode).to.equal(mockTelemetryObject.exitCode)
+    expect(result.exitState).to.equal(mockTelemetryObject.exitState)
+    expect(result.cliRunDuration).to.equal(mockTelemetryObject.cliRunDuration)
+    expect(result.commandRunDuration).to.equal(mockTelemetryObject.commandRunDuration)
+    expect(result.lifecycleHookCompletion.init).to.equal(mockTelemetryObject.lifecycleHookCompletion.init)
+    expect(result.lifecycleHookCompletion.prerun).to.equal(mockTelemetryObject.lifecycleHookCompletion.prerun)
+    expect(result.lifecycleHookCompletion.postrun).to.equal(mockTelemetryObject.lifecycleHookCompletion.postrun)
+    expect(result.lifecycleHookCompletion.command_not_found).to.equal(mockTelemetryObject.lifecycleHookCompletion.command_not_found)
+  }
 
-//   it('confirms successful telemetry object creation', () => {
-//     setupTelemetryTest(mockConfig, mockOpts)
-//   })
+  it('confirms successful telemetry object creation', () => {
+    setupTelemetryTest(mockConfig, mockOpts)
+  })
 
-//   it('confirms successfully computes time duration', () => {
-//     computeDurationTest(mockCmdStartTime)
-//   })
+  it('confirms successfully computes time duration', () => {
+    computeDurationTest(mockCmdStartTime)
+  })
 
-//   it('confirms successful telemetry object creation with invalid command', () => {
-//     reportCmdNotFoundTest(mockConfig)
-//   })
+  it('confirms successful telemetry object creation with invalid command', () => {
+    reportCmdNotFoundTest(mockConfig)
+  })
 
-//   it('confirms successful request to honeycomb', async () => {
-//     const mockTelemetry = telemetry.setupTelemetry(mockConfig, mockOpts)
-//     telemetry.initializeInstrumentation()
+  it('confirms successful request to honeycomb', async () => {
+    const mockTelemetry = telemetry.setupTelemetry(mockConfig, mockOpts)
+    telemetry.initializeInstrumentation()
 
-//     const honeycombAPI = nock(`${isDev ? 'https://backboard-staging.herokuapp.com/otel' : 'https://backboard.heroku.com/otel'}`)
-//       .post('/v1/traces', identity)
-//       .reply(200)
+    const honeycombAPI = nock(`${isDev ? 'https://backboard-staging.herokuapp.com/otel' : 'https://backboard.heroku.com/otel'}`)
+      .post('/v1/traces', identity)
+      .reply(200)
 
-//     await telemetry.sendToHoneycomb(mockTelemetry!)
-//     honeycombAPI.done()
-//   })
+    await telemetry.sendToHoneycomb(mockTelemetry!)
+    honeycombAPI.done()
+  })
 
-//   it('confirms successful request to rollbar', async () => {
-//     const mockRollbarError = {name: 'testError', message: 'testMessage', stack: 'testStack', cli_run_duration: 1234}
+  it('confirms successful request to rollbar', async () => {
+    const mockRollbarError = {name: 'testError', message: 'testMessage', stack: 'testStack', cli_run_duration: 1234}
 
-//     const rollbarAPI = nock('https://api.rollbar.com:443')
-//       .post('/api/1/item/', identity)
-//       .reply(200)
+    const rollbarAPI = nock('https://api.rollbar.com:443')
+      .post('/api/1/item/', identity)
+      .reply(200)
 
-//     await telemetry.sendToRollbar(mockRollbarError)
-//     rollbarAPI.done()
-//   })
-// })
+    await telemetry.sendToRollbar(mockRollbarError)
+    rollbarAPI.done()
+  })
+})

--- a/packages/cli/test/unit/global_telemetry.unit.test.ts
+++ b/packages/cli/test/unit/global_telemetry.unit.test.ts
@@ -1,121 +1,121 @@
-import 'dotenv/config'
-import {expect} from '@oclif/test'
-import * as telemetry from '../../src/global_telemetry'
-import {identity} from 'lodash'
-import * as os from 'os'
-const {version} = require('../../../../packages/cli/package.json')
-const nock = require('nock')
-const isDev = process.env.IS_DEV_ENVIRONMENT === 'true'
+// import 'dotenv/config'
+// import {expect} from '@oclif/test'
+// import * as telemetry from '../../src/global_telemetry'
+// import {identity} from 'lodash'
+// import * as os from 'os'
+// const {version} = require('../../../../packages/cli/package.json')
+// const nock = require('nock')
+// const isDev = process.env.IS_DEV_ENVIRONMENT === 'true'
 
-nock.disableNetConnect()
+// nock.disableNetConnect()
 
-describe('telemetry', async () => {
-  afterEach(() => {
-    nock.cleanAll()
-  })
+// describe('telemetry', async () => {
+//   afterEach(() => {
+//     nock.cleanAll()
+//   })
 
-  const now = new Date()
-  const mockCmdStartTime = now.getTime()
-  const mockOs = os.platform()
-  const mockConfig = {
-    platform: mockOs,
-    version,
-  }
-  const mockOpts = {
-    Command: {
-      id: 'pipelines:open',
-    },
-  }
-  const mockTelemetryObject = {
-    command: 'pipelines:open',
-    os: mockOs,
-    version,
-    exitCode: 0,
-    exitState: 'successful',
-    cliRunDuration: 0,
-    commandRunDuration: mockCmdStartTime,
-    lifecycleHookCompletion: {
-      init: true,
-      prerun: true,
-      postrun: false,
-      command_not_found: false,
-    },
-  }
+//   const now = new Date()
+//   const mockCmdStartTime = now.getTime()
+//   const mockOs = os.platform()
+//   const mockConfig = {
+//     platform: mockOs,
+//     version,
+//   }
+//   const mockOpts = {
+//     Command: {
+//       id: 'pipelines:open',
+//     },
+//   }
+//   const mockTelemetryObject = {
+//     command: 'pipelines:open',
+//     os: mockOs,
+//     version,
+//     exitCode: 0,
+//     exitState: 'successful',
+//     cliRunDuration: 0,
+//     commandRunDuration: mockCmdStartTime,
+//     lifecycleHookCompletion: {
+//       init: true,
+//       prerun: true,
+//       postrun: false,
+//       command_not_found: false,
+//     },
+//   }
 
-  const setupTelemetryTest = (config: any, opts: any) => {
-    const result = telemetry.setupTelemetry(config, opts)
-    expect(result.command).to.equal(mockTelemetryObject.command)
-    expect(result.os).to.equal(mockTelemetryObject.os)
-    expect(result.version).to.equal(mockTelemetryObject.version)
-    expect(result.exitCode).to.equal(mockTelemetryObject.exitCode)
-    expect(result.exitState).to.equal(mockTelemetryObject.exitState)
-    expect(result.cliRunDuration).to.equal(mockTelemetryObject.cliRunDuration)
-    expect(result.commandRunDuration).to.greaterThan(mockTelemetryObject.commandRunDuration)
-    expect(result.lifecycleHookCompletion.init).to.equal(mockTelemetryObject.lifecycleHookCompletion.init)
-    expect(result.lifecycleHookCompletion.prerun).to.equal(mockTelemetryObject.lifecycleHookCompletion.prerun)
-    expect(result.lifecycleHookCompletion.postrun).to.equal(mockTelemetryObject.lifecycleHookCompletion.postrun)
-    expect(result.lifecycleHookCompletion.command_not_found).to.equal(mockTelemetryObject.lifecycleHookCompletion.command_not_found)
-  }
+//   const setupTelemetryTest = (config: any, opts: any) => {
+//     const result = telemetry.setupTelemetry(config, opts)
+//     expect(result.command).to.equal(mockTelemetryObject.command)
+//     expect(result.os).to.equal(mockTelemetryObject.os)
+//     expect(result.version).to.equal(mockTelemetryObject.version)
+//     expect(result.exitCode).to.equal(mockTelemetryObject.exitCode)
+//     expect(result.exitState).to.equal(mockTelemetryObject.exitState)
+//     expect(result.cliRunDuration).to.equal(mockTelemetryObject.cliRunDuration)
+//     expect(result.commandRunDuration).to.greaterThan(mockTelemetryObject.commandRunDuration)
+//     expect(result.lifecycleHookCompletion.init).to.equal(mockTelemetryObject.lifecycleHookCompletion.init)
+//     expect(result.lifecycleHookCompletion.prerun).to.equal(mockTelemetryObject.lifecycleHookCompletion.prerun)
+//     expect(result.lifecycleHookCompletion.postrun).to.equal(mockTelemetryObject.lifecycleHookCompletion.postrun)
+//     expect(result.lifecycleHookCompletion.command_not_found).to.equal(mockTelemetryObject.lifecycleHookCompletion.command_not_found)
+//   }
 
-  const computeDurationTest = (cmdStartTime: any) => {
-    const timeDurationResult = telemetry.computeDuration(cmdStartTime)
-    expect(timeDurationResult).to.greaterThan(1)
-  }
+//   const computeDurationTest = (cmdStartTime: any) => {
+//     const timeDurationResult = telemetry.computeDuration(cmdStartTime)
+//     expect(timeDurationResult).to.greaterThan(1)
+//   }
 
-  const reportCmdNotFoundTest = (config: any) => {
-    mockTelemetryObject.command = 'invalid_command'
-    mockTelemetryObject.exitState = 'command_not_found'
-    mockTelemetryObject.commandRunDuration = 0
-    mockTelemetryObject.lifecycleHookCompletion.prerun = false
-    mockTelemetryObject.lifecycleHookCompletion.postrun = false
-    mockTelemetryObject.lifecycleHookCompletion.command_not_found = true
+//   const reportCmdNotFoundTest = (config: any) => {
+//     mockTelemetryObject.command = 'invalid_command'
+//     mockTelemetryObject.exitState = 'command_not_found'
+//     mockTelemetryObject.commandRunDuration = 0
+//     mockTelemetryObject.lifecycleHookCompletion.prerun = false
+//     mockTelemetryObject.lifecycleHookCompletion.postrun = false
+//     mockTelemetryObject.lifecycleHookCompletion.command_not_found = true
 
-    const result = telemetry.reportCmdNotFound(config)
-    expect(result.command).to.equal(mockTelemetryObject.command)
-    expect(result.os).to.equal(mockTelemetryObject.os)
-    expect(result.version).to.equal(mockTelemetryObject.version)
-    expect(result.exitCode).to.equal(mockTelemetryObject.exitCode)
-    expect(result.exitState).to.equal(mockTelemetryObject.exitState)
-    expect(result.cliRunDuration).to.equal(mockTelemetryObject.cliRunDuration)
-    expect(result.commandRunDuration).to.equal(mockTelemetryObject.commandRunDuration)
-    expect(result.lifecycleHookCompletion.init).to.equal(mockTelemetryObject.lifecycleHookCompletion.init)
-    expect(result.lifecycleHookCompletion.prerun).to.equal(mockTelemetryObject.lifecycleHookCompletion.prerun)
-    expect(result.lifecycleHookCompletion.postrun).to.equal(mockTelemetryObject.lifecycleHookCompletion.postrun)
-    expect(result.lifecycleHookCompletion.command_not_found).to.equal(mockTelemetryObject.lifecycleHookCompletion.command_not_found)
-  }
+//     const result = telemetry.reportCmdNotFound(config)
+//     expect(result.command).to.equal(mockTelemetryObject.command)
+//     expect(result.os).to.equal(mockTelemetryObject.os)
+//     expect(result.version).to.equal(mockTelemetryObject.version)
+//     expect(result.exitCode).to.equal(mockTelemetryObject.exitCode)
+//     expect(result.exitState).to.equal(mockTelemetryObject.exitState)
+//     expect(result.cliRunDuration).to.equal(mockTelemetryObject.cliRunDuration)
+//     expect(result.commandRunDuration).to.equal(mockTelemetryObject.commandRunDuration)
+//     expect(result.lifecycleHookCompletion.init).to.equal(mockTelemetryObject.lifecycleHookCompletion.init)
+//     expect(result.lifecycleHookCompletion.prerun).to.equal(mockTelemetryObject.lifecycleHookCompletion.prerun)
+//     expect(result.lifecycleHookCompletion.postrun).to.equal(mockTelemetryObject.lifecycleHookCompletion.postrun)
+//     expect(result.lifecycleHookCompletion.command_not_found).to.equal(mockTelemetryObject.lifecycleHookCompletion.command_not_found)
+//   }
 
-  it('confirms successful telemetry object creation', () => {
-    setupTelemetryTest(mockConfig, mockOpts)
-  })
+//   it('confirms successful telemetry object creation', () => {
+//     setupTelemetryTest(mockConfig, mockOpts)
+//   })
 
-  it('confirms successfully computes time duration', () => {
-    computeDurationTest(mockCmdStartTime)
-  })
+//   it('confirms successfully computes time duration', () => {
+//     computeDurationTest(mockCmdStartTime)
+//   })
 
-  it('confirms successful telemetry object creation with invalid command', () => {
-    reportCmdNotFoundTest(mockConfig)
-  })
+//   it('confirms successful telemetry object creation with invalid command', () => {
+//     reportCmdNotFoundTest(mockConfig)
+//   })
 
-  it('confirms successful request to honeycomb', async () => {
-    const mockTelemetry = telemetry.setupTelemetry(mockConfig, mockOpts)
-    telemetry.initializeInstrumentation()
+//   it('confirms successful request to honeycomb', async () => {
+//     const mockTelemetry = telemetry.setupTelemetry(mockConfig, mockOpts)
+//     telemetry.initializeInstrumentation()
 
-    const honeycombAPI = nock(`${isDev ? 'https://backboard-staging.herokuapp.com/otel' : 'https://backboard.heroku.com/otel'}`)
-      .post('/v1/traces', identity)
-      .reply(200)
+//     const honeycombAPI = nock(`${isDev ? 'https://backboard-staging.herokuapp.com/otel' : 'https://backboard.heroku.com/otel'}`)
+//       .post('/v1/traces', identity)
+//       .reply(200)
 
-    await telemetry.sendToHoneycomb(mockTelemetry)
-    honeycombAPI.done()
-  })
+//     await telemetry.sendToHoneycomb(mockTelemetry)
+//     honeycombAPI.done()
+//   })
 
-  it('confirms successful request to rollbar', async () => {
-    const mockRollbarError = {name: 'testError', message: 'testMessage', stack: 'testStack', cli_run_duration: 1234}
+//   it('confirms successful request to rollbar', async () => {
+//     const mockRollbarError = {name: 'testError', message: 'testMessage', stack: 'testStack', cli_run_duration: 1234}
 
-    const rollbarAPI = nock('https://api.rollbar.com:443')
-      .post('/api/1/item/', identity)
-      .reply(200)
+//     const rollbarAPI = nock('https://api.rollbar.com:443')
+//       .post('/api/1/item/', identity)
+//       .reply(200)
 
-    await telemetry.sendToRollbar(mockRollbarError)
-    rollbarAPI.done()
-  })
-})
+//     await telemetry.sendToRollbar(mockRollbarError)
+//     rollbarAPI.done()
+//   })
+// })

--- a/packages/cli/test/unit/global_telemetry.unit.test.ts
+++ b/packages/cli/test/unit/global_telemetry.unit.test.ts
@@ -1,122 +1,122 @@
-import 'dotenv/config'
-import {expect} from '@oclif/test'
-import * as telemetry from '../../src/global_telemetry'
-import {identity} from 'lodash'
-import * as os from 'os'
-const {version} = require('../../../../packages/cli/package.json')
-const nock = require('nock')
-const isDev = process.env.IS_DEV_ENVIRONMENT === 'true'
+// import 'dotenv/config'
+// import {expect} from '@oclif/test'
+// import * as telemetry from '../../src/global_telemetry'
+// import {identity} from 'lodash'
+// import * as os from 'os'
+// const {version} = require('../../../../packages/cli/package.json')
+// const nock = require('nock')
+// const isDev = process.env.IS_DEV_ENVIRONMENT === 'true'
 
-nock.disableNetConnect()
+// nock.disableNetConnect()
 
-describe('telemetry', async () => {
-  afterEach(() => {
-    nock.cleanAll()
-  })
+// describe('telemetry', async () => {
+//   afterEach(() => {
+//     nock.cleanAll()
+//   })
 
-  const now = new Date()
-  const mockCmdStartTime = now.getTime()
-  const mockOs = os.platform()
-  const mockConfig = {
-    platform: mockOs,
-    version,
-  }
-  const mockOpts = {
-    Command: {
-      id: 'pipelines:open',
-    },
-  }
-  const mockTelemetryObject = {
-    command: 'pipelines:open',
-    os: mockOs,
-    version,
-    exitCode: 0,
-    exitState: 'successful',
-    cliRunDuration: 0,
-    commandRunDuration: mockCmdStartTime,
-    lifecycleHookCompletion: {
-      init: true,
-      prerun: true,
-      postrun: false,
-      command_not_found: false,
-    },
-    isVersionOrHelp: false,
-  }
+//   const now = new Date()
+//   const mockCmdStartTime = now.getTime()
+//   const mockOs = os.platform()
+//   const mockConfig = {
+//     platform: mockOs,
+//     version,
+//   }
+//   const mockOpts = {
+//     Command: {
+//       id: 'pipelines:open',
+//     },
+//   }
+//   const mockTelemetryObject = {
+//     command: 'pipelines:open',
+//     os: mockOs,
+//     version,
+//     exitCode: 0,
+//     exitState: 'successful',
+//     cliRunDuration: 0,
+//     commandRunDuration: mockCmdStartTime,
+//     lifecycleHookCompletion: {
+//       init: true,
+//       prerun: true,
+//       postrun: false,
+//       command_not_found: false,
+//     },
+//     isVersionOrHelp: false,
+//   }
 
-  const setupTelemetryTest = (config: any, opts: any) => {
-    const result = telemetry.setupTelemetry(config, opts)
-    expect(result!.command).to.equal(mockTelemetryObject.command)
-    expect(result!.os).to.equal(mockTelemetryObject.os)
-    expect(result!.version).to.equal(mockTelemetryObject.version)
-    expect(result!.exitCode).to.equal(mockTelemetryObject.exitCode)
-    expect(result!.exitState).to.equal(mockTelemetryObject.exitState)
-    expect(result!.cliRunDuration).to.equal(mockTelemetryObject.cliRunDuration)
-    expect(result!.commandRunDuration).to.greaterThan(mockTelemetryObject.commandRunDuration)
-    expect(result!.lifecycleHookCompletion.init).to.equal(mockTelemetryObject.lifecycleHookCompletion.init)
-    expect(result!.lifecycleHookCompletion.prerun).to.equal(mockTelemetryObject.lifecycleHookCompletion.prerun)
-    expect(result!.lifecycleHookCompletion.postrun).to.equal(mockTelemetryObject.lifecycleHookCompletion.postrun)
-    expect(result!.lifecycleHookCompletion.command_not_found).to.equal(mockTelemetryObject.lifecycleHookCompletion.command_not_found)
-  }
+//   const setupTelemetryTest = (config: any, opts: any) => {
+//     const result = telemetry.setupTelemetry(config, opts)
+//     expect(result!.command).to.equal(mockTelemetryObject.command)
+//     expect(result!.os).to.equal(mockTelemetryObject.os)
+//     expect(result!.version).to.equal(mockTelemetryObject.version)
+//     expect(result!.exitCode).to.equal(mockTelemetryObject.exitCode)
+//     expect(result!.exitState).to.equal(mockTelemetryObject.exitState)
+//     expect(result!.cliRunDuration).to.equal(mockTelemetryObject.cliRunDuration)
+//     expect(result!.commandRunDuration).to.greaterThan(mockTelemetryObject.commandRunDuration)
+//     expect(result!.lifecycleHookCompletion.init).to.equal(mockTelemetryObject.lifecycleHookCompletion.init)
+//     expect(result!.lifecycleHookCompletion.prerun).to.equal(mockTelemetryObject.lifecycleHookCompletion.prerun)
+//     expect(result!.lifecycleHookCompletion.postrun).to.equal(mockTelemetryObject.lifecycleHookCompletion.postrun)
+//     expect(result!.lifecycleHookCompletion.command_not_found).to.equal(mockTelemetryObject.lifecycleHookCompletion.command_not_found)
+//   }
 
-  const computeDurationTest = (cmdStartTime: any) => {
-    const timeDurationResult = telemetry.computeDuration(cmdStartTime)
-    expect(timeDurationResult).to.greaterThan(1)
-  }
+//   const computeDurationTest = (cmdStartTime: any) => {
+//     const timeDurationResult = telemetry.computeDuration(cmdStartTime)
+//     expect(timeDurationResult).to.greaterThan(1)
+//   }
 
-  const reportCmdNotFoundTest = (config: any) => {
-    mockTelemetryObject.command = 'invalid_command'
-    mockTelemetryObject.exitState = 'command_not_found'
-    mockTelemetryObject.commandRunDuration = 0
-    mockTelemetryObject.lifecycleHookCompletion.prerun = false
-    mockTelemetryObject.lifecycleHookCompletion.postrun = false
-    mockTelemetryObject.lifecycleHookCompletion.command_not_found = true
+//   const reportCmdNotFoundTest = (config: any) => {
+//     mockTelemetryObject.command = 'invalid_command'
+//     mockTelemetryObject.exitState = 'command_not_found'
+//     mockTelemetryObject.commandRunDuration = 0
+//     mockTelemetryObject.lifecycleHookCompletion.prerun = false
+//     mockTelemetryObject.lifecycleHookCompletion.postrun = false
+//     mockTelemetryObject.lifecycleHookCompletion.command_not_found = true
 
-    const result = telemetry.reportCmdNotFound(config)
-    expect(result.command).to.equal(mockTelemetryObject.command)
-    expect(result.os).to.equal(mockTelemetryObject.os)
-    expect(result.version).to.equal(mockTelemetryObject.version)
-    expect(result.exitCode).to.equal(mockTelemetryObject.exitCode)
-    expect(result.exitState).to.equal(mockTelemetryObject.exitState)
-    expect(result.cliRunDuration).to.equal(mockTelemetryObject.cliRunDuration)
-    expect(result.commandRunDuration).to.equal(mockTelemetryObject.commandRunDuration)
-    expect(result.lifecycleHookCompletion.init).to.equal(mockTelemetryObject.lifecycleHookCompletion.init)
-    expect(result.lifecycleHookCompletion.prerun).to.equal(mockTelemetryObject.lifecycleHookCompletion.prerun)
-    expect(result.lifecycleHookCompletion.postrun).to.equal(mockTelemetryObject.lifecycleHookCompletion.postrun)
-    expect(result.lifecycleHookCompletion.command_not_found).to.equal(mockTelemetryObject.lifecycleHookCompletion.command_not_found)
-  }
+//     const result = telemetry.reportCmdNotFound(config)
+//     expect(result.command).to.equal(mockTelemetryObject.command)
+//     expect(result.os).to.equal(mockTelemetryObject.os)
+//     expect(result.version).to.equal(mockTelemetryObject.version)
+//     expect(result.exitCode).to.equal(mockTelemetryObject.exitCode)
+//     expect(result.exitState).to.equal(mockTelemetryObject.exitState)
+//     expect(result.cliRunDuration).to.equal(mockTelemetryObject.cliRunDuration)
+//     expect(result.commandRunDuration).to.equal(mockTelemetryObject.commandRunDuration)
+//     expect(result.lifecycleHookCompletion.init).to.equal(mockTelemetryObject.lifecycleHookCompletion.init)
+//     expect(result.lifecycleHookCompletion.prerun).to.equal(mockTelemetryObject.lifecycleHookCompletion.prerun)
+//     expect(result.lifecycleHookCompletion.postrun).to.equal(mockTelemetryObject.lifecycleHookCompletion.postrun)
+//     expect(result.lifecycleHookCompletion.command_not_found).to.equal(mockTelemetryObject.lifecycleHookCompletion.command_not_found)
+//   }
 
-  it('confirms successful telemetry object creation', () => {
-    setupTelemetryTest(mockConfig, mockOpts)
-  })
+//   it('confirms successful telemetry object creation', () => {
+//     setupTelemetryTest(mockConfig, mockOpts)
+//   })
 
-  it('confirms successfully computes time duration', () => {
-    computeDurationTest(mockCmdStartTime)
-  })
+//   it('confirms successfully computes time duration', () => {
+//     computeDurationTest(mockCmdStartTime)
+//   })
 
-  it('confirms successful telemetry object creation with invalid command', () => {
-    reportCmdNotFoundTest(mockConfig)
-  })
+//   it('confirms successful telemetry object creation with invalid command', () => {
+//     reportCmdNotFoundTest(mockConfig)
+//   })
 
-  it('confirms successful request to honeycomb', async () => {
-    const mockTelemetry = telemetry.setupTelemetry(mockConfig, mockOpts)
-    telemetry.initializeInstrumentation()
+//   it('confirms successful request to honeycomb', async () => {
+//     const mockTelemetry = telemetry.setupTelemetry(mockConfig, mockOpts)
+//     telemetry.initializeInstrumentation()
 
-    const honeycombAPI = nock(`${isDev ? 'https://backboard-staging.herokuapp.com/otel' : 'https://backboard.heroku.com/otel'}`)
-      .post('/v1/traces', identity)
-      .reply(200)
+//     const honeycombAPI = nock(`${isDev ? 'https://backboard-staging.herokuapp.com/otel' : 'https://backboard.heroku.com/otel'}`)
+//       .post('/v1/traces', identity)
+//       .reply(200)
 
-    await telemetry.sendToHoneycomb(mockTelemetry!)
-    honeycombAPI.done()
-  })
+//     await telemetry.sendToHoneycomb(mockTelemetry!)
+//     honeycombAPI.done()
+//   })
 
-  it('confirms successful request to rollbar', async () => {
-    const mockRollbarError = {name: 'testError', message: 'testMessage', stack: 'testStack', cli_run_duration: 1234}
+//   it('confirms successful request to rollbar', async () => {
+//     const mockRollbarError = {name: 'testError', message: 'testMessage', stack: 'testStack', cli_run_duration: 1234}
 
-    const rollbarAPI = nock('https://api.rollbar.com:443')
-      .post('/api/1/item/', identity)
-      .reply(200)
+//     const rollbarAPI = nock('https://api.rollbar.com:443')
+//       .post('/api/1/item/', identity)
+//       .reply(200)
 
-    await telemetry.sendToRollbar(mockRollbarError)
-    rollbarAPI.done()
-  })
-})
+//     await telemetry.sendToRollbar(mockRollbarError)
+//     rollbarAPI.done()
+//   })
+// })

--- a/packages/cli/test/unit/global_telemetry.unit.test.ts
+++ b/packages/cli/test/unit/global_telemetry.unit.test.ts
@@ -1,121 +1,122 @@
-// import 'dotenv/config'
-// import {expect} from '@oclif/test'
-// import * as telemetry from '../../src/global_telemetry'
-// import {identity} from 'lodash'
-// import * as os from 'os'
-// const {version} = require('../../../../packages/cli/package.json')
-// const nock = require('nock')
-// const isDev = process.env.IS_DEV_ENVIRONMENT === 'true'
+import 'dotenv/config'
+import {expect} from '@oclif/test'
+import * as telemetry from '../../src/global_telemetry'
+import {identity} from 'lodash'
+import * as os from 'os'
+const {version} = require('../../../../packages/cli/package.json')
+const nock = require('nock')
+const isDev = process.env.IS_DEV_ENVIRONMENT === 'true'
 
-// nock.disableNetConnect()
+nock.disableNetConnect()
 
-// describe('telemetry', async () => {
-//   afterEach(() => {
-//     nock.cleanAll()
-//   })
+describe('telemetry', async () => {
+  afterEach(() => {
+    nock.cleanAll()
+  })
 
-//   const now = new Date()
-//   const mockCmdStartTime = now.getTime()
-//   const mockOs = os.platform()
-//   const mockConfig = {
-//     platform: mockOs,
-//     version,
-//   }
-//   const mockOpts = {
-//     Command: {
-//       id: 'pipelines:open',
-//     },
-//   }
-//   const mockTelemetryObject = {
-//     command: 'pipelines:open',
-//     os: mockOs,
-//     version,
-//     exitCode: 0,
-//     exitState: 'successful',
-//     cliRunDuration: 0,
-//     commandRunDuration: mockCmdStartTime,
-//     lifecycleHookCompletion: {
-//       init: true,
-//       prerun: true,
-//       postrun: false,
-//       command_not_found: false,
-//     },
-//   }
+  const now = new Date()
+  const mockCmdStartTime = now.getTime()
+  const mockOs = os.platform()
+  const mockConfig = {
+    platform: mockOs,
+    version,
+  }
+  const mockOpts = {
+    Command: {
+      id: 'pipelines:open',
+    },
+  }
+  const mockTelemetryObject = {
+    command: 'pipelines:open',
+    os: mockOs,
+    version,
+    exitCode: 0,
+    exitState: 'successful',
+    cliRunDuration: 0,
+    commandRunDuration: mockCmdStartTime,
+    lifecycleHookCompletion: {
+      init: true,
+      prerun: true,
+      postrun: false,
+      command_not_found: false,
+    },
+    isVersionOrHelp: false,
+  }
 
-//   const setupTelemetryTest = (config: any, opts: any) => {
-//     const result = telemetry.setupTelemetry(config, opts)
-//     expect(result.command).to.equal(mockTelemetryObject.command)
-//     expect(result.os).to.equal(mockTelemetryObject.os)
-//     expect(result.version).to.equal(mockTelemetryObject.version)
-//     expect(result.exitCode).to.equal(mockTelemetryObject.exitCode)
-//     expect(result.exitState).to.equal(mockTelemetryObject.exitState)
-//     expect(result.cliRunDuration).to.equal(mockTelemetryObject.cliRunDuration)
-//     expect(result.commandRunDuration).to.greaterThan(mockTelemetryObject.commandRunDuration)
-//     expect(result.lifecycleHookCompletion.init).to.equal(mockTelemetryObject.lifecycleHookCompletion.init)
-//     expect(result.lifecycleHookCompletion.prerun).to.equal(mockTelemetryObject.lifecycleHookCompletion.prerun)
-//     expect(result.lifecycleHookCompletion.postrun).to.equal(mockTelemetryObject.lifecycleHookCompletion.postrun)
-//     expect(result.lifecycleHookCompletion.command_not_found).to.equal(mockTelemetryObject.lifecycleHookCompletion.command_not_found)
-//   }
+  const setupTelemetryTest = (config: any, opts: any) => {
+    const result = telemetry.setupTelemetry(config, opts)
+    expect(result!.command).to.equal(mockTelemetryObject.command)
+    expect(result!.os).to.equal(mockTelemetryObject.os)
+    expect(result!.version).to.equal(mockTelemetryObject.version)
+    expect(result!.exitCode).to.equal(mockTelemetryObject.exitCode)
+    expect(result!.exitState).to.equal(mockTelemetryObject.exitState)
+    expect(result!.cliRunDuration).to.equal(mockTelemetryObject.cliRunDuration)
+    expect(result!.commandRunDuration).to.greaterThan(mockTelemetryObject.commandRunDuration)
+    expect(result!.lifecycleHookCompletion.init).to.equal(mockTelemetryObject.lifecycleHookCompletion.init)
+    expect(result!.lifecycleHookCompletion.prerun).to.equal(mockTelemetryObject.lifecycleHookCompletion.prerun)
+    expect(result!.lifecycleHookCompletion.postrun).to.equal(mockTelemetryObject.lifecycleHookCompletion.postrun)
+    expect(result!.lifecycleHookCompletion.command_not_found).to.equal(mockTelemetryObject.lifecycleHookCompletion.command_not_found)
+  }
 
-//   const computeDurationTest = (cmdStartTime: any) => {
-//     const timeDurationResult = telemetry.computeDuration(cmdStartTime)
-//     expect(timeDurationResult).to.greaterThan(1)
-//   }
+  const computeDurationTest = (cmdStartTime: any) => {
+    const timeDurationResult = telemetry.computeDuration(cmdStartTime)
+    expect(timeDurationResult).to.greaterThan(1)
+  }
 
-//   const reportCmdNotFoundTest = (config: any) => {
-//     mockTelemetryObject.command = 'invalid_command'
-//     mockTelemetryObject.exitState = 'command_not_found'
-//     mockTelemetryObject.commandRunDuration = 0
-//     mockTelemetryObject.lifecycleHookCompletion.prerun = false
-//     mockTelemetryObject.lifecycleHookCompletion.postrun = false
-//     mockTelemetryObject.lifecycleHookCompletion.command_not_found = true
+  const reportCmdNotFoundTest = (config: any) => {
+    mockTelemetryObject.command = 'invalid_command'
+    mockTelemetryObject.exitState = 'command_not_found'
+    mockTelemetryObject.commandRunDuration = 0
+    mockTelemetryObject.lifecycleHookCompletion.prerun = false
+    mockTelemetryObject.lifecycleHookCompletion.postrun = false
+    mockTelemetryObject.lifecycleHookCompletion.command_not_found = true
 
-//     const result = telemetry.reportCmdNotFound(config)
-//     expect(result.command).to.equal(mockTelemetryObject.command)
-//     expect(result.os).to.equal(mockTelemetryObject.os)
-//     expect(result.version).to.equal(mockTelemetryObject.version)
-//     expect(result.exitCode).to.equal(mockTelemetryObject.exitCode)
-//     expect(result.exitState).to.equal(mockTelemetryObject.exitState)
-//     expect(result.cliRunDuration).to.equal(mockTelemetryObject.cliRunDuration)
-//     expect(result.commandRunDuration).to.equal(mockTelemetryObject.commandRunDuration)
-//     expect(result.lifecycleHookCompletion.init).to.equal(mockTelemetryObject.lifecycleHookCompletion.init)
-//     expect(result.lifecycleHookCompletion.prerun).to.equal(mockTelemetryObject.lifecycleHookCompletion.prerun)
-//     expect(result.lifecycleHookCompletion.postrun).to.equal(mockTelemetryObject.lifecycleHookCompletion.postrun)
-//     expect(result.lifecycleHookCompletion.command_not_found).to.equal(mockTelemetryObject.lifecycleHookCompletion.command_not_found)
-//   }
+    const result = telemetry.reportCmdNotFound(config)
+    expect(result.command).to.equal(mockTelemetryObject.command)
+    expect(result.os).to.equal(mockTelemetryObject.os)
+    expect(result.version).to.equal(mockTelemetryObject.version)
+    expect(result.exitCode).to.equal(mockTelemetryObject.exitCode)
+    expect(result.exitState).to.equal(mockTelemetryObject.exitState)
+    expect(result.cliRunDuration).to.equal(mockTelemetryObject.cliRunDuration)
+    expect(result.commandRunDuration).to.equal(mockTelemetryObject.commandRunDuration)
+    expect(result.lifecycleHookCompletion.init).to.equal(mockTelemetryObject.lifecycleHookCompletion.init)
+    expect(result.lifecycleHookCompletion.prerun).to.equal(mockTelemetryObject.lifecycleHookCompletion.prerun)
+    expect(result.lifecycleHookCompletion.postrun).to.equal(mockTelemetryObject.lifecycleHookCompletion.postrun)
+    expect(result.lifecycleHookCompletion.command_not_found).to.equal(mockTelemetryObject.lifecycleHookCompletion.command_not_found)
+  }
 
-//   it('confirms successful telemetry object creation', () => {
-//     setupTelemetryTest(mockConfig, mockOpts)
-//   })
+  it('confirms successful telemetry object creation', () => {
+    setupTelemetryTest(mockConfig, mockOpts)
+  })
 
-//   it('confirms successfully computes time duration', () => {
-//     computeDurationTest(mockCmdStartTime)
-//   })
+  it('confirms successfully computes time duration', () => {
+    computeDurationTest(mockCmdStartTime)
+  })
 
-//   it('confirms successful telemetry object creation with invalid command', () => {
-//     reportCmdNotFoundTest(mockConfig)
-//   })
+  it('confirms successful telemetry object creation with invalid command', () => {
+    reportCmdNotFoundTest(mockConfig)
+  })
 
-//   it('confirms successful request to honeycomb', async () => {
-//     const mockTelemetry = telemetry.setupTelemetry(mockConfig, mockOpts)
-//     telemetry.initializeInstrumentation()
+  it('confirms successful request to honeycomb', async () => {
+    const mockTelemetry = telemetry.setupTelemetry(mockConfig, mockOpts)
+    telemetry.initializeInstrumentation()
 
-//     const honeycombAPI = nock(`${isDev ? 'https://backboard-staging.herokuapp.com/otel' : 'https://backboard.heroku.com/otel'}`)
-//       .post('/v1/traces', identity)
-//       .reply(200)
+    const honeycombAPI = nock(`${isDev ? 'https://backboard-staging.herokuapp.com/otel' : 'https://backboard.heroku.com/otel'}`)
+      .post('/v1/traces', identity)
+      .reply(200)
 
-//     await telemetry.sendToHoneycomb(mockTelemetry)
-//     honeycombAPI.done()
-//   })
+    await telemetry.sendToHoneycomb(mockTelemetry!)
+    honeycombAPI.done()
+  })
 
-//   it('confirms successful request to rollbar', async () => {
-//     const mockRollbarError = {name: 'testError', message: 'testMessage', stack: 'testStack', cli_run_duration: 1234}
+  it('confirms successful request to rollbar', async () => {
+    const mockRollbarError = {name: 'testError', message: 'testMessage', stack: 'testStack', cli_run_duration: 1234}
 
-//     const rollbarAPI = nock('https://api.rollbar.com:443')
-//       .post('/api/1/item/', identity)
-//       .reply(200)
+    const rollbarAPI = nock('https://api.rollbar.com:443')
+      .post('/api/1/item/', identity)
+      .reply(200)
 
-//     await telemetry.sendToRollbar(mockRollbarError)
-//     rollbarAPI.done()
-//   })
-// })
+    await telemetry.sendToRollbar(mockRollbarError)
+    rollbarAPI.done()
+  })
+})


### PR DESCRIPTION
This PR addresses the [Rollbar exitCode bug](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001XrBukYAF/view)

Notes
- The oclif architecture needs to be updated as `version` and `--help` flags do not trigger oclif's `postrun` lifecycle hook
- This solution ensures that `version` and `--help` flags are accounted for in the telemetry object creation by adding a telemetry object creation function in the oclif `init` lifecycle hook

Follow up
- Update our telemetry system design diagram to reflect these new discoveries
