### PR TITLE
Fix error triggered on check for internal feature flag

### DIFF
--- a/packages/apps-v5/src/commands/ps/scale.js
+++ b/packages/apps-v5/src/commands/ps/scale.js
@@ -16,6 +16,13 @@ async function run(context, heroku) {
   // successfully launched larger dyno sizes
   let isLargerDyno = false
   const largerDynoFeatureFlag = await heroku.get('/account/features/frontend-larger-dynos')
+    .catch(error => {
+      if (error.statusCode === 404) {
+        return {enabled: false}
+      }
+
+      throw error
+    })
 
   async function parse(args) {
     // checks for larger dyno sizes

--- a/packages/apps-v5/src/commands/ps/type.js
+++ b/packages/apps-v5/src/commands/ps/type.js
@@ -18,6 +18,13 @@ async function run(context, heroku) {
   // successfully launched larger dyno sizes
   let isLargerDyno = false
   const largerDynoFeatureFlag = await heroku.get('/account/features/frontend-larger-dynos')
+    .catch(error => {
+      if (error.statusCode === 404) {
+        return {enabled: false}
+      }
+
+      throw error
+    })
 
   let parse = async function (args) {
     if (!args || args.length === 0) return []

--- a/packages/apps-v5/test/unit/commands/ps/scale.unit.test.js
+++ b/packages/apps-v5/test/unit/commands/ps/scale.unit.test.js
@@ -135,3 +135,13 @@ it('errors if user attempts to scale up using new larger dyno size and feature f
     .catch(error => expect(error.message).to.eq('No such size as Performance-L-RAM. Use eco, basic, standard-1x, standard-2x, performance-m, performance-l, private-s, private-m, private-l, shield-s, shield-m, shield-l.'))
     .then(() => api.done())
 })
+
+it("errors if user attempts to scale up using new larger dyno size and feature flag doesn't exist", function () {
+  let api = nock('https://api.heroku.com')
+    .get('/account/features/frontend-larger-dynos')
+    .reply(404, {})
+
+  return cmd.run({app: 'myapp', args: ['web=1:Performance-L-RAM']})
+    .catch(error => expect(error.message).to.eq('No such size as Performance-L-RAM. Use eco, basic, standard-1x, standard-2x, performance-m, performance-l, private-s, private-m, private-l, shield-s, shield-m, shield-l.'))
+    .then(() => api.done())
+})

--- a/packages/apps-v5/test/unit/commands/ps/type.unit.test.js
+++ b/packages/apps-v5/test/unit/commands/ps/type.unit.test.js
@@ -195,3 +195,13 @@ it('errors when user requests larger dynos and feature flag is NOT enabled', fun
     .catch(error => expect(error.message).to.eq('No such size as performance-l-ram. Use eco, basic, standard-1x, standard-2x, performance-m, performance-l, private-s, private-m, private-l, shield-s, shield-m, shield-l.'))
     .then(() => api.done())
 })
+
+it("errors when user requests larger dynos and feature flag doesn't exist", function () {
+  let api = nock('https://api.heroku.com')
+    .get('/account/features/frontend-larger-dynos')
+    .reply(404, {})
+
+  return cmd.run({app: 'myapp', args: ['web=performance-l-ram']})
+    .catch(error => expect(error.message).to.eq('No such size as performance-l-ram. Use eco, basic, standard-1x, standard-2x, performance-m, performance-l, private-s, private-m, private-l, shield-s, shield-m, shield-l.'))
+    .then(() => api.done())
+})


### PR DESCRIPTION
# Description

When we introduced an internal feature flag to selectively test the new Larger Dynos feature we didn't realize that for regular Heroku users trying to fetch the state of that feature will trigger a Not Found error that wasn't being handled.

Here we correct that problem handling the Not Found error as expected.

## SOC2 Compliance 
[GUS WI](https://gus.lightning.force.com/a07EE00001jlS2XYAU)