### PR TITLE
chore: add direwolf test run to prerelease workflow

### DIFF
--- a/.github/workflows/start-prerelease.yml
+++ b/.github/workflows/start-prerelease.yml
@@ -61,8 +61,15 @@ jobs:
       isStableCandidate: ${{ false }}
 
   prerelease-smoke-tests:
-    needs: [ create-prerelease ]
+    needs: [ get-version-channel, create-prerelease ]
     uses: ./.github/workflows/test-installed-cli.yml
     secrets: inherit
     with:
       version: ${{ needs.get-version-channel.outputs.version }}
+
+  prerelease-direwolf-tests:
+    needs: [ get-version-channel, create-prerelease ]
+    uses: ./.github/workflows/direwolf.yml
+    secrets: inherit
+    with:
+      releaseChannel: ${{ needs.get-version-channel.outputs.channel }}


### PR DESCRIPTION
Adds a job to the prerelease workflow to kick off a Direwolf test run.

[work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001bPvgjYAC/view)

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
