### PR TITLE
chore: enable alpha prereleases

### DIFF
--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -38,6 +38,7 @@ jobs:
     uses: ./.github/workflows/publish-npm.yml
     with:
       isStableRelease: ${{ fromJSON(needs.get-version-channel.outputs.isStableRelease) }}
+      channel: ${{ fromJSON(needs.get-version-channel.outputs.channel) }}
     secrets: inherit
 
   pack-upload:

--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -53,4 +53,5 @@ jobs:
     with:
       version: ${{ needs.get-version-channel.outputs.version }}
       isStableRelease: ${{ fromJSON(needs.get-version-channel.outputs.isStableRelease) }}
+      channel: ${{ fromJSON(needs.get-version-channel.outputs.channel) }}
     secrets: inherit

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -12,6 +12,13 @@ on:
         description: Is this a stable/prod release?
         required: true
         default: false
+      channel:
+        description: If this is a prerelease, is it alpha or beta?
+        type: choice
+        options:
+          - alpha
+          - beta
+        required: false
 
   workflow_dispatch:
     inputs:
@@ -24,6 +31,10 @@ on:
         description: Is this a stable/prod release?
         required: true
         default: false
+      channel:
+        type: string
+        description: Release channel for prereleases
+        required: false
 
 jobs:
   promote:
@@ -31,6 +42,7 @@ jobs:
     with:
         version: ${{ inputs.version }}
         isStableRelease: ${{ fromJSON(inputs.isStableRelease) }}
+        channel: ${{ inputs.channel }}
     secrets: inherit
 
   ## POST release jobs

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -12,6 +12,13 @@ on:
         description: Is this a stable/prod release?
         required: true
         default: false
+      channel:
+        description: If this is a prerelease, is it alpha or beta?
+        type: choice
+        options:
+          - alpha
+          - beta
+        required: false
 
   workflow_dispatch:
     inputs:
@@ -24,6 +31,10 @@ on:
         description: Is this a stable/prod release?
         required: true
         default: false
+      channel:
+        type: string
+        description: Release channel for prereleases
+        required: false
 
 jobs:
   promote:
@@ -47,9 +58,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y awscli jq
       - name: promote
+        env:
+          prerelease-channel: ${{ fromJSON(inputs.channel) || 'beta'}}
         run: |
           SHA=$(npm view heroku@${{ inputs.version }} --json | jq -r '.gitHead[0:7]')
-          yarn oclif promote --deb --xz --root="./packages/cli" --sha="$SHA" --indexes --version=${{ inputs.version }} --channel=${{ fromJSON(inputs.isStableRelease) && 'stable' || 'beta' }}
+          yarn oclif promote --deb --xz --root="./packages/cli" --sha="$SHA" --indexes --version=${{ inputs.version }} --channel=${{ fromJSON(inputs.isStableRelease) && 'stable' || env.prerelease-channel }}
         shell: bash
       - name: promote Linux install scripts
         run: node ./scripts/postrelease/install_scripts.js

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -8,6 +8,13 @@ on:
         description: Is this a stable/prod release?
         required: true
         default: false
+      channel:
+        type: choice
+        description: If this is a prerelease, is it alpha or beta?
+        options:
+          - alpha
+          - beta
+        required: false
   workflow_call:
     inputs:
       isStableRelease:
@@ -15,6 +22,10 @@ on:
         description: Is this a stable/prod release?
         required: true
         default: false
+      channel:
+        type: string
+        description: Release channel for prereleases
+        required: false
 
 jobs:
   publish-npm:
@@ -36,6 +47,6 @@ jobs:
           then
             yarn lerna publish --yes from-package
           else
-            yarn lerna publish --dist-tag beta --yes from-package
+            yarn lerna publish --dist-tag ${{ fromJSON(inputs.channel) || 'beta' }} --yes from-package
           fi
         shell: bash

--- a/.github/workflows/start-prerelease.yml
+++ b/.github/workflows/start-prerelease.yml
@@ -6,11 +6,44 @@ on:
       - prerelease/*
 
 jobs:
-  tag-and-verify:
+  get-version-channel:
+    # get the version number and release channel name from the package.json
+    runs-on: ubuntu-latest
+    outputs:
+      channel: ${{ steps.getVersion.outputs.channel }}
+      version: ${{ steps.getVersion.outputs.version }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: getVersion
+        uses: ./.github/actions/get-version-and-channel/
+        with:
+          path: './packages/cli/package.json'
+
+  validate-prerelease:
+    # validate that the release is on a pre-release branch, that it is a beta or alpha release, and check if it is already on github
+    needs: [ get-version-channel ]
+    runs-on: ubuntu-latest
+    env:
+        CHANNEL: ${{ needs.get-version-channel.outputs.channel }}
+        VERSION: ${{ needs.get-version-channel.outputs.version }}
+        CURRENT_BRANCH_NAME: $${{ github.ref_name }}
+    steps:
+      - run: ./scripts/release/validate-prerelease
+
+  beta-smoke-tests:
+    needs: [ get-version-channel, validate-prerelease ]
+    uses: ./.github/workflows/test-installed-cli.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.get-version-channel.outputs.version }}
+
+  publish-github-tag:
+    needs: [ get-version-channel, validate-prerelease ]
     # pub-hk-ubuntu-22.04- due to IP allow list issues with public repos: https://salesforce.quip.com/bu6UA0KImOxJ
     runs-on: pub-hk-ubuntu-22.04-small
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG_NAME: v${{ fromJSON(needs.get-version-channel.outputs.version) }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
@@ -20,30 +53,14 @@ jobs:
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "heroku-front-end+npm-releases@salesforce.com"
-      - name: Tag and Verify
-        run: ./scripts/release/create-git-prerelease-tag-and-push
+      - name: publish tag to Github
+        run: |
+          git tag "${{ env.TAG_NAME }}" -m "${{ env.TAG_NAME }}"
+          git push origin "${{ env.TAG_NAME }}"
 
-  start-pre-release:
-    needs: [ tag-and-verify ]
+  create-prerelease:
+    needs: [ get-version-channel, validate-prerelease ]
     uses: ./.github/workflows/create-cli-release.yml
     secrets: inherit
     with:
       isStableCandidate: ${{ false }}
-
-  get-version:
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: get CLI version
-        id: version
-        shell: bash
-        run: echo "version=$(node -e "console.log(require('./packages/cli/package.json').version)")" >> $GITHUB_OUTPUT
-
-  beta-smoke-tests:
-    needs: [ start-pre-release, get-version ]
-    uses: ./.github/workflows/test-installed-cli.yml
-    secrets: inherit
-    with:
-      version: ${{ needs.get-version.outputs.version }}

--- a/scripts/release/validate-prerelease
+++ b/scripts/release/validate-prerelease
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+PRERELEASE_PREFIX="prerelease/"
+TAG_NAME="v${VERSION}"
+EXISTING_REMOTE_TAG=$(git ls-remote origin "refs/tags/${TAG_NAME}")
+
+if [[ "${CURRENT_BRANCH_NAME}" != "${PRERELEASE_PREFIX}"* ]]; then
+  echo "script must be run on a branch that begins with '${PRERELEASE_PREFIX}'."
+  exit 1
+fi
+
+if [ -n "${EXISTING_REMOTE_TAG}" ]; then
+  echo "The tag ${TAG_NAME} already exists on github.com"
+  echo "This likely means this version has already been published."
+  echo "Please examine the tag ${TAG_NAME} on github.com/heroku/cli to see the contents of the ${TAG_NAME} release"
+  exit 1
+fi
+
+# we are only allowing for alpha and beta channel releases currently.
+if [[ "${CHANNEL}" != "alpha" ]] && [[ "${CHANNEL}" != "beta"]]; then
+  echo "script must be run on a branch with an alpha or a beta prerelease tag."
+  echo "to create an alpha or beta prerelease tag, see the Heroku CLI release instructions on creating a prerelease"
+  exit 1
+fi


### PR DESCRIPTION
[GUS ticket](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001aPZvVYAW/view)

This PR updates our pre-release workflows to allow for alpha releases. It also updates our start-prerelease workflow for clarity.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
