### PR TITLE
feat(ci): Support Linux in homebrew

### DIFF
--- a/scripts/release/homebrew.js
+++ b/scripts/release/homebrew.js
@@ -51,15 +51,21 @@ async function updateHerokuFormula (brewDir) {
 
   const fileNameMacIntel = `${fileNamePrefix}-darwin-${INTEL_ARCH}${fileSuffix}`
   const fileNameMacM1 = `${fileNamePrefix}-darwin-${M1_ARCH}${fileSuffix}`
+  const fileNameLinuxIntel = `${fileNamePrefix}-linux-${INTEL_ARCH}${fileSuffix}`
+  const fileNameLinuxArm = `${fileNamePrefix}-linux-arm${fileSuffix}`
 
   // download files from S3 for SHA calc
   await Promise.all([
     downloadFileFromS3(s3KeyPrefix, fileNameMacIntel, __dirname),
     downloadFileFromS3(s3KeyPrefix, fileNameMacM1, __dirname),
+    downloadFileFromS3(s3KeyPrefix, fileNameLinuxIntel, __dirname),
+    downloadFileFromS3(s3KeyPrefix, fileNameLinuxArm, __dirname),
   ])
 
   const sha256MacIntel = await calculateSHA256(path.join(__dirname, fileNameMacIntel))
   const sha256MacM1 = await calculateSHA256(path.join(__dirname, fileNameMacM1))
+  const sha256LinuxIntel = await calculateSHA256(path.join(__dirname, fileNameLinuxIntel))
+  const sha256LinuxArm = await calculateSHA256(path.join(__dirname, fileNameLinuxArm))
 
   const templateReplaced =
     template
@@ -67,6 +73,10 @@ async function updateHerokuFormula (brewDir) {
       .replace('__CLI_MAC_M1_DOWNLOAD_URL__', `${urlPrefix}/${fileNameMacM1}`)
       .replace('__CLI_MAC_SHA256__', sha256MacIntel)
       .replace('__CLI_MAC_M1_SHA256__', sha256MacM1)
+      .replace('__CLI_LINUX_DOWNLOAD_URL__', `${urlPrefix}/${fileNameLinuxIntel}`)
+      .replace('__CLI_LINUX_ARM_DOWNLOAD_URL__', `${urlPrefix}/${fileNameLinuxArm}`)
+      .replace('__CLI_LINUX_SHA256__', sha256LinuxIntel)
+      .replace('__CLI_LINUX_ARM_SHA256__', sha256LinuxArm)
       .replace('__CLI_VERSION__', VERSION)
 
   fs.writeFileSync(formulaPath, templateReplaced)

--- a/scripts/release/homebrew.js
+++ b/scripts/release/homebrew.js
@@ -45,29 +45,28 @@ async function updateHerokuFormula (brewDir) {
   const formulaPath = path.join(brewDir, 'Formula', 'heroku.rb')
 
   // todo: support both Linux architectures that oclif does
-  const fileNamePrefix = `heroku-v${VERSION}-${GITHUB_SHA_SHORT}-darwin-`
+  const fileNamePrefix = `heroku-v${VERSION}-${GITHUB_SHA_SHORT}`
   const s3KeyPrefix = `versions/${VERSION}/${GITHUB_SHA_SHORT}`
   const urlPrefix = `https://cli-assets.heroku.com/${s3KeyPrefix}`
-  const fileParts = [fileNamePrefix, fileSuffix]
 
-  const fileNameIntel = fileParts.join(INTEL_ARCH)
-  const fileNameM1 = fileParts.join(M1_ARCH)
+  const fileNameMacIntel = `${fileNamePrefix}-darwin-${INTEL_ARCH}${fileSuffix}`
+  const fileNameMacM1 = `${fileNamePrefix}-darwin-${M1_ARCH}${fileSuffix}`
 
   // download files from S3 for SHA calc
   await Promise.all([
-    downloadFileFromS3(s3KeyPrefix, fileNameIntel, __dirname),
-    downloadFileFromS3(s3KeyPrefix, fileNameM1, __dirname),
+    downloadFileFromS3(s3KeyPrefix, fileNameMacIntel, __dirname),
+    downloadFileFromS3(s3KeyPrefix, fileNameMacM1, __dirname),
   ])
 
-  const sha256Intel = await calculateSHA256(path.join(__dirname, fileNameIntel))
-  const sha256M1 = await calculateSHA256(path.join(__dirname, fileNameM1))
+  const sha256MacIntel = await calculateSHA256(path.join(__dirname, fileNameMacIntel))
+  const sha256MacM1 = await calculateSHA256(path.join(__dirname, fileNameMacM1))
 
   const templateReplaced =
     template
-      .replace('__CLI_DOWNLOAD_URL__', `${urlPrefix}/${fileNameIntel}`)
-      .replace('__CLI_DOWNLOAD_URL_M1__', `${urlPrefix}/${fileNameM1}`)
-      .replace('__CLI_SHA256__', sha256Intel)
-      .replace('__CLI_SHA256_M1__', sha256M1)
+      .replace('__CLI_MAC_DOWNLOAD_URL__', `${urlPrefix}/${fileNameMacIntel}`)
+      .replace('__CLI_MAC_M1_DOWNLOAD_URL__', `${urlPrefix}/${fileNameMacM1}`)
+      .replace('__CLI_MAC_SHA256__', sha256MacIntel)
+      .replace('__CLI_MAC_M1_SHA256__', sha256MacM1)
       .replace('__CLI_VERSION__', VERSION)
 
   fs.writeFileSync(formulaPath, templateReplaced)

--- a/scripts/release/homebrew/templates/heroku.rb
+++ b/scripts/release/homebrew/templates/heroku.rb
@@ -19,6 +19,17 @@ class Heroku < Formula
     end
   end
 
+  on_linux do
+    on_intel do
+      url "__CLI_LINUX_DOWNLOAD_URL__"
+      sha256 "__CLI_LINUX_SHA256__"
+    end
+    on_arm do
+      url "__CLI_LINUX_ARM_DOWNLOAD_URL__"
+      sha256 "__CLI_LINUX_ARM_SHA256__"
+    end
+  end
+
   def install
     inreplace "bin/heroku", /^CLIENT_HOME=/, "export HEROKU_OCLIF_CLIENT_HOME=#{lib/"client"}\nCLIENT_HOME="
     libexec.install Dir["*"]

--- a/scripts/release/homebrew/templates/heroku.rb
+++ b/scripts/release/homebrew/templates/heroku.rb
@@ -10,12 +10,12 @@ class Heroku < Formula
 
   on_macos do
     on_intel do
-      url "__CLI_DOWNLOAD_URL__"
-      sha256 "__CLI_SHA256__"
+      url "__CLI_MAC_DOWNLOAD_URL__"
+      sha256 "__CLI_MAC_SHA256__"
     end
     on_arm do
-      url "__CLI_DOWNLOAD_URL_M1__"
-      sha256 "__CLI_SHA256_M1__"
+      url "__CLI_MAC_M1_DOWNLOAD_URL__"
+      sha256 "__CLI_MAC_M1_SHA256__"
     end
   end
 

--- a/scripts/release/homebrew/templates/heroku.rb
+++ b/scripts/release/homebrew/templates/heroku.rb
@@ -5,13 +5,15 @@
 class Heroku < Formula
   desc "Everything you need to get started with Heroku"
   homepage "https://cli.heroku.com"
-  url "__CLI_DOWNLOAD_URL__"
-  sha256 "__CLI_SHA256__"
   version "__CLI_VERSION__"
   version_scheme 1
 
   on_macos do
-    if Hardware::CPU.arm?
+    on_intel do
+      url "__CLI_DOWNLOAD_URL__"
+      sha256 "__CLI_SHA256__"
+    end
+    on_arm do
       url "__CLI_DOWNLOAD_URL_M1__"
       sha256 "__CLI_SHA256_M1__"
     end


### PR DESCRIPTION
Installing the CLI client via homebrew on Linux always install the Mac binaries instead of using the correct binaries for Linux. 
This updates the homebrew template to use the correct URLs on Linux.

This replaces #1532, heroku/homebrew-brew#20
This fixes heroku/homebrew-brew#31