### PR TITLE
fix: alpha release fixes

### DIFF
--- a/.github/workflows/start-prerelease.yml
+++ b/.github/workflows/start-prerelease.yml
@@ -26,7 +26,6 @@ jobs:
     env:
         CHANNEL: ${{ needs.get-version-channel.outputs.channel }}
         VERSION: ${{ needs.get-version-channel.outputs.version }}
-        CURRENT_BRANCH_NAME: $${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v3
       - run: |

--- a/.github/workflows/start-prerelease.yml
+++ b/.github/workflows/start-prerelease.yml
@@ -26,6 +26,7 @@ jobs:
     env:
         CHANNEL: ${{ needs.get-version-channel.outputs.channel }}
         VERSION: ${{ needs.get-version-channel.outputs.version }}
+        CURRENT_BRANCH_NAME: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v3
       - run: |

--- a/.github/workflows/start-prerelease.yml
+++ b/.github/workflows/start-prerelease.yml
@@ -29,9 +29,8 @@ jobs:
         CURRENT_BRANCH_NAME: ${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v3
-      - run: |
-          yarn --immutable --network-timeout 1000000
-          ./scripts/release/validate-prerelease
+      - run: yarn --immutable --network-timeout 1000000
+      - run: ./scripts/release/validate-prerelease
 
   publish-github-tag:
     needs: [ get-version-channel, validate-prerelease ]

--- a/scripts/release/validate-prerelease
+++ b/scripts/release/validate-prerelease
@@ -19,7 +19,7 @@ if [ -n "${EXISTING_REMOTE_TAG}" ]; then
 fi
 
 # we are only allowing for alpha and beta channel releases currently.
-if [[ "${CHANNEL}" != "alpha" ]] && [[ "${CHANNEL}" != "beta"]]; then
+if [[ "${CHANNEL}" != "alpha" ]] && [[ "${CHANNEL}" != "beta" ]]; then
   echo "script must be run on a branch with an alpha or a beta prerelease tag."
   echo "to create an alpha or beta prerelease tag, see the Heroku CLI release instructions on creating a prerelease"
   exit 1

--- a/scripts/release/validate-prerelease
+++ b/scripts/release/validate-prerelease
@@ -5,7 +5,6 @@ set -e -o pipefail
 PRERELEASE_PREFIX="prerelease/"
 TAG_NAME="v${VERSION}"
 EXISTING_REMOTE_TAG=$(git ls-remote origin "refs/tags/${TAG_NAME}")
-CURRENT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 
 if [[ "${CURRENT_BRANCH_NAME}" != "${PRERELEASE_PREFIX}"* ]]; then
   echo "script ran on '${CURRENT_BRANCH_NAME}, must be run on a branch that begins with '${PRERELEASE_PREFIX}'."

--- a/scripts/release/validate-prerelease
+++ b/scripts/release/validate-prerelease
@@ -5,9 +5,10 @@ set -e -o pipefail
 PRERELEASE_PREFIX="prerelease/"
 TAG_NAME="v${VERSION}"
 EXISTING_REMOTE_TAG=$(git ls-remote origin "refs/tags/${TAG_NAME}")
+CURRENT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 
 if [[ "${CURRENT_BRANCH_NAME}" != "${PRERELEASE_PREFIX}"* ]]; then
-  echo "script must be run on a branch that begins with '${PRERELEASE_PREFIX}'."
+  echo "script ran on '${CURRENT_BRANCH_NAME}, must be run on a branch that begins with '${PRERELEASE_PREFIX}'."
   exit 1
 fi
 


### PR DESCRIPTION
Remove an extra `$` character that broke branch name validation.
Fix a syntax error in validate-prerelease script.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
