### PR TITLE
feat: add `publish-to-fig-autocomplete.yml` action

### DIFF
--- a/.github/workflows/publish-to-fig-autocomplete.yml
+++ b/.github/workflows/publish-to-fig-autocomplete.yml
@@ -1,0 +1,37 @@
+name: Publish to fig autocomplete
+
+on:
+  workflow_call:
+  workflow_dispatch:
+    input:
+      notUsed:
+        type: string
+        description: Run this workflow from a "release-*" branch. This input does nothing.
+        required: false
+
+jobs:
+  push-to-fig-autocomplete:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: yarn
+      - run: yarn --immutable --network-timeout 1000000
+      - name: Install Fig Oclif Plugin
+        run: ./bin/run plugins:install @fig/oclif-complete@2
+      - name: Generate Fig Spec
+        run: ./bin/run generate-fig-spec > spec.ts
+      - name: Get heroku version
+        id: cli-version
+        run: echo "version=$(./bin/run --version | sed -rn 's/^heroku\/([0-9\.]+).*$/\1/p')" >> $GITHUB_OUTPUT
+      - name: Create Fig Autocomplete PR
+        uses: withfig/push-to-fig-autocomplete-action@v1
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          autocomplete-spec-name: 'heroku'
+          spec-path: spec.ts
+          integration: oclif
+          diff-based-versioning: true
+          new-spec-version: ${{ steps.cli-version.outputs.version }}


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

This adds the `@fig/complete-oclif` plugin which generates a [Fig autocomplete spec](https://github.com/withfig/autocomplete) which is used for autocomplete in [Amazon CodeWhisperer for command line](https://aws.amazon.com/blogs/devops/introducing-amazon-codewhisperer-for-command-line/)

CC @brendanfalk