### PR TITLE
adding error for essentials for addon --follow

### DIFF
--- a/packages/addons-v5/commands/addons/create.js
+++ b/packages/addons-v5/commands/addons/create.js
@@ -42,6 +42,10 @@ async function run(context, heroku) {
     throw new Error('Usage: heroku addons:create SERVICE:PLAN')
   }
 
+  if ((args[0].includes('essential') || args[0].includes('mini')) && (args[1] === ('--follow'))) {
+    throw new Error('You can’t perform this operation on Essential-tier databases.')
+  }
+
   let {name, as, wait, confirm} = flags
   let config = parseConfig(args.slice(1))
   let addon

--- a/packages/addons-v5/commands/addons/create.js
+++ b/packages/addons-v5/commands/addons/create.js
@@ -42,7 +42,7 @@ async function run(context, heroku) {
     throw new Error('Usage: heroku addons:create SERVICE:PLAN')
   }
 
-  if ((args[0].includes('essential') || args[0].includes('mini')) && (args[1] === ('--follow'))) {
+  if ((args[0].includes('essential')) && (args[1] === ('--follow'))) {
     throw new Error('You can’t perform this operation on Essential-tier databases.')
   }
 

--- a/packages/addons-v5/test/unit/commands/addons/create.unit.test.js
+++ b/packages/addons-v5/test/unit/commands/addons/create.unit.test.js
@@ -361,16 +361,15 @@ Use heroku addons:docs heroku-db3 to view documentation
   })
 
   context('--follow=--otherdb', () => {
-    beforeEach(() => {
+
+    it('creates an addon with =-- args', () => {
       api.post('/apps/myapp/addons', {
         attachment: {name: 'mydb'},
         config: {follow: '--otherdb', rollback: true, foo: true},
         plan: {name: 'heroku-postgresql:standard-0'},
       })
         .reply(200, addon)
-    })
 
-    it('creates an addon with =-- args', () => {
       return cmd.run({
         config,
         app: 'myapp',
@@ -378,7 +377,22 @@ Use heroku addons:docs heroku-db3 to view documentation
         flags: {as: 'mydb'},
       })
     })
+
+    it('does not create if addon is essential', () => {
+      api.post('/apps/myapp/addons', {
+        plan: {name: 'heroku-postgresql:essential-0'},
+        name: 'foobar',
+      })
+        .reply(200, addon)
+
+      return expect(cmd.run({
+        config,
+        app: 'myapp',
+        args: ['heroku-postgresql:essential-0', '--follow', 'otherdb', '--foo']
+      })).to.be.rejectedWith(Error, /You can’t perform this operation on Essential-tier databases./)
+    })
   })
+
   context('no config vars supplied by add-on provider', () => {
     beforeEach(() => {
       const noConfigAddon = _.clone(addon)


### PR DESCRIPTION
**Description:**
Numbered Essential plans do not support following. This PR will not allow following if the plan name includes "essential".

**GUS:** 
https://gus.lightning.force.com/lightning/r/a07EE00001bQWaBYAW/view

**Testing:**
Before:
![Screenshot 2023-10-18 at 1 17 35 AM](https://github.com/heroku/cli/assets/22723164/23fd4071-702a-479e-99d9-05cd541a5a85)

After: 
![Screenshot 2023-10-18 at 1 25 34 AM](https://github.com/heroku/cli/assets/22723164/38888b39-dd01-4b81-8d30-2182323ba150)


(lots of oclif manifest errors)
![Screenshot 2023-10-18 at 1 21 35 AM](https://github.com/heroku/cli/assets/22723164/1b4057ce-0454-4790-8265-f8f95dada6af)

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
