### PR TITLE
fix: rollbar version segmentation and telemetry initialization

### DIFF
--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -10,6 +10,9 @@ const globalTelemetry = require('../lib/global_telemetry')
 
 process.once('beforeExit', async code => {
   // capture as successful exit
+  if (!global.cliTelemetry) {
+    console.error('global.cliTelemetry undefined')
+  }
   if (global.cliTelemetry.isVersionOrHelp) {
     const cmdStartTime = global.cliTelemetry.commandRunDuration
     global.cliTelemetry.commandRunDuration = globalTelemetry.computeDuration(cmdStartTime)

--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -10,9 +10,6 @@ const globalTelemetry = require('../lib/global_telemetry')
 
 process.once('beforeExit', async code => {
   // capture as successful exit
-  if (!global.cliTelemetry) {
-    console.error('global.cliTelemetry undefined')
-  }
   if (global.cliTelemetry.isVersionOrHelp) {
     const cmdStartTime = global.cliTelemetry.commandRunDuration
     global.cliTelemetry.commandRunDuration = globalTelemetry.computeDuration(cmdStartTime)

--- a/packages/cli/src/global_telemetry.ts
+++ b/packages/cli/src/global_telemetry.ts
@@ -3,7 +3,6 @@ import * as Rollbar from 'rollbar'
 import {APIClient} from '@heroku-cli/command'
 import {Config} from '@oclif/core'
 import opentelemetry, {SpanStatusCode} from '@opentelemetry/api'
-import {getAllHelpFlags, getAllVersionFlags} from './lib/utils/packageParser'
 const {Resource} = require('@opentelemetry/resources')
 const {SemanticResourceAttributes} = require('@opentelemetry/semantic-conventions')
 const {registerInstrumentations} = require('@opentelemetry/instrumentation')

--- a/packages/cli/src/global_telemetry.ts
+++ b/packages/cli/src/global_telemetry.ts
@@ -11,8 +11,8 @@ const {BatchSpanProcessor} = require('@opentelemetry/sdk-trace-base')
 const {OTLPTraceExporter} = require('@opentelemetry/exporter-trace-otlp-http')
 const path = require('path')
 const {version} = require('../package.json')
-const root = path.resolve(__dirname, '../package.json')
 
+const root = path.resolve(__dirname, '../package.json')
 const isDev = process.env.IS_DEV_ENVIRONMENT === 'true'
 const config = new Config({root})
 const heroku = new APIClient(config)

--- a/packages/cli/src/global_telemetry.ts
+++ b/packages/cli/src/global_telemetry.ts
@@ -110,11 +110,11 @@ export function setupTelemetry(config: any, opts: any) {
     return {
       ...irregularTelemetryObject,
       command: opts.Command.id,
+      isVersionOrHelp: false,
       lifecycleHookCompletion: {
         ...irregularTelemetryObject.lifecycleHookCompletion,
         prerun: true,
       },
-      isVersionOrHelp: false,
     }
   }
 

--- a/packages/cli/src/global_telemetry.ts
+++ b/packages/cli/src/global_telemetry.ts
@@ -89,7 +89,7 @@ export function setupTelemetry(config: any, opts: any) {
   const cmdStartTime = now.getTime()
   const isRegularCmd = Boolean(opts.Command)
 
-  const baseTelemetryObject = {
+  const irregularTelemetryObject = {
     command: opts.id,
     os: config.platform,
     version: config.version,
@@ -106,19 +106,19 @@ export function setupTelemetry(config: any, opts: any) {
     isVersionOrHelp: true,
   }
 
-  if (!isRegularCmd) {
-    return baseTelemetryObject
+  if (isRegularCmd) {
+    return {
+      ...irregularTelemetryObject,
+      command: opts.Command.id,
+      lifecycleHookCompletion: {
+        ...irregularTelemetryObject.lifecycleHookCompletion,
+        prerun: true,
+      },
+      isVersionOrHelp: false,
+    }
   }
 
-  return {
-    ...baseTelemetryObject,
-    command: opts.Command.id,
-    lifecycleHookCompletion: {
-      ...baseTelemetryObject.lifecycleHookCompletion,
-      prerun: true,
-    },
-    isVersionOrHelp: false,
-  }
+  return irregularTelemetryObject
 }
 
 export function computeDuration(cmdStartTime: any) {

--- a/packages/cli/src/global_telemetry.ts
+++ b/packages/cli/src/global_telemetry.ts
@@ -9,11 +9,11 @@ const {registerInstrumentations} = require('@opentelemetry/instrumentation')
 const {NodeTracerProvider} = require('@opentelemetry/sdk-trace-node')
 const {BatchSpanProcessor} = require('@opentelemetry/sdk-trace-base')
 const {OTLPTraceExporter} = require('@opentelemetry/exporter-trace-otlp-http')
-const isDev = process.env.IS_DEV_ENVIRONMENT === 'true'
 const path = require('path')
 const {version} = require('../package.json')
-
 const root = path.resolve(__dirname, '../package.json')
+
+const isDev = process.env.IS_DEV_ENVIRONMENT === 'true'
 const config = new Config({root})
 const heroku = new APIClient(config)
 const token = heroku.auth


### PR DESCRIPTION
https://app.rollbar.com/a/Heroku-3/fix/item/heroku-cli/161

Add CLI version to Rollbar reports. 
Hopefully fix all bugs where global telemetry isn't intialized.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
