### PR TITLE
feat(pg-v5) Adding a CLI command to relocate extensions from heroku_ext

### DIFF
--- a/packages/cli/test/acceptance/commands-output.ts
+++ b/packages/cli/test/acceptance/commands-output.ts
@@ -194,6 +194,7 @@ export default `\u001B[1m Command                                        Summary
  pg:psql                                        open a psql shell to the database                                                                                                                       
  pg:pull                                        pull Heroku database into local or remote database                                                                                                      
  pg:push                                        push local or remote into Heroku database                                                                                                               
+ pg:relocate-heroku-ext-extensions              Migrate extensions out of the heroku_ext schema and into the public schema.                                                                             
  pg:reset                                       delete all data in DATABASE                                                                                                                             
  pg:settings                                    show your current database settings                                                                                                                     
  pg:settings:auto-explain                       Automatically log execution plans of queries without running EXPLAIN by hand.                                                                           

--- a/packages/pg-v5/commands/relocate_heroku_ext_extensions.js
+++ b/packages/pg-v5/commands/relocate_heroku_ext_extensions.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const cli = require('heroku-cli-util')
+
+async function run(context, heroku) {
+  const util = require('../lib/util')
+  const host = require('../lib/host')
+  const fetcher = require('../lib/fetcher')(heroku)
+
+  const {app, args, flags} = context
+
+  let db = await fetcher.addon(app, args.database)
+
+  if (util.essentialPlan(db)) throw new Error('You can’t perform this operation on Essential-tier databases.')
+
+  let result = await heroku.post(`/client/v11/databases/${encodeURIComponent(db.name)}/migrate_extensions_to_public_schema`, {
+    host: host(db),
+  })
+
+  cli.log(result.message)
+}
+
+module.exports = {
+  topic: 'pg',
+  command: 'relocate-heroku-ext-extensions',
+  description: 'Migrate extensions out of the heroku_ext schema and into the public schema.',
+  needsApp: true,
+  needsAuth: true,
+  flags: [{name: 'verbose', char: 'v'}],
+  args: [{name: 'database', optional: true}],
+  run: cli.command({preauth: true}, run),
+}

--- a/packages/pg-v5/index.js
+++ b/packages/pg-v5/index.js
@@ -44,6 +44,7 @@ exports.commands = flatten([
   require('./commands/ps'),
   require('./commands/psql'),
   require('./commands/pull'),
+  require('./commands/relocate_heroku_ext_extensions'),
   require('./commands/repoint'),
   require('./commands/reset'),
   require('./commands/settings'),

--- a/packages/pg-v5/test/unit/commands/relocate_heroku_ext_extensions.unit.test.js
+++ b/packages/pg-v5/test/unit/commands/relocate_heroku_ext_extensions.unit.test.js
@@ -36,7 +36,7 @@ describe('pg:relocate-heroku-ext-extensions', () => {
   it('sends api request to control plane', () => {
     let message = `Extensions on ${db.name} are being migrated from 'heroku_ext' to 'public'. This operation may take a few minutes.`
 
-    pg.get(`/client/v11/databases/${db.name}/migrate_extensions_to_public_schema`).reply(200,
+    pg.post(`/client/v11/databases/${db.name}/migrate_extensions_to_public_schema`).reply(200,
       {message: message})
 
     return cmd.run({app: 'myapp', args: {}, flags: {}})

--- a/packages/pg-v5/test/unit/commands/relocate_heroku_ext_extensions.unit.test.js
+++ b/packages/pg-v5/test/unit/commands/relocate_heroku_ext_extensions.unit.test.js
@@ -1,0 +1,45 @@
+'use strict'
+/* global beforeEach afterEach */
+
+const cli = require('heroku-cli-util')
+const {expect} = require('chai')
+const nock = require('nock')
+const proxyquire = require('proxyquire')
+
+const db = {id: 1, name: 'postgres-1', plan: {name: 'heroku-postgresql:standard-0'}}
+const fetcher = () => {
+  return {
+    addon: () => db,
+  }
+}
+
+const cmd = proxyquire('../../../commands/relocate_heroku_ext_extensions', {
+  '../lib/fetcher': fetcher,
+})
+
+describe('pg:relocate-heroku-ext-extensions', () => {
+  let api
+  let pg
+
+  beforeEach(() => {
+    api = nock('https://api.heroku.com')
+    pg = nock('https://postgres-api.heroku.com')
+    cli.mockConsole()
+  })
+
+  afterEach(() => {
+    nock.cleanAll()
+    api.done()
+    pg.done()
+  })
+
+  it('sends api request to control plane', () => {
+    let message = `Extensions on ${db.name} are being migrated from 'heroku_ext' to 'public'. This operation may take a few minutes.`
+
+    pg.get(`/client/v11/databases/${db.name}/migrate_extensions_to_public_schema`).reply(200,
+      {message: message})
+
+    return cmd.run({app: 'myapp', args: {}, flags: {}})
+      .then(() => expect(cli.stdout).to.equal(`${message}\n`))
+  })
+})


### PR DESCRIPTION
Adding a new CLI command to allow users to relocate extensions from heroku_ext to public.


```shell
$ bin/dev pg:relocate-heroku-ext-extensions DATABASE -a example-app
```

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
