### PR TITLE
chore: add initial workflow for updating devcenter documentation

### DIFF
--- a/.github/workflows/devcenter-doc-update.yml
+++ b/.github/workflows/devcenter-doc-update.yml
@@ -1,0 +1,18 @@
+name: Update CLI Command DevCenter Documentation
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  update-devcenter-command-docs:
+    name: Update Devcenter command docs
+    runs-on: pub-hk-ubuntu-22.04-small
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install package deps
+        run: yarn --immutable --network-timeout 1000000
+      - name: Install Devcenter CLI
+        run: |
+          gem install devcenter
+          devcenter help


### PR DESCRIPTION
This PR adds an initial workflow for updating devcenter documentation. It does not include the script that generates and updates the documentation yet, but I need to get this workflow merged to `main` so that I can test it on a branch.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
