### PR TITLE
test: test passing additional options to run command

### DIFF
--- a/packages/cli/test/unit/commands/run/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/run/index.unit.test.ts
@@ -34,4 +34,22 @@ describe('run/index', () => {
       })
       .it('throws an error')
   })
+
+  describe('passes through additional options', async () => {
+    let dynoOpts: { command: any }
+    test
+      .nock('https://api.heroku.com', api => {
+        api.get('/account')
+          .reply(200, {})
+      })
+      .stub(Dyno.prototype, 'start', sinon.stub().callsFake(function () {
+        // @ts-ignore
+        dynoOpts = this.opts
+        return Promise.resolve()
+      }))
+      .command(['run', 'bash', '--app=heroku-cli-ci-smoke-test-app', '--', '--writable'])
+      .it('throws an error', () => {
+        expect(dynoOpts.command).to.equal('bash --writable')
+      })
+  })
 })

--- a/packages/cli/test/unit/commands/run/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/run/index.unit.test.ts
@@ -47,9 +47,9 @@ describe('run/index', () => {
         dynoOpts = this.opts
         return Promise.resolve()
       }))
-      .command(['run', 'bash', '--app=heroku-cli-ci-smoke-test-app', '--', '--writable'])
+      .command(['run', 'bash', '--app=heroku-cli-ci-smoke-test-app', '--', '--additional-option'])
       .it('throws an error', () => {
-        expect(dynoOpts.command).to.equal('bash --writable')
+        expect(dynoOpts.command).to.equal('bash --additional-option')
       })
   })
 })


### PR DESCRIPTION
[GUS ticket](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001Ym1cqYAB/view)

It turns out the behavior noted in #2445 is not necessarily a bug, but rather a change in behavior we did not realize was necessary. Any commands or flags that need to be passed through should come after a `--`. This is shown in the [documentation for that ](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-run)command as the second example.

I'm adding a unit test to make this behavior more obvious.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
