### PR TITLE
fix: set direwolf test to only run against production

### DIFF
--- a/.github/workflows/direwolf.yml
+++ b/.github/workflows/direwolf.yml
@@ -11,14 +11,6 @@ on:
         - stable
         - beta
         - alpha
-      direwolfEnvironment:
-        type: choice
-        description: Direwolf environment
-        required: false
-        options:
-        - production
-        - staging
-        default: staging
 
   workflow_call:
     inputs:
@@ -27,11 +19,6 @@ on:
         description: Channel to run the Direwolf tests against
         required: true
         default: stable
-      direwolfEnvironment:
-        type: string
-        description: Direwolf environment
-        required: false
-        default: staging
 
 jobs:
   run-direwolf-tests:
@@ -40,13 +27,6 @@ jobs:
     timeout-minutes: 20
     environment: direwolf
     steps:
-    - name: set direwolf environment UUID
-      run: |
-        direwolf_UUID=${{ secrets.DIREWOLF_CLOUD_UUID_STAGING }}
-        if [[ ${{ inputs.direwolfEnvironment }} == 'production' ]]
-        then direwolf_UUID=${{ secrets.DIREWOLF_CLOUD_UUID_PRODUCTION }}
-        fi
-        echo "DIREWOLF_CLOUD_UUID=direwolf_UUID" >> $GITHUB_ENV
     - uses: actions/checkout@v3
     - name: Install jq
       run: |
@@ -57,4 +37,4 @@ jobs:
       env:
         HEROKU_CLI_VERSION: ${{ inputs.releaseChannel }}
         DIREWOLF_TOKEN: ${{ secrets.DEV_TOOLING_DIREWOLF_TOKEN }}
-        DIREWOLF_CLOUD_UUID: ${{ env.DIREWOLF_CLOUD_UUID }}
+        DIREWOLF_CLOUD_UUID: ${{ secrets.DIREWOLF_CLOUD_UUID_PRODUCTION }}


### PR DESCRIPTION
Since we would only want to run our direwolf tests against the staging environment very rarely, this PR removes that option from the workflow to simplify things a bit and get them working. We can add this feature back in the future if we feel like it is necessary.

Successful run here: https://github.com/heroku/cli/actions/runs/6789787983/job/18457763652

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
