### PR TITLE
fix(workflow): update test-installed-cli

### DIFF
--- a/.github/workflows/test-installed-cli.yml
+++ b/.github/workflows/test-installed-cli.yml
@@ -34,7 +34,11 @@ jobs:
         run: curl https://cli-assets.heroku.com/install.sh | sh
         shell: bash
       - name: updating to heroku version ${{ inputs.version }}
-        run: heroku update --version=${{ inputs.version }}
+        id: current-cli-version
+        run: heroku update beta && version=$(heroku version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+')
+      - name: check version ${{ inputs.version }} exists
+        if: ${{ inputs.version }} == ${{ steps.current-cli-version.outputs.version }}
+        run: heroku version
         shell: bash
       - name: test release
         run: ./scripts/postrelease/test_release


### PR DESCRIPTION
## Description

It looks like our `test-installed-cli` fails when trying to update via `heroku update --version=<some version>`. This PR address that issue by running `heroku update beta` and then checking that the correct version was upgraded in a comparison statement with our expected version output. It is unclear why the previous version doesn't work, short of the github workflow trying to pick up changes that haven't finished processing.