### PR TITLE
chore: add direwolf automation

### DIFF
--- a/.github/workflows/direwolf.yml
+++ b/.github/workflows/direwolf.yml
@@ -1,0 +1,60 @@
+name: Run CLI Direwolf Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseChannel:
+        type: choice
+        description: Channel to run the Direwolf tests against
+        required: true
+        options:
+        - stable
+        - beta
+        - alpha
+      direwolfEnvironment:
+        type: choice
+        description: Direwolf environment
+        required: false
+        options:
+        - production
+        - staging
+        default: staging
+
+  workflow_call:
+    inputs:
+      releaseChannel:
+        type: string
+        description: Channel to run the Direwolf tests against
+        required: true
+        default: stable
+      direwolfEnvironment:
+        type: string
+        description: Direwolf environment
+        required: false
+        default: staging
+
+jobs:
+  run-direwolf-tests:
+    name: Run Direwolf CLI tests
+    runs-on: pub-hk-ubuntu-22.04-small
+    timeout-minutes: 20
+    environment: direwolf
+    steps:
+    - name: set direwolf environment UUID
+      run: |
+        direwolf_UUID=${{ secrets.DIREWOLF_CLOUD_UUID_STAGING }}
+        if [[ ${{ inputs.direwolfEnvironment }} == 'production' ]]
+        then direwolf_UUID=${{ secrets.DIREWOLF_CLOUD_UUID_PRODUCTION }}
+        fi
+        echo "DIREWOLF_CLOUD_UUID=direwolf_UUID" >> $GITHUB_ENV
+    - uses: actions/checkout@v3
+    - name: Install jq
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y awscli jq
+    - name: run direwolf suite
+      run: ./scripts/direwolf-test-run
+      env:
+        HEROKU_CLI_VERSION: ${{ inputs.releaseChannel }}
+        DIREWOLF_TOKEN: ${{ secrets.DEV_TOOLING_DIREWOLF_TOKEN }}
+        DIREWOLF_CLOUD_UUID: ${{ env.DIREWOLF_CLOUD_UUID }}

--- a/scripts/direwolf-test-run
+++ b/scripts/direwolf-test-run
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DIREWOLF_SUITE="cli"
+
+# default CLI version is stable
+HEROKU_CLI_VERSION=${HEROKU_CLI_VERSION:="stable"}
+
+DIREWOLF_URL="https://$DIREWOLF_TOKEN@direwolf-api.herokai.com"
+
+POST_BODY=$(jq --null-input \
+  --arg cloud "$DIREWOLF_CLOUD_UUID" \
+  --arg suite "$DIREWOLF_SUITE" \
+  --arg env "$HEROKU_CLI_VERSION \
+  '{"cloud": { "id": $cloud}, "suite": { "label": $suite }, "env": { "HEROKU_CLI_VERSION": $env })
+
+echo "Enqueuing: $POST_BODY"
+ 
+RUN_INFO=$(curl -sf $DIREWOLF_URL/runs \
+               -H "Content-Type: application/json" \
+               -d "${POST_BODY}")
+
+RUN_ID=$(echo $RUN_INFO | jq -r '.id')
+RUN_URL="https://direwolf.herokai.com/dashboard?run=$RUN_ID"
+echo "Enqueued: $RUN_URL"
+
+echo -n "Running: ..."
+RUN_STATE="running"
+while [[ $RUN_STATE == "running" ]]; do
+  echo -n "."
+  RUN_INFO=$(curl -sf $DIREWOLF_URL/runs/$RUN_ID)
+  RUN_STATE=$(echo $RUN_INFO | jq -r '.state')
+  sleep 10
+done
+echo " done"
+echo "Result: $RUN_STATE"
+echo "Details:"
+curl -sf $DIREWOLF_URL/runs/$RUN_ID/results | \
+    jq -r '.[] | .state + "\t\t" + .class + ": " + .label' | \
+    sort
+
+[[ $RUN_STATE == "passed" ]] || exit 1

--- a/scripts/direwolf-test-run
+++ b/scripts/direwolf-test-run
@@ -12,8 +12,8 @@ DIREWOLF_URL="https://$DIREWOLF_TOKEN@direwolf-api.herokai.com"
 POST_BODY=$(jq --null-input \
   --arg cloud "$DIREWOLF_CLOUD_UUID" \
   --arg suite "$DIREWOLF_SUITE" \
-  --arg env "$HEROKU_CLI_VERSION \
-  '{"cloud": { "id": $cloud}, "suite": { "label": $suite }, "env": { "HEROKU_CLI_VERSION": $env })
+  --arg env "$HEROKU_CLI_VERSION" \
+  '{"cloud": { "id": $cloud }, "suite": { "label": $suite }, "env": { "HEROKU_CLI_VERSION": $env }}')
 
 echo "Enqueuing: $POST_BODY"
  


### PR DESCRIPTION
This is the first step in adding direwolf automation to our prerelease workflow. The github action will allow me to test running Direwolf from a github action. Once that is working I will submit a second PR to add a Direwolf test run to our prerelease workflow.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
