### PR TITLE
fix: checkout repo in order to run prerelease validation script

### DIFF
--- a/.github/workflows/start-prerelease.yml
+++ b/.github/workflows/start-prerelease.yml
@@ -28,7 +28,10 @@ jobs:
         VERSION: ${{ needs.get-version-channel.outputs.version }}
         CURRENT_BRANCH_NAME: $${{ github.ref_name }}
     steps:
-      - run: ./scripts/release/validate-prerelease
+      - uses: actions/checkout@v3
+      - run: |
+          yarn --immutable --network-timeout 1000000
+          ./scripts/release/validate-prerelease
 
   beta-smoke-tests:
     needs: [ get-version-channel, validate-prerelease ]


### PR DESCRIPTION
Needed to add a checkout of the repo in order to run prerelease validation script

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
