### PR TITLE
v5 command codemods

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "test": "lerna run test --concurrency 4",
     "version": "cp packages/cli/CHANGELOG.md CHANGELOG.md && git add CHANGELOG.md",
     "cleanNodeModules": "rm -rf ./packages/*/node_modules && rm -rf ./node_modules && rm -rf ./.yarn/cache",
-    "migrateCommand": "lerna run --scope=command-migration build && node ./packages/migration/.bin/command-migration.mjs --files"
+    "migrateCommand": "lerna run --scope=command-migration build && node ./packages/migration/.bin/command-migration.mjs --files",
+    "migrateCommandTest": "lerna run --scope=command-migration build && node ./packages/migration/.bin/ommand-test-migration.mjs --files"
   },
   "workspaces": {
     "packages": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -67,6 +67,7 @@
     "semver": "5.6.0",
     "shell-escape": "^0.2.0",
     "shell-quote": "^1.6.1",
+    "stdout-stderr": "^0.1.13",
     "strftime": "^0.10.0",
     "strip-ansi": "^6",
     "tmp": "^0.0.33",

--- a/packages/cli/src/commands/apps/create.ts
+++ b/packages/cli/src/commands/apps/create.ts
@@ -195,7 +195,7 @@ $ heroku apps:create --region eu`,
   ]
 
   static args = {
-    apps: Args.string({description: 'name of app to create', required: false}),
+    app: Args.string({description: 'name of app to create', required: false}),
   }
 
   static flags = {

--- a/packages/cli/test/helpers/runCommand.ts
+++ b/packages/cli/test/helpers/runCommand.ts
@@ -1,0 +1,13 @@
+import {getConfig} from './testInstances'
+import {Command} from '@heroku-cli/command'
+import {Config} from '@oclif/core'
+
+type CmdConstructor<T extends Command = Command> = new(args: string[], config: Config) => T
+
+const runCommand = (Cmd: CmdConstructor, args: string[]) => {
+  const instance = new Cmd(args, getConfig())
+
+  return instance.run()
+}
+
+export default runCommand

--- a/packages/migration/.bin/command-test-migration.mjs
+++ b/packages/migration/.bin/command-test-migration.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { CommandMigrationFactory } from '../lib/index.js';
+import { CommandTestMigrationFactory } from '../lib/index.js';
 import { globSync } from 'glob';
 import yargs from 'yargs';
 import {hideBin} from 'yargs/helpers';
@@ -16,7 +16,7 @@ const files = filesParts.reduce((acc, filePath) => (
   [...acc, ...globSync(filePath).map(file => file.replace("/", path.sep))]
 ), []);
 
-const commandMigrationFactory = new CommandMigrationFactory(
+const commandMigrationFactory = new CommandTestMigrationFactory(
   files,
   {
     moduleResolution: ts.ModuleResolutionKind.Node10,

--- a/packages/migration/.eslintrc
+++ b/packages/migration/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "extends": "../../.eslintrc",
+  "rules": {
+    "newline-per-chained-call": ["error", { "ignoreChainWithDepth": 1 }]
+  }
+}

--- a/packages/migration/package.json
+++ b/packages/migration/package.json
@@ -4,6 +4,7 @@
     "dependencies": {
         "eslint": "8.53.0",
         "glob": "10.3.10",
+        "lodash": "^4.17.11",
         "pascalcase": "2.0.0",
         "typescript": "5.2.2",
         "yargs": "17.7.2"

--- a/packages/migration/src/node-validators/isCommandMigrationCandidate.ts
+++ b/packages/migration/src/node-validators/isCommandMigrationCandidate.ts
@@ -1,7 +1,7 @@
 import {isRunFunctionDecl} from './isRunFunctionDecl.js'
 import ts from 'typescript'
 
-export function isMigrationCandidate(sourceFile: ts.SourceFile): boolean {
+export function isCommandMigrationCandidate(sourceFile: ts.SourceFile): boolean {
   // todo: handle run in module.exports case. example: packages/redis-v5/commands/info.js
   return sourceFile.statements.some(stmt => isRunFunctionDecl(stmt))
 }

--- a/packages/migration/src/transforms/heroku-cli-utils/helpers.ts
+++ b/packages/migration/src/transforms/heroku-cli-utils/helpers.ts
@@ -110,6 +110,7 @@ export const transformColors = (args: SharedArgs) => {
 export const transformActionFuncs = (args: SharedArgs) => {
   const {callEx, propertyAccessChain, utilVarName, showWarning} = args
   const [, secondPropAccess] = propertyAccessChain
+
   if (propertyAccessChain.length === 2) {
     switch (secondPropAccess) {
     case 'status':

--- a/packages/migration/src/transforms/heroku-cli-utils/transformCliUtils.ts
+++ b/packages/migration/src/transforms/heroku-cli-utils/transformCliUtils.ts
@@ -34,10 +34,6 @@ const transformCliUtils = (node: ts.Node, utilVarName: string, file: string) => 
     case 'styledJSON':
     case 'action': // cli.action() && cli.action.start() appear to be the same
     case 'error': // ???
-      if (callName === 'action') {
-        debugger
-      }
-
       return subWithUx(node, utilVarName)
     case 'exit':
       return transformExit(node, utilVarName)

--- a/packages/migration/src/transforms/heroku-cli-utils/transformCliUtils.ts
+++ b/packages/migration/src/transforms/heroku-cli-utils/transformCliUtils.ts
@@ -32,7 +32,12 @@ const transformCliUtils = (node: ts.Node, utilVarName: string, file: string) => 
     case 'styledHeader':
     case 'styledObject':
     case 'styledJSON':
+    case 'action': // cli.action() && cli.action.start() appear to be the same
     case 'error': // ???
+      if (callName === 'action') {
+        debugger
+      }
+
       return subWithUx(node, utilVarName)
     case 'exit':
       return transformExit(node, utilVarName)

--- a/packages/migration/src/transforms/unit-tests/index.ts
+++ b/packages/migration/src/transforms/unit-tests/index.ts
@@ -1,0 +1,30 @@
+import ts from 'typescript'
+import {transformRootDescribe, transformRuns} from './migrations.js'
+import {isTestDescribeOrContextCall} from './validators.js'
+
+const {factory} = ts
+
+export const migrateTestFile = (sourceFile: ts.SourceFile) => {
+  let describeFound = false
+  const updatedStatements = [...sourceFile.statements]
+    .map(statement => {
+      if (isTestDescribeOrContextCall(statement)) {
+        //   update source file with updated beforeEach, then run on everything else in the block
+        describeFound = true
+        return transformRootDescribe(statement)
+      }
+
+      return statement
+    })
+    .map(transformRuns)
+
+  if (!describeFound) {
+    throw new Error('no describe block found')
+  }
+
+  return factory.updateSourceFile(
+    sourceFile,
+    updatedStatements,
+  )
+}
+

--- a/packages/migration/src/transforms/unit-tests/migrations.ts
+++ b/packages/migration/src/transforms/unit-tests/migrations.ts
@@ -1,0 +1,218 @@
+import ts from 'typescript'
+import {nullTransformationContext} from '../../nullTransformationContext.js'
+import {
+  BeforeEachCall,
+  isBeforeEachBlock,
+  TestFunctionCall,
+} from './validators.js'
+
+const {factory} = ts
+
+const createConsoleMockStart = (std: 'stdout' | 'stderr') => factory.createExpressionStatement(
+  factory.createCallExpression(
+    factory.createPropertyAccessExpression(
+      factory.createIdentifier(std),
+      factory.createIdentifier('start'),
+    ),
+    undefined,
+    [],
+  ),
+)
+
+const createBeforeEachWithConsoleMock = (additionalStatements: ts.Statement[] = []) => factory.createExpressionStatement(
+  factory.createCallExpression(
+    factory.createIdentifier('beforeEach'),
+    undefined,
+    [
+      factory.createArrowFunction(
+        undefined,
+        undefined,
+        [],
+        undefined,
+        factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+        factory.createBlock(
+          [
+            ...additionalStatements,
+            createConsoleMockStart('stdout'),
+            createConsoleMockStart('stderr'),
+          ],
+          true,
+        ),
+      ),
+    ],
+  ),
+)
+
+const transformBeforeEach = (statement: BeforeEachCall): ts.ExpressionStatement => {
+  let existingExpressions: ts.Statement[] = []
+  // if function has a block, add to it, if not, get the call, wrap it in ExpressionStatement and added needed expressions
+  if (ts.isBlock(statement.expression.arguments[0].body)) {
+    existingExpressions = [...statement.expression.arguments[0].body.statements]
+  } else if (ts.isCallExpression(statement.expression.arguments[0].body)) {
+    existingExpressions = [factory.createExpressionStatement(statement.expression.arguments[0].body)]
+  } else {
+    throw new Error('transformBeforeEach: unexpected pattern')
+  }
+
+  return createBeforeEachWithConsoleMock(existingExpressions)
+}
+
+export const transformRuns = (node: ts.ExpressionStatement) => {
+  const visitor = (vNode: ts.Node): ts.Node => {
+    if (
+      ts.isCallExpression(vNode) &&
+      ts.isPropertyAccessExpression(vNode.expression) &&
+      ts.isIdentifier(vNode.expression.name) &&
+      vNode.expression.name.escapedText.toString() === 'run' &&
+      vNode.arguments[0] &&
+      ts.isObjectLiteralExpression(vNode.arguments[0])
+    ) {
+      const runArr = migrateCommandRun(vNode.arguments[0])
+
+      return factory.createCallExpression(
+        factory.createIdentifier('runCommand'),
+        undefined,
+        [
+          factory.createIdentifier('Cmd'),
+          factory.createArrayLiteralExpression(
+            runArr,
+            true,
+          ),
+        ],
+      )
+    }
+
+    return ts.visitEachChild(vNode, visitor, nullTransformationContext)
+  }
+
+  return ts.visitEachChild(node, visitor, nullTransformationContext)
+}
+
+export const transformRootDescribe = (statement: TestFunctionCall): ts.ExpressionStatement  => {
+  let beforeEachFound = false
+  let transformedStatements = [...statement.expression.arguments[1].body.statements]
+    .map(describeBodyStatement => {
+      if (isBeforeEachBlock(describeBodyStatement)) {
+        beforeEachFound = true
+        return transformBeforeEach(describeBodyStatement)
+      }
+
+      return describeBodyStatement
+    })
+
+  if (!beforeEachFound) {
+    // add the beforeEach as first statement of describe
+    transformedStatements = [createBeforeEachWithConsoleMock(), ...transformedStatements]
+  }
+
+  return factory.createExpressionStatement(
+    factory.createCallExpression(
+      factory.createIdentifier('describe'),
+      undefined,
+      [
+        statement.expression.arguments[0],
+        factory.createArrowFunction(
+          undefined,
+          undefined,
+          [],
+          undefined,
+          factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+          factory.createBlock(
+            transformedStatements,
+            true,
+          ),
+        ),
+      ],
+    ),
+  )
+}
+
+export const migrateCommandRun = (runArgs: ts.ObjectLiteralExpression): ts.Expression[] => {
+  const transformedCommand: ts.Expression[] = []
+  // args handled separately because they sometimes need to be the last values added to .command(string[])
+  const transformedArgs: ts.Expression[] = []
+  for (const prop of runArgs.properties) {
+    if (!ts.isIdentifier(prop.name)) {
+      // this should never happen
+      throw new Error('unexpected migrateCommandRun input')
+    }
+
+    const isShorthand = ts.isShorthandPropertyAssignment(prop)
+    const isLongHand = ts.isPropertyAssignment(prop)
+
+    if (!(isShorthand || isLongHand)) {
+      continue
+    }
+
+    // check ShorthandPropertyAssignment vs PropertyAssignment
+    switch (prop.name.escapedText.toString()) {
+    case 'app': {
+      if (isShorthand) {
+        transformedCommand.push(factory.createStringLiteral('--app'), prop.name)
+      } else {
+        transformedCommand.push(factory.createStringLiteral('--app'), prop.initializer)
+      }
+
+      break
+    }
+
+    case 'flags': {
+      if (!isLongHand || !ts.isObjectLiteralExpression(prop.initializer)) {
+        // todo: could spread and transform, but will be a nightmare to create via TS
+        console.error('can not transform command.run({flags})) shorthand property assignment')
+        break
+      }
+
+      for (const flagProp of prop.initializer.properties) {
+        if (!ts.isIdentifier(flagProp.name)) {
+          continue
+        }
+
+        if (ts.isShorthandPropertyAssignment(flagProp)) {
+          transformedCommand.push(factory.createStringLiteral(`--${flagProp.name.escapedText.toString()}`), flagProp.name)
+        } else if (ts.isPropertyAssignment(flagProp)) {
+          if (flagProp.initializer.kind === ts.SyntaxKind.FalseKeyword) {
+            // filter out args when value false.
+            break
+          }
+
+          transformedCommand.push(factory.createStringLiteral(`--${flagProp.name.escapedText.toString()}`))
+          if (flagProp.initializer.kind !== ts.SyntaxKind.TrueKeyword) {
+            transformedCommand.push(flagProp.initializer)
+          }
+        } else {
+          console.error('deeply nested issue in migrateCommandRun')
+        }
+      }
+
+      break
+    }
+
+    case 'args': {
+      if (isLongHand && ts.isArrayLiteralExpression(prop.initializer)) {
+        // it's already an array, just spread what is in there
+        transformedArgs.push(...prop.initializer.elements)
+      } else if (isShorthand) {
+        transformedArgs.push(factory.createSpreadElement(prop.name))
+      }  else if (ts.isObjectLiteralExpression(prop.initializer)) {
+        for (const argProp of prop.initializer.properties) {
+          if (!ts.isIdentifier(argProp.name)) {
+            continue
+          }
+
+          if (ts.isShorthandPropertyAssignment(argProp)) {
+            transformedCommand.push(argProp.name)
+          } else if (ts.isPropertyAssignment(argProp)) {
+            transformedCommand.push(argProp.initializer)
+          }
+        }
+      } else {
+        console.error('can not map command.run({args}))')
+      }
+    }
+
+      // args need to come last due to `static strict false` argv handling
+      return [...transformedCommand, ...transformedArgs]
+    }
+  }
+}

--- a/packages/migration/src/transforms/unit-tests/validators.ts
+++ b/packages/migration/src/transforms/unit-tests/validators.ts
@@ -1,0 +1,37 @@
+import ts from 'typescript'
+
+// matches describe(), context(), it() calls
+export type TestFunctionCall = ts.ExpressionStatement & {
+  expression:  ts.CallExpression & {
+    expression: ts.Identifier
+    arguments: [ts.StringLiteral, ts.FunctionLikeDeclaration & {body: ts.Block}]
+  }
+}
+
+export type BeforeEachCall = ts.ExpressionStatement & {
+  expression: ts.CallExpression & {
+    expression: ts.Identifier & {
+      escapedText: 'beforeEach'
+    }
+    arguments: [ts.FunctionLikeDeclaration & {body: ts.Block}]
+  }
+}
+
+export const isTestDescribeOrContextCall = (node: ts.Node): node is TestFunctionCall => (
+  ts.isExpressionStatement(node) &&
+  ts.isCallExpression(node.expression) &&
+  ts.isIdentifier(node.expression.expression) &&
+  (node.expression.expression.escapedText === 'describe' || node.expression.expression.escapedText === 'context') &&
+  ts.isStringLiteral(node.expression.arguments[0]) &&
+  ts.isFunctionLike(node.expression.arguments[1]) &&
+  ts.isBlock(node.expression.arguments[1].body)
+)
+
+export const isBeforeEachBlock = (node: ts.Node): node is BeforeEachCall => (
+  ts.isExpressionStatement(node) &&
+  ts.isCallExpression(node.expression) &&
+  ts.isIdentifier(node.expression.expression) &&
+  node.expression.expression.escapedText === 'beforeEach' &&
+  ts.isFunctionLike(node.expression.arguments[0])
+)
+

--- a/packages/migration/src/transforms/unit-tests/validators.ts
+++ b/packages/migration/src/transforms/unit-tests/validators.ts
@@ -13,7 +13,7 @@ export type BeforeEachCall = ts.ExpressionStatement & {
     expression: ts.Identifier & {
       escapedText: 'beforeEach'
     }
-    arguments: [ts.FunctionLikeDeclaration & {body: ts.Block}]
+    arguments: [ts.FunctionLikeDeclaration]
   }
 }
 

--- a/packages/pg-v5/test/unit/commands/backups/restore.unit.test.js
+++ b/packages/pg-v5/test/unit/commands/backups/restore.unit.test.js
@@ -13,7 +13,7 @@ let restoringText = () => {
   return process.stderr.isTTY ? 'Restoring... pending\nRestoring... done\n' : 'Restoring... done\n'
 }
 
-const shouldRestore = function (cmdRun) {
+const shouldRestore = function () {
   let pg
   let api
 
@@ -52,7 +52,7 @@ const shouldRestore = function (cmdRun) {
     })
 
     it('restores a db', () => {
-      return cmdRun({app: 'myapp', args: {}, flags: {confirm: 'myapp'}})
+      return cmd.run({app: 'myapp', args: {}, flags: {confirm: 'myapp'}})
         .then(() => expect(cli.stdout).to.equal(`
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue restoring.
 Use heroku pg:backups to check progress.
@@ -63,7 +63,7 @@ Stop a running restore with heroku pg:backups:cancel.
     })
 
     it('restores a specific db', () => {
-      return cmdRun({app: 'myapp', args: {backup: 'b005'}, flags: {confirm: 'myapp'}})
+      return cmd.run({app: 'myapp', args: {backup: 'b005'}, flags: {confirm: 'myapp'}})
         .then(() => expect(cli.stdout).to.equal(`
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue restoring.
 Use heroku pg:backups to check progress.
@@ -74,7 +74,7 @@ Stop a running restore with heroku pg:backups:cancel.
     })
 
     it('restores a specific app db', () => {
-      return cmdRun({app: 'myapp', args: {backup: 'myapp::b005'}, flags: {confirm: 'myapp'}})
+      return cmd.run({app: 'myapp', args: {backup: 'myapp::b005'}, flags: {confirm: 'myapp'}})
         .then(() => expect(cli.stdout).to.equal(`
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue restoring.
 Use heroku pg:backups to check progress.
@@ -103,7 +103,7 @@ Stop a running restore with heroku pg:backups:cancel.
     })
 
     it('shows verbose output', () => {
-      return cmdRun({app: 'myapp', args: {}, flags: {confirm: 'myapp', verbose: true}})
+      return cmd.run({app: 'myapp', args: {}, flags: {confirm: 'myapp', verbose: true}})
         .then(() => expect(cli.stdout).to.equal(`
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue restoring.
 Use heroku pg:backups to check progress.
@@ -130,7 +130,7 @@ Restoring...
     })
 
     it('restores a db from a URL', () => {
-      return cmdRun({app: 'myapp', args: {backup: 'https://www.dropbox.com'}, flags: {confirm: 'myapp'}})
+      return cmd.run({app: 'myapp', args: {backup: 'https://www.dropbox.com'}, flags: {confirm: 'myapp'}})
         .then(() => expect(cli.stdout).to.equal(`
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue restoring.
 Use heroku pg:backups to check progress.
@@ -158,7 +158,7 @@ Stop a running restore with heroku pg:backups:cancel.
     })
 
     it('restores a db with pre-installed extensions', () => {
-      return cmdRun({app: 'myapp', args: {}, flags: {confirm: 'myapp', extensions: 'uuid-ossp, Postgis'}})
+      return cmd.run({app: 'myapp', args: {}, flags: {confirm: 'myapp', extensions: 'uuid-ossp, Postgis'}})
         .then(() => expect(cli.stdout).to.equal(`
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue restoring.
 Use heroku pg:backups to check progress.
@@ -175,5 +175,5 @@ describe('pg:backups:restore', () => {
 })
 
 describe('pg:backups restore', () => {
-  shouldRestore(require('./helpers.js').dup('restore', cmd))
+  shouldRestore()
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6269,6 +6269,7 @@ __metadata:
     "@types/pascalcase": ^1.0.3
     eslint: 8.53.0
     glob: 10.3.10
+    lodash: ^4.17.11
     pascalcase: 2.0.0
     typescript: 5.2.2
     yargs: 17.7.2
@@ -9748,6 +9749,7 @@ __metadata:
     shell-escape: ^0.2.0
     shell-quote: ^1.6.1
     sinon: ^7.2.4
+    stdout-stderr: ^0.1.13
     strftime: ^0.10.0
     strip-ansi: 6.0.1
     tmp: ^0.0.33
@@ -16116,6 +16118,16 @@ __metadata:
   dependencies:
     lodash: ^4.11.1
   checksum: b7b97a39c77e373ea243443e195030ca0e41e0f7e8ba7908993511c4346dfdee0fb0d6edc0a72d2ed4ad3a26a1a4434d7dbde65629172452f3462745a8c8433a
+  languageName: node
+  linkType: hard
+
+"stdout-stderr@npm:^0.1.13":
+  version: 0.1.13
+  resolution: "stdout-stderr@npm:0.1.13"
+  dependencies:
+    debug: ^4.1.1
+    strip-ansi: ^6.0.0
+  checksum: 3955a0afa9a483188929796fd9fa9417f845c3bfcd92f132b3ae7d2a862f91a846312e4244f07eb4dd4c5bd2fe95035db5db01679e7d3795d3ea0b772fc7a6f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Everything but the last commit has been previously reviewed & approved.
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001g49b9YAA/view
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001g4LA4YAM/view
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001ec0nVYAQ/view

Example PR from using codemod for addons:detach that took about 10 minutes with codemods: https://github.com/heroku/cli/pull/2583

**Note**: aliases below still need to be added manually.
```
module.exports = [
  Object.assign({command: 'create'}, cmd),
  Object.assign({command: 'add', hidden: true}, cmd),
]
```

Example usage:
convert command:
`yarn migrateCommand --files "./packages/addons-v5/commands/addons/detach.js"`
convert command unit test:
`yarn migrateCommandTest --files "./packages/addons-v5/test/unit/commands/addons/detach.unit.test.js"`


<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
