### PR TITLE
fix(pg-v5): update rules for essentialPlan

### DIFF
--- a/packages/pg-v5/lib/util.js
+++ b/packages/pg-v5/lib/util.js
@@ -131,7 +131,7 @@ exports.getConnectionDetails = function (attachment, config) {
 }
 
 // eslint-disable-next-line no-implicit-coercion
-exports.essentialPlan = a => !!a.plan.name.match(/(dev|basic|mini)$/)
+exports.essentialPlan = a => !!a.plan.name.match(/(dev|basic|mini)$|^essential/)
 
 // eslint-disable-next-line no-implicit-coercion
 exports.bastionKeyPlan = a => !!a.plan.name.match(/private/)

--- a/packages/pg-v5/test/unit/lib/util.unit.test.js
+++ b/packages/pg-v5/test/unit/lib/util.unit.test.js
@@ -36,5 +36,17 @@ describe('util', () => {
       expect(parsed.user).to.equal('user')
       expect(parsed.password).to.equal('pass')
     })
+
+    it('correctly identifies essential plans', () => {
+      const addon = (plan) => ({ plan: { name: plan } })
+      const parsed = (addon) => util.essentialPlan(addon)
+
+      expect(parsed(addon("mini"))).to.equal(true)
+      expect(parsed(addon("basic"))).to.equal(true)
+      expect(parsed(addon("essential-0"))).to.equal(true)
+      expect(parsed(addon("standard-0"))).to.equal(false)
+      expect(parsed(addon("private-0"))).to.equal(false)
+      expect(parsed(addon("shield-0"))).to.equal(false)
+    })
   })
 })


### PR DESCRIPTION
updates the `essentialPlan` regex to allow more plans