### PR TITLE
fix: remove any oclif manifests during release PR generation

### DIFF
--- a/scripts/create-release-pr
+++ b/scripts/create-release-pr
@@ -39,6 +39,9 @@ echo "Installing dependencies with yarn..."
 yarn
 echo "Done installing dependencies with yarn"
 
+# remove any oclif manifests. They interfere with doc generation
+rm -rf ./packages/*/oclif.manifest.json
+
 echo "Creating new CLI package(s) versions with yarn lerna version..."
 yarn lerna version \
   --allow-branch ${BRANCH_NAME} \


### PR DESCRIPTION
They interfere with doc generation and this should lead to less confusion going forward. 
See https://github.com/heroku/cli/pull/2534

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
