### PR TITLE
test: update run-v5 integration test

### DIFF
--- a/packages/run-v5/test/integration/run.integration.test.js
+++ b/packages/run-v5/test/integration/run.integration.test.js
@@ -40,7 +40,7 @@ describe('run', () => {
     })
     return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: {password: global.apikey}, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo":"bar"}']})
       .then(() => fixture.release())
-      .then(() => expect(stdout).to.equal('{"foo":"bar"}\n'))
+      .then(() => expect(stdout).to.contain('{"foo":"bar"}\n'))
   })
 
   it('runs a command with env vars', () => {


### PR DESCRIPTION
Updates a run-v5 integration test to allow them to pass.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
