### PR TITLE
v5 codemod: find non-module.exports command definitions and migrate

### DIFF
--- a/scripts/migration/src/getCommandDeclaration.ts
+++ b/scripts/migration/src/getCommandDeclaration.ts
@@ -1,5 +1,6 @@
 import ts from 'typescript'
-import {isModuleExportsObject} from './node-validators/isModuleExportsObject'
+import {isModuleExportsObject} from './node-validators/isModuleExportsObject.js'
+import {isCommandDeclaration} from './node-validators/isCommandDeclaration.js'
 
 /**
  * Finds command declaration and returns it if found
@@ -10,16 +11,11 @@ import {isModuleExportsObject} from './node-validators/isModuleExportsObject'
 
 export function getCommandDeclaration(sourceFile: ts.SourceFile): undefined | ts.ObjectLiteralExpression {
   for (const node of sourceFile.statements) {
-    if (
-      ts.isVariableStatement(node) &&
-      ts.isObjectLiteralExpression(node.declarationList.declarations[0].initializer)
-    ) {
-      for (const prop of  node.declarationList.declarations[0].initializer.properties) {
-        if (ts.isIdentifier(prop.name) && prop.name.escapedText === 'run') {
-          return node.declarationList.declarations[0].initializer
-        }
-      }
-    } else if (ts.isExpressionStatement(node) && isModuleExportsObject(node.expression)) {
+    if (isCommandDeclaration(node)) {
+      return node.declarationList.declarations[0].initializer
+    }
+
+    if (ts.isExpressionStatement(node) && isModuleExportsObject(node.expression)) {
       return node.expression.right
     }
   }

--- a/scripts/migration/src/getCommandDeclaration.ts
+++ b/scripts/migration/src/getCommandDeclaration.ts
@@ -1,0 +1,27 @@
+import ts from 'typescript'
+import {isModuleExportsObject} from './node-validators/isModuleExportsObject'
+
+/**
+ * Finds command declaration and returns it if found
+ *
+ * @param sourceFile
+ * @returns undefined | ts.ObjectLiteralExpression
+ */
+
+export function getCommandDeclaration(sourceFile: ts.SourceFile): undefined | ts.ObjectLiteralExpression {
+  for (const node of sourceFile.statements) {
+    if (
+      ts.isVariableStatement(node) &&
+      ts.isObjectLiteralExpression(node.declarationList.declarations[0].initializer)
+    ) {
+      for (const prop of  node.declarationList.declarations[0].initializer.properties) {
+        if (ts.isIdentifier(prop.name) && prop.name.escapedText === 'run') {
+          return node.declarationList.declarations[0].initializer
+        }
+      }
+    } else if (ts.isExpressionStatement(node) && isModuleExportsObject(node.expression)) {
+      return node.expression.right
+    }
+  }
+}
+

--- a/scripts/migration/src/index.ts
+++ b/scripts/migration/src/index.ts
@@ -7,11 +7,13 @@ import {ESLint} from 'eslint'
 
 import {createClassElementsFromModuleExports} from './createClassElementFromModuleExports.js'
 import {createCommandClass} from './createCommandClass.js'
-import {isModuleExports} from './node-validators/isModuleExports.js'
+import {isModuleExportsObject} from './node-validators/isModuleExportsObject.js'
 import {isRunFunctionDecl} from './node-validators/isRunFunctionDecl.js'
 import {nullTransformationContext} from './nullTransformationContext.js'
 import {isMigrationCandidate} from './node-validators/isMigrationCandidate.js'
 import {isExtendedCommandClassDeclaration} from './node-validators/isExtendedCommandClassDeclaration.js'
+import {isModuleExportsArray} from './node-validators/isModuleExportsArray'
+import {getCommandDeclaration} from './getCommandDeclaration'
 
 const commonImports = `import {createRequire} from 'node:module'
 import color from '@heroku-cli/color'
@@ -46,7 +48,7 @@ export class CommandMigrationFactory {
         }
 
         ast = this.migrateRunFunctionDecl(ast, file)
-        ast = this.migrateModuleExports(ast)
+        ast = this.migrateCommandDeclaration(ast)
         ast = this.updateOrRemoveStatements(ast)
         const sourceFile = ts.createSourceFile(path.basename(file), '', ts.ScriptTarget.Latest, false, ts.ScriptKind.TS)
         const sourceStr = commonImports + this.printer.printList(ts.ListFormat.MultiLine, ast.statements, sourceFile)
@@ -72,18 +74,10 @@ export class CommandMigrationFactory {
       return ts.visitEachChild(node, visitor, nullTransformationContext)
     }
 
-    private migrateModuleExports(sourceFile: ts.SourceFile): ts.SourceFile {
-      let staticClassMembers: ts.PropertyDeclaration[]
-      const visitor = (node: ts.Node): ts.Node => {
-        if (isModuleExports(node)) {
-          staticClassMembers = createClassElementsFromModuleExports(node.right)
-        }
-
-        return ts.visitEachChild(node, visitor, nullTransformationContext)
-      }
-
-      sourceFile = ts.visitEachChild(sourceFile, visitor, nullTransformationContext)
-      if (staticClassMembers) {
+    private migrateCommandDeclaration(sourceFile: ts.SourceFile): ts.SourceFile {
+      const command = getCommandDeclaration(sourceFile)
+      if (command) {
+        const staticClassMembers = createClassElementsFromModuleExports(command)
         const updateClassDef = (node: ts.Node): ts.Node => {
           if (isExtendedCommandClassDeclaration(node)) {
             return ts.factory.updateClassDeclaration(
@@ -113,7 +107,7 @@ export class CommandMigrationFactory {
         }
 
         // module.exports
-        if (ts.isExpressionStatement(node) && isModuleExports(node.expression)) {
+        if (ts.isExpressionStatement(node) && (isModuleExportsObject(node.expression) || isModuleExportsArray(node.expression))) {
           return null
         }
 

--- a/scripts/migration/src/node-validators/isCommandDeclaration.ts
+++ b/scripts/migration/src/node-validators/isCommandDeclaration.ts
@@ -1,0 +1,27 @@
+import ts from 'typescript'
+
+type CommandDeclaration = ts.VariableStatement & {
+  declarationList: ts.VariableDeclarationList & {
+    declarations: (ts.Declaration & {
+      initializer: ts.ObjectLiteralExpression
+    })[]
+  }
+}
+
+export const isCommandDeclaration = (node: ts.Node): node is CommandDeclaration => {
+  if (
+    ts.isVariableStatement(node) &&
+    // only look at first declaration. Ignore multiple declarations cases like:
+    // let a, b, c, d;
+    node.declarationList.declarations[0]?.initializer &&
+    ts.isObjectLiteralExpression(node.declarationList.declarations[0].initializer)
+  ) {
+    for (const prop of  node.declarationList.declarations[0].initializer.properties) {
+      if (ts.isIdentifier(prop.name) && prop.name.escapedText === 'run') {
+        return true
+      }
+    }
+  }
+
+  return false
+}

--- a/scripts/migration/src/node-validators/isModuleExportsArray.ts
+++ b/scripts/migration/src/node-validators/isModuleExportsArray.ts
@@ -1,0 +1,23 @@
+import ts from 'typescript'
+
+/**
+ * Determines if the specified node is a 'module.exports = []' binary expression.
+ * This verification also determines if the right hand expression
+ * is an array.
+ *
+ * @param node The node to evaluate
+ * @returns boolean if the node is a module.exports = []
+ */
+
+export function isModuleExportsArray(node: ts.Node): node is (ts.Node & {right: ts.ArrayLiteralExpression}) {
+  return ts.isBinaryExpression(node) &&
+
+    ts.isPropertyAccessExpression(node.left) &&
+    ts.isIdentifier(node.left.name) &&
+    node.left.name.escapedText === 'exports' &&
+    ts.isArrayLiteralExpression(node.right) &&
+
+    ts.isIdentifier(node.left.expression) &&
+    node.left.expression.escapedText === 'module'
+}
+

--- a/scripts/migration/src/node-validators/isModuleExportsObject.ts
+++ b/scripts/migration/src/node-validators/isModuleExportsObject.ts
@@ -9,7 +9,7 @@ import ts from 'typescript'
  * @returns boolean if the node is a module.exports
  */
 
-export function isModuleExports(node: ts.Node): node is (ts.Node & {right: ts.ObjectLiteralExpression}) {
+export function isModuleExportsObject(node: ts.Node): node is (ts.Node & {right: ts.ObjectLiteralExpression}) {
   return ts.isBinaryExpression(node) &&
 
         ts.isPropertyAccessExpression(node.left) &&
@@ -18,7 +18,6 @@ export function isModuleExports(node: ts.Node): node is (ts.Node & {right: ts.Ob
         ts.isObjectLiteralExpression(node.right) &&
 
         ts.isIdentifier(node.left.expression) &&
-        node.left.expression.escapedText === 'module' &&
-        ts.isObjectLiteralExpression(node.right)
+        node.left.expression.escapedText === 'module'
 }
 


### PR DESCRIPTION
Find, migrate and remove command definitions when they are not in module.exports. 
case:
```
let cmd = {
  topic: 'addons',
  description: 'change add-on plan',
  help: `See available plans with \`heroku addons:plans SERVICE\`.

Note that \`heroku addons:upgrade\` and \`heroku addons:downgrade\` are the same.
Either one can be used to change an add-on plan up or down.

https://devcenter.heroku.com/articles/managing-add-ons`,
  examples: [
    `Upgrade an add-on by service name:
$ heroku addons:upgrade heroku-redis:premium-2

Upgrade a specific add-on:
$ heroku addons:upgrade swimming-briskly-123 heroku-redis:premium-2`,
  ],
  needsAuth: true,
  wantsApp: true,
  args: [{name: 'addon'}, {name: 'plan', optional: true}],
  run: cli.command({preauth: true}, run),
}
```

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
