### PR TITLE
feat(pg-v5): prefer HEROKU_DATA_HOST when set

### DIFF
--- a/packages/pg-v5/lib/host.js
+++ b/packages/pg-v5/lib/host.js
@@ -3,7 +3,7 @@
 const util = require('./util')
 
 module.exports = function (addon) {
-  let host = process.env.HEROKU_POSTGRESQL_HOST
+  let host = process.env.HEROKU_DATA_HOST || process.env.HEROKU_POSTGRESQL_HOST
   let essentialHost = process.env.HEROKU_POSTGRESQL_ESSENTIAL_HOST
 
   if (addon && util.essentialPlan(addon)) {

--- a/packages/pg-v5/test/unit/lib/host.unit.test.js
+++ b/packages/pg-v5/test/unit/lib/host.unit.test.js
@@ -6,39 +6,56 @@ let host = require('../../../lib/host')
 
 describe('host', () => {
   it('shows dev host', () => {
-    expect(host({plan: {name: 'heroku-postgresql:hobby-dev'}})).to.equal('https://postgres-starter-api.heroku.com')
+    expect(host({plan: {name: 'heroku-postgresql:mini'}})).to.equal('https://postgres-starter-api.heroku.com')
   })
 
   it('shows prod host', () => {
     expect(host({plan: {name: 'heroku-postgresql:premium-0'}})).to.equal('https://postgres-api.heroku.com')
   })
 
+  context('with HEROKU_DATA_HOST set', () => {
+    beforeEach(() => {
+      process.env.HEROKU_DATA_HOST = 'data-host.herokuapp.com'
+      process.env.HEROKU_POSTGRESQL_HOST = 'postgresql-host.herokuapp.com'
+    })
+    afterEach(() => delete process.env.HEROKU_DATA_HOST)
+    afterEach(() => delete process.env.HEROKU_POSTGRESQL_HOST)
+
+    it('shows essential host', () => {
+      expect(host({plan: {name: 'heroku-postgresql:mini'}})).to.equal('https://postgres-starter-api.heroku.com')
+    })
+
+    it('shows data host', () => {
+      expect(host({plan: {name: 'heroku-postgresql:premium-0'}})).to.equal('https://data-host.herokuapp.com')
+    })
+  })
+
   context('with HEROKU_POSTGRESQL_HOST set', () => {
     beforeEach(() => {
-      process.env.HEROKU_POSTGRESQL_HOST = 'foo.herokuapp.com'
+      process.env.HEROKU_POSTGRESQL_HOST = 'postgresql-host.herokuapp.com'
     })
     afterEach(() => delete process.env.HEROKU_POSTGRESQL_HOST)
 
-    it('shows dev host', () => {
-      expect(host({plan: {name: 'heroku-postgresql:hobby-dev'}})).to.equal('https://postgres-starter-api.heroku.com')
+    it('shows essential host', () => {
+      expect(host({plan: {name: 'heroku-postgresql:mini'}})).to.equal('https://postgres-starter-api.heroku.com')
     })
 
-    it('shows shogun host', () => {
-      expect(host({plan: {name: 'heroku-postgresql:premium-0'}})).to.equal('https://foo.herokuapp.com')
+    it('shows postgresql host', () => {
+      expect(host({plan: {name: 'heroku-postgresql:premium-0'}})).to.equal('https://postgresql-host.herokuapp.com')
     })
   })
 
   context('with HEROKU_POSTGRESQL_ESSENTIAL_HOST set', () => {
     beforeEach(() => {
-      process.env.HEROKU_POSTGRESQL_ESSENTIAL_HOST = 'bar.herokuapp.com'
+      process.env.HEROKU_POSTGRESQL_ESSENTIAL_HOST = 'essential-host.herokuapp.com'
     })
     afterEach(() => delete process.env.HEROKU_POSTGRESQL_ESSENTIAL_HOST)
 
-    it('shows dev host', () => {
-      expect(host({plan: {name: 'heroku-postgresql:hobby-dev'}})).to.equal('https://bar.herokuapp.com')
+    it('shows essential host', () => {
+      expect(host({plan: {name: 'heroku-postgresql:mini'}})).to.equal('https://essential-host.herokuapp.com')
     })
 
-    it('shows shogun host', () => {
+    it('shows prod host', () => {
       expect(host({plan: {name: 'heroku-postgresql:premium-0'}})).to.equal('https://postgres-api.heroku.com')
     })
   })


### PR DESCRIPTION
If `HEROKU_DATA_HOST` is set when running `heroku pg` commands, let's prefer that first.