### PR TITLE
fix(tests): Increasing Mocha timeouts

### DIFF
--- a/packages/addons-v5/test/mocha.opts
+++ b/packages/addons-v5/test/mocha.opts
@@ -2,4 +2,4 @@
 --recursive
 --check-leaks
 --require ./test/init.js
---timeout 60000
+--timeout 180000

--- a/packages/apps-v5/test/mocha.opts
+++ b/packages/apps-v5/test/mocha.opts
@@ -2,4 +2,4 @@
 --require ./test/helpers.js
 --reporter list
 --recursive
---timeout 60000
+--timeout 180000

--- a/packages/certs-v5/test/mocha.opts
+++ b/packages/certs-v5/test/mocha.opts
@@ -2,4 +2,4 @@
 --require ./test/helpers.js
 --reporter list
 --recursive
---timeout 60000
+--timeout 180000

--- a/packages/ci-v5/test/mocha.opts
+++ b/packages/ci-v5/test/mocha.opts
@@ -1,5 +1,5 @@
 test
 --recursive
---timeout 60000
+--timeout 180000
 -R dot
 --require test/test-setup.js

--- a/packages/cli/test/acceptance/smoke.acceptance.test.ts
+++ b/packages/cli/test/acceptance/smoke.acceptance.test.ts
@@ -142,7 +142,7 @@ describe('@acceptance smoke tests', () => {
     })
 
     it('heroku run', async () => {
-      const {stdout} = await run(['run', '--exit-code', appFlag, 'echo', 'it works!'].join(' '))
+      const {stdout} = await run(['run', '--size=private-s', '--exit-code', appFlag, 'echo', 'it works!'].join(' '))
       expect(stdout).to.contain('it works!')
     })
 

--- a/packages/cli/test/mocha.opts
+++ b/packages/cli/test/mocha.opts
@@ -4,4 +4,4 @@
 --watch-extensions ts
 --recursive
 --reporter spec
---timeout 60000
+--timeout 180000

--- a/packages/container-registry-v5/test/mocha.opts
+++ b/packages/container-registry-v5/test/mocha.opts
@@ -1,4 +1,4 @@
 --require ./test/helpers.js
 --reporter list
 --recursive
---timeout 60000
+--timeout 180000

--- a/packages/oauth-v5/test/mocha.opts
+++ b/packages/oauth-v5/test/mocha.opts
@@ -1,3 +1,3 @@
 --require ./test/init.js
 --recursive
---timeout 60000
+--timeout 180000

--- a/packages/orgs-v5/test/mocha.opts
+++ b/packages/orgs-v5/test/mocha.opts
@@ -1,3 +1,3 @@
 --require ./test/helpers.js
 --recursive
---timeout 60000
+--timeout 180000

--- a/packages/pg-v5/test/mocha.opts
+++ b/packages/pg-v5/test/mocha.opts
@@ -1,3 +1,3 @@
 --recursive
 --require ./test/init.js
---timeout 60000
+--timeout 180000

--- a/packages/redis-v5/test/mocha.opts
+++ b/packages/redis-v5/test/mocha.opts
@@ -2,4 +2,4 @@
 --reporter list
 --recursive
 --exit
---timeout 60000
+--timeout 180000

--- a/packages/run-v5/test/integration/run.integration.test.js
+++ b/packages/run-v5/test/integration/run.integration.test.js
@@ -18,7 +18,7 @@ describe('run', () => {
     })
     return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: {password: global.apikey}, args: ['echo', '1', '2', '3']})
       .then(() => fixture.release())
-      .then(() => expect(stdout).to.contain('1 2 3\n'))
+      .then(() => expect(stdout).to.contain('1 2 3'))
   })
 
   it('runs a command with spaces', () => {
@@ -29,7 +29,7 @@ describe('run', () => {
     })
     return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: {password: global.apikey}, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo": "bar"} ']})
       .then(() => fixture.release())
-      .then(() => expect(stdout).to.contain('{"foo": "bar"} \n'))
+      .then(() => expect(stdout).to.contain('{"foo": "bar"} '))
   })
 
   it('runs a command with quotes', () => {
@@ -40,7 +40,7 @@ describe('run', () => {
     })
     return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: {password: global.apikey}, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo":"bar"}']})
       .then(() => fixture.release())
-      .then(() => expect(stdout).to.contain('{"foo":"bar"}\n'))
+      .then(() => expect(stdout).to.contain('{"foo":"bar"}'))
   })
 
   it('runs a command with env vars', () => {

--- a/packages/run-v5/test/integration/run.integration.test.js
+++ b/packages/run-v5/test/integration/run.integration.test.js
@@ -16,7 +16,7 @@ describe('run', () => {
     fixture.capture(s => {
       stdout += s
     })
-    return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: {password: global.apikey}, args: ['echo', '1', '2', '3']})
+    return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {size: 'private-s'}, auth: {password: global.apikey}, args: ['echo', '1', '2', '3']})
       .then(() => fixture.release())
       .then(() => expect(stdout).to.contain('1 2 3'))
   })
@@ -27,7 +27,7 @@ describe('run', () => {
     fixture.capture(s => {
       stdout += s
     })
-    return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: {password: global.apikey}, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo": "bar"} ']})
+    return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {size: 'private-s'}, auth: {password: global.apikey}, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo": "bar"} ']})
       .then(() => fixture.release())
       .then(() => expect(stdout).to.contain('{"foo": "bar"} '))
   })
@@ -38,7 +38,7 @@ describe('run', () => {
     fixture.capture(s => {
       stdout += s
     })
-    return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {}, auth: {password: global.apikey}, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo":"bar"}']})
+    return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {size: 'private-s'}, auth: {password: global.apikey}, args: ['ruby', '-e', 'puts ARGV[0]', '{"foo":"bar"}']})
       .then(() => fixture.release())
       .then(() => expect(stdout).to.contain('{"foo":"bar"}'))
   })
@@ -49,7 +49,7 @@ describe('run', () => {
     fixture.capture(s => {
       stdout += s
     })
-    return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {env: 'FOO=bar'}, auth: {password: global.apikey}, args: ['env']})
+    return cmd.run({app: 'heroku-cli-ci-smoke-test-app', flags: {size: 'private-s', env: 'FOO=bar'}, auth: {password: global.apikey}, args: ['env']})
       .then(() => fixture.release())
       .then(() => expect(stdout).to.contain('FOO=bar'))
   })

--- a/packages/run-v5/test/mocha.opts
+++ b/packages/run-v5/test/mocha.opts
@@ -1,4 +1,4 @@
 --require ./test/init.js
 --recursive
---timeout 60000
+--timeout 180000
 --exit

--- a/packages/spaces/test/mocha.opts
+++ b/packages/spaces/test/mocha.opts
@@ -1,4 +1,4 @@
 --require ./test/helpers.js
 --reporter list
 --recursive
---timeout 60000
+--timeout 180000


### PR DESCRIPTION
## Description

Here we're increasing the Mocha timeouts for async calls to avoid failures on integration and acceptance tests that work spinning up one-off dynos, because our test app was moved from the Common Runtime to one of our Private Spaces and the start up time for one-off dynos on PS exceeds the timeout of one minute.

The terminal configuration also changes between Common Runtime and Private Spaces, changing the line termination from Unix (`\n`) to DOS (`\r\n`).

We changed the tests using `heroku run` command to set the dyno size to `private-s`.

## Testing

There's no behavior effected for the actual CLI, this only changes a configuration when running tests.

## SOC2 Compliance

[GUS Work Item](https://gus.lightning.force.com/a07EE00001kXKgUYAW)