### PR TITLE
fix: fix inputs for workflow_call in promote and promote-release

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -13,11 +13,8 @@ on:
         required: true
         default: false
       channel:
-        description: If this is a prerelease, is it alpha or beta?
-        type: choice
-        options:
-          - alpha
-          - beta
+        type: string
+        description: Release channel for prereleases
         required: false
 
   workflow_dispatch:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -13,11 +13,8 @@ on:
         required: true
         default: false
       channel:
-        description: If this is a prerelease, is it alpha or beta?
-        type: choice
-        options:
-          - alpha
-          - beta
+        type: string
+        description: Release channel for prereleases
         required: false
 
   workflow_dispatch:


### PR DESCRIPTION
Fixes inputs for workflow_call trigger in promote and promote-release workflows.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
