### PR TITLE
fix: correctly handling CLI errors again.

### DIFF
--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -41,12 +41,14 @@ globalTelemetry.initializeInstrumentation()
 
 const oclif = require('@oclif/core')
 
-oclif.run().then(require('@oclif/core/flush')).catch(async error => {
-  // capture any errors raised by oclif
-  const cliError = error
-  cliError.cliRunDuration = globalTelemetry.computeDuration(cliStartTime)
-  await globalTelemetry.sendTelemetry(cliError)
+oclif.run()
+  .then(require('@oclif/core/flush'))
+  .catch(async error => {
+    // capture any errors raised by oclif
+    const cliError = error
+    cliError.cliRunDuration = globalTelemetry.computeDuration(cliStartTime)
+    await globalTelemetry.sendTelemetry(cliError)
 
-  return require('@oclif/core/handle')(error)
-})
+    return require('@oclif/core/handle')(error)
+  })
 

--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -46,6 +46,7 @@ oclif.run().then(require('@oclif/core/flush')).catch(async error => {
   const cliError = error
   cliError.cliRunDuration = globalTelemetry.computeDuration(cliStartTime)
   await globalTelemetry.sendTelemetry(cliError)
-  console.log(`Error: ${error.message}`)
+
+  return require('@oclif/core/handle')(error)
 })
 

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -1,5 +1,5 @@
 import {Command, flags} from '@heroku-cli/command-v9'
-import {DynoSizeCompletion, ProcessTypeCompletion} from '@heroku-cli/command/lib/completions'
+import {DynoSizeCompletion, ProcessTypeCompletion} from '@heroku-cli/command-v9/lib/completions'
 import {CliUx} from '@oclif/core-v1'
 import '@oclif/core-v1/lib/parser'
 import debugFactory from 'debug'

--- a/scripts/postrelease/test_release
+++ b/scripts/postrelease/test_release
@@ -56,6 +56,7 @@ declare -a COMMANDS=(
   "$CMD_BIN regions"
   "$CMD_BIN releases --app heroku-cli-test-staging"
   "$CMD_BIN run ls -a heroku-cli-test-staging -- --color"
+  "$CMD_BIN run -x -a heroku-cli-test-staging -- 'bash -c \"exit 2\"'"
   "$CMD_BIN run:detached \"echo 'Hello World'\" -a heroku-cli-test-staging"
   "$CMD_BIN sessions"
   "$CMD_BIN spaces"


### PR DESCRIPTION
https://github.com/heroku/cli/issues/2466

Revert to standard error handling within the CLI while maintaing error reporting & telemetry.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
