### PR TITLE
fix(codemods): test flags transform fix

### DIFF
--- a/packages/addons-v5/test/unit/commands/addons/attach.unit.test.js
+++ b/packages/addons-v5/test/unit/commands/addons/attach.unit.test.js
@@ -17,21 +17,21 @@ describe('addons:attach', function () {
     nock.cleanAll()
   })
 
-  //   it('attaches an add-on', function () {
-  //     let api = nock('https://api.heroku.com:443')
-  //       .get('/addons/redis-123')
-  //       .reply(200, {name: 'redis-123'})
-  //       .post('/addon-attachments', {app: {name: 'myapp'}, addon: {name: 'redis-123'}})
-  //       .reply(201, {name: 'REDIS'})
-  //       .get('/apps/myapp/releases')
-  //       .reply(200, [{version: 10}])
-  //     return cmd.run({app: 'myapp', args: {addon_name: 'redis-123'}, flags: {}})
-  //       .then(() => expect(cli.stdout, 'to be empty'))
-  //       .then(() => expect(cli.stderr).to.equal(`Attaching redis-123 to myapp... done
-  // Setting REDIS config vars and restarting myapp... done, v10
-  // `))
-  //       .then(() => api.done())
-  //   })
+  it('attaches an add-on', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/addons/redis-123')
+      .reply(200, {name: 'redis-123'})
+      .post('/addon-attachments', {app: {name: 'myapp'}, addon: {name: 'redis-123'}})
+      .reply(201, {name: 'REDIS'})
+      .get('/apps/myapp/releases')
+      .reply(200, [{version: 10}])
+    return cmd.run({app: 'myapp', args: {addon_name: 'redis-123'}, flags: {}})
+      .then(() => expect(cli.stdout, 'to be empty'))
+      .then(() => expect(cli.stderr).to.equal(`Attaching redis-123 to myapp... done
+Setting REDIS config vars and restarting myapp... done, v10
+`))
+      .then(() => api.done())
+  })
 
   it('attaches an add-on as foo', function () {
     let api = nock('https://api.heroku.com:443')
@@ -44,79 +44,79 @@ describe('addons:attach', function () {
     return cmd.run({app: 'myapp', args: {addon_name: 'redis-123'}, flags: {as: 'foo'}})
       .then(() => expect(cli.stdout, 'to be empty'))
       .then(() => expect(cli.stderr).to.equal(`Attaching redis-123 as foo to myapp... done
-  Setting foo config vars and restarting myapp... done, v10
-  `))
+Setting foo config vars and restarting myapp... done, v10
+`))
       .then(() => api.done())
   })
 
-  //   it('overwrites an add-on as foo when confirmation is set', function () {
-  //     let api = nock('https://api.heroku.com:443')
-  //       .get('/addons/redis-123')
-  //       .reply(200, {name: 'redis-123'})
-  //       .post('/addon-attachments', {name: 'foo', app: {name: 'myapp'}, addon: {name: 'redis-123'}})
-  //       .reply(400, {id: 'confirmation_required'})
-  //       .post('/addon-attachments', {name: 'foo', app: {name: 'myapp'}, addon: {name: 'redis-123'}, confirm: 'myapp'})
-  //       .reply(201, {name: 'foo'})
-  //       .get('/apps/myapp/releases')
-  //       .reply(200, [{version: 10}])
-  //     return cmd.run({app: 'myapp', args: {addon_name: 'redis-123'}, flags: {as: 'foo'}})
-  //       .then(() => expect(cli.stdout, 'to be empty'))
-  //       .then(() => expect(cli.stderr).to.equal(`Attaching redis-123 as foo to myapp... !
-  // Attaching redis-123 as foo to myapp... done
-  // Setting foo config vars and restarting myapp... done, v10
-  // `))
-  //       .then(() => api.done())
-  //   })
+  it('overwrites an add-on as foo when confirmation is set', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/addons/redis-123')
+      .reply(200, {name: 'redis-123'})
+      .post('/addon-attachments', {name: 'foo', app: {name: 'myapp'}, addon: {name: 'redis-123'}})
+      .reply(400, {id: 'confirmation_required'})
+      .post('/addon-attachments', {name: 'foo', app: {name: 'myapp'}, addon: {name: 'redis-123'}, confirm: 'myapp'})
+      .reply(201, {name: 'foo'})
+      .get('/apps/myapp/releases')
+      .reply(200, [{version: 10}])
+    return cmd.run({app: 'myapp', args: {addon_name: 'redis-123'}, flags: {as: 'foo'}})
+      .then(() => expect(cli.stdout, 'to be empty'))
+      .then(() => expect(cli.stderr).to.equal(`Attaching redis-123 as foo to myapp... !
+Attaching redis-123 as foo to myapp... done
+Setting foo config vars and restarting myapp... done, v10
+`))
+      .then(() => api.done())
+  })
 
-//   it('attaches an addon without a namespace if the credential flag is set to default', function () {
-//     let api = nock('https://api.heroku.com:443')
-//       .get('/addons/postgres-123')
-//       .reply(200, {name: 'postgres-123'})
-//       .post('/addon-attachments', {app: {name: 'myapp'}, addon: {name: 'postgres-123'}})
-//       .reply(201, {name: 'POSTGRES_HELLO'})
-//       .get('/apps/myapp/releases')
-//       .reply(200, [{version: 10}])
-//     return cmd.run({app: 'myapp', args: {addon_name: 'postgres-123'}, flags: {credential: 'default'}})
-//       .then(() => expect(cli.stdout, 'to be empty'))
-//       .then(() => expect(cli.stderr).to.equal(`Attaching default of postgres-123 to myapp... done
-// Setting POSTGRES_HELLO config vars and restarting myapp... done, v10
-// `))
-//       .then(() => api.done())
-//   })
-//
-//   it('attaches in the credential namespace if the credential flag is specified', function () {
-//     let api = nock('https://api.heroku.com:443')
-//       .get('/addons/postgres-123')
-//       .reply(200, {name: 'postgres-123'})
-//       .get('/addons/postgres-123/config/credential:hello')
-//       .reply(200, [{some: 'config'}])
-//       .post('/addon-attachments', {app: {name: 'myapp'}, addon: {name: 'postgres-123'}, namespace: 'credential:hello'})
-//       .reply(201, {name: 'POSTGRES_HELLO'})
-//       .get('/apps/myapp/releases')
-//       .reply(200, [{version: 10}])
-//     return cmd.run({app: 'myapp', args: {addon_name: 'postgres-123'}, flags: {credential: 'hello'}})
-//       .then(() => expect(cli.stdout, 'to be empty'))
-//       .then(() => expect(cli.stderr).to.equal(`Attaching hello of postgres-123 to myapp... done
-// Setting POSTGRES_HELLO config vars and restarting myapp... done, v10
-// `))
-//       .then(() => api.done())
-//   })
-//
-//   it('errors if the credential flag is specified but that credential does not exist for that addon', function () {
-//     nock('https://api.heroku.com:443')
-//       .get('/addons/postgres-123')
-//       .reply(200, {name: 'postgres-123'})
-//       .get('/addons/postgres-123/config/credential:hello')
-//       .reply(200, [])
-//
-//     return cmd.run({
-//       app: 'myapp',
-//       args: {addon_name: 'postgres-123'},
-//       flags: {credential: 'hello'},
-//     })
-//       .then(() => {
-//         throw new Error('unreachable')
-//       })
-//       .catch(error => expect(error.message).to.equal('Could not find credential hello for database postgres-123'))
-//   })
+  it('attaches an addon without a namespace if the credential flag is set to default', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/addons/postgres-123')
+      .reply(200, {name: 'postgres-123'})
+      .post('/addon-attachments', {app: {name: 'myapp'}, addon: {name: 'postgres-123'}})
+      .reply(201, {name: 'POSTGRES_HELLO'})
+      .get('/apps/myapp/releases')
+      .reply(200, [{version: 10}])
+    return cmd.run({app: 'myapp', args: {addon_name: 'postgres-123'}, flags: {credential: 'default'}})
+      .then(() => expect(cli.stdout, 'to be empty'))
+      .then(() => expect(cli.stderr).to.equal(`Attaching default of postgres-123 to myapp... done
+Setting POSTGRES_HELLO config vars and restarting myapp... done, v10
+`))
+      .then(() => api.done())
+  })
+
+  it('attaches in the credential namespace if the credential flag is specified', function () {
+    let api = nock('https://api.heroku.com:443')
+      .get('/addons/postgres-123')
+      .reply(200, {name: 'postgres-123'})
+      .get('/addons/postgres-123/config/credential:hello')
+      .reply(200, [{some: 'config'}])
+      .post('/addon-attachments', {app: {name: 'myapp'}, addon: {name: 'postgres-123'}, namespace: 'credential:hello'})
+      .reply(201, {name: 'POSTGRES_HELLO'})
+      .get('/apps/myapp/releases')
+      .reply(200, [{version: 10}])
+    return cmd.run({app: 'myapp', args: {addon_name: 'postgres-123'}, flags: {credential: 'hello'}})
+      .then(() => expect(cli.stdout, 'to be empty'))
+      .then(() => expect(cli.stderr).to.equal(`Attaching hello of postgres-123 to myapp... done
+Setting POSTGRES_HELLO config vars and restarting myapp... done, v10
+`))
+      .then(() => api.done())
+  })
+
+  it('errors if the credential flag is specified but that credential does not exist for that addon', function () {
+    nock('https://api.heroku.com:443')
+      .get('/addons/postgres-123')
+      .reply(200, {name: 'postgres-123'})
+      .get('/addons/postgres-123/config/credential:hello')
+      .reply(200, [])
+
+    return cmd.run({
+      app: 'myapp',
+      args: {addon_name: 'postgres-123'},
+      flags: {credential: 'hello'},
+    })
+      .then(() => {
+        throw new Error('unreachable')
+      })
+      .catch(error => expect(error.message).to.equal('Could not find credential hello for database postgres-123'))
+  })
 })

--- a/packages/addons-v5/test/unit/commands/addons/attach.unit.test.js
+++ b/packages/addons-v5/test/unit/commands/addons/attach.unit.test.js
@@ -17,21 +17,21 @@ describe('addons:attach', function () {
     nock.cleanAll()
   })
 
-  it('attaches an add-on', function () {
-    let api = nock('https://api.heroku.com:443')
-      .get('/addons/redis-123')
-      .reply(200, {name: 'redis-123'})
-      .post('/addon-attachments', {app: {name: 'myapp'}, addon: {name: 'redis-123'}})
-      .reply(201, {name: 'REDIS'})
-      .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
-    return cmd.run({app: 'myapp', args: {addon_name: 'redis-123'}, flags: {}})
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal(`Attaching redis-123 to myapp... done
-Setting REDIS config vars and restarting myapp... done, v10
-`))
-      .then(() => api.done())
-  })
+  //   it('attaches an add-on', function () {
+  //     let api = nock('https://api.heroku.com:443')
+  //       .get('/addons/redis-123')
+  //       .reply(200, {name: 'redis-123'})
+  //       .post('/addon-attachments', {app: {name: 'myapp'}, addon: {name: 'redis-123'}})
+  //       .reply(201, {name: 'REDIS'})
+  //       .get('/apps/myapp/releases')
+  //       .reply(200, [{version: 10}])
+  //     return cmd.run({app: 'myapp', args: {addon_name: 'redis-123'}, flags: {}})
+  //       .then(() => expect(cli.stdout, 'to be empty'))
+  //       .then(() => expect(cli.stderr).to.equal(`Attaching redis-123 to myapp... done
+  // Setting REDIS config vars and restarting myapp... done, v10
+  // `))
+  //       .then(() => api.done())
+  //   })
 
   it('attaches an add-on as foo', function () {
     let api = nock('https://api.heroku.com:443')
@@ -44,79 +44,79 @@ Setting REDIS config vars and restarting myapp... done, v10
     return cmd.run({app: 'myapp', args: {addon_name: 'redis-123'}, flags: {as: 'foo'}})
       .then(() => expect(cli.stdout, 'to be empty'))
       .then(() => expect(cli.stderr).to.equal(`Attaching redis-123 as foo to myapp... done
-Setting foo config vars and restarting myapp... done, v10
-`))
+  Setting foo config vars and restarting myapp... done, v10
+  `))
       .then(() => api.done())
   })
 
-  it('overwrites an add-on as foo when confirmation is set', function () {
-    let api = nock('https://api.heroku.com:443')
-      .get('/addons/redis-123')
-      .reply(200, {name: 'redis-123'})
-      .post('/addon-attachments', {name: 'foo', app: {name: 'myapp'}, addon: {name: 'redis-123'}})
-      .reply(400, {id: 'confirmation_required'})
-      .post('/addon-attachments', {name: 'foo', app: {name: 'myapp'}, addon: {name: 'redis-123'}, confirm: 'myapp'})
-      .reply(201, {name: 'foo'})
-      .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
-    return cmd.run({app: 'myapp', args: {addon_name: 'redis-123'}, flags: {as: 'foo'}})
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal(`Attaching redis-123 as foo to myapp... !
-Attaching redis-123 as foo to myapp... done
-Setting foo config vars and restarting myapp... done, v10
-`))
-      .then(() => api.done())
-  })
+  //   it('overwrites an add-on as foo when confirmation is set', function () {
+  //     let api = nock('https://api.heroku.com:443')
+  //       .get('/addons/redis-123')
+  //       .reply(200, {name: 'redis-123'})
+  //       .post('/addon-attachments', {name: 'foo', app: {name: 'myapp'}, addon: {name: 'redis-123'}})
+  //       .reply(400, {id: 'confirmation_required'})
+  //       .post('/addon-attachments', {name: 'foo', app: {name: 'myapp'}, addon: {name: 'redis-123'}, confirm: 'myapp'})
+  //       .reply(201, {name: 'foo'})
+  //       .get('/apps/myapp/releases')
+  //       .reply(200, [{version: 10}])
+  //     return cmd.run({app: 'myapp', args: {addon_name: 'redis-123'}, flags: {as: 'foo'}})
+  //       .then(() => expect(cli.stdout, 'to be empty'))
+  //       .then(() => expect(cli.stderr).to.equal(`Attaching redis-123 as foo to myapp... !
+  // Attaching redis-123 as foo to myapp... done
+  // Setting foo config vars and restarting myapp... done, v10
+  // `))
+  //       .then(() => api.done())
+  //   })
 
-  it('attaches an addon without a namespace if the credential flag is set to default', function () {
-    let api = nock('https://api.heroku.com:443')
-      .get('/addons/postgres-123')
-      .reply(200, {name: 'postgres-123'})
-      .post('/addon-attachments', {app: {name: 'myapp'}, addon: {name: 'postgres-123'}})
-      .reply(201, {name: 'POSTGRES_HELLO'})
-      .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
-    return cmd.run({app: 'myapp', args: {addon_name: 'postgres-123'}, flags: {credential: 'default'}})
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal(`Attaching default of postgres-123 to myapp... done
-Setting POSTGRES_HELLO config vars and restarting myapp... done, v10
-`))
-      .then(() => api.done())
-  })
-
-  it('attaches in the credential namespace if the credential flag is specified', function () {
-    let api = nock('https://api.heroku.com:443')
-      .get('/addons/postgres-123')
-      .reply(200, {name: 'postgres-123'})
-      .get('/addons/postgres-123/config/credential:hello')
-      .reply(200, [{some: 'config'}])
-      .post('/addon-attachments', {app: {name: 'myapp'}, addon: {name: 'postgres-123'}, namespace: 'credential:hello'})
-      .reply(201, {name: 'POSTGRES_HELLO'})
-      .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
-    return cmd.run({app: 'myapp', args: {addon_name: 'postgres-123'}, flags: {credential: 'hello'}})
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.equal(`Attaching hello of postgres-123 to myapp... done
-Setting POSTGRES_HELLO config vars and restarting myapp... done, v10
-`))
-      .then(() => api.done())
-  })
-
-  it('errors if the credential flag is specified but that credential does not exist for that addon', function () {
-    nock('https://api.heroku.com:443')
-      .get('/addons/postgres-123')
-      .reply(200, {name: 'postgres-123'})
-      .get('/addons/postgres-123/config/credential:hello')
-      .reply(200, [])
-
-    return cmd.run({
-      app: 'myapp',
-      args: {addon_name: 'postgres-123'},
-      flags: {credential: 'hello'},
-    })
-      .then(() => {
-        throw new Error('unreachable')
-      })
-      .catch(error => expect(error.message).to.equal('Could not find credential hello for database postgres-123'))
-  })
+//   it('attaches an addon without a namespace if the credential flag is set to default', function () {
+//     let api = nock('https://api.heroku.com:443')
+//       .get('/addons/postgres-123')
+//       .reply(200, {name: 'postgres-123'})
+//       .post('/addon-attachments', {app: {name: 'myapp'}, addon: {name: 'postgres-123'}})
+//       .reply(201, {name: 'POSTGRES_HELLO'})
+//       .get('/apps/myapp/releases')
+//       .reply(200, [{version: 10}])
+//     return cmd.run({app: 'myapp', args: {addon_name: 'postgres-123'}, flags: {credential: 'default'}})
+//       .then(() => expect(cli.stdout, 'to be empty'))
+//       .then(() => expect(cli.stderr).to.equal(`Attaching default of postgres-123 to myapp... done
+// Setting POSTGRES_HELLO config vars and restarting myapp... done, v10
+// `))
+//       .then(() => api.done())
+//   })
+//
+//   it('attaches in the credential namespace if the credential flag is specified', function () {
+//     let api = nock('https://api.heroku.com:443')
+//       .get('/addons/postgres-123')
+//       .reply(200, {name: 'postgres-123'})
+//       .get('/addons/postgres-123/config/credential:hello')
+//       .reply(200, [{some: 'config'}])
+//       .post('/addon-attachments', {app: {name: 'myapp'}, addon: {name: 'postgres-123'}, namespace: 'credential:hello'})
+//       .reply(201, {name: 'POSTGRES_HELLO'})
+//       .get('/apps/myapp/releases')
+//       .reply(200, [{version: 10}])
+//     return cmd.run({app: 'myapp', args: {addon_name: 'postgres-123'}, flags: {credential: 'hello'}})
+//       .then(() => expect(cli.stdout, 'to be empty'))
+//       .then(() => expect(cli.stderr).to.equal(`Attaching hello of postgres-123 to myapp... done
+// Setting POSTGRES_HELLO config vars and restarting myapp... done, v10
+// `))
+//       .then(() => api.done())
+//   })
+//
+//   it('errors if the credential flag is specified but that credential does not exist for that addon', function () {
+//     nock('https://api.heroku.com:443')
+//       .get('/addons/postgres-123')
+//       .reply(200, {name: 'postgres-123'})
+//       .get('/addons/postgres-123/config/credential:hello')
+//       .reply(200, [])
+//
+//     return cmd.run({
+//       app: 'myapp',
+//       args: {addon_name: 'postgres-123'},
+//       flags: {credential: 'hello'},
+//     })
+//       .then(() => {
+//         throw new Error('unreachable')
+//       })
+//       .catch(error => expect(error.message).to.equal('Could not find credential hello for database postgres-123'))
+//   })
 })

--- a/packages/migration/src/transforms/unit-tests/migrations.ts
+++ b/packages/migration/src/transforms/unit-tests/migrations.ts
@@ -51,8 +51,8 @@ export const migrateCommandRun = (runArgs: ts.ObjectLiteralExpression): ts.Expre
       continue
     }
 
-    // check ShorthandPropertyAssignment vs PropertyAssignment
-    switch (prop.name.escapedText.toString()) {
+    const keyName = prop.name.escapedText.toString()
+    switch (keyName) {
     case 'app': {
       if (isShorthand) {
         transformedCommand.push(factory.createStringLiteral('--app'), prop.name)
@@ -108,18 +108,23 @@ export const migrateCommandRun = (runArgs: ts.ObjectLiteralExpression): ts.Expre
           }
 
           if (ts.isShorthandPropertyAssignment(argProp)) {
-            transformedCommand.push(argProp.name)
+            transformedArgs.push(argProp.name)
           } else if (ts.isPropertyAssignment(argProp)) {
-            transformedCommand.push(argProp.initializer)
+            transformedArgs.push(argProp.initializer)
           }
         }
       } else {
         console.error('can not map command.run({args}))')
       }
+
+      break
     }
 
-      // args need to come last due to `static strict false` argv handling
-      return [...transformedCommand, ...transformedArgs]
+    default:
+      break
     }
   }
+
+  // args need to come last due to `static strict false` argv handling
+  return [...transformedCommand, ...transformedArgs]
 }


### PR DESCRIPTION
Fix a bug that caused any args in cmd.run({}) object to get dropped if they came after `args`

This case: `return cmd.run({app: 'myapp', args: {addon_name: 'redis-123'}, flags: {as: 'foo'}})` would lead to an output of 
```
 return runCommand(Cmd, [
      '--app',
      'myapp',
      'redis-123',
    ])
```
without this fix.
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
