### PR TITLE
feat(apps-v5): Use colors when showing run dynos in the ps output

### DIFF
--- a/packages/apps-v5/src/commands/ps/index.js
+++ b/packages/apps-v5/src/commands/ps/index.js
@@ -96,9 +96,10 @@ function printDynos(dynos) {
     let size = dyno.size || '1X'
 
     if (dyno.type === 'run') {
-      let key = 'run: one-off processes'
+      let key = `${cli.color.green('run')}: one-off processes`
       if (dynosByCommand[key] === undefined) dynosByCommand[key] = []
-      dynosByCommand[key].push(`${dyno.name} (${size}): ${dyno.state} ${since}: ${dyno.command}`)
+      let state = dyno.state === 'up' ? cli.color.green(dyno.state) : cli.color.yellow(dyno.state)
+      dynosByCommand[key].push(`${dyno.name} (${cli.color.cyan(size)}): ${state} ${cli.color.dim(since)}: ${dyno.command}`)
     } else {
       let key = `${cli.color.green(dyno.type)} (${cli.color.cyan(size)}): ${dyno.command}`
       if (dynosByCommand[key] === undefined) dynosByCommand[key] = []


### PR DESCRIPTION
A re-do of #2469 so CI can run.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
