### PR TITLE
chore(W-15263489): improve unit test performance

### DIFF
--- a/packages/cli/src/global_telemetry.ts
+++ b/packages/cli/src/global_telemetry.ts
@@ -13,9 +13,12 @@ const {version} = require('../package.json')
 
 const root = path.resolve(__dirname, '../package.json')
 const isDev = process.env.IS_DEV_ENVIRONMENT === 'true'
-const config = new Config({root})
-const heroku = new APIClient(config)
-const token = heroku.auth
+
+function getToken() {
+  const config = new Config({root})
+  const heroku = new APIClient(config)
+  return heroku.auth
+}
 
 const debug = require('debug')('global_telemetry')
 
@@ -44,7 +47,7 @@ const provider = new NodeTracerProvider({
   resource,
 })
 
-const headers = {Authorization: `Bearer ${token}`}
+const headers = {Authorization: `Bearer ${process.env.IS_HEROKU_TEST_ENV !== 'true' ? getToken() : ''}`}
 
 const exporter = new OTLPTraceExporter({
   url: isDev ? 'https://backboard-staging.herokuapp.com/otel/v1/traces' : 'https://backboard.heroku.com/otel/v1/traces',

--- a/packages/cli/src/hooks/postrun/performance_analytics.ts
+++ b/packages/cli/src/hooks/postrun/performance_analytics.ts
@@ -5,11 +5,13 @@ import * as telemetry from '../../global_telemetry'
 declare const global: telemetry.TelemetryGlobal
 
 const performance_analytics: Hook<'postrun'> = async function () {
-  if (global.cliTelemetry) {
-    const cmdStartTime = global.cliTelemetry.commandRunDuration
-    global.cliTelemetry.commandRunDuration = telemetry.computeDuration(cmdStartTime)
-    global.cliTelemetry.lifecycleHookCompletion.postrun = true
+  if (process.env.IS_HEROKU_TEST_ENV === 'true' || !global.cliTelemetry) {
+    return
   }
+
+  const cmdStartTime = global.cliTelemetry.commandRunDuration
+  global.cliTelemetry.commandRunDuration = telemetry.computeDuration(cmdStartTime)
+  global.cliTelemetry.lifecycleHookCompletion.postrun = true
 }
 
 export default performance_analytics

--- a/packages/cli/src/hooks/prerun/analytics.ts
+++ b/packages/cli/src/hooks/prerun/analytics.ts
@@ -6,6 +6,10 @@ import * as telemetry from '../../global_telemetry'
 declare const global: telemetry.TelemetryGlobal
 
 const analytics: Hook<'prerun'> = async function (options) {
+  if (process.env.IS_HEROKU_TEST_ENV === 'true') {
+    return
+  }
+
   global.cliTelemetry = telemetry.setupTelemetry(this.config, options)
   const analytics = new Analytics(this.config)
   await analytics.record(options)

--- a/packages/cli/test/acceptance/smoke.acceptance.test.ts
+++ b/packages/cli/test/acceptance/smoke.acceptance.test.ts
@@ -1,5 +1,4 @@
 // tslint:disable no-console
-
 import * as fs from 'fs-extra'
 import {expect} from 'chai'
 import * as path from 'path'

--- a/packages/cli/test/helpers/init.js
+++ b/packages/cli/test/helpers/init.js
@@ -1,5 +1,13 @@
 const path = require('path')
+
+globalThis.setInterval = () => ({unref: () => {}})
+const tm = globalThis.setTimeout
+globalThis.setTimeout = cb => {
+  return tm(cb)
+}
+
 process.env.TS_NODE_PROJECT = path.resolve('test/tsconfig.json')
+process.env.IS_HEROKU_TEST_ENV = 'true'
 
 let nock = require('nock')
 nock.disableNetConnect()


### PR DESCRIPTION
This PR improves unit test run performance the following ways:
1. setTimeout is stubbed to be sync with no timeout value. This mainly affects the use of `us.actions.start()` which seems to have a mandatory wait of ~200ms on mac and linux
2. Prevents analytics from bootstrapping before each command is run. This bootstrapping process kicked off file reads and child processes before each command which significantly slowed down tests and caused flappy test on some configurations.