### PR TITLE
fix(workflow): remove fig command & update workflow

### DIFF
--- a/.github/workflows/publish-to-fig-autocomplete.yml
+++ b/.github/workflows/publish-to-fig-autocomplete.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   push-to-fig-autocomplete:
-    runs-on: pub-hk-ubuntu-22.04-small
+    runs-on: pub-hk-macos-latest
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 16.x
@@ -14,21 +14,25 @@ jobs:
         with:
           node-version: 16.x
           cache: yarn
+      - name: Install jq
+        run: brew install jq
+      - name: Install Fig Oclif Plugin
+        run: yarn add @fig/complete-oclif && jq '.oclif.plugins += ["@fig/complete-oclif"]' package.json > temp.json && mv temp.json package.json
       - run: yarn --immutable --network-timeout 1000000
       - name: Build Heroku CLI
         run: yarn build
-      - name: Generate Fig Spec
-        run: ./bin/run generate-fig-spec > spec.ts
-      - name: Get Heroku Version
-        id: cli-version
-        run: echo "version=$(./bin/run --version | sed -rn 's/^heroku\/([0-9\.]+).*$/\1/p')"
-      - name: Create Fig Autocomplete PR
-        uses: withfig/push-to-fig-autocomplete-action@v1
-        with:
-          token: ${{ secrets.HEROKU_CLI_BOT_TOKEN }}
-          autocomplete-spec-name: 'heroku'
-          spec-path: spec.ts
-          integration: oclif
-          diff-based-versioning: true
-          new-spec-version: ${{ steps.cli-version.outputs.version }}
-          pr-body: Automated PR for latest Heroku CLI release
+      # - name: Generate Fig Spec
+      #   run: ./bin/run generate-fig-spec > spec.ts
+      # - name: Get Heroku Version
+      #   id: cli-version
+      #   run: echo "version=$(./bin/run --version | sed -rn 's/^heroku\/([0-9\.]+).*$/\1/p')"
+      # - name: Create Fig Autocomplete PR
+      #   uses: withfig/push-to-fig-autocomplete-action@v1
+      #   with:
+      #     token: ${{ secrets.HEROKU_CLI_BOT_TOKEN }}
+      #     autocomplete-spec-name: 'heroku'
+      #     spec-path: spec.ts
+      #     integration: oclif
+      #     diff-based-versioning: true
+      #     new-spec-version: ${{ steps.cli-version.outputs.version }}
+      #     pr-body: Automated PR for latest Heroku CLI release

--- a/.github/workflows/publish-to-fig-autocomplete.yml
+++ b/.github/workflows/publish-to-fig-autocomplete.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   push-to-fig-autocomplete:
-    runs-on: pub-hk-macos-latest
+    runs-on: pub-hk-ubuntu-22.04-small
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 16.x

--- a/.github/workflows/publish-to-fig-autocomplete.yml
+++ b/.github/workflows/publish-to-fig-autocomplete.yml
@@ -14,15 +14,13 @@ jobs:
         with:
           node-version: 16.x
           cache: yarn
-      # - name: Install jq
-      #   run: brew install jq
       - name: Install Fig Oclif Plugin
         run: yarn add @fig/complete-oclif && jq '.oclif.plugins += ["@fig/complete-oclif"]' package.json > temp.json && mv temp.json package.json
       - run: yarn --immutable --network-timeout 1000000
       - name: Build Heroku CLI
         run: yarn build
-      # - name: Generate Fig Spec
-      #   run: ./bin/run generate-fig-spec > spec.ts
+      - name: Generate Fig Spec
+        run: ./bin/run generate-fig-spec > spec.ts
       # - name: Get Heroku Version
       #   id: cli-version
       #   run: echo "version=$(./bin/run --version | sed -rn 's/^heroku\/([0-9\.]+).*$/\1/p')"

--- a/.github/workflows/publish-to-fig-autocomplete.yml
+++ b/.github/workflows/publish-to-fig-autocomplete.yml
@@ -14,8 +14,8 @@ jobs:
         with:
           node-version: 16.x
           cache: yarn
-      - name: Install jq
-        run: brew install jq
+      # - name: Install jq
+      #   run: brew install jq
       - name: Install Fig Oclif Plugin
         run: yarn add @fig/complete-oclif && jq '.oclif.plugins += ["@fig/complete-oclif"]' package.json > temp.json && mv temp.json package.json
       - run: yarn --immutable --network-timeout 1000000

--- a/.github/workflows/publish-to-fig-autocomplete.yml
+++ b/.github/workflows/publish-to-fig-autocomplete.yml
@@ -21,16 +21,16 @@ jobs:
         run: yarn build
       - name: Generate Fig Spec
         run: ./bin/run generate-fig-spec > spec.ts
-      # - name: Get Heroku Version
-      #   id: cli-version
-      #   run: echo "version=$(./bin/run --version | sed -rn 's/^heroku\/([0-9\.]+).*$/\1/p')"
-      # - name: Create Fig Autocomplete PR
-      #   uses: withfig/push-to-fig-autocomplete-action@v1
-      #   with:
-      #     token: ${{ secrets.HEROKU_CLI_BOT_TOKEN }}
-      #     autocomplete-spec-name: 'heroku'
-      #     spec-path: spec.ts
-      #     integration: oclif
-      #     diff-based-versioning: true
-      #     new-spec-version: ${{ steps.cli-version.outputs.version }}
-      #     pr-body: Automated PR for latest Heroku CLI release
+      - name: Get Heroku Version
+        id: cli-version
+        run: echo "version=$(./bin/run --version | sed -rn 's/^heroku\/([0-9\.]+).*$/\1/p')"
+      - name: Create Fig Autocomplete PR
+        uses: withfig/push-to-fig-autocomplete-action@v1
+        with:
+          token: ${{ secrets.HEROKU_CLI_BOT_TOKEN }}
+          autocomplete-spec-name: 'heroku'
+          spec-path: spec.ts
+          integration: oclif
+          diff-based-versioning: true
+          new-spec-version: ${{ steps.cli-version.outputs.version }}
+          pr-body: Automated PR for latest Heroku CLI release - this is a test PR

--- a/.github/workflows/publish-to-fig-autocomplete.yml
+++ b/.github/workflows/publish-to-fig-autocomplete.yml
@@ -15,12 +15,12 @@ jobs:
           node-version: 16.x
           cache: yarn
       - name: Install Fig Oclif Plugin
-        run: yarn add @fig/complete-oclif && jq '.oclif.plugins += ["@fig/complete-oclif"]' package.json > temp.json && mv temp.json package.json
+        run: cd packages/cli && yarn add @fig/complete-oclif && jq '.oclif.plugins += ["@fig/complete-oclif"]' package.json > temp.json && mv temp.json package.json
       - run: yarn --immutable --network-timeout 1000000
       - name: Build Heroku CLI
         run: yarn build
       - name: Generate Fig Spec
-        run: ./bin/run generate-fig-spec > spec.ts
+        run: cd packages/cli && ./bin/run generate-fig-spec > spec.ts && cat spec.ts
       - name: Get Heroku Version
         id: cli-version
         run: echo "version=$(./bin/run --version | sed -rn 's/^heroku\/([0-9\.]+).*$/\1/p')"
@@ -29,7 +29,7 @@ jobs:
         with:
           token: ${{ secrets.HEROKU_CLI_BOT_TOKEN }}
           autocomplete-spec-name: 'heroku'
-          spec-path: spec.ts
+          spec-path: ./packages/cli/spec.ts
           integration: oclif
           diff-based-versioning: true
           new-spec-version: ${{ steps.cli-version.outputs.version }}

--- a/.github/workflows/publish-to-fig-autocomplete.yml
+++ b/.github/workflows/publish-to-fig-autocomplete.yml
@@ -25,7 +25,7 @@ jobs:
         id: cli-version
         run: echo "version=$(./bin/run --version | sed -rn 's/^heroku\/([0-9\.]+).*$/\1/p')"
       - name: Create Fig Autocomplete PR
-        uses: withfig/push-to-fig-autocomplete-action@v1
+        uses: withfig/push-to-fig-autocomplete-action@v2
         with:
           token: ${{ secrets.HEROKU_CLI_BOT_TOKEN }}
           autocomplete-spec-name: 'heroku'

--- a/.github/workflows/publish-to-fig-autocomplete.yml
+++ b/.github/workflows/publish-to-fig-autocomplete.yml
@@ -25,7 +25,7 @@ jobs:
         id: cli-version
         run: echo "version=$(./bin/run --version | sed -rn 's/^heroku\/([0-9\.]+).*$/\1/p')"
       - name: Create Fig Autocomplete PR
-        uses: withfig/push-to-fig-autocomplete-action@v2
+        uses: withfig/push-to-fig-autocomplete-action@console-log-eslint
         with:
           token: ${{ secrets.HEROKU_CLI_BOT_TOKEN }}
           autocomplete-spec-name: 'heroku'

--- a/.github/workflows/publish-to-fig-autocomplete.yml
+++ b/.github/workflows/publish-to-fig-autocomplete.yml
@@ -25,7 +25,7 @@ jobs:
         id: cli-version
         run: echo "version=$(./bin/run --version | sed -rn 's/^heroku\/([0-9\.]+).*$/\1/p')"
       - name: Create Fig Autocomplete PR
-        uses: withfig/push-to-fig-autocomplete-action@console-log-eslint
+        uses: withfig/push-to-fig-autocomplete-action@v2
         with:
           token: ${{ secrets.HEROKU_CLI_BOT_TOKEN }}
           autocomplete-spec-name: 'heroku'
@@ -33,4 +33,4 @@ jobs:
           integration: oclif
           diff-based-versioning: true
           new-spec-version: ${{ steps.cli-version.outputs.version }}
-          pr-body: Automated PR for latest Heroku CLI release - this is a test PR
+          pr-body: Automated PR for latest Heroku CLI release

--- a/.github/workflows/publish-to-fig-autocomplete.yml
+++ b/.github/workflows/publish-to-fig-autocomplete.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build Heroku CLI
         run: yarn build
       - name: Generate Fig Spec
-        run: cd packages/cli && ./bin/run generate-fig-spec > spec.ts && cat spec.ts
+        run: cd packages/cli && ./bin/run generate-fig-spec > spec.ts
       - name: Get Heroku Version
         id: cli-version
         run: echo "version=$(./bin/run --version | sed -rn 's/^heroku\/([0-9\.]+).*$/\1/p')"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,6 @@
   "bin": "./bin/run",
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
-    "@fig/complete-oclif": "^2.0.0",
     "@heroku-cli/color": "1.1.14",
     "@heroku-cli/command": "^10.0.0",
     "@heroku-cli/command-v9": "npm:@heroku-cli/command@^9.0.2",
@@ -156,7 +155,6 @@
     ],
     "commands": "./lib/commands",
     "plugins": [
-      "@fig/complete-oclif",
       "@oclif/plugin-legacy",
       "@heroku-cli/plugin-addons-v5",
       "@heroku-cli/plugin-apps-v5",

--- a/packages/cli/test/acceptance/commands-output.ts
+++ b/packages/cli/test/acceptance/commands-output.ts
@@ -124,7 +124,6 @@ export default `\u001B[1m Command                                        Summary
  features:disable                               disables an app feature                                                                                                                                 
  features:enable                                enables an app feature                                                                                                                                  
  features:info                                  display information about a feature                                                                                                                     
- generate-fig-spec                              Generate a Fig completion spec
  git:clone                                      clones a heroku app to your local machine at DIRECTORY (defaults to app name)                                                                           
  git:remote                                     adds a git remote to an app repo                                                                                                                        
  help                                           Display help for heroku.                                                                                                                                

--- a/yarn.lock
+++ b/yarn.lock
@@ -1099,16 +1099,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fig/complete-oclif@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@fig/complete-oclif@npm:2.0.0"
-  dependencies:
-    "@oclif/core": ^2.8.11
-    prettier: ^3.1.1
-  checksum: c7b148073456723cd85baaab5179a667c8078fb317ea03e184523ac9164ac4ff8f80452006c527e9c4340b08467fe480a2046554a5e6ca75b2e3aa1f27cac8da
-  languageName: node
-  linkType: hard
-
 "@gar/promisify@npm:^1.0.1, @gar/promisify@npm:^1.1.3":
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
@@ -10905,7 +10895,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "heroku@workspace:packages/cli"
   dependencies:
-    "@fig/complete-oclif": ^2.0.0
     "@heroku-cli/color": 1.1.14
     "@heroku-cli/command": ^10.0.0
     "@heroku-cli/command-v9": "npm:@heroku-cli/command@^9.0.2"
@@ -15564,15 +15553,6 @@ __metadata:
   version: 2.0.0
   resolution: "prepend-http@npm:2.0.0"
   checksum: 7694a9525405447662c1ffd352fcb41b6410c705b739b6f4e3a3e21cf5fdede8377890088e8934436b8b17ba55365a615f153960f30877bf0d0392f9e93503ea
-  languageName: node
-  linkType: hard
-
-"prettier@npm:^3.1.1":
-  version: 3.2.5
-  resolution: "prettier@npm:3.2.5"
-  bin:
-    prettier: bin/prettier.cjs
-  checksum: 2ee4e1417572372afb7a13bb446b34f20f1bf1747db77cf6ccaf57a9be005f2f15c40f903d41a6b79eec3f57fff14d32a20fb6dee1f126da48908926fe43c311
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description
This PR removes the FIG plugin and updates the Fig Autocomplete workflow.


<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->