### PR TITLE
Fix: syntax fixes for GHA prerelease refactor

### DIFF
--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -38,7 +38,7 @@ jobs:
     uses: ./.github/workflows/publish-npm.yml
     with:
       isStableRelease: ${{ fromJSON(needs.get-version-channel.outputs.isStableRelease) }}
-      channel: ${{ fromJSON(needs.get-version-channel.outputs.channel) }}
+      channel: ${{ needs.get-version-channel.outputs.channel }}
     secrets: inherit
 
   pack-upload:
@@ -53,5 +53,5 @@ jobs:
     with:
       version: ${{ needs.get-version-channel.outputs.version }}
       isStableRelease: ${{ fromJSON(needs.get-version-channel.outputs.isStableRelease) }}
-      channel: ${{ fromJSON(needs.get-version-channel.outputs.channel) }}
+      channel: ${{ needs.get-version-channel.outputs.channel }}
     secrets: inherit

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -56,7 +56,7 @@ jobs:
           sudo apt-get install -y awscli jq
       - name: promote
         env:
-          prerelease-channel: ${{ fromJSON(inputs.channel) || 'beta'}}
+          prerelease-channel: ${{ inputs.channel || 'beta'}}
         run: |
           SHA=$(npm view heroku@${{ inputs.version }} --json | jq -r '.gitHead[0:7]')
           yarn oclif promote --deb --xz --root="./packages/cli" --sha="$SHA" --indexes --version=${{ inputs.version }} --channel=${{ fromJSON(inputs.isStableRelease) && 'stable' || env.prerelease-channel }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -47,6 +47,6 @@ jobs:
           then
             yarn lerna publish --yes from-package
           else
-            yarn lerna publish --dist-tag ${{ fromJSON(inputs.channel) || 'beta' }} --yes from-package
+            yarn lerna publish --dist-tag ${{ inputs.channel || 'beta' }} --yes from-package
           fi
         shell: bash

--- a/.github/workflows/start-prerelease.yml
+++ b/.github/workflows/start-prerelease.yml
@@ -33,20 +33,13 @@ jobs:
           yarn --immutable --network-timeout 1000000
           ./scripts/release/validate-prerelease
 
-  beta-smoke-tests:
-    needs: [ get-version-channel, validate-prerelease ]
-    uses: ./.github/workflows/test-installed-cli.yml
-    secrets: inherit
-    with:
-      version: ${{ needs.get-version-channel.outputs.version }}
-
   publish-github-tag:
     needs: [ get-version-channel, validate-prerelease ]
     # pub-hk-ubuntu-22.04- due to IP allow list issues with public repos: https://salesforce.quip.com/bu6UA0KImOxJ
     runs-on: pub-hk-ubuntu-22.04-small
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      TAG_NAME: v${{ fromJSON(needs.get-version-channel.outputs.version) }}
+      TAG_NAME: ${{ format('v{0}', needs.get-version-channel.outputs.version) }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
@@ -67,3 +60,10 @@ jobs:
     secrets: inherit
     with:
       isStableCandidate: ${{ false }}
+
+  prerelease-smoke-tests:
+    needs: [ create-prerelease ]
+    uses: ./.github/workflows/test-installed-cli.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.get-version-channel.outputs.version }}

--- a/scripts/postrelease/test_release
+++ b/scripts/postrelease/test_release
@@ -56,7 +56,7 @@ declare -a COMMANDS=(
   "$CMD_BIN regions"
   "$CMD_BIN releases --app heroku-cli-test-staging"
   "$CMD_BIN run ls -a heroku-cli-test-staging -- --color"
-  "$CMD_BIN run -x -a heroku-cli-test-staging -- 'bash -c \"exit 2\"'"
+  "$CMD_BIN run -x -a heroku-cli-test-staging -- 'bash -c \"exit 0\"'"
   "$CMD_BIN run:detached \"echo 'Hello World'\" -a heroku-cli-test-staging"
   "$CMD_BIN sessions"
   "$CMD_BIN spaces"


### PR DESCRIPTION
Mostly removed `fromJSON` calls on strings.
Fix a test in test_release that only passed due to a prior bug that has been fixed.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
