### PR TITLE
fix(cli): update boolean logic and add package parser util

### DIFF
--- a/packages/cli/src/global_telemetry.ts
+++ b/packages/cli/src/global_telemetry.ts
@@ -86,7 +86,7 @@ export function initializeInstrumentation() {
 export function setupTelemetry(config: any, opts: any) {
   const now = new Date()
   const cmdStartTime = now.getTime()
-  const isHelpOrVersionCmd = (['--version', ...getAllVersionFlags()].includes(opts.id) || ['--help', 'help', ...getAllHelpFlags()].includes(opts.id))
+  const isHelpOrVersionCmd = (getAllVersionFlags().includes(opts.id) || getAllHelpFlags().includes(opts.id))
   const isRegularCmd = Boolean(opts.Command)
 
   const baseTelemetryObject = {

--- a/packages/cli/src/hooks/init/version.ts
+++ b/packages/cli/src/hooks/init/version.ts
@@ -1,4 +1,5 @@
 import {Hook} from '@oclif/core'
+import {getAllVersionFlags} from '../../lib/utils/packageParser'
 
 const allowlist = [
   'HEROKU_API_KEY',
@@ -12,7 +13,7 @@ const allowlist = [
 ]
 
 const version: Hook.Init = async function () {
-  if (['-v', '--version', 'version'].includes(process.argv[2])) {
+  if (['--version', ...getAllVersionFlags()].includes(process.argv[2])) {
     for (const env of allowlist) {
       if (process.env[env]) {
         const value = env === 'HEROKU_API_KEY' ? 'to [REDACTED]' : `to ${process.env[env]}`

--- a/packages/cli/src/hooks/init/version.ts
+++ b/packages/cli/src/hooks/init/version.ts
@@ -13,7 +13,7 @@ const allowlist = [
 ]
 
 const version: Hook.Init = async function () {
-  if (['--version', ...getAllVersionFlags()].includes(process.argv[2])) {
+  if (getAllVersionFlags().includes(process.argv[2])) {
     for (const env of allowlist) {
       if (process.env[env]) {
         const value = env === 'HEROKU_API_KEY' ? 'to [REDACTED]' : `to ${process.env[env]}`

--- a/packages/cli/src/lib/utils/packageParser.ts
+++ b/packages/cli/src/lib/utils/packageParser.ts
@@ -1,7 +1,7 @@
 const {oclif} = require('../../../package.json')
 
 export function getAllVersionFlags() {
-  return oclif.additionalVersionFlags
+  return [...oclif.additionalVersionFlags, '--version']
 }
 
 export function getAllHelpFlags() {

--- a/packages/cli/src/lib/utils/packageParser.ts
+++ b/packages/cli/src/lib/utils/packageParser.ts
@@ -5,5 +5,5 @@ export function getAllVersionFlags() {
 }
 
 export function getAllHelpFlags() {
-  return oclif.additionalHelpFlags
+  return [...oclif.additionalHelpFlags, '--help', 'help']
 }

--- a/packages/cli/src/lib/utils/packageParser.ts
+++ b/packages/cli/src/lib/utils/packageParser.ts
@@ -1,0 +1,9 @@
+const {oclif} = require('../../../package.json')
+
+export function getAllVersionFlags() {
+  return oclif.additionalVersionFlags
+}
+
+export function getAllHelpFlags() {
+  return oclif.additionalHelpFlags
+}


### PR DESCRIPTION
This PR fixes a bug caught in our telemetry testing that didn't capture all `version` and `help` cli inputs. A package parser util has also been added as similar logic exists in our `version` function inside our oclif `init` lifecycle hook.