### PR TITLE
chore: fix empty stampy workflow

### DIFF
--- a/.github/workflows/empty-stampy-buckets.yml
+++ b/.github/workflows/empty-stampy-buckets.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch
 
 jobs:
-  copy-to-stable:
+  empty-stampy-buckets:
     runs-on: ubuntu-latest
     environment: Stampy
     steps:
@@ -21,4 +21,4 @@ jobs:
           export AWS_ACCESS_KEY_ID=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.AccessKeyId')
           export AWS_SECRET_ACCESS_KEY=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SecretAccessKey')
           export AWS_SESSION_TOKEN=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SessionToken')
-          node scripts/stampy/empty-stampy-buckets.js
+          node ./scripts/stampy/empty-stampy-buckets.js

--- a/.github/workflows/empty-stampy-buckets.yml
+++ b/.github/workflows/empty-stampy-buckets.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Stampy
     steps:
+      - uses: actions/checkout@v3
       - name: Empty Stampy signed and unsigned buckets
         env:
           STAMPY_ARN: ${{ secrets.STAMPY_ARN }}

--- a/scripts/stampy/empty-stampy-buckets.js
+++ b/scripts/stampy/empty-stampy-buckets.js
@@ -6,7 +6,7 @@ fs.readdirSync('.')
   .flatMap(f =>
     [process.env.STAMPY_UNSIGNED_BUCKET, process.env.STAMPY_SIGNED_BUCKET].map(b => `aws s3 rm ${b}/${f}`),
   )
-  .map(c => {
+  .forEach(c => {
     exec(c, (error, stdout) => {
       if (error) {
         console.error(`exec error: ${error}`)


### PR DESCRIPTION
A couple of quick updates to the empty stampy job.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
