### PR TITLE
fix(spaces) heroku space:wait and space:info will not fail if space/space_name/nat is not available

### DIFF
--- a/packages/spaces/commands/info.js
+++ b/packages/spaces/commands/info.js
@@ -17,7 +17,7 @@ async function run(context, heroku) {
     try {
       space.outbound_ips = await heroku.get(`/spaces/${spaceName}/nat`)
     } catch (error) {
-      cli.warn(error)
+      cli.warn(`Retrieving NAT details for the space failed with ${error}`)
     }
   }
 

--- a/packages/spaces/commands/info.js
+++ b/packages/spaces/commands/info.js
@@ -17,7 +17,8 @@ async function run(context, heroku) {
     try {
       space.outbound_ips = await heroku.get(`/spaces/${spaceName}/nat`)
     } catch (error) {
-      cli.warn(`Retrieving NAT details for the space failed with ${error}`)
+      const debug = require('debug')('spaces:info')
+      debug(`Retrieving NAT details for the space failed with ${error}`)
     }
   }
 

--- a/packages/spaces/commands/info.js
+++ b/packages/spaces/commands/info.js
@@ -14,7 +14,11 @@ async function run(context, heroku) {
 
   let space = await heroku.get(`/spaces/${spaceName}`, {headers})
   if (space.state === 'allocated') {
-    space.outbound_ips = await heroku.get(`/spaces/${spaceName}/nat`)
+    try {
+      space.outbound_ips = await heroku.get(`/spaces/${spaceName}/nat`)
+    } catch (error) {
+      cli.warn(error)
+    }
   }
 
   render(space, context.flags)

--- a/packages/spaces/commands/info.js
+++ b/packages/spaces/commands/info.js
@@ -17,7 +17,7 @@ async function run(context, heroku) {
     try {
       space.outbound_ips = await heroku.get(`/spaces/${spaceName}/nat`)
     } catch (error) {
-      const debug = require('debug')('spaces:info')
+      const debug = require('debug')('spaces:info') // eslint-disable-line node/no-extraneous-require
       debug(`Retrieving NAT details for the space failed with ${error}`)
     }
   }

--- a/packages/spaces/commands/wait.js
+++ b/packages/spaces/commands/wait.js
@@ -33,7 +33,7 @@ async function run(context, heroku) {
   try {
     space.outbound_ips = await heroku.get(`/spaces/${spaceName}/nat`)
   } catch (error) {
-    const debug = require('debug')('spaces:wait')
+    const debug = require('debug')('spaces:wait') // eslint-disable-line node/no-extraneous-require
     debug(`Retrieving NAT details for the space failed with ${error}`)
   }
 

--- a/packages/spaces/commands/wait.js
+++ b/packages/spaces/commands/wait.js
@@ -33,7 +33,7 @@ async function run(context, heroku) {
   try {
     space.outbound_ips = await heroku.get(`/spaces/${spaceName}/nat`)
   } catch (error) {
-    cli.warn(error)
+    cli.warn(`Retrieving NAT details for the space failed with ${error}`)
   }
   spinner.stop('done\n')
 

--- a/packages/spaces/commands/wait.js
+++ b/packages/spaces/commands/wait.js
@@ -33,7 +33,8 @@ async function run(context, heroku) {
   try {
     space.outbound_ips = await heroku.get(`/spaces/${spaceName}/nat`)
   } catch (error) {
-    cli.warn(`Retrieving NAT details for the space failed with ${error}`)
+    const debug = require('debug')('spaces:wait')
+    debug(`Retrieving NAT details for the space failed with ${error}`)
   }
 
   spinner.stop('done\n')

--- a/packages/spaces/commands/wait.js
+++ b/packages/spaces/commands/wait.js
@@ -30,7 +30,11 @@ async function run(context, heroku) {
     space = await heroku.get(`/spaces/${spaceName}`, {headers})
   }
 
-  space.outbound_ips = await heroku.get(`/spaces/${spaceName}/nat`)
+  try {
+    space.outbound_ips = await heroku.get(`/spaces/${spaceName}/nat`)
+  } catch (error) {
+    cli.warn(error)
+  }
   spinner.stop('done\n')
 
   info.render(space, context.flags)

--- a/packages/spaces/commands/wait.js
+++ b/packages/spaces/commands/wait.js
@@ -35,6 +35,7 @@ async function run(context, heroku) {
   } catch (error) {
     cli.warn(`Retrieving NAT details for the space failed with ${error}`)
   }
+
   spinner.stop('done\n')
 
   info.render(space, context.flags)

--- a/packages/spaces/test/unit/commands/info.unit.test.js
+++ b/packages/spaces/test/unit/commands/info.unit.test.js
@@ -136,4 +136,25 @@ Created at:   ${now.toISOString()}
 `))
       .then(() => api.done())
   })
+
+  it('test if nat API call fails ', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space')
+      .reply(200,
+        {shield: false, name: 'my-space', team: {name: 'my-team'}, region: {name: 'my-region', description: 'region'}, state: 'allocated', created_at: now, cidr: '10.0.0.0/16', data_cidr: '172.23.0.0/20'},
+      )
+    return cmd.run({flags: {space: 'my-space'}})
+      .then(() => expect(cli.stdout).to.equal(
+        `=== my-space
+Team:         my-team
+Region:       region
+CIDR:         10.0.0.0/16
+Data CIDR:    172.23.0.0/20
+State:        allocated
+Shield:       off
+Created at:   ${now.toISOString()}
+`))
+      .then(() => api.done())
+  })
+
 })

--- a/packages/spaces/test/unit/commands/info.unit.test.js
+++ b/packages/spaces/test/unit/commands/info.unit.test.js
@@ -156,5 +156,4 @@ Created at:   ${now.toISOString()}
 `))
       .then(() => api.done())
   })
-
 })

--- a/packages/spaces/test/unit/commands/wait_test.unit.test.js
+++ b/packages/spaces/test/unit/commands/wait_test.unit.test.js
@@ -88,4 +88,35 @@ Created at:   ${now.toISOString()}
       .then(() => outbound.done())
       .then(() => api.done())
   })
+
+  it('not failing when nat is unavailable for space which is allocated', function () {
+    const sandbox = sinon.createSandbox()
+    const notifySpy = sandbox.spy(require('@heroku-cli/notifications'), 'notify')
+
+    let api = nock('https://api.heroku.com:443', {reqheaders: {'Accept-Expansion': 'region'}})
+      .get('/spaces/my-space')
+      .reply(200,
+        {shield: false, name: 'my-space', team: {name: 'my-team'}, region: {name: 'my-region', description: 'region'}, state: 'allocated', created_at: now},
+      )
+
+    let outbound = nock('https://api.heroku.com:443')
+      .get('/spaces/my-space/nat')
+      .reply(503,
+        {},
+      )
+
+    return cmd.run({flags: {space: 'my-space', interval: 0}})
+      .then(() => expect(cli.stdout).to.equal(`=== my-space
+Team:         my-team
+Region:       region
+State:        allocated
+Shield:       off
+Created at:   ${now.toISOString()}
+`))
+      .then(() => outbound.done())
+      .then(() => api.done())
+      .then(() => expect(notifySpy.called).to.be.true)
+      .then(() => expect(notifySpy.calledOnce).to.be.true)
+      .then(() => sandbox.restore())
+  })
 })


### PR DESCRIPTION


Currently for Next Gen Private spaces or when space/nat API call fails, the following spaces command fails without returning any data. This change would fix that , 


```
> heroku spaces:wait telemetry-kiran --json
Waiting for space telemetry-kiran to allocate... ⣟
 ▸    Could not complete the action. Please try again later.
 
 > heroku spaces:info telemetry-kiran
 ▸    Could not complete the action. Please try again later.
```

 
This is the new output 

```
https://github.com/heroku/cli/pull/2526/files
> ./bin/run spaces:wait telemetry-kiran
Waiting for space telemetry-kiran to allocate... ⡿
Waiting for space telemetry-kiran to allocate... done

=== telemetry-kiran
ID:           7d0187ca-814c-4fc2-89d8-c9ff25d4bf47
Team:         heroku-runtime-playground
Region:       Virginia, United States
CIDR:         10.0.0.0/16
Data CIDR:    10.1.0.0/16
State:        allocated
Shield:       off
Created at:   2023-10-16T17:59:03Z

> ./bin/run spaces:info telemetry-kiran
 ▸    Retrieving NAT details for the space failed with Error: Expected response to be successful, got 503
=== telemetry-kiran
ID:           7d0187ca-814c-4fc2-89d8-c9ff25d4bf47
Team:         heroku-runtime-playground
Region:       Virginia, United States
CIDR:         10.0.0.0/16
Data CIDR:    10.1.0.0/16
State:        allocated
Shield:       off
```

More discussion here : https://salesforce-internal.slack.com/archives/C04TH2ZQG72/p1698266446550449


