### PR TITLE
fix: add yarn to snyk commands

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -18,5 +18,5 @@ jobs:
           node-version: 16.x
       - run: yarn --immutable --network-timeout 1000000
       - run: yarn dlx snyk
-      - run: snyk test --all-projects --fail-on=all
-      - run: snyk monitor --all-projects --org=hit
+      - run: yarn snyk test --all-projects --fail-on=all
+      - run: yarn snyk monitor --all-projects --org=hit


### PR DESCRIPTION
Now that we are installing snyk with `yarn dlx` instead of installing it globally, we need to add `yarn` to the beginning of our snyk commands.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
