### PR TITLE
chore: Switch from --rebase to --ff-only

### DIFF
--- a/scripts/create-release-pr
+++ b/scripts/create-release-pr
@@ -27,7 +27,7 @@ if !(gh auth status --hostname "github.com" > /dev/null 2>&1); then
   exit 1
 fi
 
-git pull --rebase origin "${MAIN_BRANCH}"
+git pull --ff-only origin "${MAIN_BRANCH}"
 
 # Create a branch with the unix timestamp of the current second
 BRANCH_NAME="release-$(date +%s)"


### PR DESCRIPTION
### Description
Opened this in favor of https://github.com/heroku/cli/pull/1779 to avoid rebasing.

### Testing
The `create-release-pr` script must be run on `main`, so you'll have to just locally edit `main` with these changes to test. Simply running `create-release-pr` from your terminal with those changes and verifying it correctly creates a release pr is sufficient for testing.