### PR TITLE
fix: updates to stampy actions

### DIFF
--- a/.github/workflows/empty-stampy-buckets.yml
+++ b/.github/workflows/empty-stampy-buckets.yml
@@ -21,4 +21,4 @@ jobs:
           export AWS_ACCESS_KEY_ID=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.AccessKeyId')
           export AWS_SECRET_ACCESS_KEY=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SecretAccessKey')
           export AWS_SESSION_TOKEN=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SessionToken')
-          node scripts/empty-stampy-buckets.js
+          node scripts/stampy/empty-stampy-buckets.js

--- a/.github/workflows/get-signed-from-stampy.yml
+++ b/.github/workflows/get-signed-from-stampy.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Stampy
     steps:
-      - uses: actions/checkout@3
+      - uses: actions/checkout@v3
       - name: download signed Windows installer from from Stampy
         env:
           STAMPY_ARN: ${{ secrets.STAMPY_ARN }}
@@ -21,10 +21,10 @@ jobs:
           export AWS_ACCESS_KEY_ID=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.AccessKeyId')
           export AWS_SECRET_ACCESS_KEY=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SecretAccessKey')
           export AWS_SESSION_TOKEN=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SessionToken')
-          aws s3 cp --recursive ${{ secrets.STAMPY_SIGNED_BUCKET }}/ .
+          aws s3 cp --recursive s3://${{ secrets.STAMPY_SIGNED_BUCKET }}/ .
       - name: upload signed Windows installer to Heroku CLI s3
         env:
           AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
           AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
           AWS_EC2_METADATA_DISABLED: true
-        run: node ./scripts/upload-stampy-signed.js
+        run: node ./scripts/stampy/upload-stampy-signed.js

--- a/.github/workflows/promote-windows.yml
+++ b/.github/workflows/promote-windows.yml
@@ -7,6 +7,18 @@ on:
         description: version to promote to stable (this should be the latest release version)
         type: string
         required: true
+      isStableRelease:
+        type: boolean
+        description: Is this a stable/prod release?
+        required: true
+        default: false
+      channel:
+        type: choice
+        description: Release channel for prereleases
+        required: false
+        options:
+          - beta
+          - alpha
 
 jobs:
   promote:
@@ -34,5 +46,5 @@ jobs:
           prerelease-channel: ${{ inputs.channel || 'beta'}}
         run: |
           SHA=$(npm view heroku@${{ inputs.version }} --json | jq -r '.gitHead[0:7]')
-          yarn oclif promote --win --root="./packages/cli" --sha="$SHA" --indexes --version=${{ inputs.version }} --channel="stable"
+          yarn oclif promote --win --root="./packages/cli" --sha="$SHA" --indexes --version=${{ inputs.version }} --channel=${{ fromJSON(inputs.isStableRelease) && 'stable' || env.prerelease-channel }}
         shell: bash

--- a/.github/workflows/upload-to-stampy.yml
+++ b/.github/workflows/upload-to-stampy.yml
@@ -8,25 +8,21 @@ on:
         required: true
 
 jobs:
-  get-signed-from-stampy:
+  upload-to-stampy-unsigned:
     runs-on: ubuntu-latest
     environment: Stampy
     steps:
-      - uses: actions/checkout@3
-      - name: get version sha
-        id: versionSha
-        run: echo SHA=$(npm view heroku@${{ inputs.version }} --json | jq -r '.gitHead[0:7]') >> "$GITHUB_ENV"
-      - name: save filename (without arch/extension) for reuse
-        id: filename
-        run: echo "FILEBASE=heroku-v${{inputs.version}}-${{steps.versionSha.outputs.SHA}}" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v3
       - name: download Windows installers from s3
         env:
           AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
           AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
           AWS_EC2_METADATA_DISABLED: true
         run: |
-          aws s3 cp s3://heroku-cli-assets/versions/${{inputs.version}}/${{steps.versionSha.outputs.SHA}}/${{steps.filename.outputs.FILEBASE}}-x86.exe .
-          aws s3 cp s3://heroku-cli-assets/versions/${{inputs.version}}/${{steps.versionSha.outputs.SHA}}/${{steps.filename.outputs.FILEBASE}}-x64.exe .
+          SHA=$(npm view heroku@${{ inputs.version }} --json | jq -r '.gitHead[0:7]')
+          FILEBASE=heroku-v${{inputs.version}}-$SHA
+          aws s3 cp s3://heroku-cli-assets/versions/${{inputs.version}}/$SHA/$FILEBASE-x86.exe .
+          aws s3 cp s3://heroku-cli-assets/versions/${{inputs.version}}/$SHA/$FILEBASE-x64.exe .
       - name: upload unsigned Windows installers to Stampy
         env:
           STAMPY_ARN: ${{ secrets.STAMPY_ARN }}
@@ -36,10 +32,12 @@ jobs:
           AWS_EC2_METADATA_DISABLED: true
         # switch AWS identity to the one that can access stampy
         run: |
+          SHA=$(npm view heroku@${{ inputs.version }} --json | jq -r '.gitHead[0:7]')
+          FILEBASE=heroku-v${{inputs.version}}-$SHA
           ACCOUNT_ID=$(aws sts get-caller-identity | jq -r '.Account')
           TEMP_ROLE=$(aws sts assume-role --role-arn $STAMPY_ARN --role-session-name artifact-signing)
           export AWS_ACCESS_KEY_ID=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.AccessKeyId')
           export AWS_SECRET_ACCESS_KEY=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SecretAccessKey')
           export AWS_SESSION_TOKEN=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SessionToken')
-          aws s3 cp ${{steps.filename.outputs.FILEBASE}}-x86.exe $STAMPY_UNSIGNED_BUCKET/${{steps.filename.outputs.FILEBASE}}-x86.exe
-          aws s3 cp ${{steps.filename.outputs.FILEBASE}}-x64.exe $STAMPY_UNSIGNED_BUCKET/${{steps.filename.outputs.FILEBASE}}-x64.exe
+          aws s3 cp $FILEBASE-x86.exe s3://$STAMPY_UNSIGNED_BUCKET/$FILEBASE-x86.exe
+          aws s3 cp $FILEBASE-x64.exe s3://$STAMPY_UNSIGNED_BUCKET/$FILEBASE-x64.exe


### PR DESCRIPTION
A few updates to the stampy-related github actions.

[Work item 1](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001elgflYAA/view)
[Work item 2
](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001elVCoYAM/view)
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
