### PR TITLE
chore: Increase network timeout for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
-      - run: yarn --immutable --network-timeout 1000000
+      - run: yarn --immutable --network-timeout 1500000
       - run: yarn lerna run test:integration
 
   acceptance:


### PR DESCRIPTION
With our test app now residing in a private space, this gives more time to the integration test to complete.
