### PR TITLE
fix(codemods): handle string literal prop name in flags

### DIFF
--- a/packages/migration/src/transforms/unit-tests/migrations.ts
+++ b/packages/migration/src/transforms/unit-tests/migrations.ts
@@ -71,7 +71,7 @@ export const migrateCommandRun = (runArgs: ts.ObjectLiteralExpression): ts.Expre
       }
 
       for (const flagProp of prop.initializer.properties) {
-        if (!ts.isIdentifier(flagProp.name)) {
+        if (!ts.isIdentifier(flagProp.name) && !ts.isStringLiteral(flagProp.name)) {
           continue
         }
 
@@ -83,7 +83,9 @@ export const migrateCommandRun = (runArgs: ts.ObjectLiteralExpression): ts.Expre
             break
           }
 
-          transformedCommand.push(factory.createStringLiteral(`--${flagProp.name.escapedText.toString()}`))
+          const propName = ts.isIdentifier(flagProp.name) ? flagProp.name.escapedText.toString() : flagProp.name.text
+
+          transformedCommand.push(factory.createStringLiteral(`--${propName}`))
           if (flagProp.initializer.kind !== ts.SyntaxKind.TrueKeyword) {
             transformedCommand.push(flagProp.initializer)
           }


### PR DESCRIPTION
Before fix: 
`flags: {'show-url': true, thing: true}}` => `runCommand(Cmd, ['--thing'])`
with fix: 
`flags: {'show-url': true, thing: true}}` => `runCommand(Cmd, ['--show-url', '--thing'])`

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
