### PR TITLE
fix: explicitly run homebrew release as node script

### DIFF
--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -27,7 +27,7 @@ jobs:
         run: yarn --immutable --network-timeout 1000000
       - run: echo "GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c 1-7)" >> $GITHUB_ENV
       - name: release homebrew
-        run: ./scripts/release/homebrew.js
+        run: node ./scripts/release/homebrew.js
         env:
           GITHUB_SHA_SHORT: ${{ env.GITHUB_SHA_SHORT }}
           CLOUDFRONT_DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION }}


### PR DESCRIPTION
https://github.com/heroku/cli/actions/runs/6539272126/job/17757726522

Script was being run via bash, changed to node.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
