### PR TITLE
chore: pg-v5 lint fixes

### DIFF
--- a/packages/pg-v5/lib/util.js
+++ b/packages/pg-v5/lib/util.js
@@ -129,6 +129,7 @@ exports.getConnectionDetails = function (attachment, config) {
 
   return payload
 }
+
 // eslint-disable-next-line no-implicit-coercion
 exports.essentialNumPlan = a => !!a.plan.name.split(':')[1].match(/^essential/)
 
@@ -136,7 +137,7 @@ exports.essentialNumPlan = a => !!a.plan.name.split(':')[1].match(/^essential/)
 exports.legacyEssentialPlan = a => !!a.plan.name.split(':')[1].match(/(dev|basic|mini)$/)
 
 // eslint-disable-next-line no-implicit-coercion
-exports.essentialPlan = (a) => {
+exports.essentialPlan = a => {
   return this.essentialNumPlan(a) || this.legacyEssentialPlan(a)
 }
 

--- a/packages/pg-v5/test/unit/lib/host.unit.test.js
+++ b/packages/pg-v5/test/unit/lib/host.unit.test.js
@@ -14,7 +14,7 @@ describe('host', () => {
   })
 
   context('for numbered essential plans', () => {
-    it ('shows data host', () => {
+    it('shows data host', () => {
       expect(host({plan: {name: 'heroku-postgresql:essential-0'}})).to.equal('https://postgres-api.heroku.com')
     })
   })
@@ -36,7 +36,7 @@ describe('host', () => {
     })
 
     context('for numbered essential plans', () => {
-      it ('shows data host', () => {
+      it('shows data host', () => {
         expect(host({plan: {name: 'heroku-postgresql:essential-0'}})).to.equal('https://data-host.herokuapp.com')
       })
     })
@@ -57,7 +57,7 @@ describe('host', () => {
     })
 
     context('for numbered essential plans', () => {
-      it ('shows data host', () => {
+      it('shows data host', () => {
         expect(host({plan: {name: 'heroku-postgresql:essential-0'}})).to.equal('https://postgresql-host.herokuapp.com')
       })
     })
@@ -78,7 +78,7 @@ describe('host', () => {
     })
 
     context('for numbered essential plans', () => {
-      it ('shows prod host', () => {
+      it('shows prod host', () => {
         expect(host({plan: {name: 'heroku-postgresql:essential-0'}})).to.equal('https://postgres-api.heroku.com')
       })
     })


### PR DESCRIPTION
A few quick linting fixes for pg-v5

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
