### PR TITLE
bug(local): Ignore env specification when it's not a file

### DIFF
--- a/packages/cli/src/commands/local/index.ts
+++ b/packages/cli/src/commands/local/index.ts
@@ -1,6 +1,7 @@
 import {FileCompletion} from '@heroku-cli/command/lib/completions'
 import {Args, Command, Flags} from '@oclif/core'
-
+import * as fs from 'fs'
+import color from '@heroku-cli/color'
 import {fork as foreman} from '../../lib/local/fork-foreman'
 
 // eslint-disable-next-line node/no-missing-require
@@ -63,8 +64,15 @@ $ heroku local web=1,worker=2`,
       this.error('--concurrency is no longer available\nUse forego instead: https://github.com/ddollar/forego')
     }
 
+    let envFile = flags.env || '.env'
+    envFile = fs.existsSync(envFile) ? envFile : '.env'
+    const envFileInfo = fs.statSync(envFile)
+    if (!envFileInfo.isFile()) {
+      throw new Error(`The specified location for the env file, ${color.bold(envFile)}, is not a file. Please specify a valid file location with the --env flag.`)
+    }
+
     if (flags.procfile) execArgv.push('--procfile', flags.procfile)
-    if (flags.env) execArgv.push('--env', flags.env)
+    if (flags.env) execArgv.push('--env', envFile)
     if (flags.port) execArgv.push('--port', flags.port)
 
     if (args.processname) {

--- a/packages/cli/src/commands/local/index.ts
+++ b/packages/cli/src/commands/local/index.ts
@@ -65,14 +65,13 @@ $ heroku local web=1,worker=2`,
     }
 
     let envFile = flags.env || '.env'
-    envFile = fs.existsSync(envFile) ? envFile : '.env'
-    const envFileInfo = fs.statSync(envFile)
-    if (!envFileInfo.isFile()) {
-      throw new Error(`The specified location for the env file, ${color.bold(envFile)}, is not a file. Please specify a valid file location with the --env flag.`)
+    if (fs.existsSync(envFile) && !fs.statSync(envFile).isFile()) {
+      this.warn(`The specified location for the env file, ${color.bold(envFile)}, is not a file, ignoring.`)
+      envFile = ''
     }
 
     if (flags.procfile) execArgv.push('--procfile', flags.procfile)
-    if (flags.env) execArgv.push('--env', envFile)
+    execArgv.push('--env', envFile)
     if (flags.port) execArgv.push('--port', flags.port)
 
     if (args.processname) {

--- a/packages/cli/src/commands/local/run.ts
+++ b/packages/cli/src/commands/local/run.ts
@@ -1,7 +1,8 @@
 import {FileCompletion} from '@heroku-cli/command/lib/completions'
 import {Command, Flags} from '@oclif/core'
-
+import color from '@heroku-cli/color'
 import {fork as foreman} from '../../lib/local/fork-foreman'
+import * as fs from 'fs'
 
 export default class Run extends Command {
   static description = 'run a one-off command'
@@ -31,7 +32,14 @@ export default class Run extends Command {
       this.error(errorMessage, {exit: -1})
     }
 
-    if (flags.env) execArgv.push('--env', flags.env)
+    let envFile = flags.env || '.env'
+    envFile = fs.existsSync(envFile) ? envFile : '.env'
+    const envFileInfo = fs.statSync(envFile)
+    if (!envFileInfo.isFile()) {
+      throw new Error(`The specified location for the env file, ${color.bold(envFile)}, is not a file. Please specify a valid file location with the --env flag.`)
+    }
+
+    if (flags.env) execArgv.push('--env', envFile)
     if (flags.port) execArgv.push('--port', flags.port)
 
     execArgv.push('--') // disable node-foreman flag parsing

--- a/packages/cli/src/commands/local/run.ts
+++ b/packages/cli/src/commands/local/run.ts
@@ -33,13 +33,12 @@ export default class Run extends Command {
     }
 
     let envFile = flags.env || '.env'
-    envFile = fs.existsSync(envFile) ? envFile : '.env'
-    const envFileInfo = fs.statSync(envFile)
-    if (!envFileInfo.isFile()) {
-      throw new Error(`The specified location for the env file, ${color.bold(envFile)}, is not a file. Please specify a valid file location with the --env flag.`)
+    if (fs.existsSync(envFile) && !fs.statSync(envFile).isFile()) {
+      this.warn(`The specified location for the env file, ${color.bold(envFile)}, is not a file, ignoring.`)
+      envFile = ''
     }
 
-    if (flags.env) execArgv.push('--env', envFile)
+    execArgv.push('--env', envFile)
     if (flags.port) execArgv.push('--port', flags.port)
 
     execArgv.push('--') // disable node-foreman flag parsing

--- a/packages/cli/test/unit/commands/local/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/local/index.unit.test.ts
@@ -17,7 +17,7 @@ describe('local', () => {
       .stub(foreman, 'fork', function () {
       // eslint-disable-next-line prefer-rest-params
         const argv = arguments[0]
-        expect(argv).is.eql(['start', 'web,other'])
+        expect(argv).is.eql(['start', '--env', '.env', 'web,other'])
       })
       .command(['local:start'])
       .it('can call foreman start via the local:start alias')
@@ -37,7 +37,7 @@ describe('local', () => {
         })
         .stub(foreman, 'fork', function () {
         // eslint-disable-next-line prefer-rest-params
-          expect(arguments[0]).is.eql(['start', 'web,other'])
+          expect(arguments[0]).is.eql(['start', '--env', '.env', 'web,other'])
         })
         .command(['local'])
         .it('can call foreman start with no arguments')
@@ -58,7 +58,7 @@ describe('local', () => {
         .stub(foreman, 'fork', function () {
         // eslint-disable-next-line prefer-rest-params
           const argv = arguments[0]
-          expect(argv).is.eql(['start', '--procfile', 'Procfile.other', 'web,background'])
+          expect(argv).is.eql(['start', '--procfile', 'Procfile.other', '--env', '.env', 'web,background'])
           expect(argv).to.not.include('release', 'the release process is not included')
         })
         .command(['local', '--procfile', 'Procfile.other'])
@@ -103,7 +103,7 @@ describe('local', () => {
         .stub(foreman, 'fork', function () {
         // eslint-disable-next-line prefer-rest-params
           const argv = arguments[0]
-          expect(argv).is.eql(['start', 'web,other'])
+          expect(argv).is.eql(['start', '--env', '.env', 'web,other'])
         })
         .command(['local', 'web,other'])
         .it('can call foreman start with only arguments')

--- a/packages/cli/test/unit/commands/local/run.unit.test.ts
+++ b/packages/cli/test/unit/commands/local/run.unit.test.ts
@@ -15,7 +15,7 @@ describe('local:run', () => {
       .stub(foreman, 'fork', function () {
       // eslint-disable-next-line prefer-rest-params
         const argv = arguments[0]
-        expect(argv).is.eql(['run', '--', 'echo', 'hello'])
+        expect(argv).is.eql(['run', '--env', '.env', '--', 'echo', 'hello'])
       })
       .command(['local:run', 'echo', 'hello'])
       .it('can handle one argument passed to foreman after the -- argument separator')
@@ -24,7 +24,7 @@ describe('local:run', () => {
       .stub(foreman, 'fork', function () {
       // eslint-disable-next-line prefer-rest-params
         const argv = arguments[0]
-        expect(argv).is.eql(['run', '--', 'echo', 'hello', 'world'])
+        expect(argv).is.eql(['run', '--env', '.env', '--', 'echo', 'hello', 'world'])
       })
       .command(['local:run', 'echo', 'hello', 'world'])
       .it('can handle multiple argument passed to foreman after the `--` argument separator')
@@ -55,7 +55,7 @@ describe('local:run', () => {
       .stub(foreman, 'fork', function () {
       // eslint-disable-next-line prefer-rest-params
         const argv = arguments[0]
-        expect(argv).is.eql(['run', '--port', '4200', '--', 'bin/serve'])
+        expect(argv).is.eql(['run', '--env', '.env', '--port', '4200', '--', 'bin/serve'])
       })
       .command(['local:run', 'bin/serve', '--port', '4200'])
       .it('is passed to foreman an a --port flag before the `--` argument separator')
@@ -64,7 +64,7 @@ describe('local:run', () => {
       .stub(foreman, 'fork', function () {
       // eslint-disable-next-line prefer-rest-params
         const argv = arguments[0]
-        expect(argv).is.eql(['run', '--port', '4200', '--', 'bin/serve'])
+        expect(argv).is.eql(['run', '--env', '.env', '--port', '4200', '--', 'bin/serve'])
       })
       .command(['local:run', 'bin/serve', '-p', '4200'])
       .it('is can pass the `-p` shorthand to foreman an a --port flag before the `--` argument separator')


### PR DESCRIPTION
https://github.com/heroku/cli/issues/2007

### Description
`heroku local` and `heroku run` allow users to specify an env file location. If that location is a directory instead, the command fails. This adds logic to ignore `env` file locations that are not files, and warns the user.

### Testing
1) Pull down branch and run `local web` within an app's directory that has a `.env` that is a directory
2) See that `.env` is ignored and warns the user
