### PR TITLE
feat(ps): add larger dyno information to ps:type

### DIFF
--- a/packages/apps-v5/src/commands/ps/type.js
+++ b/packages/apps-v5/src/commands/ps/type.js
@@ -58,6 +58,15 @@ Types: ${cli.color.yellow(formation.map(f => f.type).join(', '))}`)
 
         // add logic to check if size is Shield-Memory-L | XL | 2XL
         // then add $100 if L, $150 if XL and $300 if 2XL
+
+        // eslint-disable-next-line unicorn/prefer-switch
+        if (d.size === 'Shield-Memory-L') {
+          costMonthly[d.size] += 100
+        } else if (d.size === 'Shield-Memory-XL') {
+          costMonthly[d.size] += 150
+        } else if (d.size === 'Shield-Memory-2XL') {
+          costMonthly[d.size] += 300
+        }
       }
 
       if (d.size in dynoTotals) {

--- a/packages/apps-v5/src/commands/ps/type.js
+++ b/packages/apps-v5/src/commands/ps/type.js
@@ -3,7 +3,7 @@
 let cli = require('heroku-cli-util')
 const {sortBy, compact} = require('lodash')
 
-const costMonthly = {Free: 0, Eco: 0, Hobby: 7, Basic: 7, 'Standard-1X': 25, 'Standard-2X': 50, 'Performance-M': 250, Performance: 500, 'Performance-L': 500, '1X': 36, '2X': 72, PX: 576, 'Performance-Memory-L': 500, 'Performance-Memory-XL': 750, 'Performance-Memory-2XL': 1500}
+const costMonthly = {Free: 0, Eco: 0, Hobby: 7, Basic: 7, 'Standard-1X': 25, 'Standard-2X': 50, 'Performance-M': 250, Performance: 500, 'Performance-L': 500, '1X': 36, '2X': 72, PX: 576, 'Performance-L-Ram': 500, 'Performance-XL': 750, 'Performance-2XL': 1500}
 
 let emptyFormationErr = app => {
   return new Error(`No process types on ${app}.
@@ -55,18 +55,6 @@ Types: ${cli.color.yellow(formation.map(f => f.type).join(', '))}`)
 
       if (shielded) {
         d.size = d.size.replace('Private-', 'Shield-')
-
-        // add logic to check if size is Shield-Memory-L | XL | 2XL
-        // then add $100 if L, $150 if XL and $300 if 2XL
-
-        // eslint-disable-next-line unicorn/prefer-switch
-        if (d.size === 'Shield-Memory-L') {
-          costMonthly[d.size] += 100
-        } else if (d.size === 'Shield-Memory-XL') {
-          costMonthly[d.size] += 150
-        } else if (d.size === 'Shield-Memory-2XL') {
-          costMonthly[d.size] += 300
-        }
       }
 
       if (d.size in dynoTotals) {

--- a/packages/apps-v5/src/commands/ps/type.js
+++ b/packages/apps-v5/src/commands/ps/type.js
@@ -3,7 +3,7 @@
 let cli = require('heroku-cli-util')
 const {sortBy, compact} = require('lodash')
 
-const costMonthly = {Free: 0, Eco: 0, Hobby: 7, Basic: 7, 'Standard-1X': 25, 'Standard-2X': 50, 'Performance-M': 250, Performance: 500, 'Performance-L': 500, '1X': 36, '2X': 72, PX: 576}
+const costMonthly = {Free: 0, Eco: 0, Hobby: 7, Basic: 7, 'Standard-1X': 25, 'Standard-2X': 50, 'Performance-M': 250, Performance: 500, 'Performance-L': 500, '1X': 36, '2X': 72, PX: 576, 'Performance-Memory-L': 500, 'Performance-Memory-XL': 750, 'Performance-Memory-2XL': 1500}
 
 let emptyFormationErr = app => {
   return new Error(`No process types on ${app}.
@@ -55,6 +55,9 @@ Types: ${cli.color.yellow(formation.map(f => f.type).join(', '))}`)
 
       if (shielded) {
         d.size = d.size.replace('Private-', 'Shield-')
+
+        // add logic to check if size is Shield-Memory-L | XL | 2XL
+        // then add $100 if L, $150 if XL and $300 if 2XL
       }
 
       if (d.size in dynoTotals) {

--- a/packages/apps-v5/test/unit/commands/ps/type.unit.test.js
+++ b/packages/apps-v5/test/unit/commands/ps/type.unit.test.js
@@ -29,28 +29,37 @@ describe('ps:type', function () {
         {type: 'web', quantity: 1, size: 'Standard-2X'},
         {type: 'web', quantity: 1, size: 'Performance-M'},
         {type: 'web', quantity: 1, size: 'Performance-L'},
+        {type: 'web', quantity: 1, size: 'Performance-L-Ram'},
+        {type: 'web', quantity: 1, size: 'Performance-XL'},
+        {type: 'web', quantity: 1, size: 'Performance-2XL'},
       ])
 
     return cmd.run({app: 'myapp'})
       .then(() => {
         expect(cli.stdout).to.eq(`=== Dyno Types
-type  size           qty  cost/hour  max cost/month
-────  ─────────────  ───  ─────────  ──────────────
-web   Eco            1
-web   Basic          1    ~$0.010    $7
-web   Standard-1X    1    ~$0.035    $25
-web   Standard-2X    1    ~$0.069    $50
-web   Performance-M  1    ~$0.347    $250
-web   Performance-L  1    ~$0.694    $500
+type  size               qty  cost/hour  max cost/month
+────  ─────────────────  ───  ─────────  ──────────────
+web   Eco                1
+web   Basic              1    ~$0.010    $7
+web   Standard-1X        1    ~$0.035    $25
+web   Standard-2X        1    ~$0.069    $50
+web   Performance-M      1    ~$0.347    $250
+web   Performance-L      1    ~$0.694    $500
+web   Performance-L-Ram  1    ~$0.694    $500
+web   Performance-XL     1    ~$1.042    $750
+web   Performance-2XL    1    ~$2.083    $1500
 === Dyno Totals
-type           total
-─────────────  ─────
-Eco            1
-Basic          1
-Standard-1X    1
-Standard-2X    1
-Performance-M  1
-Performance-L  1
+type               total
+─────────────────  ─────
+Eco                1
+Basic              1
+Standard-1X        1
+Standard-2X        1
+Performance-M      1
+Performance-L      1
+Performance-L-Ram  1
+Performance-XL     1
+Performance-2XL    1
 
 $5 (flat monthly fee, shared across all Eco dynos)
 `)


### PR DESCRIPTION
# Description
[Work Item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001iRUjsYAG/view)

This PR adds larger dyno size information to the CLI.



<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Testing

### Changing Dyno Types
- `./bin/dev ps:type -a <common-runtime-based-app> performance-l-ram`
- `./bin/dev ps:type -a <common-runtime-based-app> performance-xl`
- `./bin/dev ps:type -a <common-runtime-based-app> performance-2xl`

NOTE: Running the first 3 commands above requires a common runtime based app. If you have trouble locating an app with said specifications, please reach out to me and I'll add you to my example app (`docker-test-image`)

- `./bin/dev ps:type -a heroku-cli-test-staging --space compliant-services-staging web=1:private-l-ram`
- `./bin/dev ps:type -a heroku-cli-test-staging --space compliant-services-staging web=1:private-xl`
- `./bin/dev ps:type -a heroku-cli-test-staging --space compliant-services-staging web=1:private-2xl`

### Scaling Larger Dyno Types
- `./bin/dev ps:scale -a <common-runtime-based-app> web=1:performance-l-ram`
- `./bin/dev ps:scale -a <common-runtime-based-app> web=1:performance-xl`
- `./bin/dev ps:scale -a <common-runtime-based-app> web=1:performance-2xl`

NOTE: Running the first 3 commands above requires a common runtime based app. If you have trouble locating an app with said specifications, please reach out to me and I'll add you to my example app (`docker-test-image`)

- `./bin/dev ps:scale -a heroku-cli-test-staging --space compliant-services-staging web=1:private-l-ram`
- `./bin/dev ps:scale -a heroku-cli-test-staging --space compliant-services-staging web=1:private-xl`
- `./bin/dev ps:scale -a heroku-cli-test-staging --space compliant-services-staging web=1:private-2xl`


Remember to shutdown any active dynos by running
`heroku ps:stop -a <common-runtime-based-app> web.1`

Using `heroku ps -a heroku-cli-test-staging`, ensure all dynos are in `provisioning` state