### PR TITLE
chore: update readme Developing instructions

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -82,15 +82,14 @@ This project is built with [lerna](https://lerna.js.org/). The core plugins are 
 
 After cloning the repo
 1. Run `yarn` to install dependencies
-2. Run `yarn lerna bootstrap` set up Lerna and link the packages together
-    - This repo currently uses an older version of Lerna. We recommend using the version specified in the package.json instead of a newer version that you may have installed globally.
+2. Run `yarn build` to build the CLI. This will need to be re-run any time you make changes and want to test them locally.
 
 To execute Heroku CLI commands locally, use `./bin/run <command>`. For example, to run the `heroku apps` command with your local code, run `./bin/run apps` from the root directory.
 
 Testing
 =======
 
-Run all tests with `yarn lerna run test`.
+Run all tests with `yarn test`.
 
 Run one test, in this case plugin-certs-v5, with `yarn lerna run --scope @heroku-cli/plugin-certs-v5 test`.
 


### PR DESCRIPTION
A quick update to our developing instructions. Running `yarn lerna bootstrap` no longer works.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
