### PR TITLE
chore(deps): Bump @heroku-cli/color to 2.0.1

### DIFF
--- a/packages/certs-v5/package.json
+++ b/packages/certs-v5/package.json
@@ -15,7 +15,7 @@
     "repositoryPrefix": "<%- repo %>/blob/v<%- version %>/packages/certs-v5/<%- commandPath %>"
   },
   "dependencies": {
-    "@heroku-cli/color": "^1.1.14",
+    "@heroku-cli/color": "^2.0.1",
     "@heroku-cli/notifications": "^1.2.4",
     "date-fns": "^1.29.0",
     "heroku-cli-util": "^8.0.11",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,7 @@
   "bin": "./bin/run",
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
-    "@heroku-cli/color": "1.1.14",
+    "@heroku-cli/color": "2.0.1",
     "@heroku-cli/command": "^10.0.0",
     "@heroku-cli/command-v9": "npm:@heroku-cli/command@^9.0.2",
     "@heroku-cli/notifications": "^1.2.4",

--- a/packages/run-v5/package.json
+++ b/packages/run-v5/package.json
@@ -18,7 +18,7 @@
     "repositoryPrefix": "<%- repo %>/blob/v<%- version %>/packages/run-v5/<%- commandPath %>"
   },
   "dependencies": {
-    "@heroku-cli/color": "^1.1.14",
+    "@heroku-cli/color": "^2.0.1",
     "@heroku-cli/command": "^9.0.2",
     "@heroku-cli/notifications": "^1.2.4",
     "@heroku/eventsource": "^1.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1173,7 +1173,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@heroku-cli/color@npm:1.1.14, @heroku-cli/color@npm:^1.1.14, @heroku-cli/color@npm:^1.1.3":
+"@heroku-cli/color@npm:2.0.1, @heroku-cli/color@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@heroku-cli/color@npm:2.0.1"
+  dependencies:
+    ansi-styles: ^4.3.0
+    chalk: ^4.1.2
+    supports-color: ^7.2.0
+    tslib: ^1.9.3
+  checksum: 3f2591fab0d28a88592b78b8b6e171cafd927e8b6ea1b807878ad3a9b46636c07e63d6983b64b94ec47f05a5a9fe2db80f95d5f381e4b6c14dac48c4aab7ba93
+  languageName: node
+  linkType: hard
+
+"@heroku-cli/color@npm:^1.1.14, @heroku-cli/color@npm:^1.1.3":
   version: 1.1.14
   resolution: "@heroku-cli/color@npm:1.1.14"
   dependencies:
@@ -1354,7 +1366,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@heroku-cli/plugin-certs-v5@workspace:packages/certs-v5"
   dependencies:
-    "@heroku-cli/color": ^1.1.14
+    "@heroku-cli/color": ^2.0.1
     "@heroku-cli/notifications": ^1.2.4
     "@oclif/plugin-legacy": ^1.3.0
     chai: ^4.2.0
@@ -1551,7 +1563,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@heroku-cli/plugin-run-v5@workspace:packages/run-v5"
   dependencies:
-    "@heroku-cli/color": ^1.1.14
+    "@heroku-cli/color": ^2.0.1
     "@heroku-cli/command": ^9.0.2
     "@heroku-cli/notifications": ^1.2.4
     "@heroku/eventsource": ^1.0.7
@@ -11180,7 +11192,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "heroku@workspace:packages/cli"
   dependencies:
-    "@heroku-cli/color": 1.1.14
+    "@heroku-cli/color": 2.0.1
     "@heroku-cli/command": ^10.0.0
     "@heroku-cli/command-v9": "npm:@heroku-cli/command@^9.0.2"
     "@heroku-cli/notifications": ^1.2.4
@@ -18346,6 +18358,15 @@ __metadata:
   dependencies:
     has-flag: ^4.0.0
   checksum: 899480ac858a650abcca4a02ae655555270e6ace833b15a74e4a2d3456f54cd19b6b12ce14e9bac997c18dd69a0596ee65b95ba013f209dd0f99ebfe87783e41
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "supports-color@npm:7.2.0"
+  dependencies:
+    has-flag: ^4.0.0
+  checksum: 3dda818de06ebbe5b9653e07842d9479f3555ebc77e9a0280caf5a14fb877ffee9ed57007c3b78f5a6324b8dbeec648d9e97a24e2ed9fdb81ddc69ea07100f4a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Follow-up to work on `heroku-cli-color` to bump versions of things. This should have to observable impact on CLI behavior