### PR TITLE
refactor(app): move apps:open to CLI & upgrade to oclif

### DIFF
--- a/packages/cli/src/commands/apps/open.ts
+++ b/packages/cli/src/commands/apps/open.ts
@@ -1,0 +1,32 @@
+import {Args} from '@oclif/core'
+import {Command, flags} from '@heroku-cli/command'
+import * as Heroku from '@heroku-cli/schema'
+import * as url from 'url'
+import * as open from 'open'
+
+export default class AppsOpen extends Command {
+  static description = 'open the app in a web browser'
+  static topic = 'apps'
+  static aliases = ['apps:open', 'open']
+
+  static examples = [
+    '$ heroku open -a myapp',
+    '$ heroku open -a myapp /foo',
+  ]
+
+  static flags = {
+    app: flags.app({required: true}),
+  }
+
+  static args = {
+    path: Args.string({required: false}),
+  }
+
+  async run() {
+    const {flags, args} = await this.parse(AppsOpen)
+
+    const appResponse = await this.heroku.get<Heroku.App>(`/apps/${flags.app}`)
+    const app = appResponse.body
+    await open(url.resolve(app.web_url!, args.path || ''))
+  }
+}

--- a/packages/cli/test/unit/commands/apps/open.unit.test.ts
+++ b/packages/cli/test/unit/commands/apps/open.unit.test.ts
@@ -1,0 +1,19 @@
+import {expect, test} from '@oclif/test'
+
+describe('apps', () => {
+  test
+    .stdout()
+    .stderr()
+    .nock('https://api.heroku.com:443', api => {
+      api.get('/account')
+        .reply(200, {email: 'foo@bar.com'})
+
+      api.get('/users/~/apps')
+        .reply(200, [])
+    })
+    .command(['apps'])
+    .it('displays a message when the user has no apps', ({stdout, stderr}) => {
+      expect(stderr).to.equal('')
+      expect(stdout).to.equal('You have no apps.\n')
+    })
+})


### PR DESCRIPTION
# Description
[Work Item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001awdWsYAI/view)


<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Testing
`.bin/dev apps:open -a heroku-cli-test-staging`
`.bin/dev apps:open -a heroku-cli-test-staging /<figuring out path to use>`