### PR TITLE
feat(pg): enable credentials url/rotation command for essential tier dbs

### DIFF
--- a/packages/pg-v5/commands/credentials/rotate.js
+++ b/packages/pg-v5/commands/credentials/rotate.js
@@ -16,8 +16,8 @@ async function run(context, heroku) {
     throw new Error('cannot pass both --all and --name')
   }
 
-  if (util.essentialNumPlan(db) || (util.legacyEssentialPlan(db) && cred !== 'default')) {
-    throw new Error("You can't rotate credentials on Essential-tier databases.")
+  if (util.legacyEssentialPlan(db) && cred !== 'default') {
+    throw new Error('You can only rotate default credentials on legacy Essential-tier databases.')
   }
 
   if (all && flags.force) {

--- a/packages/pg-v5/commands/credentials/rotate.js
+++ b/packages/pg-v5/commands/credentials/rotate.js
@@ -17,7 +17,7 @@ async function run(context, heroku) {
   }
 
   if (util.legacyEssentialPlan(db) && cred !== 'default') {
-    throw new Error('You can only rotate default credentials on legacy Essential-tier databases.')
+    throw new Error('Legacy Essential-tier databases do not support named credentials.')
   }
 
   if (all && flags.force) {

--- a/packages/pg-v5/commands/credentials/url.js
+++ b/packages/pg-v5/commands/credentials/url.js
@@ -12,8 +12,8 @@ async function run(context, heroku) {
 
   let db = await fetcher.addon(app, args.database)
   let cred = flags.name || 'default'
-  if (util.essentialNumPlan(db) || (util.legacyEssentialPlan(db) && cred !== 'default')) {
-    throw new Error("You can't view credentials on Essential-tier databases.")
+  if (util.legacyEssentialPlan(db) && cred !== 'default') {
+    throw new Error('You can only view default credentials on legacy Essential-tier databases.')
   }
 
   let credInfo = await heroku.get(`/postgres/v0/databases/${db.name}/credentials/${encodeURIComponent(cred)}`,

--- a/packages/pg-v5/commands/credentials/url.js
+++ b/packages/pg-v5/commands/credentials/url.js
@@ -13,7 +13,7 @@ async function run(context, heroku) {
   let db = await fetcher.addon(app, args.database)
   let cred = flags.name || 'default'
   if (util.legacyEssentialPlan(db) && cred !== 'default') {
-    throw new Error('You can only view default credentials on legacy Essential-tier databases.')
+    throw new Error('Legacy Essential-tier databases do not support named credentials.')
   }
 
   let credInfo = await heroku.get(`/postgres/v0/databases/${db.name}/credentials/${encodeURIComponent(cred)}`,

--- a/packages/pg-v5/test/unit/commands/credentials/rotate.unit.test.js
+++ b/packages/pg-v5/test/unit/commands/credentials/rotate.unit.test.js
@@ -122,11 +122,11 @@ describe('pg:credentials:rotate', () => {
       '../../lib/fetcher': fetcher,
     })
 
-    const err = "You can't rotate credentials on Essential-tier databases."
+    const err = 'You can only rotate default credentials on legacy Essential-tier databases.'
     return expect(cmd.run({app: 'myapp', args: {}, flags: {name: 'jeff'}})).to.be.rejectedWith(Error, err)
   })
 
-  it('throws an error when the db is numbered essential plan', () => {
+  it('rotates credentials when the db is numbered essential plan', () => {
     const essentialAddon = {
       name: 'postgres-1',
       plan: {name: 'heroku-postgresql:essential-0'},
@@ -143,8 +143,11 @@ describe('pg:credentials:rotate', () => {
       '../../lib/fetcher': fetcher,
     })
 
-    const err = "You can't rotate credentials on Essential-tier databases."
-    return expect(cmd.run({app: 'myapp', args: {}, flags: {name: 'jeff'}})).to.be.rejectedWith(Error, err)
+    pg.post('/postgres/v0/databases/postgres-1/credentials/lucy/credentials_rotation').reply(200)
+
+    return cmd.run({app: 'myapp', args: {}, flags: {name: 'lucy', confirm: 'myapp', force: true}})
+      .then(() => expect(cli.stdout).to.equal(''))
+      .then(() => expect(cli.stderr).to.equal('Rotating lucy on postgres-1... done\n'))
   })
 
   it('rotates credentials with no --name with starter plan', () => {

--- a/packages/pg-v5/test/unit/commands/credentials/rotate.unit.test.js
+++ b/packages/pg-v5/test/unit/commands/credentials/rotate.unit.test.js
@@ -122,7 +122,7 @@ describe('pg:credentials:rotate', () => {
       '../../lib/fetcher': fetcher,
     })
 
-    const err = 'You can only rotate default credentials on legacy Essential-tier databases.'
+    const err = 'Legacy Essential-tier databases do not support named credentials.'
     return expect(cmd.run({app: 'myapp', args: {}, flags: {name: 'jeff'}})).to.be.rejectedWith(Error, err)
   })
 

--- a/packages/pg-v5/test/unit/commands/credentials/url.unit.test.js
+++ b/packages/pg-v5/test/unit/commands/credentials/url.unit.test.js
@@ -95,7 +95,7 @@ Connection URL:
       '../../lib/fetcher': fetcher,
     })
 
-    const err = 'You can only view default credentials on legacy Essential-tier databases.'
+    const err = 'Legacy Essential-tier databases do not support named credentials.'
     return expect(cmd.run({app: 'myapp', args: {}, flags: {name: 'jeff'}})).to.be.rejectedWith(Error, err)
   })
 

--- a/packages/pg-v5/test/unit/commands/credentials/url.unit.test.js
+++ b/packages/pg-v5/test/unit/commands/credentials/url.unit.test.js
@@ -95,29 +95,40 @@ Connection URL:
       '../../lib/fetcher': fetcher,
     })
 
-    const err = "You can't view credentials on Essential-tier databases."
+    const err = 'You can only view default credentials on legacy Essential-tier databases.'
     return expect(cmd.run({app: 'myapp', args: {}, flags: {name: 'jeff'}})).to.be.rejectedWith(Error, err)
   })
 
-  it('throws an error when the db is numbered essential plan', () => {
-    const essentialAddon = {
-      name: 'postgres-1',
-      plan: {name: 'heroku-postgresql:essential-0'},
+  it('shows the credentials when the db is numbered essential plan', () => {
+    let roleInfo = {
+      uuid: 'bbbb',
+      name: 'lucy',
+      state: 'created',
+      database: 'd123',
+      host: 'localhost',
+      port: 5442,
+      credentials: [
+        {
+          user: 'lucy-rotating',
+          password: 'passw0rd',
+          state: 'revoking',
+        },
+        {
+          user: 'lucy',
+          password: 'hunter2',
+          state: 'active',
+        },
+      ],
     }
 
-    const fetcher = () => {
-      return {
-        database: () => db,
-        addon: () => essentialAddon,
-      }
-    }
+    pg.get('/postgres/v0/databases/postgres-1/credentials/lucy').reply(200, roleInfo)
 
-    const cmd = proxyquire('../../../../commands/credentials/url', {
-      '../../lib/fetcher': fetcher,
-    })
-
-    const err = "You can't view credentials on Essential-tier databases."
-    return expect(cmd.run({app: 'myapp', args: {}, flags: {name: 'jeff'}})).to.be.rejectedWith(Error, err)
+    return cmd.run({app: 'myapp', args: {}, flags: {name: 'lucy'}})
+      .then(() => expect(cli.stdout).to.equal(`Connection information for lucy credential.\nConnection info string:
+   "dbname=d123 host=localhost port=5442 user=lucy password=hunter2 sslmode=require"
+Connection URL:
+   postgres://lucy:hunter2@localhost:5442/d123
+`))
   })
 
   it('shows the correct credentials with starter plan', () => {


### PR DESCRIPTION
This updates logic in our `pg:credentials` command to allow for essential tier dbs.
