### PR TITLE
fix: bump @oclif/plugin-update to a version that doesn't delete the CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,7 @@
     "@oclif/plugin-legacy": "^1.3.0",
     "@oclif/plugin-not-found": "2.3.16",
     "@oclif/plugin-plugins": "2.4.3",
-    "@oclif/plugin-update": "3.1.10",
+    "@oclif/plugin-update": "3.2.4",
     "@oclif/plugin-version": "^1.2.1",
     "@oclif/plugin-warn-if-update-available": "2.0.29",
     "@oclif/plugin-which": "2.2.8",

--- a/packages/run-v5/test/integration/run.integration.test.js
+++ b/packages/run-v5/test/integration/run.integration.test.js
@@ -29,7 +29,7 @@ describe('run', () => {
     })
     return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: {password: global.apikey}, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo": "bar"} ']})
       .then(() => fixture.release())
-      .then(() => expect(stdout).to.equal('{"foo": "bar"} \n'))
+      .then(() => expect(stdout).to.contain('{"foo": "bar"} \n'))
   })
 
   it('runs a command with quotes', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2502,6 +2502,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oclif/core@npm:^2.11.8":
+  version: 2.15.0
+  resolution: "@oclif/core@npm:2.15.0"
+  dependencies:
+    "@types/cli-progress": ^3.11.0
+    ansi-escapes: ^4.3.2
+    ansi-styles: ^4.3.0
+    cardinal: ^2.1.1
+    chalk: ^4.1.2
+    clean-stack: ^3.0.1
+    cli-progress: ^3.12.0
+    debug: ^4.3.4
+    ejs: ^3.1.8
+    get-package-type: ^0.1.0
+    globby: ^11.1.0
+    hyperlinker: ^1.0.0
+    indent-string: ^4.0.0
+    is-wsl: ^2.2.0
+    js-yaml: ^3.14.1
+    natural-orderby: ^2.0.3
+    object-treeify: ^1.1.33
+    password-prompt: ^1.1.2
+    slice-ansi: ^4.0.0
+    string-width: ^4.2.3
+    strip-ansi: ^6.0.1
+    supports-color: ^8.1.1
+    supports-hyperlinks: ^2.2.0
+    ts-node: ^10.9.1
+    tslib: ^2.5.0
+    widest-line: ^3.1.0
+    wordwrap: ^1.0.0
+    wrap-ansi: ^7.0.0
+  checksum: a4ef8ad00d9bc7cb48e5847bad7def6947f913875f4b0ecec65ab423a3c2a82c87df173c709c3c25396d545f60d20d17d562c474f66230d76de43061ce22ba90
+  languageName: node
+  linkType: hard
+
 "@oclif/core@npm:^2.6.3":
   version: 2.6.3
   resolution: "@oclif/core@npm:2.6.3"
@@ -2574,43 +2610,6 @@ __metadata:
     wordwrap: ^1.0.0
     wrap-ansi: ^7.0.0
   checksum: 492715fa5454c18c38d8718f042512775a58cada8ee4e61b188fbee7afcd75157fa3e53cbc3df7b3790e6a3d9278cde90385bb14c0627aae251f5f37c4ee83c5
-  languageName: node
-  linkType: hard
-
-"@oclif/core@npm:^2.7.1":
-  version: 2.8.1
-  resolution: "@oclif/core@npm:2.8.1"
-  dependencies:
-    "@types/cli-progress": ^3.11.0
-    ansi-escapes: ^4.3.2
-    ansi-styles: ^4.3.0
-    cardinal: ^2.1.1
-    chalk: ^4.1.2
-    clean-stack: ^3.0.1
-    cli-progress: ^3.12.0
-    debug: ^4.3.4
-    ejs: ^3.1.8
-    fs-extra: ^9.1.0
-    get-package-type: ^0.1.0
-    globby: ^11.1.0
-    hyperlinker: ^1.0.0
-    indent-string: ^4.0.0
-    is-wsl: ^2.2.0
-    js-yaml: ^3.14.1
-    natural-orderby: ^2.0.3
-    object-treeify: ^1.1.33
-    password-prompt: ^1.1.2
-    semver: ^7.3.7
-    string-width: ^4.2.3
-    strip-ansi: ^6.0.1
-    supports-color: ^8.1.1
-    supports-hyperlinks: ^2.2.0
-    ts-node: ^10.9.1
-    tslib: ^2.5.0
-    widest-line: ^3.1.0
-    wordwrap: ^1.0.0
-    wrap-ansi: ^7.0.0
-  checksum: d18614268542137807056fdf3dd039567489aa9baa162acd95ae1b1a51a834c9283d0297d59046837875be1d89f1c831e5ab5df616320574efe217fff0d6ba85
   languageName: node
   linkType: hard
 
@@ -2916,23 +2915,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oclif/plugin-update@npm:3.1.10":
-  version: 3.1.10
-  resolution: "@oclif/plugin-update@npm:3.1.10"
+"@oclif/plugin-update@npm:3.2.4":
+  version: 3.2.4
+  resolution: "@oclif/plugin-update@npm:3.2.4"
   dependencies:
-    "@oclif/color": ^1.0.4
-    "@oclif/core": ^2.7.1
+    "@oclif/core": ^2.11.8
+    chalk: ^4
     cross-spawn: ^7.0.3
     debug: ^4.3.1
     filesize: ^6.1.0
     fs-extra: ^9.0.1
     http-call: ^5.3.0
-    inquirer: ^8.2.5
+    inquirer: ^8.2.6
     lodash.throttle: ^4.1.1
     log-chopper: ^1.0.2
-    semver: ^7.3.8
+    semver: ^7.5.4
     tar-fs: ^2.1.1
-  checksum: 7d1ef9f26f3b3352bfa711a1982a82760c3a88824fbbe8409fbfed2c441c9332985d6a437c5af7e4f54efd25a732724efb071197729f4b0988531e2e98b5d450
+  checksum: 1c98efe1180e5ff6ad7e343b6bdeed9a8f530924c46721746d2994151c4928f79377b8f41cda53f52a9b8272c1426ecfe8e2e45b993a0cb368b4b5fb4a008205
   languageName: node
   linkType: hard
 
@@ -5531,7 +5530,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.0.2, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
+"chalk@npm:^4, chalk@npm:^4.0.0, chalk@npm:^4.0.2, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -9272,7 +9271,7 @@ __metadata:
     "@oclif/plugin-legacy": ^1.3.0
     "@oclif/plugin-not-found": 2.3.16
     "@oclif/plugin-plugins": 2.4.3
-    "@oclif/plugin-update": 3.1.10
+    "@oclif/plugin-update": 3.2.4
     "@oclif/plugin-version": ^1.2.1
     "@oclif/plugin-warn-if-update-available": 2.0.29
     "@oclif/plugin-which": 2.2.8
@@ -9852,7 +9851,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inquirer@npm:^8.0.0, inquirer@npm:^8.2.4, inquirer@npm:^8.2.5":
+"inquirer@npm:^8.0.0, inquirer@npm:^8.2.4":
   version: 8.2.5
   resolution: "inquirer@npm:8.2.5"
   dependencies:
@@ -9872,6 +9871,29 @@ __metadata:
     through: ^2.3.6
     wrap-ansi: ^7.0.0
   checksum: f13ee4c444187786fb393609dedf6b30870115a57b603f2e6424f29a99abc13446fd45ee22461c33c9c40a92a60a8df62d0d6b25d74fc6676fa4cb211de55b55
+  languageName: node
+  linkType: hard
+
+"inquirer@npm:^8.2.6":
+  version: 8.2.6
+  resolution: "inquirer@npm:8.2.6"
+  dependencies:
+    ansi-escapes: ^4.2.1
+    chalk: ^4.1.1
+    cli-cursor: ^3.1.0
+    cli-width: ^3.0.0
+    external-editor: ^3.0.3
+    figures: ^3.0.0
+    lodash: ^4.17.21
+    mute-stream: 0.0.8
+    ora: ^5.4.1
+    run-async: ^2.4.0
+    rxjs: ^7.5.5
+    string-width: ^4.1.0
+    strip-ansi: ^6.0.0
+    through: ^2.3.6
+    wrap-ansi: ^6.0.1
+  checksum: 387ffb0a513559cc7414eb42c57556a60e302f820d6960e89d376d092e257a919961cd485a1b4de693dbb5c0de8bc58320bfd6247dfd827a873aa82a4215a240
   languageName: node
   linkType: hard
 
@@ -17308,7 +17330,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrap-ansi@npm:^6.2.0":
+"wrap-ansi@npm:^6.0.1, wrap-ansi@npm:^6.2.0":
   version: 6.2.0
   resolution: "wrap-ansi@npm:6.2.0"
   dependencies:


### PR DESCRIPTION
Fix bug reports of the CLI breaking with errors like: 
```
% heroku addons:detach
/opt/homebrew/Cellar/heroku/8.5.0/lib/client/bin/heroku: line 16: /opt/homebrew/Cellar/heroku/8.5.0/lib/client/bin/../8.7.1-3f5e369/bin/heroku: No such file or directory
```
Fix here: https://github.com/oclif/plugin-update/releases/tag/3.2.1
Bumped to the last version before a major bump of @oclif/plugin-update

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
