### PR TITLE
fix(pg-v5) Disallow pg:links for essential-tier plans

### DIFF
--- a/packages/pg-v5/commands/links/create.js
+++ b/packages/pg-v5/commands/links/create.js
@@ -5,6 +5,7 @@ const cli = require('heroku-cli-util')
 async function run(context, heroku) {
   const host = require('../../lib/host')
   const fetcher = require('../../lib/fetcher')(heroku)
+  const util = require('../../lib/util')
   const addons = require('@heroku-cli/plugin-addons').resolve
   let {app, args, flags} = context
 
@@ -18,6 +19,9 @@ async function run(context, heroku) {
     fetcher.addon(app, args.database),
     service(args.remote),
   ])
+
+  if (util.essentialPlan(db)) throw new Error('pg:links isn’t available for Essential-tier databases.')
+  if (util.essentialPlan(target)) throw new Error('pg:links isn’t available for Essential-tier databases.')
 
   await cli.action(`Adding link from ${cli.color.addon(target.name)} to ${cli.color.addon(db.name)}`, (async function () {
     let link = await heroku.post(`/client/v11/databases/${db.id}/links`, {

--- a/packages/pg-v5/commands/links/destroy.js
+++ b/packages/pg-v5/commands/links/destroy.js
@@ -5,9 +5,12 @@ const cli = require('heroku-cli-util')
 async function run(context, heroku) {
   const host = require('../../lib/host')
   const fetcher = require('../../lib/fetcher')(heroku)
+  const util = require('../../lib/util')
   let {app, args, flags} = context
 
   const db = await fetcher.addon(app, args.database)
+
+  if (util.essentialPlan(db)) throw new Error('pg:links isn’t available for Essential-tier databases.')
 
   await cli.confirmApp(app, flags.confirm, `WARNING: Destructive action
 This command will affect the database ${cli.color.addon(db.name)}

--- a/packages/pg-v5/test/unit/commands/links/create.unit.test.js
+++ b/packages/pg-v5/test/unit/commands/links/create.unit.test.js
@@ -6,21 +6,18 @@ const {expect} = require('chai')
 const nock = require('nock')
 const proxyquire = require('proxyquire')
 
-const addon = {
-  id: 1,
-  name: 'postgres-1',
-  plan: {name: 'heroku-postgresql:standard-0'},
-}
 
-const cmd = proxyquire('../../../../commands/links/create', {
-  '@heroku-cli/plugin-addons': {
-    resolve: {addon: () => addon},
-  },
-  '../../lib/fetcher': () => ({
-    all: () => [addon],
-    addon: () => addon,
-  }),
-})
+const buildCmd = (addon) => {
+  return proxyquire('../../../../commands/links/create', {
+    '@heroku-cli/plugin-addons': {
+      resolve: {addon: () => addon},
+    },
+    '../../lib/fetcher': () => ({
+      all: () => [addon],
+      addon: () => addon,
+    }),
+  })
+}
 
 describe('pg:links:create', () => {
   let api
@@ -38,10 +35,35 @@ describe('pg:links:create', () => {
     pg.done()
   })
 
-  it('creates a link', () => {
-    pg.post('/client/v11/databases/1/links', {target: 'postgres-1', as: 'foobar'}).reply(200, {name: 'foobar'})
-    return cmd.run({app: 'myapp', args: {}, flags: {confirm: 'myapp', as: 'foobar'}})
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('Adding link from postgres-1 to postgres-1... done, foobar\n'))
+  context("on an essential database", () => {
+    let addon = {
+      id: 2,
+      name: 'postgres-1',
+      plan: {name: 'heroku-postgresql:basic'},
+    }
+    let cmd = buildCmd(addon)
+
+    it('errors when attempting to create a link', () => {
+      return cmd.run({app: 'myapp', args: {}, flags: {confirm: 'myapp', as: 'foobar'}})
+        .catch(error => {
+          expect(error.message).to.equal('pg:links isn’t available for Essential-tier databases.')
+        })
+    })
+  })
+
+  context("on a production database", () => {
+    let addon = {
+      id: 1,
+      name: 'postgres-1',
+      plan: {name: 'heroku-postgresql:standard-0'},
+    }
+    let cmd = buildCmd(addon)
+
+    it('creates a link', () => {
+      pg.post('/client/v11/databases/1/links', {target: 'postgres-1', as: 'foobar'}).reply(200, {name: 'foobar'})
+      return cmd.run({app: 'myapp', args: {}, flags: {confirm: 'myapp', as: 'foobar'}})
+        .then(() => expect(cli.stdout).to.equal(''))
+        .then(() => expect(cli.stderr).to.equal('Adding link from postgres-1 to postgres-1... done, foobar\n'))
+    })
   })
 })

--- a/packages/pg-v5/test/unit/commands/links/create.unit.test.js
+++ b/packages/pg-v5/test/unit/commands/links/create.unit.test.js
@@ -6,8 +6,7 @@ const {expect} = require('chai')
 const nock = require('nock')
 const proxyquire = require('proxyquire')
 
-
-const buildCmd = (addon) => {
+const buildCmd = addon => {
   return proxyquire('../../../../commands/links/create', {
     '@heroku-cli/plugin-addons': {
       resolve: {addon: () => addon},
@@ -35,7 +34,7 @@ describe('pg:links:create', () => {
     pg.done()
   })
 
-  context("on an essential database", () => {
+  describe('on an essential database', () => {
     let addon = {
       id: 2,
       name: 'postgres-1',
@@ -51,7 +50,7 @@ describe('pg:links:create', () => {
     })
   })
 
-  context("on a production database", () => {
+  describe('on a production database', () => {
     let addon = {
       id: 1,
       name: 'postgres-1',

--- a/packages/pg-v5/test/unit/commands/links/destroy.unit.test.js
+++ b/packages/pg-v5/test/unit/commands/links/destroy.unit.test.js
@@ -6,7 +6,7 @@ const {expect} = require('chai')
 const nock = require('nock')
 const proxyquire = require('proxyquire')
 
-const buildCmd = (addon) => {
+const buildCmd = addon => {
   return proxyquire('../../../../commands/links/destroy', {
     '@heroku-cli/plugin-addons': {
       resolve: {addon: () => addon},
@@ -34,7 +34,7 @@ describe('pg:links:destroy', () => {
     pg.done()
   })
 
-  context("on an essential database", () => {
+  describe('on an essential database', () => {
     let addon = {
       id: 1,
       name: 'postgres-1',
@@ -50,7 +50,7 @@ describe('pg:links:destroy', () => {
     })
   })
 
-  context("on a production database", () => {
+  describe('on a production database', () => {
     let addon = {
       id: 1,
       name: 'postgres-1',

--- a/packages/pg-v5/test/unit/commands/links/destroy.unit.test.js
+++ b/packages/pg-v5/test/unit/commands/links/destroy.unit.test.js
@@ -6,21 +6,17 @@ const {expect} = require('chai')
 const nock = require('nock')
 const proxyquire = require('proxyquire')
 
-const addon = {
-  id: 1,
-  name: 'postgres-1',
-  plan: {name: 'heroku-postgresql:standard-0'},
+const buildCmd = (addon) => {
+  return proxyquire('../../../../commands/links/destroy', {
+    '@heroku-cli/plugin-addons': {
+      resolve: {addon: () => addon},
+    },
+    '../../lib/fetcher': () => ({
+      all: () => [addon],
+      addon: () => addon,
+    }),
+  })
 }
-
-const cmd = proxyquire('../../../../commands/links/destroy', {
-  '@heroku-cli/plugin-addons': {
-    resolve: {addon: () => addon},
-  },
-  '../../lib/fetcher': () => ({
-    all: () => [addon],
-    addon: () => addon,
-  }),
-})
 
 describe('pg:links:destroy', () => {
   let api
@@ -38,10 +34,35 @@ describe('pg:links:destroy', () => {
     pg.done()
   })
 
-  it('destroys a link', () => {
-    pg.delete('/client/v11/databases/1/links/redis').reply(200)
-    return cmd.run({app: 'myapp', args: {link: 'redis'}, flags: {confirm: 'myapp'}})
-      .then(() => expect(cli.stdout).to.equal(''))
-      .then(() => expect(cli.stderr).to.equal('Destroying link redis from postgres-1... done\n'))
+  context("on an essential database", () => {
+    let addon = {
+      id: 1,
+      name: 'postgres-1',
+      plan: {name: 'heroku-postgresql:mini'},
+    }
+    let cmd = buildCmd(addon)
+
+    it('errors when attempting to destroy a link', () => {
+      return cmd.run({app: 'myapp', args: {}, flags: {confirm: 'myapp', as: 'foobar'}})
+        .catch(error => {
+          expect(error.message).to.equal('pg:links isn’t available for Essential-tier databases.')
+        })
+    })
+  })
+
+  context("on a production database", () => {
+    let addon = {
+      id: 1,
+      name: 'postgres-1',
+      plan: {name: 'heroku-postgresql:standard-0'},
+    }
+    let cmd = buildCmd(addon)
+
+    it('destroys a link', () => {
+      pg.delete('/client/v11/databases/1/links/redis').reply(200)
+      return cmd.run({app: 'myapp', args: {link: 'redis'}, flags: {confirm: 'myapp'}})
+        .then(() => expect(cli.stdout).to.equal(''))
+        .then(() => expect(cli.stderr).to.equal('Destroying link redis from postgres-1... done\n'))
+    })
   })
 })


### PR DESCRIPTION
Users will now see a detailed error message if they try and setup `pg:links` with an essential-tier database. The `pg:links` feature has never been supported for essential-tier databases and users that would attempt to create links would be greeted with a non-helpful error message.

This PR updates to give users more helpful information and bring the CLI more in-line with our docs.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
