### PR TITLE
chore(ci) Switch ctc check to original change-management script

### DIFF
--- a/.github/workflows/ctc.yml
+++ b/.github/workflows/ctc.yml
@@ -5,59 +5,16 @@ on:
   workflow_call:
 
 jobs:
-  create-ctc-lock:
+  change-management:
     runs-on: ubuntu-latest
     environment: ChangeManagement
+    env:
+      TPS_API_APP_ID: ${{ secrets.TPS_API_APP_ID }}
+      TPS_API_RELEASE_ACTOR_EMAIL: ${{ secrets.TPS_API_RELEASE_ACTOR_EMAIL }}
+      TPS_API_STAGE: ${{ secrets.TPS_API_STAGE }}
+      TPS_API_TOKEN_PARAM: ${{ secrets.TPS_API_TOKEN_PARAM }}
+      TPS_API_URL_PARAM: ${{ secrets.TPS_API_URL_PARAM }}
     steps:
       - uses: actions/checkout@v3
-      - name: Call CTC API TO Create Lock
-        id: create-lock
-        run: |
-          CODE=`curl --w '%{http_code}' \
-          -X PUT \
-          -H "Accept: application/json" \
-          -H "Content-Type: application/json" \
-          -H "Authorization: Token ${{ secrets.TPS_API_TOKEN_PARAM }}" \
-          -d '{"lock": {"sha": "${{ github.sha }}", "component_name": "${{ secrets.TPS_API_APP_ID }}"}}' \
-          ${{ secrets.TPS_API_URL_PARAM }}/api/ctc`
-          echo "STATUS_CODE=$CODE" >> $GITHUB_ENV
-          echo "Response status code is $CODE."
-
-      - name: Retry if TPS returns 409
-        env:
-          RETRY_LATER: "409"
-        uses:
-          nick-fields/retry@v2
-        if: ${{ env.STATUS_CODE == env.RETRY_LATER}}
-        with:
-          max_attempts: 15
-          warning_on_retry: true
-          retry_wait_seconds: 3600
-          retry_on_exit_code: 1
-          timeout_minutes: 3600
-          command: |
-            CODE=`curl --w '%{http_code}' \
-            -X PUT \
-            -H "Accept: application/json" \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Token ${{ secrets.TPS_API_TOKEN_PARAM }}" \
-            -d '{"lock": {"sha": "${{ github.sha }}", "component_name": "${{ secrets.TPS_API_APP_ID }}"}}' \
-            ${{ secrets.TPS_API_URL_PARAM }}/api/ctc`
-
-            echo "Response status code is $CODE"
-            if [ $CODE == "409" ]
-            then
-              exit 1
-            else
-              echo "STATUS_CODE=$CODE" >> $GITHUB_ENV
-            fi
-
-      - name: Verify CTC Lock Did Not Fail for Other Reasons
-        env:
-          UPDATE_LOCK_SUCCESS: "200"
-          NEW_LOCK_SUCCESS: "201"
-        if: ${{ env.STATUS_CODE != env.NEW_LOCK_SUCCESS && env.STATUS_CODE != env.UPDATE_LOCK_SUCCESS}}
-        uses: actions/github-script@v6
-        with:
-          script: |
-              core.setFailed("Failed to create CTC lock with TPS with response code ${{ env.STATUS_CODE }}")
+      - run: yarn --immutable --network-timeout 1000000
+      - run: ./scripts/postrelease/change_management


### PR DESCRIPTION
This swaps out the curl script with the original change management script that we had in the old `promote-release` workflow. It used to be working a year ago so as long as creds haven't expired this should do the trick. The only thing is we don't know what these secrets are so if they are wrong we might have to start over from scratch.
