### PR TITLE
fix: allow ps:scale to handle extra args

### DIFF
--- a/packages/apps-v5/src/commands/ps/scale.js
+++ b/packages/apps-v5/src/commands/ps/scale.js
@@ -32,6 +32,7 @@ async function run(context, heroku) {
         // eslint-disable-next-line array-callback-return
         compact(args.map(arg => {
           let match = arg.match(/^([\w-]+)([=+-]\d+)(?::([\w-]+))?$/)
+          if (match === null) return
           let size = match[3]
 
           const largerDynoNames = /^(?!standard-[12]x$)(performance|private|shield)-(l-ram|xl|2xl)$/i


### PR DESCRIPTION
Fix for #2636. Allows the `ps:scale` command to handle extra args.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
