### PR TITLE
chore: add windows pack, upload, and promote scripts to workflows

### DIFF
--- a/.github/workflows/pack-upload.yml
+++ b/.github/workflows/pack-upload.yml
@@ -104,3 +104,26 @@ jobs:
           pwd
           yarn oclif upload tarballs
           ./scripts/upload/deb
+
+  pack-and-upload-windows:
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+          cache: yarn
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@41775cf0c82ef066f1eb39cea1bd74697ca5b735
+      - name: Install NSIS
+        run: brew install nsis
+      - name: yarn install
+        run: yarn --immutable --network-timeout 1000000
+      - name: pack windows installer
+        run: yarn pack:win
+      - name: upload windows installer
+        run: yarn upload:win

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -60,6 +60,7 @@ jobs:
         run: |
           SHA=$(npm view heroku@${{ inputs.version }} --json | jq -r '.gitHead[0:7]')
           yarn oclif promote --deb --xz --root="./packages/cli" --sha="$SHA" --indexes --version=${{ inputs.version }} --channel=${{ fromJSON(inputs.isStableRelease) && 'stable' || env.prerelease-channel }}
+          yarn oclif promote --win --xz --root="./packages/cli" --sha="$SHA" --indexes --version=${{ inputs.version }} --channel=${{ fromJson(inputs.isStableRelease) && 'stable' || env.prerelease-channel }}
         shell: bash
       - name: promote Linux install scripts
         run: node ./scripts/postrelease/install_scripts.js

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -323,20 +323,25 @@
       "heroku-sudo": "@heroku/sudo",
       "heroku-webhooks": null,
       "sudo": "@heroku/sudo"
+    },
+    "windows": {
+      "name": "Heroku CLI"
     }
   },
   "repository": "heroku/cli",
   "scripts": {
-    "lint": "eslint . --ext .ts --config ../../.eslintrc --ignore-path ../../.eslintignore-lib",
     "build": "rm -rf lib && tsc",
+    "lint": "eslint . --ext .ts --config ../../.eslintrc --ignore-path ../../.eslintignore-lib",
+    "pack:win": "oclif pack:win --defender-exclusion hidden",
     "postpublish": "rm -f oclif.manifest.json",
+    "posttest": "yarn lint",
     "prepack": "yarn run build && oclif manifest",
     "pretest": "tsc -p test --noEmit && cd ../.. && yarn build",
-    "test": "yarn pretest && nyc mocha --forbid-only \"test/**/*.unit.test.ts\" && yarn posttest",
     "test:acceptance": "yarn pretest && mocha --forbid-only \"test/**/*.acceptance.test.ts\" && node ./bin/bats-test-runner",
     "test:integration": "yarn pretest && mocha --forbid-only \"test/**/*.integration.test.ts\"",
     "test:smoke": "yarn pretest && mocha --forbid-only \"test/**/smoke.acceptance.test.ts\"",
-    "posttest": "yarn lint",
+    "test": "yarn pretest && nyc mocha --forbid-only \"test/**/*.unit.test.ts\" && yarn posttest",
+    "upload:win": "oclif upload:win",
     "version": "oclif readme --multi && git add README.md ../../docs"
   },
   "types": "lib/index.d.ts"


### PR DESCRIPTION
[Work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001elI32YAE/view)

Adds steps to pack and upload the windows installer to s3 and then promote it to the current release.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
