### PR TITLE
backfill missing remote flag options

### DIFF
--- a/packages/cli/src/commands/access/update.ts
+++ b/packages/cli/src/commands/access/update.ts
@@ -14,6 +14,7 @@ export default class Update extends Command {
         required: true,
       }),
       app: flags.app({required: true}),
+      remote: flags.remote(),
     };
 
     static args = {

--- a/packages/cli/src/commands/addons/attach.ts
+++ b/packages/cli/src/commands/addons/attach.ts
@@ -12,7 +12,7 @@ export default class Attach extends Command {
       credential: flags.string({description: 'credential name for scoped access to Heroku Postgres'}),
       confirm: flags.string({description: 'overwrite existing add-on attachment with same name'}),
       app: flags.app({required: true}),
-      flags: flags.remote(),
+      remote: flags.remote(),
     };
 
     static args = {

--- a/packages/cli/src/commands/addons/attach.ts
+++ b/packages/cli/src/commands/addons/attach.ts
@@ -12,6 +12,7 @@ export default class Attach extends Command {
       credential: flags.string({description: 'credential name for scoped access to Heroku Postgres'}),
       confirm: flags.string({description: 'overwrite existing add-on attachment with same name'}),
       app: flags.app({required: true}),
+      flags: flags.remote(),
     };
 
     static args = {

--- a/packages/cli/src/commands/addons/create.ts
+++ b/packages/cli/src/commands/addons/create.ts
@@ -47,6 +47,7 @@ export default class Create extends Command {
     confirm: flags.string({description: 'overwrite existing config vars or existing add-on attachments'}),
     wait: flags.boolean({description: 'watch add-on creation status and exit when complete'}),
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   static args = {

--- a/packages/cli/src/commands/addons/destroy.ts
+++ b/packages/cli/src/commands/addons/destroy.ts
@@ -19,6 +19,7 @@ export default class Destroy extends Command {
     confirm: flags.string({char: 'c'}),
     wait: flags.boolean({description: 'watch add-on destruction status and exit when complete'}),
     app: flags.app(),
+    remote: flags.remote(),
   }
 
   static args = {

--- a/packages/cli/src/commands/addons/detach.ts
+++ b/packages/cli/src/commands/addons/detach.ts
@@ -8,6 +8,7 @@ export default class Detach extends Command {
   static description = 'detach an existing add-on resource from an app'
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   static args = {

--- a/packages/cli/src/commands/addons/docs.ts
+++ b/packages/cli/src/commands/addons/docs.ts
@@ -11,6 +11,7 @@ export default class Docs extends Command {
     static flags = {
       'show-url': flags.boolean({description: 'show URL, do not open browser'}),
       app: flags.app(),
+      remote: flags.remote(),
     };
 
     static args = {

--- a/packages/cli/src/commands/addons/index.ts
+++ b/packages/cli/src/commands/addons/index.ts
@@ -227,6 +227,7 @@ export default class Addons extends Command {
     all: flags.boolean({char: 'A', description: 'show add-ons and attachments for all accessible apps'}),
     json: flags.boolean({description: 'return add-ons in json format'}),
     app: flags.app(),
+    remote: flags.remote(),
   }
 
   static examples = [

--- a/packages/cli/src/commands/addons/info.ts
+++ b/packages/cli/src/commands/addons/info.ts
@@ -12,6 +12,7 @@ export default class Info extends Command {
   static description = 'show detailed add-on resource and attachment information'
   static flags = {
     app: flags.app(),
+    remote: flags.remote(),
   }
 
   static usage = `${topic}:info ADDON`

--- a/packages/cli/src/commands/addons/open.ts
+++ b/packages/cli/src/commands/addons/open.ts
@@ -76,6 +76,7 @@ export default class Open extends Command {
   public static flags = {
     'show-url': flags.boolean({description: 'show URL, do not open browser'}),
     app: flags.app(),
+    remote: flags.remote(),
   }
 
   public static args = {

--- a/packages/cli/src/commands/addons/upgrade.ts
+++ b/packages/cli/src/commands/addons/upgrade.ts
@@ -16,6 +16,7 @@ export default class Upgrade extends Command {
   static examples = ['Upgrade an add-on by service name:\n$ heroku addons:upgrade heroku-redis:premium-2\n\nUpgrade a specific add-on:\n$ heroku addons:upgrade swimming-briskly-123 heroku-redis:premium-2']
   static flags = {
     app: flags.app(),
+    remote: flags.remote(),
   }
 
   static args = {

--- a/packages/cli/src/commands/addons/wait.ts
+++ b/packages/cli/src/commands/addons/wait.ts
@@ -12,6 +12,7 @@ export default class Wait extends Command {
     static flags = {
       'wait-interval': flags.string({description: 'how frequently to poll in seconds'}),
       app: flags.app(),
+      remote: flags.remote(),
     };
 
     static args = {

--- a/packages/cli/src/commands/apps/destroy.ts
+++ b/packages/cli/src/commands/apps/destroy.ts
@@ -11,6 +11,7 @@ export default class Destroy extends Command {
   static aliases = ['destroy', 'apps:delete']
   static flags = {
     app: flags.app(),
+    remote: flags.remote(),
     confirm: flags.string({char: 'c'}),
   }
 

--- a/packages/cli/src/commands/apps/errors.ts
+++ b/packages/cli/src/commands/apps/errors.ts
@@ -47,6 +47,7 @@ export default class Errors extends Command {
 
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
     json: flags.boolean({description: 'output in json format'}),
     hours: flags.string({description: 'number of hours to look back (default 24)', default: '24'}),
     router: flags.boolean({description: 'show only router errors'}),

--- a/packages/cli/src/commands/apps/favorites/add.ts
+++ b/packages/cli/src/commands/apps/favorites/add.ts
@@ -8,6 +8,7 @@ export default class Add extends Command {
   static topic = 'apps'
   static flags  = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   async run() {

--- a/packages/cli/src/commands/apps/favorites/remove.ts
+++ b/packages/cli/src/commands/apps/favorites/remove.ts
@@ -8,6 +8,7 @@ export default class Remove extends Command {
   static topic = 'apps'
   static flags  = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   async run() {

--- a/packages/cli/src/commands/apps/info.ts
+++ b/packages/cli/src/commands/apps/info.ts
@@ -118,6 +118,7 @@ repo_size=5000000
 
   static flags = {
     app: flags.app(),
+    remote: flags.remote(),
     shell: flags.boolean({char: 's', description: 'output more shell friendly key/value pairs'}),
     extended: flags.boolean({char: 'x', hidden: true}),
     json: flags.boolean({char: 'j', description: 'output in json format'}),

--- a/packages/cli/src/commands/apps/open.ts
+++ b/packages/cli/src/commands/apps/open.ts
@@ -15,6 +15,7 @@ export default class AppsOpen extends Command {
 
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   static args = {

--- a/packages/cli/src/commands/apps/rename.ts
+++ b/packages/cli/src/commands/apps/rename.ts
@@ -17,6 +17,7 @@ export default class AppsRename extends Command {
 
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   static args = {

--- a/packages/cli/src/commands/apps/stacks/index.ts
+++ b/packages/cli/src/commands/apps/stacks/index.ts
@@ -19,6 +19,7 @@ export default class StacksIndex extends Command {
 
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   async run() {

--- a/packages/cli/src/commands/certs/auto/disable.ts
+++ b/packages/cli/src/commands/certs/auto/disable.ts
@@ -10,6 +10,7 @@ export default class Disable extends Command {
   static flags = {
     confirm: flags.string({char: 'c', hidden: true}),
     app: flags.app({required: true}),
+    remote: flags.remote(),
   };
 
   public async run(): Promise<void> {

--- a/packages/cli/src/commands/certs/auto/enable.ts
+++ b/packages/cli/src/commands/certs/auto/enable.ts
@@ -10,6 +10,7 @@ export default class Enable extends Command {
     static flags = {
       wait: flags.boolean({description: 'watch ACM status and exit when complete'}),
       app: flags.app({required: true}),
+      remote: flags.remote(),
     };
 
     public async run(): Promise<void> {

--- a/packages/cli/src/commands/certs/auto/index.ts
+++ b/packages/cli/src/commands/certs/auto/index.ts
@@ -42,6 +42,7 @@ export default class Index extends Command {
   static flags = {
     wait: flags.boolean({description: 'watch ACM status and display the status when complete'}),
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   public async run(): Promise<void> {

--- a/packages/cli/src/commands/certs/auto/refresh.ts
+++ b/packages/cli/src/commands/certs/auto/refresh.ts
@@ -6,7 +6,7 @@ export default class Refresh extends Command {
   static description = 'refresh ACM for an app';
   static flags = {
     app: flags.app({required: true}),
-    flags: flags.remote(),
+    remote: flags.remote(),
   };
 
   public async run(): Promise<void> {

--- a/packages/cli/src/commands/certs/auto/refresh.ts
+++ b/packages/cli/src/commands/certs/auto/refresh.ts
@@ -6,6 +6,7 @@ export default class Refresh extends Command {
   static description = 'refresh ACM for an app';
   static flags = {
     app: flags.app({required: true}),
+    flags: flags.remote(),
   };
 
   public async run(): Promise<void> {

--- a/packages/cli/src/commands/certs/index.ts
+++ b/packages/cli/src/commands/certs/index.ts
@@ -9,6 +9,7 @@ export default class Index extends Command {
   static description = 'list SSL certificates for an app';
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   };
 
   public async run(): Promise<void> {

--- a/packages/cli/src/commands/certs/info.ts
+++ b/packages/cli/src/commands/certs/info.ts
@@ -14,6 +14,7 @@ export default class Info extends Command {
     endpoint: flags.string({description: 'endpoint to check info on'}),
     'show-domains': flags.boolean({description: 'show associated domains'}),
     app: flags.app({required: true}),
+    remote: flags.remote(),
   };
 
   public async run(): Promise<void> {

--- a/packages/cli/src/commands/ci/config/get.ts
+++ b/packages/cli/src/commands/ci/config/get.ts
@@ -15,6 +15,7 @@ export default class CiConfigGet extends Command {
   static flags = {
     help: flags.help({char: 'h'}),
     app: flags.app({required: false}),
+    remote: flags.remote(),
     pipeline: flags.pipeline({required: false}),
     shell: flags.boolean({char: 's', description: 'output config var in shell format'}),
   }

--- a/packages/cli/src/commands/ci/config/set.ts
+++ b/packages/cli/src/commands/ci/config/set.ts
@@ -26,6 +26,7 @@ export default class CiConfigSet extends Command {
 
   static flags = {
     app: flags.app(),
+    remote: flags.remote(),
     pipeline: flags.pipeline({required: true}),
   }
 

--- a/packages/cli/src/commands/ci/config/unset.ts
+++ b/packages/cli/src/commands/ci/config/unset.ts
@@ -16,6 +16,7 @@ export default class CiConfigUnset extends Command {
   static flags = {
     help: flags.help({char: 'h'}),
     app: flags.app({required: false}),
+    remote: flags.remote(),
     pipeline: flags.pipeline({required: false}),
   }
 

--- a/packages/cli/src/commands/ci/index.ts
+++ b/packages/cli/src/commands/ci/index.ts
@@ -14,6 +14,7 @@ export default class CiIndex extends Command {
 
   static flags = {
     app: flags.string({char: 'a', description: 'app name'}),
+    remote: flags.remote(),
     watch: flags.boolean({description: 'keep running and watch for new and update tests', required: false}),
     pipeline: flags.pipeline({required: false}),
     json: flags.boolean({description: 'output in json format', required: false}),

--- a/packages/cli/src/commands/ci/info.ts
+++ b/packages/cli/src/commands/ci/info.ts
@@ -15,6 +15,7 @@ export default class CiInfo extends Command {
 
   static flags = {
     app: flags.string({char: 'a', description: 'app name'}),
+    remote: flags.remote(),
     node: flags.string({description: 'the node number to show its setup and output', required: false}),
     pipeline: flags.pipeline({required: false}),
   }

--- a/packages/cli/src/commands/ci/last.ts
+++ b/packages/cli/src/commands/ci/last.ts
@@ -15,6 +15,7 @@ export default class CiLast extends Command {
 
   static flags = {
     app: flags.string({char: 'a', description: 'app name'}),
+    remote: flags.remote(),
     node: flags.string({description: 'the node number to show its setup and output', required: false}),
     pipeline: flags.pipeline({required: false}),
   }

--- a/packages/cli/src/commands/ci/open.ts
+++ b/packages/cli/src/commands/ci/open.ts
@@ -12,6 +12,7 @@ export default class CiOpen extends Command {
   static flags = {
     help: flags.help({char: 'h'}),
     app: flags.app({required: true}),
+    remote: flags.remote(),
     pipeline: flags.pipeline({required: false}),
   }
 

--- a/packages/cli/src/commands/ci/rerun.ts
+++ b/packages/cli/src/commands/ci/rerun.ts
@@ -18,6 +18,7 @@ export default class CiReRun extends Command {
 
   static flags = {
     app: flags.string({char: 'a', description: 'app name'}),
+    remote: flags.remote(),
     pipeline: flags.pipeline({required: false}),
   }
 

--- a/packages/cli/src/commands/config/set.ts
+++ b/packages/cli/src/commands/config/set.ts
@@ -30,6 +30,7 @@ RACK_ENV:  staging`,
 
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   async run() {

--- a/packages/cli/src/commands/container/pull.ts
+++ b/packages/cli/src/commands/container/pull.ts
@@ -17,6 +17,7 @@ export default class Pull extends Command {
 
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
     verbose: flags.boolean({char: 'v'}),
   }
 

--- a/packages/cli/src/commands/container/release.ts
+++ b/packages/cli/src/commands/container/release.ts
@@ -27,7 +27,7 @@ export default class ContainerRelease extends Command {
   static strict = false
 
   static flags = {
-    app: flags.app({required: true})
+    app: flags.app({required: true}),
     remote: flags.remote(),
     verbose: flags.boolean({char: 'v'}),
   }

--- a/packages/cli/src/commands/container/release.ts
+++ b/packages/cli/src/commands/container/release.ts
@@ -27,7 +27,8 @@ export default class ContainerRelease extends Command {
   static strict = false
 
   static flags = {
-    app: flags.app({required: true}),
+    app: flags.app({required: true})
+    remote: flags.remote(),
     verbose: flags.boolean({char: 'v'}),
   }
 

--- a/packages/cli/src/commands/container/rm.ts
+++ b/packages/cli/src/commands/container/rm.ts
@@ -14,6 +14,7 @@ export default class Rm extends Command {
 
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   async run() {

--- a/packages/cli/src/commands/container/run.ts
+++ b/packages/cli/src/commands/container/run.ts
@@ -17,6 +17,7 @@ export default class Run extends Command {
 
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
     port: flags.integer({char: 'p', description: 'port the app will run on', default: 5000}),
     verbose: flags.boolean({char: 'v'}),
   }

--- a/packages/cli/src/commands/drains/add.ts
+++ b/packages/cli/src/commands/drains/add.ts
@@ -7,6 +7,7 @@ export default class Add extends Command {
   static description = 'adds a log drain to an app'
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   static args = {

--- a/packages/cli/src/commands/drains/index.ts
+++ b/packages/cli/src/commands/drains/index.ts
@@ -15,6 +15,7 @@ export default class Drains extends Command {
 
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
     extended: flags.boolean({char: 'x', hidden: true}),
     json: flags.boolean({description: 'output in json format'}),
   }

--- a/packages/cli/src/commands/drains/remove.ts
+++ b/packages/cli/src/commands/drains/remove.ts
@@ -7,6 +7,7 @@ export default class Remove extends Command {
   static description = 'removes a log drain from an app'
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   static example = 'drains:remove [URL|TOKEN]'

--- a/packages/cli/src/commands/features/disable.ts
+++ b/packages/cli/src/commands/features/disable.ts
@@ -7,6 +7,7 @@ export default class Disable extends Command {
   static description = 'disables an app feature'
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   static args = {

--- a/packages/cli/src/commands/features/enable.ts
+++ b/packages/cli/src/commands/features/enable.ts
@@ -7,6 +7,7 @@ export default class Enable extends Command {
   static description = 'enables an app feature'
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   static args = {

--- a/packages/cli/src/commands/features/index.ts
+++ b/packages/cli/src/commands/features/index.ts
@@ -8,6 +8,7 @@ export default class Features extends Command {
   static description = 'list available app features'
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
     json: flags.boolean({description: 'output in json format'}),
   }
 

--- a/packages/cli/src/commands/features/info.ts
+++ b/packages/cli/src/commands/features/info.ts
@@ -7,6 +7,7 @@ export default class Info extends Command {
   static description = 'display information about a feature'
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
     json: flags.boolean({description: 'output in json format'}),
   }
 

--- a/packages/cli/src/commands/labs/enable.ts
+++ b/packages/cli/src/commands/labs/enable.ts
@@ -15,6 +15,7 @@ export default class LabsEnable extends Command {
 
   static flags = {
     app: flags.app({required: false}),
+    remote: flags.remote(),
   }
 
   static args = {

--- a/packages/cli/src/commands/labs/index.ts
+++ b/packages/cli/src/commands/labs/index.ts
@@ -31,6 +31,7 @@ export default class LabsIndex extends Command {
 
   static flags = {
     app: flags.app({required: false}),
+    remote: flags.remote(),
     json: flags.boolean({description: 'display as json', required: false}),
   }
 

--- a/packages/cli/src/commands/labs/info.ts
+++ b/packages/cli/src/commands/labs/info.ts
@@ -22,6 +22,7 @@ export default class LabsInfo extends Command {
 
   static flags = {
     app: flags.app({required: false}),
+    remote: flags.remote(),
     json: flags.boolean({description: 'display as json', required: false}),
   }
 

--- a/packages/cli/src/commands/maintenance/index.ts
+++ b/packages/cli/src/commands/maintenance/index.ts
@@ -8,6 +8,7 @@ export default class MaintenanceIndex extends Command {
 
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   async run() {

--- a/packages/cli/src/commands/maintenance/off.ts
+++ b/packages/cli/src/commands/maintenance/off.ts
@@ -9,6 +9,7 @@ export default class MaintenanceOff extends Command {
 
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   async run() {

--- a/packages/cli/src/commands/maintenance/on.ts
+++ b/packages/cli/src/commands/maintenance/on.ts
@@ -9,6 +9,7 @@ export default class MaintenanceOn extends Command {
 
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   async run() {

--- a/packages/cli/src/commands/notifications/index.ts
+++ b/packages/cli/src/commands/notifications/index.ts
@@ -25,6 +25,7 @@ export default class NotificationsIndex extends Command {
 
   static flags = {
     app: flags.app({required: false}),
+    remote: flags.remote(),
     all: flags.boolean({description: 'view all notifications (not just the ones for the current app)'}),
     json: flags.boolean({description: 'output in json format'}),
     read: flags.boolean({description: 'show notifications already read'}),

--- a/packages/cli/src/commands/pg/backups/info.ts
+++ b/packages/cli/src/commands/pg/backups/info.ts
@@ -37,6 +37,7 @@ export default class Info extends Command {
   static description = 'get information about a specific backup';
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   };
 
   static args = {

--- a/packages/cli/src/commands/pg/backups/restore.ts
+++ b/packages/cli/src/commands/pg/backups/restore.ts
@@ -36,6 +36,7 @@ export default class Restore extends Command {
     verbose: flags.boolean({char: 'v'}),
     confirm: flags.string({char: 'c'}),
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   static args = {

--- a/packages/cli/src/commands/pg/backups/schedule.ts
+++ b/packages/cli/src/commands/pg/backups/schedule.ts
@@ -54,6 +54,7 @@ export default class Schedule extends Command {
   static flags = {
     at: flags.string({required: true, description: "at a specific (24h) hour in the given timezone. Defaults to UTC. --at '[HOUR]:00 [TIMEZONE]'"}),
     app: flags.app({required: true}),
+    remote: flags.remote(),
   };
 
   static args = {

--- a/packages/cli/src/commands/pg/backups/schedules.ts
+++ b/packages/cli/src/commands/pg/backups/schedules.ts
@@ -10,6 +10,7 @@ export default class Schedules extends Command {
   static description = 'list backup schedule';
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   };
 
   public async run(): Promise<void> {

--- a/packages/cli/src/commands/pg/backups/unschedule.ts
+++ b/packages/cli/src/commands/pg/backups/unschedule.ts
@@ -10,6 +10,7 @@ export default class Unschedule extends Command {
   static description = 'stop daily backups';
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   };
 
   static args = {

--- a/packages/cli/src/commands/pg/credentials/destroy.ts
+++ b/packages/cli/src/commands/pg/credentials/destroy.ts
@@ -15,6 +15,7 @@ export default class Destroy extends Command {
     name: flags.string({char: 'n', required: true, description: 'unique identifier for the credential'}),
     confirm: flags.string({char: 'c'}),
     app: flags.app({required: true}),
+    remote: flags.remote(),
   };
 
   static args = {

--- a/packages/cli/src/commands/pg/credentials/repair-default.ts
+++ b/packages/cli/src/commands/pg/credentials/repair-default.ts
@@ -13,6 +13,7 @@ export default class RepairDefault extends Command {
   static flags = {
     confirm: flags.string({char: 'c'}),
     app: flags.app({required: true}),
+    remote: flags.remote(),
   };
 
   static args = {

--- a/packages/cli/src/commands/ps/index.ts
+++ b/packages/cli/src/commands/ps/index.ts
@@ -186,6 +186,7 @@ export default class Index extends Command {
 
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
     json: flags.boolean({description: 'display as json'}),
     extended: flags.boolean({char: 'x', hidden: true}), // should be removed? Platform API doesn't serialize extended attributes even if the query param `extended=true` is sent.
   }

--- a/packages/cli/src/commands/ps/restart.ts
+++ b/packages/cli/src/commands/ps/restart.ts
@@ -22,6 +22,7 @@ export default class Restart extends Command {
 
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   async run() {

--- a/packages/cli/src/commands/ps/scale.ts
+++ b/packages/cli/src/commands/ps/scale.ts
@@ -30,6 +30,7 @@ export default class Scale extends Command {
   static aliases = ['dyno:scale', 'scale']
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   public async run(): Promise<void> {

--- a/packages/cli/src/commands/ps/stop.ts
+++ b/packages/cli/src/commands/ps/stop.ts
@@ -21,6 +21,7 @@ export default class Stop extends Command {
 
   static flags = {
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   async run() {

--- a/packages/cli/src/commands/redis/cli.ts
+++ b/packages/cli/src/commands/redis/cli.ts
@@ -177,6 +177,7 @@ export default class Cli extends Command {
   static flags = {
     confirm: flags.string({char: 'c'}),
     app: flags.app({required: true}),
+    remote: flags.remote(),
   }
 
   static args = {


### PR DESCRIPTION
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001nXKWDYA4/view


### Description

Some of the converted commands forgot to include `--remote` as a flag option. This backfills those commands.