### PR TITLE
feat(pg-v5) Configuring pq-v5 to use api.data.heroku.com

### DIFF
--- a/packages/pg-v5/commands/backups/capture.js
+++ b/packages/pg-v5/commands/backups/capture.js
@@ -13,11 +13,11 @@ async function run(context, heroku) {
 
   if (flags.snapshot) {
     await cli.action(`Taking snapshot of ${cli.color.addon(db.name)}`, (async function () {
-      await heroku.post(`/postgres/v0/databases/${db.id}/snapshots`, {host: host(db)})
+      await heroku.post(`/postgres/v0/databases/${db.id}/snapshots`, {host: host()})
     })())
   } else {
     let dbInfo = await heroku.request({
-      host: host(db),
+      host: host(),
       method: 'get',
       path: `/client/v11/databases/${db.id}`,
     }).catch(error => {
@@ -34,7 +34,7 @@ async function run(context, heroku) {
 
     let backup
     await cli.action(`Starting backup of ${cli.color.addon(db.name)}`, (async function () {
-      backup = await heroku.post(`/client/v11/databases/${db.id}/backups`, {host: host(db)})
+      backup = await heroku.post(`/client/v11/databases/${db.id}/backups`, {host: host()})
     })())
     cli.log(`
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue running.

--- a/packages/pg-v5/commands/backups/restore.js
+++ b/packages/pg-v5/commands/backups/restore.js
@@ -62,7 +62,7 @@ async function run(context, heroku) {
   await cli.action(`Starting restore of ${cli.color.cyan(backupName)} to ${cli.color.addon(db.name)}`, (async function () {
     restore = await heroku.post(`/client/v11/databases/${db.id}/restores`, {
       body: {backup_url: backupURL, extensions: extensions},
-      host: host(db),
+      host: host(),
     })
   })())
   cli.log(`

--- a/packages/pg-v5/commands/backups/schedule.js
+++ b/packages/pg-v5/commands/backups/schedule.js
@@ -40,7 +40,7 @@ async function run(context, heroku) {
   let at = cli.color.cyan(`${schedule.hour}:00 ${schedule.timezone}`)
 
   let dbInfo = await heroku.request({
-    host: host(db),
+    host: host(),
     method: 'get',
     path: `/client/v11/databases/${db.id}`,
   }).catch(error => {
@@ -62,7 +62,7 @@ async function run(context, heroku) {
 
     await heroku.post(`/client/v11/databases/${db.id}/transfer-schedules`, {
       body: schedule,
-      host: host(db),
+      host: host(),
     })
   })())
 }

--- a/packages/pg-v5/commands/backups/schedules.js
+++ b/packages/pg-v5/commands/backups/schedules.js
@@ -8,7 +8,7 @@ async function run(context, heroku) {
   const {app} = context
 
   let db = await fetcher.arbitraryAppDB(app)
-  let schedules = await heroku.get(`/client/v11/databases/${db.id}/transfer-schedules`, {host: host(db)})
+  let schedules = await heroku.get(`/client/v11/databases/${db.id}/transfer-schedules`, {host: host()})
 
   if (schedules.length === 0) {
     cli.warn(`No backup schedules found on ${cli.color.app(app)}

--- a/packages/pg-v5/commands/backups/unschedule.js
+++ b/packages/pg-v5/commands/backups/unschedule.js
@@ -11,7 +11,7 @@ async function run(context, heroku) {
 
   if (!args.database) {
     let appDB = await fetcher.arbitraryAppDB(app)
-    let schedules = await heroku.get(`/client/v11/databases/${appDB.id}/transfer-schedules`, {host: host(appDB)})
+    let schedules = await heroku.get(`/client/v11/databases/${appDB.id}/transfer-schedules`, {host: host()})
     if (schedules.length === 0) throw new Error(`No schedules on ${cli.color.app(app)}`)
     if (schedules.length > 1) {
       throw new Error(`Specify schedule on ${cli.color.app(app)}. Existing schedules: ${schedules.map(s => cli.color.configVar(s.name)).join(', ')}`)
@@ -22,11 +22,11 @@ async function run(context, heroku) {
 
   await cli.action(`Unscheduling ${cli.color.configVar(db)} daily backups`, (async function () {
     let addon = await fetcher.addon(app, db)
-    let schedules = await heroku.get(`/client/v11/databases/${addon.id}/transfer-schedules`, {host: host(addon)})
+    let schedules = await heroku.get(`/client/v11/databases/${addon.id}/transfer-schedules`, {host: host()})
     let schedule = schedules.find(s => s.name.match(new RegExp(db, 'i')))
     if (!schedule) throw new Error(`No daily backups found for ${cli.color.addon(addon.name)}`)
     await heroku.delete(`/client/v11/databases/${addon.id}/transfer-schedules/${schedule.uuid}`, {
-      host: host(addon),
+      host: host(),
     })
   })())
 }

--- a/packages/pg-v5/commands/connection_pooling.js
+++ b/packages/pg-v5/commands/connection_pooling.js
@@ -17,7 +17,7 @@ async function run(context, heroku) {
     `Enabling Connection Pooling on ${cli.color.addon(addon.name)} to ${cli.color.app(app)}`,
     heroku.post(`/client/v11/databases/${encodeURIComponent(db.name)}/connection-pooling`, {
       body: {name: flags.as, credential: 'default', app: app},
-      host: host(db),
+      host: host(),
     }),
   )
 

--- a/packages/pg-v5/commands/copy.js
+++ b/packages/pg-v5/commands/copy.js
@@ -75,13 +75,13 @@ Data from ${cli.color.yellow(source.name)} will then be transferred to ${cli.col
         to_name: target.name,
         to_url: target.url,
       },
-      host: host(attachment.addon),
+      host: host(),
     })
   })())
 
   if (source.attachment) {
     let credentials = await heroku.get(`/postgres/v0/databases/${source.attachment.addon.name}/credentials`,
-      {host: host(source.attachment.addon)})
+      {host: host()})
     if (credentials.length > 1) {
       cli.action.warn('pg:copy will only copy your default credential and the data it has access to. Any additional credentials and data that only they can access will not be copied.')
     }

--- a/packages/pg-v5/commands/credentials.js
+++ b/packages/pg-v5/commands/credentials.js
@@ -27,7 +27,7 @@ async function run(context, heroku) {
     }
 
     credentials = await heroku.get(`/postgres/v0/databases/${addon.name}/credentials`,
-      {host: host(addon)})
+      {host: host()})
     let isDefaultCredential = cred => cred.name !== 'default'
     credentials = sortBy(credentials, isDefaultCredential, 'name')
     attachments = await heroku.get(`/addons/${addon.name}/addon-attachments`)

--- a/packages/pg-v5/commands/credentials/create.js
+++ b/packages/pg-v5/commands/credentials/create.js
@@ -16,7 +16,7 @@ async function run(context, heroku) {
     name: flags.name,
   }
   await cli.action(`Creating credential ${cli.color.cmd(flags.name)}`, (async function () {
-    await heroku.post(`/postgres/v0/databases/${db.name}/credentials`, {host: host(db), body: data})
+    await heroku.post(`/postgres/v0/databases/${db.name}/credentials`, {host: host(), body: data})
   })())
   let attachCmd = `heroku addons:attach ${db.name} --credential ${flags.name} -a ${app}`
   let psqlCmd = `heroku pg:psql ${db.name} -a ${app}`

--- a/packages/pg-v5/commands/credentials/destroy.js
+++ b/packages/pg-v5/commands/credentials/destroy.js
@@ -27,7 +27,7 @@ async function run(context, heroku) {
   await cli.confirmApp(app, flags.confirm, 'WARNING: Destructive action')
 
   await cli.action(`Destroying credential ${cli.color.cmd(cred)}`, (async function () {
-    await heroku.delete(`/postgres/v0/databases/${db.name}/credentials/${encodeURIComponent(cred)}`, {host: host(db)})
+    await heroku.delete(`/postgres/v0/databases/${db.name}/credentials/${encodeURIComponent(cred)}`, {host: host()})
   })())
 
   cli.log(`The credential has been destroyed within ${db.name}.`)

--- a/packages/pg-v5/commands/credentials/repair_default.js
+++ b/packages/pg-v5/commands/credentials/repair_default.js
@@ -18,7 +18,7 @@ This command will also grant the default credential admin option for all additio
 `)
 
   await cli.action('Resetting permissions and object ownership for default role to factory settings', (async function () {
-    await heroku.post(`/postgres/v0/databases/${db.name}/repair-default`, {host: host(db)})
+    await heroku.post(`/postgres/v0/databases/${db.name}/repair-default`, {host: host()})
   })())
 }
 

--- a/packages/pg-v5/commands/credentials/rotate.js
+++ b/packages/pg-v5/commands/credentials/rotate.js
@@ -50,7 +50,7 @@ async function run(context, heroku) {
   await cli.confirmApp(app, flags.confirm, `WARNING: Destructive Action
 ${warnings.join('\n')}`)
 
-  let body = flags.force ? {host: host(db), forced: true} : {host: host(db)}
+  let body = flags.force ? {host: host(), forced: true} : {host: host()}
   if (all) {
     await cli.action(`Rotating all credentials on ${cli.color.addon(db.name)}`, (async function () {
       await heroku.post(`/postgres/v0/databases/${db.name}/credentials_rotation`,

--- a/packages/pg-v5/commands/credentials/url.js
+++ b/packages/pg-v5/commands/credentials/url.js
@@ -17,7 +17,7 @@ async function run(context, heroku) {
   }
 
   let credInfo = await heroku.get(`/postgres/v0/databases/${db.name}/credentials/${encodeURIComponent(cred)}`,
-    {host: host(db)})
+    {host: host()})
 
   let activeCreds = credInfo.credentials.find(c => c.state === 'active')
   if (!activeCreds) {

--- a/packages/pg-v5/commands/diagnose.js
+++ b/packages/pg-v5/commands/diagnose.js
@@ -22,8 +22,8 @@ async function run(context, heroku) {
     }
 
     if (!util.essentialPlan(db)) {
-      base_params.metrics = await heroku.get(`/client/v11/databases/${db.id}/metrics`, {host: host(db)})
-      let burstData = await heroku.get(`/client/v11/databases/${db.id}/burst_status`, {host: host(db)})
+      base_params.metrics = await heroku.get(`/client/v11/databases/${db.id}/metrics`, {host: host()})
+      let burstData = await heroku.get(`/client/v11/databases/${db.id}/burst_status`, {host: host()})
       if (burstData && Object.keys(burstData).length > 0) {
         base_params.burst_data_present = true
         base_params.burst_status = burstData.burst_status

--- a/packages/pg-v5/commands/info.js
+++ b/packages/pg-v5/commands/info.js
@@ -59,7 +59,7 @@ async function run(context, heroku) {
       addon,
       config,
       db: await heroku.request({
-        host: host(addon),
+        host: host(),
         method: 'get',
         path: `/client/v11/databases/${addon.id}`,
       }).catch(error => {

--- a/packages/pg-v5/commands/killall.js
+++ b/packages/pg-v5/commands/killall.js
@@ -8,7 +8,7 @@ async function run(context, heroku) {
 
   await cli.action('Terminating connections for all credentials', (async function () {
     const db = await fetcher.addon(context.app, context.args.database)
-    await heroku.post(`/client/v11/databases/${db.id}/connection_reset`, {host: host(db)})
+    await heroku.post(`/client/v11/databases/${db.id}/connection_reset`, {host: host()})
   })())
 }
 

--- a/packages/pg-v5/commands/links/create.js
+++ b/packages/pg-v5/commands/links/create.js
@@ -25,7 +25,7 @@ async function run(context, heroku) {
         target: target.name,
         as: flags.as,
       },
-      host: host(db),
+      host: host(),
     })
     if (link.message) throw new Error(link.message)
     cli.action.done(`done, ${cli.color.cyan(link.name)}`)

--- a/packages/pg-v5/commands/links/destroy.js
+++ b/packages/pg-v5/commands/links/destroy.js
@@ -15,7 +15,7 @@ This will delete ${cli.color.cyan(args.link)} along with the tables and views cr
 This may have adverse effects for software written against the ${cli.color.cyan(args.link)} schema.
 `)
   await cli.action(`Destroying link ${cli.color.cyan(args.link)} from ${cli.color.addon(db.name)}`, (async function () {
-    await heroku.delete(`/client/v11/databases/${db.id}/links/${encodeURIComponent(args.link)}`, {host: host(db)})
+    await heroku.delete(`/client/v11/databases/${db.id}/links/${encodeURIComponent(args.link)}`, {host: host()})
   })())
 }
 

--- a/packages/pg-v5/commands/links/index.js
+++ b/packages/pg-v5/commands/links/index.js
@@ -14,7 +14,7 @@ async function run(context, heroku) {
   if (dbs.length === 0) throw new Error(`No databases on ${cli.color.app(app)}`)
 
   dbs = await Promise.all(dbs.map(async db => {
-    db.links = await heroku.get(`/client/v11/databases/${db.id}/links`, {host: host(db)})
+    db.links = await heroku.get(`/client/v11/databases/${db.id}/links`, {host: host()})
     return db
   }))
 

--- a/packages/pg-v5/commands/maintenance/index.js
+++ b/packages/pg-v5/commands/maintenance/index.js
@@ -10,7 +10,7 @@ async function run(context, heroku) {
   const db = await fetcher.addon(app, args.database)
 
   if (util.essentialPlan(db)) throw new Error('pg:maintenance is only available for production databases')
-  let info = await heroku.get(`/client/v11/databases/${db.id}/maintenance`, {host: host(db)})
+  let info = await heroku.get(`/client/v11/databases/${db.id}/maintenance`, {host: host()})
   cli.log(info.message)
 }
 

--- a/packages/pg-v5/commands/maintenance/run.js
+++ b/packages/pg-v5/commands/maintenance/run.js
@@ -16,7 +16,7 @@ async function run(context, heroku) {
       if (!appInfo.maintenance) throw new Error('Application must be in maintenance mode or run with --force')
     }
 
-    let response = await heroku.post(`/client/v11/databases/${db.id}/maintenance`, {host: host(db)})
+    let response = await heroku.post(`/client/v11/databases/${db.id}/maintenance`, {host: host()})
     cli.action.done(response.message || 'done')
   })())
 }

--- a/packages/pg-v5/commands/maintenance/window.js
+++ b/packages/pg-v5/commands/maintenance/window.js
@@ -16,7 +16,7 @@ async function run(context, heroku) {
   await cli.action(`Setting maintenance window for ${cli.color.addon(db.name)} to ${cli.color.cyan(args.window)}`, (async function () {
     let response = await heroku.put(`/client/v11/databases/${db.id}/maintenance_window`, {
       body: {description: args.window},
-      host: host(db),
+      host: host(),
     })
     cli.action.done(response.message || 'done')
   })())

--- a/packages/pg-v5/commands/promote.js
+++ b/packages/pg-v5/commands/promote.js
@@ -51,7 +51,7 @@ async function run(context, heroku) {
 
   if (!force) {
     let status = await heroku.request({
-      host: host(attachment.addon),
+      host: host(),
       path: `/client/v11/databases/${attachment.addon.id}/wait_status`,
     })
 
@@ -99,7 +99,7 @@ async function run(context, heroku) {
   }
 
   let promotedDatabaseDetails = await heroku.request({
-    host: host(attachment.addon),
+    host: host(),
     path: `/client/v11/databases/${attachment.addon.id}`,
   })
 

--- a/packages/pg-v5/commands/repoint.js
+++ b/packages/pg-v5/commands/repoint.js
@@ -12,7 +12,7 @@ async function run(context, heroku) {
 
   if (util.essentialPlan(db)) throw new Error('pg:repoint is only available for follower databases on at least the Standard tier.')
 
-  let replica = await heroku.get(`/client/v11/databases/${db.id}`, {host: host(db)})
+  let replica = await heroku.get(`/client/v11/databases/${db.id}`, {host: host()})
 
   if (!replica.following) {
     throw new Error('pg:repoint is only available for follower databases on at least the Standard tier.')
@@ -29,7 +29,7 @@ This cannot be undone.`)
 
   let data = {follow: newLeader.id}
   await cli.action(`Starting repoint of ${cli.color.addon(db.name)}`, (async function () {
-    await heroku.post(`/client/v11/databases/${db.id}/repoint`, {host: host(db), body: data})
+    await heroku.post(`/client/v11/databases/${db.id}/repoint`, {host: host(), body: data})
     cli.action.done(`${cli.color.cmd('heroku pg:wait')} to track status`)
   })())
 }

--- a/packages/pg-v5/commands/reset.js
+++ b/packages/pg-v5/commands/reset.js
@@ -19,7 +19,7 @@ ${cli.color.addon(db.name)} will lose all of its data
   await cli.action(`Resetting ${cli.color.addon(db.name)}`, (async function () {
     await heroku.put(`/client/v11/databases/${db.id}/reset`, {
       body: {extensions: extensions},
-      host: host(db),
+      host: host(),
     })
   })())
 }

--- a/packages/pg-v5/commands/settings/index.js
+++ b/packages/pg-v5/commands/settings/index.js
@@ -12,7 +12,7 @@ async function run(context, heroku) {
 
   if (util.essentialPlan(db)) throw new Error('You can’t perform this operation on Essential-tier databases.')
 
-  let settings = await heroku.get(`/postgres/v0/databases/${db.id}/config`, {host: host(db)})
+  let settings = await heroku.get(`/postgres/v0/databases/${db.id}/config`, {host: host()})
   cli.styledHeader(db.name)
   let remapped = Object.keys(settings).reduce((s, key) => {
     s[key.replace(/_/g, '-')] = settings[key].value

--- a/packages/pg-v5/commands/unfollow.js
+++ b/packages/pg-v5/commands/unfollow.js
@@ -9,7 +9,7 @@ async function run(context, heroku) {
   let {app, args, flags} = context
   let db = await fetcher.addon(app, args.database)
 
-  let replica = await heroku.get(`/client/v11/databases/${db.id}`, {host: host(db)})
+  let replica = await heroku.get(`/client/v11/databases/${db.id}`, {host: host()})
 
   if (!replica.following) throw new Error(`${cli.color.addon(db.name)} is not a follower`)
 
@@ -19,7 +19,7 @@ ${cli.color.addon(db.name)} will become writeable and no longer follow ${origin}
 `)
 
   await cli.action(`${cli.color.addon(db.name)} unfollowing`, (async function () {
-    await heroku.put(`/client/v11/databases/${db.id}/unfollow`, {host: host(db)})
+    await heroku.put(`/client/v11/databases/${db.id}/unfollow`, {host: host()})
   })())
 }
 

--- a/packages/pg-v5/commands/upgrade.js
+++ b/packages/pg-v5/commands/upgrade.js
@@ -12,8 +12,8 @@ async function run(context, heroku) {
   if (util.essentialPlan(db)) throw new Error('pg:upgrade is only available for follower databases on at least the Standard tier.')
 
   let [replica, status] = await Promise.all([
-    heroku.get(`/client/v11/databases/${db.id}`, {host: host(db)}),
-    heroku.get(`/client/v11/databases/${db.id}/upgrade_status`, {host: host(db)}),
+    heroku.get(`/client/v11/databases/${db.id}`, {host: host()}),
+    heroku.get(`/client/v11/databases/${db.id}/upgrade_status`, {host: host()}),
   ])
 
   if (status.error) throw new Error(status.error)
@@ -32,7 +32,7 @@ This cannot be undone.`)
   let data = {version: flags.version}
 
   await cli.action(`Starting upgrade of ${cli.color.addon(db.name)}`, (async function () {
-    await heroku.post(`/client/v11/databases/${db.id}/upgrade`, {host: host(db), body: data})
+    await heroku.post(`/client/v11/databases/${db.id}/upgrade`, {host: host(), body: data})
     cli.action.done(`${cli.color.cmd('heroku pg:wait')} to track status`)
   })())
 }

--- a/packages/pg-v5/commands/wait.js
+++ b/packages/pg-v5/commands/wait.js
@@ -24,7 +24,7 @@ async function run(context, heroku) {
     while (true) {
       try {
         status = await heroku.request({
-          host: host(db),
+          host: host(),
           path: `/client/v11/databases/${db.id}/wait_status`,
         })
       } catch (error) {

--- a/packages/pg-v5/lib/bastion.js
+++ b/packages/pg-v5/lib/bastion.js
@@ -136,7 +136,7 @@ async function fetchConfig(heroku, db) {
   return heroku.get(
     `/client/v11/databases/${encodeURIComponent(db.id)}/bastion`,
     {
-      host: host(db),
+      host: host(),
     },
   )
 }

--- a/packages/pg-v5/lib/host.js
+++ b/packages/pg-v5/lib/host.js
@@ -2,14 +2,8 @@
 
 const util = require('./util')
 
-module.exports = function (addon) {
+module.exports = function () {
   let host = process.env.HEROKU_POSTGRESQL_HOST
-  let essentialHost = process.env.HEROKU_POSTGRESQL_ESSENTIAL_HOST
-
-  if (addon && util.essentialPlan(addon)) {
-    if (essentialHost) return `https://${essentialHost}`
-    return 'https://postgres-starter-api.heroku.com'
-  }
 
   if (host) return `https://${host}`
   return 'https://postgres-api.heroku.com'

--- a/packages/pg-v5/lib/setter.js
+++ b/packages/pg-v5/lib/setter.js
@@ -39,13 +39,13 @@ exports.generate = (name, convert, explain) => {
     if (util.essentialPlan(db)) throw new Error('You can’t perform this operation on Essential-tier databases.')
 
     if (!value) {
-      let settings = await heroku.get(`/postgres/v0/databases/${db.id}/config`, {host: host(db)})
+      let settings = await heroku.get(`/postgres/v0/databases/${db.id}/config`, {host: host()})
       let setting = settings[name]
       cli.log(`${name.replace(/_/g, '-')} is set to ${setting.value} for ${db.name}.`)
       cli.log(explain(setting))
     } else {
       let settings = await heroku.patch(`/postgres/v0/databases/${db.id}/config`, {
-        host: host(db),
+        host: host(),
         body: {[name]: convert(value)},
       })
       let setting = settings[name]

--- a/packages/pg-v5/test/unit/lib/host.unit.test.js
+++ b/packages/pg-v5/test/unit/lib/host.unit.test.js
@@ -5,10 +5,6 @@ const {expect} = require('chai')
 let host = require('../../../lib/host')
 
 describe('host', () => {
-  it('shows dev host', () => {
-    expect(host({plan: {name: 'heroku-postgresql:hobby-dev'}})).to.equal('https://postgres-starter-api.heroku.com')
-  })
-
   it('shows prod host', () => {
     expect(host({plan: {name: 'heroku-postgresql:premium-0'}})).to.equal('https://postgres-api.heroku.com')
   })
@@ -19,27 +15,8 @@ describe('host', () => {
     })
     afterEach(() => delete process.env.HEROKU_POSTGRESQL_HOST)
 
-    it('shows dev host', () => {
-      expect(host({plan: {name: 'heroku-postgresql:hobby-dev'}})).to.equal('https://postgres-starter-api.heroku.com')
-    })
-
     it('shows shogun host', () => {
       expect(host({plan: {name: 'heroku-postgresql:premium-0'}})).to.equal('https://foo.herokuapp.com')
-    })
-  })
-
-  context('with HEROKU_POSTGRESQL_ESSENTIAL_HOST set', () => {
-    beforeEach(() => {
-      process.env.HEROKU_POSTGRESQL_ESSENTIAL_HOST = 'bar.herokuapp.com'
-    })
-    afterEach(() => delete process.env.HEROKU_POSTGRESQL_ESSENTIAL_HOST)
-
-    it('shows dev host', () => {
-      expect(host({plan: {name: 'heroku-postgresql:hobby-dev'}})).to.equal('https://bar.herokuapp.com')
-    })
-
-    it('shows shogun host', () => {
-      expect(host({plan: {name: 'heroku-postgresql:premium-0'}})).to.equal('https://postgres-api.heroku.com')
     })
   })
 })


### PR DESCRIPTION
This PR removes the parameter from `host()` since going forward all requests will go to api.data.heroku.com.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
