### PR TITLE
chore: add workflow to upload windows installer to stampy

### DIFF
--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -30,6 +30,24 @@ jobs:
         uses: ./.github/actions/get-version-and-channel/
         with:
           path: './packages/cli/package.json'
+  
+  get-release-sha:
+    needs: [get-version-channel]
+    runs-on: ubuntu-latest
+    outputs:
+      release-sha: ${{ steps.getSha.outputs.SHA }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: yarn
+      - name: get release sha
+        id: getSha
+        run: |
+          SHA=$(npm view heroku@${{ needs.get-version-channel.outputs.version }} --json | jq -r '.gitHead[0:7]')
+          echo $SHA >> $GITHUB_OUTPUT
 
   publish-npm:
     needs: [get-version-channel]
@@ -55,3 +73,11 @@ jobs:
       isStableRelease: ${{ fromJSON(needs.get-version-channel.outputs.isStableRelease) }}
       channel: ${{ needs.get-version-channel.outputs.channel }}
     secrets: inherit
+  
+  upload-to-stampy:
+    needs: [get-version-channel, get-release-sha, promote]
+    name: Upload windows installer to Stampy
+    uses: "./.github/workflows/stampy-upload.yml"
+    with:
+      sha: ${{ needs.get-release-sha.outputs.release-sha }}
+      version: ${{ needs.get-version-channel.outputs.version }}

--- a/.github/workflows/stampy-upload.yml
+++ b/.github/workflows/stampy-upload.yml
@@ -1,0 +1,43 @@
+on:
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        required: true
+        description: version for upload. Do not include the 'v'.
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: get sha
+        id: get-sha
+      # need sha
+      - name: save filename (without arch/extension) for reuse
+        id: filename
+        run: echo "FILEBASE=heroku-v${{inputs.version}}-${{steps.get-sha.sha}}" >> "$GITHUB_OUTPUT"
+      - name: download from s3
+        env:
+          # workaround for AWS CLI not having its region set.  see https://github.com/actions/runner-images/issues/2791
+          AWS_EC2_METADATA_DISABLED: true
+          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+        run: |
+          aws s3 cp s3://dfc-data-production/media/salesforce-cli/heroku/versions/${{inputs.version}}/${{steps.get-sha.sha}}/${{steps.filename.outputs.FILEBASE}}-x86.exe .
+          aws s3 cp s3://dfc-data-production/media/salesforce-cli/heroku/versions/${{inputs.version}}/${{steps.get-sha.sha}}/${{steps.filename.outputs.FILEBASE}}-x64.exe .
+      - name: upload to unsigned bucket
+        env:
+          STAMPY_ARN: ${{ secrets.STAMPY_ARN }}
+          STAMPY_UNSIGNED_BUCKET: ${{ secrets.STAMPY_UNSIGNED_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+          AWS_EC2_METADATA_DISABLED: true
+        # switch AWS identity to the one that can access stampy
+        run: |
+          ACCOUNT_ID=$(aws sts get-caller-identity | jq -r '.Account')
+          TEMP_ROLE=$(aws sts assume-role --role-arn $STAMPY_ARN --role-session-name artifact-signing)
+          export AWS_ACCESS_KEY_ID=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.AccessKeyId')
+          export AWS_SECRET_ACCESS_KEY=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SecretAccessKey')
+          export AWS_SESSION_TOKEN=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SessionToken')
+          aws s3 cp ${{steps.filename.outputs.FILEBASE}}-x86.exe $STAMPY_UNSIGNED_BUCKET/${{steps.filename.outputs.FILEBASE}}-x86.exe
+          aws s3 cp ${{steps.filename.outputs.FILEBASE}}-x64.exe $STAMPY_UNSIGNED_BUCKET/${{steps.filename.outputs.FILEBASE}}-x64.exe

--- a/.github/workflows/stampy-upload.yml
+++ b/.github/workflows/stampy-upload.yml
@@ -5,17 +5,18 @@ on:
         type: string
         required: true
         description: version for upload. Do not include the 'v'.
+      sha:
+        type: string
+        required: true
+        description: release sha
 
 jobs:
   upload:
     runs-on: ubuntu-latest
     steps:
-      - name: get sha
-        id: get-sha
-      # need sha
       - name: save filename (without arch/extension) for reuse
         id: filename
-        run: echo "FILEBASE=heroku-v${{inputs.version}}-${{steps.get-sha.sha}}" >> "$GITHUB_OUTPUT"
+        run: echo "FILEBASE=heroku-v${{inputs.version}}-${{inputs.sha}}" >> "$GITHUB_OUTPUT"
       - name: download from s3
         env:
           # workaround for AWS CLI not having its region set.  see https://github.com/actions/runner-images/issues/2791
@@ -23,8 +24,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
           AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
         run: |
-          aws s3 cp s3://dfc-data-production/media/salesforce-cli/heroku/versions/${{inputs.version}}/${{steps.get-sha.sha}}/${{steps.filename.outputs.FILEBASE}}-x86.exe .
-          aws s3 cp s3://dfc-data-production/media/salesforce-cli/heroku/versions/${{inputs.version}}/${{steps.get-sha.sha}}/${{steps.filename.outputs.FILEBASE}}-x64.exe .
+          aws s3 cp s3://dfc-data-production/media/salesforce-cli/heroku/versions/${{inputs.version}}/${{inputs.sha}}/${{steps.filename.outputs.FILEBASE}}-x86.exe .
+          aws s3 cp s3://dfc-data-production/media/salesforce-cli/heroku/versions/${{inputs.version}}/${{inputs.sha}}/${{steps.filename.outputs.FILEBASE}}-x64.exe .
       - name: upload to unsigned bucket
         env:
           STAMPY_ARN: ${{ secrets.STAMPY_ARN }}


### PR DESCRIPTION
[Work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001elgflYAA/view)

Adds a workflow for uploading the windows installer to Stampy for signing.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
