### PR TITLE
fix: default to --port 5001 for heroku local

### DIFF
--- a/packages/cli/src/commands/local/index.ts
+++ b/packages/cli/src/commands/local/index.ts
@@ -38,6 +38,7 @@ $ heroku local web=1,worker=2`,
     port: Flags.string({
       char: 'p',
       description: 'port to listen on',
+      default: '5001',
     }),
     restart: Flags.boolean({
       char: 'r',

--- a/packages/cli/test/unit/commands/local/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/local/index.unit.test.ts
@@ -17,7 +17,7 @@ describe('local', () => {
       .stub(foreman, 'fork', function () {
       // eslint-disable-next-line prefer-rest-params
         const argv = arguments[0]
-        expect(argv).is.eql(['start', 'web,other'])
+        expect(argv).is.eql(['start', '--port', '5001', 'web,other'])
       })
       .command(['local:start'])
       .it('can call foreman start via the local:start alias')
@@ -37,7 +37,7 @@ describe('local', () => {
         })
         .stub(foreman, 'fork', function () {
         // eslint-disable-next-line prefer-rest-params
-          expect(arguments[0]).is.eql(['start', 'web,other'])
+          expect(arguments[0]).is.eql(['start', '--port', '5001', 'web,other'])
         })
         .command(['local'])
         .it('can call foreman start with no arguments')
@@ -58,7 +58,7 @@ describe('local', () => {
         .stub(foreman, 'fork', function () {
         // eslint-disable-next-line prefer-rest-params
           const argv = arguments[0]
-          expect(argv).is.eql(['start', '--procfile', 'Procfile.other', 'web,background'])
+          expect(argv).is.eql(['start', '--procfile', 'Procfile.other', '--port', '5001', 'web,background'])
           expect(argv).to.not.include('release', 'the release process is not included')
         })
         .command(['local', '--procfile', 'Procfile.other'])
@@ -103,7 +103,7 @@ describe('local', () => {
         .stub(foreman, 'fork', function () {
         // eslint-disable-next-line prefer-rest-params
           const argv = arguments[0]
-          expect(argv).is.eql(['start', 'web,other'])
+          expect(argv).is.eql(['start', '--port', '5001', 'web,other'])
         })
         .command(['local', 'web,other'])
         .it('can call foreman start with only arguments')


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

This is a followup to #2261, where we added a default `--port 5001` for `heroku local web`. This PR expands that same default to `heroku local`. It's really an oversight that the original PR didn't include the changes for `heroku local`.

The same reasoning from #2261 applies:

> Port 5000 is node-foreman's default starting port. However, that port is commonly bound by MacOS's "AirPlayReceiver". When developers use commands like `heroku local web`, errors like `[ERROR] listen tcp :5000: bind: address already in use` are common as a result.<br/><br/>The workarounds for this are to either turn off "AirPlayReceiver" in MacOS System Preferences Sharing menu, or specify a `--port` that isn't already in use like this: `heroku local web --port 5001`.<br/><br/>However, by choosing a starting port that is not already occupied for a large subset of users (MacOS Monterrey and greater), we can prevent a few developers from scratching their heads and having to figure this out on their own.<br/><br/>We've already filed a change upstream, which has a bit more context: https://github.com/strongloop/node-foreman/issues/173.

[GUS](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001ajpt6YAA/view)
