### PR TITLE
fix: update snyk workflow to use yarn dlx correctly

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -17,6 +17,5 @@ jobs:
         with:
           node-version: 16.x
       - run: yarn --immutable --network-timeout 1000000
-      - run: yarn dlx snyk
-      - run: yarn snyk test --all-projects --fail-on=all
-      - run: yarn snyk monitor --all-projects --org=hit
+      - run: yarn dlx -p snyk test --all-projects --fail-on=all
+      - run: yarn dlx -p snyk monitor --all-projects --org=hit


### PR DESCRIPTION
Updating the snyk workflow to hopefully get it right this time. 

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
