### PR TITLE
fix: remove dotenv as no longer necessary

### DIFF
--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-require('dotenv').config()
-
 process.env.HEROKU_UPDATE_INSTRUCTIONS = process.env.HEROKU_UPDATE_INSTRUCTIONS || 'update with: "npm update -g heroku"'
 
 const now = new Date()

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,6 @@
     "chalk": "^2.4.2",
     "date-fns": "^2.30.0",
     "debug": "4.1.1",
-    "dotenv": "^16.3.1",
     "edit-string": "^1.1.6",
     "execa": "5.1.1",
     "foreman": "^3.0.1",

--- a/packages/cli/src/global_telemetry.ts
+++ b/packages/cli/src/global_telemetry.ts
@@ -1,4 +1,3 @@
-import 'dotenv/config'
 import * as Rollbar from 'rollbar'
 import {APIClient} from '@heroku-cli/command'
 import {Config} from '@oclif/core'

--- a/packages/cli/test/unit/global_telemetry.unit.test.ts
+++ b/packages/cli/test/unit/global_telemetry.unit.test.ts
@@ -1,4 +1,3 @@
-import 'dotenv/config'
 import {expect} from '@oclif/test'
 import * as telemetry from '../../src/global_telemetry'
 import {identity} from 'lodash'

--- a/yarn.lock
+++ b/yarn.lock
@@ -6803,13 +6803,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.3.1":
-  version: 16.3.1
-  resolution: "dotenv@npm:16.3.1"
-  checksum: 15d75e7279018f4bafd0ee9706593dd14455ddb71b3bcba9c52574460b7ccaf67d5cf8b2c08a5af1a9da6db36c956a04a1192b101ee102a3e0cf8817bbcf3dfd
-  languageName: node
-  linkType: hard
-
 "dotenv@npm:~10.0.0":
   version: 10.0.0
   resolution: "dotenv@npm:10.0.0"
@@ -9319,7 +9312,6 @@ __metadata:
     chalk: ^2.4.2
     date-fns: ^2.30.0
     debug: 4.1.1
-    dotenv: ^16.3.1
     edit-string: ^1.1.6
     execa: 5.1.1
     foreman: ^3.0.1


### PR DESCRIPTION
Fixes #2457. I confirmed with @mars and @zwhitfield3 that we no longer need the dotenv package for telemetry.

To test locally:
1. Add two files to the root of your local cli repo
    - .env
        - `BASE_ENV_VAR="value for base"`
    - read_some_env_vars
        - ```
          #!/usr/bin/env ruby
          puts <<~EOF
            ⚠️
            BASE_ENV_VAR=#{ENV.fetch("BASE_ENV_VAR", :not_set)}
            OTHER_ENV_VAR=#{ENV.fetch("OTHER_ENV_VAR", :not_set)}
           ⚠️
           EOF
2. run `yarn` and `yarn build`
3. run the command `./bin/run local:run ./read_some_env_vars --env=/dev/null`
4. You should get the result
    ```
    ⚠️
    BASE_ENV_VAR=not_set
    OTHER_ENV_VAR=not_set
    ⚠️
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
