### PR TITLE
fix: add -i to base64 decode command for debian signing

### DIFF
--- a/scripts/sign/deb
+++ b/scripts/sign/deb
@@ -15,4 +15,4 @@ sha256sum *Release*
 # echo $HEROKU_DEB_PUBLIC_KEY | base64 --decode > /build/dist/apt/release.key
 #
 mkdir -p /home/runner/work/cli/cli/packages/cli/dist/apt
-echo $HEROKU_DEB_PUBLIC_KEY | base64 --decode > /home/runner/work/cli/cli/packages/cli/dist/apt/release.key
+echo $HEROKU_DEB_PUBLIC_KEY | base64 --decode -i > /home/runner/work/cli/cli/packages/cli/dist/apt/release.key


### PR DESCRIPTION
Adds `-i` to ignore non-alphabet characters when running the `base64 --decode` command in the debian signing script.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
