### PR TITLE
chore: update mocha, increase timeout

### DIFF
--- a/packages/certs-v5/package.json
+++ b/packages/certs-v5/package.json
@@ -28,7 +28,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "lolex": "^3.1.0",
-    "mocha": "^8.0.0",
+    "mocha": "^9.2.2",
     "nock": "^10.0.6",
     "nyc": "^15.1.0",
     "oclif": "3.11.3",
@@ -55,7 +55,7 @@
     ],
     "reporter": "list",
     "recursive": true,
-    "timeout": 180000
+    "timeout": 360000
   },
   "repository": "heroku/cli",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -120,7 +120,7 @@
     "globby": "^10.0.2",
     "lodash": "^4.17.11",
     "lolex": "^3.1.0",
-    "mocha": "^8.0.0",
+    "mocha": "^9.2.2",
     "nock": "^13.5.1",
     "nyc": "^15.1.0",
     "oclif": "3.11.3",
@@ -162,7 +162,7 @@
     "watch-extensions": "ts",
     "recursive": true,
     "reporter": "spec",
-    "timeout": 180000
+    "timeout": 360000
   },
   "oclif": {
     "additionalHelpFlags": [

--- a/packages/oauth-v5/package.json
+++ b/packages/oauth-v5/package.json
@@ -30,7 +30,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cross-env": "^7.0.2",
-    "mocha": "^8.0.0",
+    "mocha": "^9.2.2",
     "mocha-junit-reporter": "1.18.0",
     "nock": "10.0.6",
     "nyc": "^15.1.0",
@@ -51,7 +51,7 @@
       "./test/init.js"
     ],
     "recursive": true,
-    "timeout": 180000
+    "timeout": 360000
   },
   "publishConfig": {
     "access": "public"

--- a/packages/orgs-v5/package.json
+++ b/packages/orgs-v5/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@oclif/plugin-legacy": "^1.3.0",
     "chai": "^4.2.0",
-    "mocha": "^8.0.0",
+    "mocha": "^9.2.2",
     "nock": "^10.0.6",
     "nyc": "^15.1.0",
     "oclif": "3.11.3",
@@ -71,7 +71,7 @@
       "./test/helpers.js"
     ],
     "recursive": true,
-    "timeout": 180000
+    "timeout": 360000
   },
   "repository": "heroku/cli",
   "scripts": {

--- a/packages/pg-v5/package.json
+++ b/packages/pg-v5/package.json
@@ -33,7 +33,7 @@
     "chai-as-promised": "^7.1.1",
     "cross-env": "^7.0.2",
     "heroku-client": "^3.0.7",
-    "mocha": "^8.0.0",
+    "mocha": "^9.2.2",
     "nock": "^10.0.6",
     "nyc": "^15.1.0",
     "oclif": "3.11.3",
@@ -61,7 +61,7 @@
     "require": [
       "./test/init.js"
     ],
-    "timeout": 180000
+    "timeout": 360000
   },
   "repository": "heroku/cli",
   "scripts": {

--- a/packages/redis-v5/package.json
+++ b/packages/redis-v5/package.json
@@ -23,7 +23,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "lolex": "^3.1.0",
-    "mocha": "^8.0.0",
+    "mocha": "^9.2.2",
     "nock": "^10.0.6",
     "nyc": "^15.1.0",
     "oclif": "3.11.3",
@@ -49,7 +49,7 @@
     "reporter": "list",
     "recursive": true,
     "exit": true,
-    "timeout": 180000
+    "timeout": 360000
   },
   "repository": "heroku/cli",
   "scripts": {

--- a/packages/run-v5/package.json
+++ b/packages/run-v5/package.json
@@ -33,7 +33,7 @@
     "@oclif/plugin-legacy": "^1.3.0",
     "chai": "^4.2.0",
     "fixture-stdout": "0.2.1",
-    "mocha": "^8.0.0",
+    "mocha": "^9.2.2",
     "mocha-junit-reporter": "1.18.0",
     "netrc": "0.1.4",
     "nock": "^10.0.6",
@@ -57,7 +57,7 @@
       "./test/init.js"
     ],
     "recursive": true,
-    "timeout": 180000,
+    "timeout": 360000,
     "exit": true
   },
   "oclif": {

--- a/packages/spaces/package.json
+++ b/packages/spaces/package.json
@@ -27,7 +27,7 @@
     "@oclif/plugin-legacy": "^1.3.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "mocha": "^8.0.0",
+    "mocha": "^9.2.2",
     "nock": "^10.0.6",
     "nyc": "^15.1.0",
     "oclif": "3.11.3",
@@ -51,7 +51,7 @@
     ],
     "reporter": "list",
     "recursive": true,
-    "timeout": 180000
+    "timeout": 360000
   },
   "repository": "heroku/cli",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1255,7 +1255,7 @@ __metadata:
     inquirer: ^6.2.2
     lodash: ^4.17.13
     lolex: ^3.1.0
-    mocha: ^8.0.0
+    mocha: ^9.2.2
     nock: ^10.0.6
     nyc: ^15.1.0
     oclif: 3.11.3
@@ -1298,7 +1298,7 @@ __metadata:
     date-fns: ^1.29.0
     heroku-cli-util: ^8.0.11
     lodash: ^4.17.11
-    mocha: ^8.0.0
+    mocha: ^9.2.2
     mocha-junit-reporter: 1.18.0
     nock: 10.0.6
     nyc: ^15.1.0
@@ -1317,7 +1317,7 @@ __metadata:
     inquirer: ^6.2.2
     lodash: ^4.17.11
     lodash.flatten: ^4.4.0
-    mocha: ^8.0.0
+    mocha: ^9.2.2
     nock: ^10.0.6
     nyc: ^15.1.0
     oclif: 3.11.3
@@ -1342,7 +1342,7 @@ __metadata:
     heroku-client: ^3.0.7
     lodash: ^4.17.11
     mkdirp: ^0.5.2
-    mocha: ^8.0.0
+    mocha: ^9.2.2
     nock: ^10.0.6
     node-notifier: ^10.0.0
     nyc: ^15.1.0
@@ -1392,7 +1392,7 @@ __metadata:
     chai-as-promised: ^7.1.1
     heroku-cli-util: ^8.0.11
     lolex: ^3.1.0
-    mocha: ^8.0.0
+    mocha: ^9.2.2
     nock: ^10.0.6
     nyc: ^15.1.0
     oclif: 3.11.3
@@ -1419,7 +1419,7 @@ __metadata:
     fs-extra: ^7.0.1
     heroku-cli-util: ^8.0.11
     http-call: 5.3.0
-    mocha: ^8.0.0
+    mocha: ^9.2.2
     mocha-junit-reporter: 1.18.0
     netrc: 0.1.4
     nock: ^10.0.6
@@ -1456,7 +1456,7 @@ __metadata:
     chai-as-promised: ^7.1.1
     heroku-cli-util: ^8.0.11
     lodash: ^4.17.11
-    mocha: ^8.0.0
+    mocha: ^9.2.2
     nock: ^10.0.6
     nyc: ^15.1.0
     oclif: 3.11.3
@@ -6063,7 +6063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"anymatch@npm:~3.1.1":
+"anymatch@npm:~3.1.2":
   version: 3.1.3
   resolution: "anymatch@npm:3.1.3"
   dependencies:
@@ -7038,22 +7038,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:3.5.1":
-  version: 3.5.1
-  resolution: "chokidar@npm:3.5.1"
+"chokidar@npm:3.5.3":
+  version: 3.5.3
+  resolution: "chokidar@npm:3.5.3"
   dependencies:
-    anymatch: ~3.1.1
+    anymatch: ~3.1.2
     braces: ~3.0.2
-    fsevents: ~2.3.1
-    glob-parent: ~5.1.0
+    fsevents: ~2.3.2
+    glob-parent: ~5.1.2
     is-binary-path: ~2.1.0
     is-glob: ~4.0.1
     normalize-path: ~3.0.0
-    readdirp: ~3.5.0
+    readdirp: ~3.6.0
   dependenciesMeta:
     fsevents:
       optional: true
-  checksum: b7774e6e3aeca084d39e8542041555a11452414c744122436101243f89580fad97154ae11525e46bfa816313ae32533e2a88e8587e4d50b14ea716a9e6538978
+  checksum: b49fcde40176ba007ff361b198a2d35df60d9bb2a5aab228279eb810feae9294a6b4649ab15981304447afe1e6ffbf4788ad5db77235dc770ab777c6e771980c
   languageName: node
   linkType: hard
 
@@ -7925,15 +7925,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4.3.1":
-  version: 4.3.1
-  resolution: "debug@npm:4.3.1"
+"debug@npm:4.3.3":
+  version: 4.3.3
+  resolution: "debug@npm:4.3.3"
   dependencies:
     ms: 2.1.2
   peerDependenciesMeta:
     supports-color:
       optional: true
-  checksum: 2c3352e37d5c46b0d203317cd45ea0e26b2c99f2d9dfec8b128e6ceba90dfb65425f5331bf3020fe9929d7da8c16758e737f4f3bfc0fce6b8b3d503bae03298b
+  checksum: 14472d56fe4a94dbcfaa6dbed2dd3849f1d72ba78104a1a328047bb564643ca49df0224c3a17fa63533fd11dd3d4c8636cd861191232a2c6735af00cc2d4de16
   languageName: node
   linkType: hard
 
@@ -9977,7 +9977,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:~2.3.1":
+"fsevents@npm:~2.3.2":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
@@ -9987,7 +9987,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@~2.3.1#~builtin<compat/fsevents>":
+"fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
   version: 2.3.3
   resolution: "fsevents@patch:fsevents@npm%3A2.3.3#~builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
@@ -10284,7 +10284,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^5.1.1, glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.0":
+"glob-parent@npm:^5.1.1, glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
   dependencies:
@@ -10331,9 +10331,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:7.1.6, glob@npm:^7.1.6":
-  version: 7.1.6
-  resolution: "glob@npm:7.1.6"
+"glob@npm:7.2.0":
+  version: 7.2.0
+  resolution: "glob@npm:7.2.0"
   dependencies:
     fs.realpath: ^1.0.0
     inflight: ^1.0.4
@@ -10341,7 +10341,7 @@ __metadata:
     minimatch: ^3.0.4
     once: ^1.3.0
     path-is-absolute: ^1.0.0
-  checksum: 351d549dd90553b87c2d3f90ce11aed9e1093c74130440e7ae0592e11bbcd2ce7f0ebb8ba6bfe63aaf9b62166a7f4c80cb84490ae5d78408bb2572bf7d4ee0a6
+  checksum: 78a8ea942331f08ed2e055cb5b9e40fe6f46f579d7fd3d694f3412fe5db23223d29b7fee1575440202e9a7ff9a72ab106a39fee39934c7bedafe5e5f8ae20134
   languageName: node
   linkType: hard
 
@@ -10399,6 +10399,20 @@ __metadata:
     once: ^1.3.0
     path-is-absolute: ^1.0.0
   checksum: 0b8329b1b6da5f73bd2102247d1fe784059dc178a42b51ff2945bf8b984dc3ebe5a9c8c11de8835e2c6b061bdad142fe6906748bdae802bb318ee695a0879e76
+  languageName: node
+  linkType: hard
+
+"glob@npm:^7.1.6":
+  version: 7.1.6
+  resolution: "glob@npm:7.1.6"
+  dependencies:
+    fs.realpath: ^1.0.0
+    inflight: ^1.0.4
+    inherits: 2
+    minimatch: ^3.0.4
+    once: ^1.3.0
+    path-is-absolute: ^1.0.0
+  checksum: 351d549dd90553b87c2d3f90ce11aed9e1093c74130440e7ae0592e11bbcd2ce7f0ebb8ba6bfe63aaf9b62166a7f4c80cb84490ae5d78408bb2572bf7d4ee0a6
   languageName: node
   linkType: hard
 
@@ -10938,7 +10952,7 @@ __metadata:
     js-yaml: ^4.0.8
     lodash: ^4.17.11
     lolex: ^3.1.0
-    mocha: ^8.0.0
+    mocha: ^9.2.2
     netrc-parser: 3.1.6
     nock: ^13.5.1
     node-fetch: ^2.6.7
@@ -12235,17 +12249,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.0.0":
-  version: 4.0.0
-  resolution: "js-yaml@npm:4.0.0"
-  dependencies:
-    argparse: ^2.0.1
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 931d6dddb3589fa272c8273366c6dffa99fd6bd26ac7b70f9bac925c28cb7ae352b964192df84f90ecd7a2ff50ab87e6d58e2148eb19c89aa155c73ed847ab92
-  languageName: node
-  linkType: hard
-
 "js-yaml@npm:4.1.0, js-yaml@npm:^4.0.8, js-yaml@npm:^4.1.0":
   version: 4.1.0
   resolution: "js-yaml@npm:4.1.0"
@@ -12855,16 +12858,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"log-symbols@npm:4.0.0":
-  version: 4.0.0
-  resolution: "log-symbols@npm:4.0.0"
-  dependencies:
-    chalk: ^4.0.0
-  checksum: a7c1fb5cc504ff04422460dcae3a830002426432fbed81280c8a49f4c6f5ef244c28b987636bf1c871ba6866d7024713388be391e92c0d5af6a70598fcabc46b
-  languageName: node
-  linkType: hard
-
-"log-symbols@npm:^4.0.0, log-symbols@npm:^4.1.0":
+"log-symbols@npm:4.1.0, log-symbols@npm:^4.0.0, log-symbols@npm:^4.1.0":
   version: 4.1.0
   resolution: "log-symbols@npm:4.1.0"
   dependencies:
@@ -13291,15 +13285,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:3.0.4, minimatch@npm:^3.0.3, minimatch@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "minimatch@npm:3.0.4"
-  dependencies:
-    brace-expansion: ^1.1.7
-  checksum: 66ac295f8a7b59788000ea3749938b0970344c841750abd96694f80269b926ebcafad3deeb3f1da2522978b119e6ae3a5869b63b13a7859a456b3408bd18a078
-  languageName: node
-  linkType: hard
-
 "minimatch@npm:3.0.5":
   version: 3.0.5
   resolution: "minimatch@npm:3.0.5"
@@ -13309,12 +13294,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:4.2.1":
+  version: 4.2.1
+  resolution: "minimatch@npm:4.2.1"
+  dependencies:
+    brace-expansion: ^1.1.7
+  checksum: 2b1514e3d0f29a549912f0db7ae7b82c5cab4a8f2dd0369f1c6451a325b3f12b2cf473c95873b6157bb8df183d6cf6db82ff03614b6adaaf1d7e055beccdfd01
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:9.0.3, minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:^9.0.3":
   version: 9.0.3
   resolution: "minimatch@npm:9.0.3"
   dependencies:
     brace-expansion: ^2.0.1
   checksum: 253487976bf485b612f16bf57463520a14f512662e592e95c571afdab1442a6a6864b6c88f248ce6fc4ff0b6de04ac7aa6c8bb51e868e99d1d65eb0658a708b5
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^3.0.3, minimatch@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "minimatch@npm:3.0.4"
+  dependencies:
+    brace-expansion: ^1.1.7
+  checksum: 66ac295f8a7b59788000ea3749938b0970344c841750abd96694f80269b926ebcafad3deeb3f1da2522978b119e6ae3a5869b63b13a7859a456b3408bd18a078
   languageName: node
   linkType: hard
 
@@ -13549,39 +13552,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mocha@npm:^8.0.0":
-  version: 8.4.0
-  resolution: "mocha@npm:8.4.0"
+"mocha@npm:^9.2.2":
+  version: 9.2.2
+  resolution: "mocha@npm:9.2.2"
   dependencies:
     "@ungap/promise-all-settled": 1.1.2
     ansi-colors: 4.1.1
     browser-stdout: 1.3.1
-    chokidar: 3.5.1
-    debug: 4.3.1
+    chokidar: 3.5.3
+    debug: 4.3.3
     diff: 5.0.0
     escape-string-regexp: 4.0.0
     find-up: 5.0.0
-    glob: 7.1.6
+    glob: 7.2.0
     growl: 1.10.5
     he: 1.2.0
-    js-yaml: 4.0.0
-    log-symbols: 4.0.0
-    minimatch: 3.0.4
+    js-yaml: 4.1.0
+    log-symbols: 4.1.0
+    minimatch: 4.2.1
     ms: 2.1.3
-    nanoid: 3.1.20
-    serialize-javascript: 5.0.1
+    nanoid: 3.3.1
+    serialize-javascript: 6.0.0
     strip-json-comments: 3.1.1
     supports-color: 8.1.1
     which: 2.0.2
-    wide-align: 1.1.3
-    workerpool: 6.1.0
+    workerpool: 6.2.0
     yargs: 16.2.0
     yargs-parser: 20.2.4
     yargs-unparser: 2.0.0
   bin:
     _mocha: bin/_mocha
     mocha: bin/mocha
-  checksum: 4bcf00670580f009f9e20cc596cce5e2434d3562c468da783a8f935e38c4476435f12ecade43341cb8730b9d4987358038e76a075201d4bc51010927d3f8cd7c
+  checksum: 4d5ca4ce33fc66627e63acdf09a634e2358c9a00f61de7788b1091b6aad430da04f97f9ecb82d56dc034b623cb833b65576136fd010d77679c03fcea5bc1e12d
   languageName: node
   linkType: hard
 
@@ -13695,12 +13697,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:3.1.20":
-  version: 3.1.20
-  resolution: "nanoid@npm:3.1.20"
+"nanoid@npm:3.3.1":
+  version: 3.3.1
+  resolution: "nanoid@npm:3.3.1"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: f6246023d5d8313c2c16be05c18cdb189a6de50ab6418b513b34086eda4aabd12866b2cbe435548c760dc43cf11830b26b14b113afde47305398e3345795e433
+  checksum: 4ef0969e1bbe866fc223eb32276cbccb0961900bfe79104fa5abe34361979dead8d0e061410a5c03bc3d47455685adf32c09d6f27790f4a6898fb51f7df7ec86
   languageName: node
   linkType: hard
 
@@ -16035,12 +16037,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readdirp@npm:~3.5.0":
-  version: 3.5.0
-  resolution: "readdirp@npm:3.5.0"
+"readdirp@npm:~3.6.0":
+  version: 3.6.0
+  resolution: "readdirp@npm:3.6.0"
   dependencies:
     picomatch: ^2.2.1
-  checksum: 6b1a9341e295e15d4fb40c010216cbcb6266587cd0b3ce7defabd66fa1b4e35f9fba3d64c2187fd38fadd01ccbfc5f1b33fdfb1da63b3cbf66224b7c6d75ce5a
+  checksum: 1ced032e6e45670b6d7352d71d21ce7edf7b9b928494dcaba6f11fba63180d9da6cd7061ebc34175ffda6ff529f481818c962952004d273178acd70f7059b320
   languageName: node
   linkType: hard
 
@@ -16805,12 +16807,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:5.0.1":
-  version: 5.0.1
-  resolution: "serialize-javascript@npm:5.0.1"
+"serialize-javascript@npm:6.0.0":
+  version: 6.0.0
+  resolution: "serialize-javascript@npm:6.0.0"
   dependencies:
     randombytes: ^2.1.0
-  checksum: bb45a427690c3d2711e28499de0fbf25036af1e23c63c6a9237ed0aa572fd0941fcdefe50a2dccf26d9df8c8b86ae38659e19d8ba7afd3fbc1f1c7539a2a48d2
+  checksum: 56f90b562a1bdc92e55afb3e657c6397c01a902c588c0fe3d4c490efdcc97dcd2a3074ba12df9e94630f33a5ce5b76a74784a7041294628a6f4306e0ec84bf93
   languageName: node
   linkType: hard
 
@@ -17460,7 +17462,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^1.0.2 || 2, string-width@npm:^2.0.0, string-width@npm:^2.1.0, string-width@npm:^2.1.1":
+"string-width@npm:^2.0.0, string-width@npm:^2.1.0, string-width@npm:^2.1.1":
   version: 2.1.1
   resolution: "string-width@npm:2.1.1"
   dependencies:
@@ -18943,15 +18945,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wide-align@npm:1.1.3":
-  version: 1.1.3
-  resolution: "wide-align@npm:1.1.3"
-  dependencies:
-    string-width: ^1.0.2 || 2
-  checksum: d09c8012652a9e6cab3e82338d1874a4d7db2ad1bd19ab43eb744acf0b9b5632ec406bdbbbb970a8f4771a7d5ef49824d038ba70aa884e7723f5b090ab87134d
-  languageName: node
-  linkType: hard
-
 "wide-align@npm:^1.1.2, wide-align@npm:^1.1.5":
   version: 1.1.5
   resolution: "wide-align@npm:1.1.5"
@@ -19005,10 +18998,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"workerpool@npm:6.1.0":
-  version: 6.1.0
-  resolution: "workerpool@npm:6.1.0"
-  checksum: 519d03a4d008fd95ff9e1a583afe537e6a0eecd8250452044e390db3e1dc4ce91616a8ee6c4bba9a2fda38440c2666664c31b50b5a9fd05cc43c739df54d5781
+"workerpool@npm:6.2.0":
+  version: 6.2.0
+  resolution: "workerpool@npm:6.2.0"
+  checksum: 3493b4f0ef979a23d2c1583d7ef85f62fc9463cc02f82829d3e7e663b517f8ae9707da0249b382e46ac58986deb0ca2232ee1081713741211bda9254b429c9bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://gus.lightning.force.com/lightning/_classic/%2F00TEE000000W7w1

### Description

This will upgrade the version of mocha we use to 9.2. Also, this increases our mocha test timeouts, doubling from 3 mins to 6 mins. Hopefully this will be enough for our interaction with space apps. If not.. well, we need to rethink our smoke tests and/or smoke test app.

### Testing

Tests pass?