### PR TITLE
fix(container-registry-v5): Error out `container:push` command if stack is not `container`

### DIFF
--- a/packages/container-registry-v5/commands/pull.js
+++ b/packages/container-registry-v5/commands/pull.js
@@ -18,7 +18,7 @@ let pull = async function (context, heroku) {
   }
 
   let app = await heroku.get(`/apps/${context.app}`)
-  helpers.checkAppStack(app)
+  helpers.ensureContainerStack(app)
 
   let herokuHost = process.env.HEROKU_HOST || 'heroku.com'
   let registry = `registry.${herokuHost}`

--- a/packages/container-registry-v5/commands/pull.js
+++ b/packages/container-registry-v5/commands/pull.js
@@ -18,7 +18,7 @@ let pull = async function (context, heroku) {
   }
 
   let app = await heroku.get(`/apps/${context.app}`)
-  helpers.ensureContainerStack(app)
+  helpers.ensureContainerStack(app, 'pull')
 
   let herokuHost = process.env.HEROKU_HOST || 'heroku.com'
   let registry = `registry.${herokuHost}`

--- a/packages/container-registry-v5/commands/pull.js
+++ b/packages/container-registry-v5/commands/pull.js
@@ -2,6 +2,7 @@ const cli = require('heroku-cli-util')
 
 const Sanbashi = require('../lib/sanbashi')
 const debug = require('../lib/debug')
+const helpers = require('../lib/helpers')
 
 let usage = `
     ${cli.color.bold.underline.magenta('Usage:')}
@@ -9,12 +10,15 @@ let usage = `
     ${cli.color.cmd('heroku container:pull web worker')} # Pulls both the web and worker images from the app
     ${cli.color.cmd('heroku container:pull web:latest')} # Pulls the latest tag from the web image`
 
-let pull = async function (context) {
+let pull = async function (context, heroku) {
   if (context.flags.verbose) debug.enabled = true
 
   if (context.args.length === 0) {
     cli.exit(1, `Error: Requires one or more process types\n ${usage}`)
   }
+
+  let app = await heroku.get(`/apps/${context.app}`)
+  helpers.checkAppStack(app)
 
   let herokuHost = process.env.HEROKU_HOST || 'heroku.com'
   let registry = `registry.${herokuHost}`

--- a/packages/container-registry-v5/commands/push.js
+++ b/packages/container-registry-v5/commands/push.js
@@ -61,7 +61,7 @@ let push = async function (context, heroku) {
   }
 
   let app = await heroku.get(`/apps/${context.app}`)
-  helpers.checkAppStack(app)
+  helpers.ensureContainerStack(app)
 
   let herokuHost = process.env.HEROKU_HOST || 'heroku.com'
   let registry = `registry.${herokuHost}`

--- a/packages/container-registry-v5/commands/push.js
+++ b/packages/container-registry-v5/commands/push.js
@@ -59,7 +59,11 @@ let push = async function (context, heroku) {
     return
   }
 
-  await heroku.get(`/apps/${context.app}`)
+  let app = await heroku.get(`/apps/${context.app}`)
+  if (app.stack.name !== 'container') {
+    cli.exit(1, `This command is only supported for the ${cli.color.cyan('container')} stack. The stack for app ${cli.color.cyan(app.name)} is ${cli.color.cyan(app.stack.name)}.`)
+    return
+  }
 
   let herokuHost = process.env.HEROKU_HOST || 'heroku.com'
   let registry = `registry.${herokuHost}`

--- a/packages/container-registry-v5/commands/push.js
+++ b/packages/container-registry-v5/commands/push.js
@@ -1,6 +1,7 @@
 const cli = require('heroku-cli-util')
 const Sanbashi = require('../lib/sanbashi')
 const debug = require('../lib/debug')
+const helpers = require('../lib/helpers')
 
 module.exports = function (topic) {
   return {
@@ -60,10 +61,7 @@ let push = async function (context, heroku) {
   }
 
   let app = await heroku.get(`/apps/${context.app}`)
-  if (app.stack.name !== 'container') {
-    cli.exit(1, `This command is only supported for the ${cli.color.cyan('container')} stack. The stack for app ${cli.color.cyan(app.name)} is ${cli.color.cyan(app.stack.name)}.`)
-    return
-  }
+  helpers.checkAppStack(app)
 
   let herokuHost = process.env.HEROKU_HOST || 'heroku.com'
   let registry = `registry.${herokuHost}`

--- a/packages/container-registry-v5/commands/push.js
+++ b/packages/container-registry-v5/commands/push.js
@@ -61,7 +61,7 @@ let push = async function (context, heroku) {
   }
 
   let app = await heroku.get(`/apps/${context.app}`)
-  helpers.ensureContainerStack(app)
+  helpers.ensureContainerStack(app, 'push')
 
   let herokuHost = process.env.HEROKU_HOST || 'heroku.com'
   let registry = `registry.${herokuHost}`

--- a/packages/container-registry-v5/commands/release.js
+++ b/packages/container-registry-v5/commands/release.js
@@ -37,7 +37,7 @@ let release = async function (context, heroku) {
   }
 
   let app = await heroku.get(`/apps/${context.app}`)
-  helpers.checkAppStack(app)
+  helpers.ensureContainerStack(app)
 
   let herokuHost = process.env.HEROKU_HOST || 'heroku.com'
 

--- a/packages/container-registry-v5/commands/release.js
+++ b/packages/container-registry-v5/commands/release.js
@@ -37,7 +37,7 @@ let release = async function (context, heroku) {
   }
 
   let app = await heroku.get(`/apps/${context.app}`)
-  helpers.ensureContainerStack(app)
+  helpers.ensureContainerStack(app, 'release')
 
   let herokuHost = process.env.HEROKU_HOST || 'heroku.com'
 

--- a/packages/container-registry-v5/commands/release.js
+++ b/packages/container-registry-v5/commands/release.js
@@ -1,6 +1,7 @@
 const cli = require('heroku-cli-util')
 const debug = require('../lib/debug')
 const streamer = require('../lib/streamer')
+const helpers = require('../lib/helpers')
 
 let usage = `
     ${cli.color.bold.underline.magenta('Usage:')}
@@ -35,7 +36,8 @@ let release = async function (context, heroku) {
     return
   }
 
-  await heroku.get(`/apps/${context.app}`)
+  let app = await heroku.get(`/apps/${context.app}`)
+  helpers.checkAppStack(app)
 
   let herokuHost = process.env.HEROKU_HOST || 'heroku.com'
 

--- a/packages/container-registry-v5/commands/rm.js
+++ b/packages/container-registry-v5/commands/rm.js
@@ -26,7 +26,7 @@ let rm = async function (context, heroku) {
   }
 
   let app = await heroku.get(`/apps/${context.app}`)
-  helpers.checkAppStack(app)
+  helpers.ensureContainerStack(app)
 
   for (let container of context.args) {
     let r = heroku.request({

--- a/packages/container-registry-v5/commands/rm.js
+++ b/packages/container-registry-v5/commands/rm.js
@@ -1,4 +1,5 @@
 const cli = require('heroku-cli-util')
+const helpers = require('../lib/helpers')
 
 let usage = `
     ${cli.color.bold.underline.magenta('Usage:')}
@@ -23,6 +24,9 @@ let rm = async function (context, heroku) {
   if (context.args.length === 0) {
     cli.exit(1, `Error: Please specify at least one target process type\n ${usage} `)
   }
+
+  let app = await heroku.get(`/apps/${context.app}`)
+  helpers.checkAppStack(app)
 
   for (let container of context.args) {
     let r = heroku.request({

--- a/packages/container-registry-v5/commands/rm.js
+++ b/packages/container-registry-v5/commands/rm.js
@@ -26,7 +26,7 @@ let rm = async function (context, heroku) {
   }
 
   let app = await heroku.get(`/apps/${context.app}`)
-  helpers.ensureContainerStack(app)
+  helpers.ensureContainerStack(app, 'rm')
 
   for (let container of context.args) {
     let r = heroku.request({

--- a/packages/container-registry-v5/commands/run.js
+++ b/packages/container-registry-v5/commands/run.js
@@ -41,7 +41,7 @@ let run = async function (context, heroku) {
   }
 
   let app = await heroku.get(`/apps/${context.app}`)
-  helpers.checkAppStack(app)
+  helpers.ensureContainerStack(app)
 
   let processType = context.args.shift()
   let command = context.args

--- a/packages/container-registry-v5/commands/run.js
+++ b/packages/container-registry-v5/commands/run.js
@@ -41,7 +41,7 @@ let run = async function (context, heroku) {
   }
 
   let app = await heroku.get(`/apps/${context.app}`)
-  helpers.ensureContainerStack(app)
+  helpers.ensureContainerStack(app, 'run')
 
   let processType = context.args.shift()
   let command = context.args

--- a/packages/container-registry-v5/commands/run.js
+++ b/packages/container-registry-v5/commands/run.js
@@ -1,6 +1,7 @@
 const cli = require('heroku-cli-util')
 const Sanbashi = require('../lib/sanbashi')
 const debug = require('../lib/debug')
+const helpers = require('../lib/helpers')
 
 let usage = `
     ${cli.color.bold.underline.magenta('Usage:')}
@@ -33,11 +34,14 @@ module.exports = function (topic) {
   }
 }
 
-let run = async function (context) {
+let run = async function (context, heroku) {
   if (context.flags.verbose) debug.enabled = true
   if (context.args.length === 0) {
     cli.exit(1, `Error: Requires one process type\n ${usage}`)
   }
+
+  let app = await heroku.get(`/apps/${context.app}`)
+  helpers.checkAppStack(app)
 
   let processType = context.args.shift()
   let command = context.args

--- a/packages/container-registry-v5/lib/helpers.js
+++ b/packages/container-registry-v5/lib/helpers.js
@@ -1,11 +1,16 @@
 const cli = require('heroku-cli-util')
 
-function checkAppStack(app) {
+/**
+ * Ensure that the given app is a container app.
+ * @param app {Object} heroku app
+ * @returns {null} null
+ */
+function ensureContainerStack(app) {
   if (app.stack.name !== 'container') {
     cli.exit(1, `This command is only supported for the ${cli.color.cyan('container')} stack. The stack for app ${cli.color.cyan(app.name)} is ${cli.color.cyan(app.stack.name)}.`)
   }
 }
 
 module.exports = {
-  checkAppStack,
+  ensureContainerStack,
 }

--- a/packages/container-registry-v5/lib/helpers.js
+++ b/packages/container-registry-v5/lib/helpers.js
@@ -1,5 +1,9 @@
 const cli = require('heroku-cli-util')
 
+const stackLabelMap = {
+  cnb: 'Cloud Native Buildpack',
+}
+
 /**
  * Ensure that the given app is a container app.
  * @param app {Object} heroku app
@@ -7,7 +11,8 @@ const cli = require('heroku-cli-util')
  */
 function ensureContainerStack(app) {
   if (app.stack.name !== 'container') {
-    cli.exit(1, `This command is only supported for the ${cli.color.cyan('container')} stack. The stack for app ${cli.color.cyan(app.name)} is ${cli.color.cyan(app.stack.name)}.`)
+    const appLabel = stackLabelMap[app.stack.name] || app.stack.name
+    cli.exit(1, `This command is for Docker apps only. Run ${cli.color.cyan('git push heroku main')} to deploy your ${cli.color.cyan(app.name)} ${cli.color.cyan(appLabel)} app instead.`)
   }
 }
 

--- a/packages/container-registry-v5/lib/helpers.js
+++ b/packages/container-registry-v5/lib/helpers.js
@@ -7,12 +7,18 @@ const stackLabelMap = {
 /**
  * Ensure that the given app is a container app.
  * @param app {Object} heroku app
+ * @param cmd {String} command name
  * @returns {null} null
  */
-function ensureContainerStack(app) {
+function ensureContainerStack(app, cmd) {
   if (app.stack.name !== 'container') {
     const appLabel = stackLabelMap[app.stack.name] || app.stack.name
-    cli.exit(1, `This command is for Docker apps only. Run ${cli.color.cyan('git push heroku main')} to deploy your ${cli.color.cyan(app.name)} ${cli.color.cyan(appLabel)} app instead.`)
+    let message = 'This command is for Docker apps only.'
+    if (cmd === 'push' || cmd === 'release') {
+      message += ` Run ${cli.color.cyan('git push heroku main')} to deploy your ${cli.color.cyan(app.name)} ${cli.color.cyan(appLabel)} app instead.`
+    }
+
+    cli.exit(1, message)
   }
 }
 

--- a/packages/container-registry-v5/lib/helpers.js
+++ b/packages/container-registry-v5/lib/helpers.js
@@ -1,0 +1,11 @@
+const cli = require('heroku-cli-util')
+
+function checkAppStack(app) {
+  if (app.stack.name !== 'container') {
+    cli.exit(1, `This command is only supported for the ${cli.color.cyan('container')} stack. The stack for app ${cli.color.cyan(app.name)} is ${cli.color.cyan(app.stack.name)}.`)
+  }
+}
+
+module.exports = {
+  checkAppStack,
+}

--- a/packages/container-registry-v5/test/helpers.js
+++ b/packages/container-registry-v5/test/helpers.js
@@ -16,3 +16,22 @@ if (process.env.ENABLE_NET_CONNECT === 'true') {
 
 const chai = require('chai')
 chai.use(require('chai-as-promised'))
+
+const expect = require('chai').expect
+
+function assertExit(code, gen) {
+  let actualError
+  return gen.catch(function (error) {
+    expect(error).to.be.an.instanceof(cli.exit.ErrorExit)
+    actualError = error
+  }).then(function () {
+    expect(actualError).to.not.equal(undefined, 'Expected Error to be thrown')
+    expect(actualError.code).to.be.an('number', 'Expected error.exit(i) to be called with a number')
+    expect(actualError.code).to.equal(code)
+    return actualError
+  })
+}
+
+module.exports = {
+  assertExit,
+}

--- a/packages/container-registry-v5/test/helpers.js
+++ b/packages/container-registry-v5/test/helpers.js
@@ -16,22 +16,3 @@ if (process.env.ENABLE_NET_CONNECT === 'true') {
 
 const chai = require('chai')
 chai.use(require('chai-as-promised'))
-
-const expect = require('chai').expect
-
-function assertExit(code, gen) {
-  let actualError
-  return gen.catch(function (error) {
-    expect(error).to.be.an.instanceof(cli.exit.ErrorExit)
-    actualError = error
-  }).then(function () {
-    expect(actualError).to.not.equal(undefined, 'Expected Error to be thrown')
-    expect(actualError.code).to.be.an('number', 'Expected error.exit(i) to be called with a number')
-    expect(actualError.code).to.equal(code)
-    return actualError
-  })
-}
-
-module.exports = {
-  assertExit,
-}

--- a/packages/container-registry-v5/test/testutil.js
+++ b/packages/container-registry-v5/test/testutil.js
@@ -1,19 +1,22 @@
 const cli = require('heroku-cli-util')
 const expect = require('chai').expect
 
-function assertExit(code, gen) {
-  let actualError
+/**
+ * Asserts that the given function throws an ErrorExit with the given code.
+ * @param code
+ * @param gen
+ * @returns {*} a promise that resolves with the error thrown
+ */
+function assertErrorExit(code, gen) {
   return gen.catch(function (error) {
+    expect(error).to.not.equal(undefined, 'Expected Error to be thrown')
     expect(error).to.be.an.instanceof(cli.exit.ErrorExit)
-    actualError = error
-  }).then(function () {
-    expect(actualError).to.not.equal(undefined, 'Expected Error to be thrown')
-    expect(actualError.code).to.be.an('number', 'Expected error.exit(i) to be called with a number')
-    expect(actualError.code).to.equal(code)
-    return actualError
+    expect(error.code).to.be.an('number', 'Expected error.exit(i) to be called with a number')
+    expect(error.code).to.equal(code)
+    return error
   })
 }
 
 module.exports = {
-  assertExit,
+  assertErrorExit,
 }

--- a/packages/container-registry-v5/test/testutil.js
+++ b/packages/container-registry-v5/test/testutil.js
@@ -8,12 +8,15 @@ const expect = require('chai').expect
  * @returns {*} a promise that resolves with the error thrown
  */
 function assertErrorExit(code, gen) {
+  let actualError
   return gen.catch(function (error) {
-    expect(error).to.not.equal(undefined, 'Expected Error to be thrown')
-    expect(error).to.be.an.instanceof(cli.exit.ErrorExit)
-    expect(error.code).to.be.an('number', 'Expected error.exit(i) to be called with a number')
-    expect(error.code).to.equal(code)
-    return error
+    actualError = error
+  }).then(function () {
+    expect(actualError).to.not.equal(undefined, 'Expected Error to be thrown')
+    expect(actualError).to.be.an.instanceof(cli.exit.ErrorExit)
+    expect(actualError.code).to.be.an('number', 'Expected error.exit(i) to be called with a number')
+    expect(actualError.code).to.equal(code)
+    return actualError
   })
 }
 

--- a/packages/container-registry-v5/test/testutil.js
+++ b/packages/container-registry-v5/test/testutil.js
@@ -1,0 +1,19 @@
+const cli = require('heroku-cli-util')
+const expect = require('chai').expect
+
+function assertExit(code, gen) {
+  let actualError
+  return gen.catch(function (error) {
+    expect(error).to.be.an.instanceof(cli.exit.ErrorExit)
+    actualError = error
+  }).then(function () {
+    expect(actualError).to.not.equal(undefined, 'Expected Error to be thrown')
+    expect(actualError.code).to.be.an('number', 'Expected error.exit(i) to be called with a number')
+    expect(actualError.code).to.equal(code)
+    return actualError
+  })
+}
+
+module.exports = {
+  assertExit,
+}

--- a/packages/container-registry-v5/test/unit/commands/pull.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/pull.unit.test.js
@@ -32,11 +32,11 @@ describe('container pull', () => {
   it('exits when the app stack is not "container"', () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/testapp')
-      .reply(200, {name: 'testapp', stack: {name: 'heroku-22'}})
+      .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
 
     return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
       .then(error => {
-        expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-22.')
+        expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
         api.done()
       })
   })

--- a/packages/container-registry-v5/test/unit/commands/pull.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/pull.unit.test.js
@@ -7,31 +7,52 @@ const {expect} = require('chai')
 const sinon = require('sinon')
 
 const Sanbashi = require('../../../lib/sanbashi')
+const nock = require('nock')
+const helpers = require('../../helpers')
 let sandbox
 
 describe('container pull', () => {
   beforeEach(() => {
     cli.mockConsole()
     sandbox = sinon.createSandbox()
+    cli.exit.mock()
   })
-  afterEach(() => sandbox.restore())
+  afterEach(() => {
+    sandbox.restore()
+    nock.cleanAll()
+  })
 
   it('requires a process type', async () => {
-    sandbox.stub(process, 'exit')
+    await helpers.assertExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
+      .then(error => {
+        expect(error.message).to.contain('Requires one or more process types')
+      })
+  })
 
-    await cmd.run({app: 'testapp', args: [], flags: {}})
-      .then(() => expect(cli.stderr).to.contain('Requires one or more process types'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(process.exit.calledWith(1)).to.equal(true))
+  it('exits when the app stack is not "container"', () => {
+    let api = nock('https://api.heroku.com:443')
+      .get('/apps/testapp')
+      .reply(200, {name: 'testapp', stack: {name: 'heroku-22'}})
+
+    return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+      .then(error => {
+        expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-22.')
+        api.done()
+      })
   })
 
   it('pulls from the docker registry', () => {
+    let api = nock('https://api.heroku.com:443')
+      .get('/apps/testapp')
+      .reply(200, {name: 'testapp', stack: {name: 'container'}})
+
     let pull = sandbox.stub(Sanbashi, 'pullImage')
       .withArgs('registry.heroku.com/testapp/web')
 
     return cmd.run({app: 'testapp', args: ['web'], flags: {}})
-      .then(() => expect(cli.stderr, 'to be empty'))
+      .then(() => expect(cli.stderr).to.equal(''))
       .then(() => expect(cli.stdout).to.contain('Pulling web as registry.heroku.com/testapp/web'))
       .then(() => sandbox.assert.calledOnce(pull))
+      .then(() => api.done())
   })
 })

--- a/packages/container-registry-v5/test/unit/commands/pull.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/pull.unit.test.js
@@ -36,7 +36,7 @@ describe('container pull', () => {
 
     return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
       .then(error => {
-        expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
+        expect(error.message).to.equal('This command is for Docker apps only. Run git push heroku main to deploy your testapp heroku-24 app instead.')
         api.done()
       })
   })

--- a/packages/container-registry-v5/test/unit/commands/pull.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/pull.unit.test.js
@@ -23,7 +23,7 @@ describe('container pull', () => {
   })
 
   it('requires a process type', async () => {
-    await testutil.assertExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
+    await testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
       .then(error => {
         expect(error.message).to.contain('Requires one or more process types')
       })
@@ -34,7 +34,7 @@ describe('container pull', () => {
       .get('/apps/testapp')
       .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
 
-    return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+    return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
       .then(error => {
         expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
         api.done()

--- a/packages/container-registry-v5/test/unit/commands/pull.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/pull.unit.test.js
@@ -8,7 +8,7 @@ const sinon = require('sinon')
 
 const Sanbashi = require('../../../lib/sanbashi')
 const nock = require('nock')
-const helpers = require('../../helpers')
+const testutil = require('../../testutil')
 let sandbox
 
 describe('container pull', () => {
@@ -23,7 +23,7 @@ describe('container pull', () => {
   })
 
   it('requires a process type', async () => {
-    await helpers.assertExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
+    await testutil.assertExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
       .then(error => {
         expect(error.message).to.contain('Requires one or more process types')
       })
@@ -34,7 +34,7 @@ describe('container pull', () => {
       .get('/apps/testapp')
       .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
 
-    return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+    return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
       .then(error => {
         expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
         api.done()

--- a/packages/container-registry-v5/test/unit/commands/pull.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/pull.unit.test.js
@@ -36,7 +36,7 @@ describe('container pull', () => {
 
     return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
       .then(error => {
-        expect(error.message).to.equal('This command is for Docker apps only. Run git push heroku main to deploy your testapp heroku-24 app instead.')
+        expect(error.message).to.equal('This command is for Docker apps only.')
         api.done()
       })
   })

--- a/packages/container-registry-v5/test/unit/commands/push.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/push.unit.test.js
@@ -6,199 +6,175 @@ const cmd = require('../../..').commands.find(c => c.topic === 'container' && c.
 const {expect} = require('chai')
 const sinon = require('sinon')
 const nock = require('nock')
+const helpers = require('../../helpers')
 
 const Sanbashi = require('../../../lib/sanbashi')
 let sandbox
 
 describe('container push', () => {
+  let api
   beforeEach(() => {
     cli.mockConsole()
     sandbox = sinon.createSandbox()
+    cli.exit.mock()
   })
-  afterEach(() => sandbox.restore())
-
-  it('exits when the app stack is not "container"', () => {
-    sandbox.stub(process, 'exit')
-
-    let api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp', stack: {name: 'heroku-22'}})
-
-    let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
-      .returns(['/path/to/Dockerfile'])
-    let build = sandbox.stub(Sanbashi, 'buildImage')
-
-    return cmd.run({app: 'testapp', args: ['web'], flags: {}})
-      .then(() => expect(cli.stderr).to.contain('This command is only supported for the container stack'))
-      .then(() => expect(process.exit.calledWith(1)).to.equal(true))
-      .then(() => sandbox.assert.notCalled(dockerfiles))
-      .then(() => sandbox.assert.notCalled(build))
-      .then(() => api.done())
+  afterEach(() => {
+    sandbox.restore()
+    nock.cleanAll()
   })
 
-  it('gets a build error', () => {
-    sandbox.stub(process, 'exit')
+  context('when the app stack is not "container"', () => {
+    beforeEach(() => {
+      api = nock('https://api.heroku.com:443')
+        .get('/apps/testapp')
+        .reply(200, {name: 'testapp', stack: {name: 'heroku-22'}})
+    })
+    afterEach(() => api.done())
 
-    let api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-
-    let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
-      .returns(['/path/to/Dockerfile'])
-    let build = sandbox.stub(Sanbashi, 'buildImage').throws()
-
-    return cmd.run({app: 'testapp', args: ['web'], flags: {}})
-      .then(() => expect(cli.stderr).to.contain('docker build exited with Error: Error'))
-      .then(() => expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile)'))
-      .then(() => expect(process.exit.calledWith(1)).to.equal(true))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
-      .then(() => sandbox.assert.calledOnce(build))
-      .then(() => api.done())
+    it('exits', () => {
+      return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+        .then(error => {
+          expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-22.')
+        })
+    })
   })
 
-  it('gets a push error', () => {
-    sandbox.stub(process, 'exit')
+  context('when the app is a container app', () => {
+    beforeEach(() => {
+      api = nock('https://api.heroku.com:443')
+        .get('/apps/testapp')
+        .reply(200, {name: 'testapp', stack: {name: 'container'}})
+    })
+    afterEach(() => api.done())
 
-    let api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
+    it('gets a build error', () => {
+      let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
+        .returns(['/path/to/Dockerfile'])
+      let build = sandbox.stub(Sanbashi, 'buildImage').throws()
 
-    let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
-      .returns(['/path/to/Dockerfile'])
-    let build = sandbox.stub(Sanbashi, 'buildImage')
-    let push = sandbox.stub(Sanbashi, 'pushImage').throws()
+      return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+        .then(error => {
+          expect(error.message).to.equal('Error: docker build exited with Error: Error')
+          expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile)')
+          sandbox.assert.calledOnce(dockerfiles)
+          sandbox.assert.calledOnce(build)
+        })
+    })
 
-    return cmd.run({app: 'testapp', args: ['web'], flags: {}})
-      .then(() => expect(cli.stderr).to.contain('docker push exited with Error: Error'))
-      .then(() => expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile)'))
-      .then(() => expect(process.exit.calledWith(1)).to.equal(true))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
-      .then(() => sandbox.assert.calledOnce(build))
-      .then(() => sandbox.assert.calledOnce(push))
-      .then(() => api.done())
-  })
+    it('gets a push error', () => {
+      let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
+        .returns(['/path/to/Dockerfile'])
+      let build = sandbox.stub(Sanbashi, 'buildImage')
+      let push = sandbox.stub(Sanbashi, 'pushImage').throws()
 
-  it('pushes to the docker registry', () => {
-    let api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
+      return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+        .then(error => {
+          expect(error.message).to.contain('docker push exited with Error: Error')
+          expect(cli.stderr).to.contain('docker push exited with Error: Error')
+          expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile)')
+          sandbox.assert.calledOnce(dockerfiles)
+          sandbox.assert.calledOnce(build)
+          sandbox.assert.calledOnce(push)
+        })
+    })
 
-    let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
-      .returns(['/path/to/Dockerfile'])
-    let build = sandbox.stub(Sanbashi, 'buildImage')
-      .withArgs('/path/to/Dockerfile', 'registry.heroku.com/testapp/web', [])
-    let push = sandbox.stub(Sanbashi, 'pushImage')
-      .withArgs('registry.heroku.com/testapp/web')
+    it('pushes to the docker registry', () => {
+      let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
+        .returns(['/path/to/Dockerfile'])
+      let build = sandbox.stub(Sanbashi, 'buildImage')
+        .withArgs('/path/to/Dockerfile', 'registry.heroku.com/testapp/web', [])
+      let push = sandbox.stub(Sanbashi, 'pushImage')
+        .withArgs('registry.heroku.com/testapp/web')
 
-    return cmd.run({app: 'testapp', args: ['web'], flags: {}})
-      .then(() => expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile)'))
-      .then(() => expect(cli.stdout).to.contain('Pushing web (/path/to/Dockerfile)'))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
-      .then(() => sandbox.assert.calledOnce(build))
-      .then(() => sandbox.assert.calledOnce(push))
-      .then(() => api.done())
-  })
+      return cmd.run({app: 'testapp', args: ['web'], flags: {}})
+        .then(() => expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile)'))
+        .then(() => expect(cli.stdout).to.contain('Pushing web (/path/to/Dockerfile)'))
+        .then(() => sandbox.assert.calledOnce(dockerfiles))
+        .then(() => sandbox.assert.calledOnce(build))
+        .then(() => sandbox.assert.calledOnce(push))
+    })
 
-  it('pushes the standard dockerfile to non-web', () => {
-    let api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
+    it('pushes the standard dockerfile to non-web', () => {
+      let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
+        .returns(['/path/to/Dockerfile'])
+      let build = sandbox.stub(Sanbashi, 'buildImage')
+        .withArgs('/path/to/Dockerfile', 'registry.heroku.com/testapp/worker', [])
+      let push = sandbox.stub(Sanbashi, 'pushImage')
+        .withArgs('registry.heroku.com/testapp/worker')
 
-    let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
-      .returns(['/path/to/Dockerfile'])
-    let build = sandbox.stub(Sanbashi, 'buildImage')
-      .withArgs('/path/to/Dockerfile', 'registry.heroku.com/testapp/worker', [])
-    let push = sandbox.stub(Sanbashi, 'pushImage')
-      .withArgs('registry.heroku.com/testapp/worker')
+      return cmd.run({app: 'testapp', args: ['worker'], flags: {}})
+        .then(() => expect(cli.stdout).to.contain('Building worker (/path/to/Dockerfile)'))
+        .then(() => expect(cli.stdout).to.contain('Pushing worker (/path/to/Dockerfile)'))
+        .then(() => sandbox.assert.calledOnce(dockerfiles))
+        .then(() => sandbox.assert.calledOnce(build))
+        .then(() => sandbox.assert.calledOnce(push))
+    })
 
-    return cmd.run({app: 'testapp', args: ['worker'], flags: {}})
-      .then(() => expect(cli.stdout).to.contain('Building worker (/path/to/Dockerfile)'))
-      .then(() => expect(cli.stdout).to.contain('Pushing worker (/path/to/Dockerfile)'))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
-      .then(() => sandbox.assert.calledOnce(build))
-      .then(() => sandbox.assert.calledOnce(push))
-      .then(() => api.done())
-  })
+    it('pushes several dockerfiles recursively', () => {
+      let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
+        .returns(['/path/to/Dockerfile.web', '/path/to/Dockerfile.worker'])
+      let build = sandbox.stub(Sanbashi, 'buildImage')
+      build.withArgs('/path/to/Dockerfile.web', 'registry.heroku.com/testapp/web', [])
+      build.withArgs('/path/to/Dockerfile.worker', 'registry.heroku.com/testapp/worker', [])
+      let push = sandbox.stub(Sanbashi, 'pushImage')
+      push.withArgs('registry.heroku.com/testapp/web')
+      push.withArgs('registry.heroku.com/testapp/worker')
 
-  it('pushes several dockerfiles recursively', () => {
-    let api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
+      return cmd.run({app: 'testapp', args: ['web', 'worker'], flags: {recursive: true}})
+        .then(() => expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile.web)'))
+        .then(() => expect(cli.stdout).to.contain('Building worker (/path/to/Dockerfile.worker)'))
+        .then(() => expect(cli.stdout).to.contain('Pushing web (/path/to/Dockerfile.web)'))
+        .then(() => expect(cli.stdout).to.contain('Pushing worker (/path/to/Dockerfile.worker)'))
+        .then(() => sandbox.assert.calledOnce(dockerfiles))
+        .then(() => sandbox.assert.calledTwice(build))
+        .then(() => sandbox.assert.calledTwice(push))
+    })
 
-    let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
-      .returns(['/path/to/Dockerfile.web', '/path/to/Dockerfile.worker'])
-    let build = sandbox.stub(Sanbashi, 'buildImage')
-    build.withArgs('/path/to/Dockerfile.web', 'registry.heroku.com/testapp/web', [])
-    build.withArgs('/path/to/Dockerfile.worker', 'registry.heroku.com/testapp/worker', [])
-    let push = sandbox.stub(Sanbashi, 'pushImage')
-    push.withArgs('registry.heroku.com/testapp/web')
-    push.withArgs('registry.heroku.com/testapp/worker')
+    it('builds with custom context path and pushes to the docker registry', () => {
+      let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
+        .returns(['/path/to/Dockerfile'])
+      let build = sandbox.stub(Sanbashi, 'buildImage')
+        .withArgs('/path/to/Dockerfile', 'registry.heroku.com/testapp/web', [], '/custom/context/path')
+      let push = sandbox.stub(Sanbashi, 'pushImage')
+        .withArgs('registry.heroku.com/testapp/web')
 
-    return cmd.run({app: 'testapp', args: ['web', 'worker'], flags: {recursive: true}})
-      .then(() => expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile.web)'))
-      .then(() => expect(cli.stdout).to.contain('Building worker (/path/to/Dockerfile.worker)'))
-      .then(() => expect(cli.stdout).to.contain('Pushing web (/path/to/Dockerfile.web)'))
-      .then(() => expect(cli.stdout).to.contain('Pushing worker (/path/to/Dockerfile.worker)'))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
-      .then(() => sandbox.assert.calledTwice(build))
-      .then(() => sandbox.assert.calledTwice(push))
-      .then(() => api.done())
-  })
+      return cmd.run({app: 'testapp', args: ['web'], flags: {'context-path': '/custom/context/path'}})
+        .then(() => expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile)'))
+        .then(() => expect(cli.stdout).to.contain('Pushing web (/path/to/Dockerfile)'))
+        .then(() => sandbox.assert.calledOnce(dockerfiles))
+        .then(() => sandbox.assert.calledOnce(build))
+        .then(() => sandbox.assert.calledOnce(push))
+    })
 
-  it('builds with custom context path and pushes to the docker registry', () => {
-    let api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
+    it('does not find an image to push', () => {
+      let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
+        .returns([])
 
-    let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
-      .returns(['/path/to/Dockerfile'])
-    let build = sandbox.stub(Sanbashi, 'buildImage')
-      .withArgs('/path/to/Dockerfile', 'registry.heroku.com/testapp/web', [], '/custom/context/path')
-    let push = sandbox.stub(Sanbashi, 'pushImage')
-      .withArgs('registry.heroku.com/testapp/web')
-
-    return cmd.run({app: 'testapp', args: ['web'], flags: {'context-path': '/custom/context/path'}})
-      .then(() => expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile)'))
-      .then(() => expect(cli.stdout).to.contain('Pushing web (/path/to/Dockerfile)'))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
-      .then(() => sandbox.assert.calledOnce(build))
-      .then(() => sandbox.assert.calledOnce(push))
-      .then(() => api.done())
-  })
-
-  it('does not find an image to push', () => {
-    sandbox.stub(process, 'exit')
-
-    let api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-
-    let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
-      .returns([])
-
-    return cmd.run({app: 'testapp', args: ['web'], flags: {}})
-      .then(() => expect(cli.stderr).to.contain('No images to push'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(process.exit.calledWith(1)).to.equal(true))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
-      .then(() => api.done())
+      return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+        .then(error => {
+          expect(error.message).to.contain('No images to push')
+          expect(cli.stderr).to.contain('No images to push')
+          expect(cli.stdout).to.equal('')
+          sandbox.assert.calledOnce(dockerfiles)
+        })
+    })
   })
 
   it('requires a process type if we are not recursive', () => {
-    sandbox.stub(process, 'exit')
-
-    return cmd.run({app: 'testapp', args: [], flags: {}})
-      .then(() => expect(cli.stderr).to.contain('Requires either --recursive or one or more process types'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(process.exit.calledWith(1)).to.equal(true))
+    return helpers.assertExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
+      .then(error => {
+        expect(error.message).to.contain('Requires either --recursive or one or more process types')
+        expect(cli.stderr).to.contain('Requires either --recursive or one or more process types')
+        expect(cli.stdout).to.equal('')
+      })
   })
 
   it('rejects multiple process types if we are not recursive', () => {
-    sandbox.stub(process, 'exit')
-
-    return cmd.run({app: 'testapp', args: ['web', 'worker'], flags: {}})
-      .then(() => expect(cli.stderr).to.contain('Requires exactly one target process type, or --recursive option'))
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(process.exit.calledWith(1)).to.equal(true))
+    return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web', 'worker'], flags: {}}))
+      .then(error => {
+        expect(error.message).to.contain('Requires exactly one target process type, or --recursive option')
+        expect(cli.stderr).to.contain('Requires exactly one target process type, or --recursive option')
+        expect(cli.stdout).to.equal('')
+      })
   })
 })

--- a/packages/container-registry-v5/test/unit/commands/push.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/push.unit.test.js
@@ -27,14 +27,14 @@ describe('container push', () => {
     beforeEach(() => {
       api = nock('https://api.heroku.com:443')
         .get('/apps/testapp')
-        .reply(200, {name: 'testapp', stack: {name: 'heroku-22'}})
+        .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
     })
     afterEach(() => api.done())
 
     it('exits', () => {
       return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
         .then(error => {
-          expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-22.')
+          expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
         })
     })
   })

--- a/packages/container-registry-v5/test/unit/commands/push.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/push.unit.test.js
@@ -34,7 +34,7 @@ describe('container push', () => {
     it('exits', () => {
       return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
         .then(error => {
-          expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
+          expect(error.message).to.equal('This command is for Docker apps only. Run git push heroku main to deploy your testapp heroku-24 app instead.')
         })
     })
   })

--- a/packages/container-registry-v5/test/unit/commands/push.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/push.unit.test.js
@@ -1,12 +1,12 @@
 'use strict'
-/* globals beforeEach afterEach */
+/* globals beforeEach afterEach context */
 
 const cli = require('heroku-cli-util')
 const cmd = require('../../..').commands.find(c => c.topic === 'container' && c.command === 'push')
 const {expect} = require('chai')
 const sinon = require('sinon')
 const nock = require('nock')
-const helpers = require('../../helpers')
+const testutil = require('../../testutil')
 
 const Sanbashi = require('../../../lib/sanbashi')
 let sandbox
@@ -32,7 +32,7 @@ describe('container push', () => {
     afterEach(() => api.done())
 
     it('exits', () => {
-      return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+      return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
         .then(error => {
           expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
         })
@@ -52,7 +52,7 @@ describe('container push', () => {
         .returns(['/path/to/Dockerfile'])
       let build = sandbox.stub(Sanbashi, 'buildImage').throws()
 
-      return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+      return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
         .then(error => {
           expect(error.message).to.equal('Error: docker build exited with Error: Error')
           expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile)')
@@ -67,7 +67,7 @@ describe('container push', () => {
       let build = sandbox.stub(Sanbashi, 'buildImage')
       let push = sandbox.stub(Sanbashi, 'pushImage').throws()
 
-      return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+      return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
         .then(error => {
           expect(error.message).to.contain('docker push exited with Error: Error')
           expect(cli.stderr).to.contain('docker push exited with Error: Error')
@@ -150,7 +150,7 @@ describe('container push', () => {
       let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
         .returns([])
 
-      return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+      return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
         .then(error => {
           expect(error.message).to.contain('No images to push')
           expect(cli.stderr).to.contain('No images to push')
@@ -161,7 +161,7 @@ describe('container push', () => {
   })
 
   it('requires a process type if we are not recursive', () => {
-    return helpers.assertExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
+    return testutil.assertExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
       .then(error => {
         expect(error.message).to.contain('Requires either --recursive or one or more process types')
         expect(cli.stderr).to.contain('Requires either --recursive or one or more process types')
@@ -170,7 +170,7 @@ describe('container push', () => {
   })
 
   it('rejects multiple process types if we are not recursive', () => {
-    return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web', 'worker'], flags: {}}))
+    return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web', 'worker'], flags: {}}))
       .then(error => {
         expect(error.message).to.contain('Requires exactly one target process type, or --recursive option')
         expect(cli.stderr).to.contain('Requires exactly one target process type, or --recursive option')

--- a/packages/container-registry-v5/test/unit/commands/push.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/push.unit.test.js
@@ -32,7 +32,7 @@ describe('container push', () => {
     afterEach(() => api.done())
 
     it('exits', () => {
-      return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+      return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
         .then(error => {
           expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
         })
@@ -52,7 +52,7 @@ describe('container push', () => {
         .returns(['/path/to/Dockerfile'])
       let build = sandbox.stub(Sanbashi, 'buildImage').throws()
 
-      return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+      return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
         .then(error => {
           expect(error.message).to.equal('Error: docker build exited with Error: Error')
           expect(cli.stdout).to.contain('Building web (/path/to/Dockerfile)')
@@ -67,7 +67,7 @@ describe('container push', () => {
       let build = sandbox.stub(Sanbashi, 'buildImage')
       let push = sandbox.stub(Sanbashi, 'pushImage').throws()
 
-      return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+      return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
         .then(error => {
           expect(error.message).to.contain('docker push exited with Error: Error')
           expect(cli.stderr).to.contain('docker push exited with Error: Error')
@@ -150,7 +150,7 @@ describe('container push', () => {
       let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
         .returns([])
 
-      return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+      return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
         .then(error => {
           expect(error.message).to.contain('No images to push')
           expect(cli.stderr).to.contain('No images to push')
@@ -161,7 +161,7 @@ describe('container push', () => {
   })
 
   it('requires a process type if we are not recursive', () => {
-    return testutil.assertExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
+    return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
       .then(error => {
         expect(error.message).to.contain('Requires either --recursive or one or more process types')
         expect(cli.stderr).to.contain('Requires either --recursive or one or more process types')
@@ -170,7 +170,7 @@ describe('container push', () => {
   })
 
   it('rejects multiple process types if we are not recursive', () => {
-    return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web', 'worker'], flags: {}}))
+    return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web', 'worker'], flags: {}}))
       .then(error => {
         expect(error.message).to.contain('Requires exactly one target process type, or --recursive option')
         expect(cli.stderr).to.contain('Requires exactly one target process type, or --recursive option')

--- a/packages/container-registry-v5/test/unit/commands/release.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/release.unit.test.js
@@ -1,12 +1,12 @@
 'use strict'
-/* globals beforeEach afterEach */
+/* globals beforeEach afterEach context */
 
 const cli = require('heroku-cli-util')
 const cmd = require('../../..').commands.find(c => c.topic === 'container' && c.command === 'release')
 const {expect} = require('chai')
 const nock = require('nock')
 const stdMocks = require('std-mocks')
-const helpers = require('../../helpers')
+const testutil = require('../../testutil')
 
 describe('container release', () => {
   beforeEach(() => {
@@ -22,7 +22,7 @@ describe('container release', () => {
       .get('/apps/testapp')
       .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
 
-    return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+    return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
       .then(error => {
         expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
         api.done()
@@ -30,7 +30,7 @@ describe('container release', () => {
   })
 
   it('has no process type specified', () => {
-    return helpers.assertExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
+    return testutil.assertExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
       .then(error => {
         expect(error.message).to.contain('Requires one or more process types')
         expect(cli.stderr).to.contain('Requires one or more process types')
@@ -256,7 +256,7 @@ describe('container release', () => {
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
 
-      return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+      return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
         .then(error => {
           expect(error.message).to.contain('Error: release command failed')
           expect(cli.stderr).to.contain('Releasing images web to testapp...')
@@ -288,7 +288,7 @@ describe('container release', () => {
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
 
-      return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+      return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
         .then(error => {
           expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content')
           expect(error.message).to.contain('Error: release command failed')
@@ -371,7 +371,7 @@ describe('container release', () => {
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
 
-      return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+      return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
         .then(error => {
           expect(error.message).to.contain('Error: release command failed')
           expect(stdMocks.flush().stdout.join('')).to.equal('')
@@ -404,7 +404,7 @@ describe('container release', () => {
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
 
-      return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+      return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
         .then(error => {
           expect(error.message).to.contain('Error: release command failed')
           expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content')

--- a/packages/container-registry-v5/test/unit/commands/release.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/release.unit.test.js
@@ -24,7 +24,7 @@ describe('container release', () => {
 
     return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
       .then(error => {
-        expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
+        expect(error.message).to.equal('This command is for Docker apps only. Run git push heroku main to deploy your testapp heroku-24 app instead.')
         api.done()
       })
   })

--- a/packages/container-registry-v5/test/unit/commands/release.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/release.unit.test.js
@@ -4,21 +4,16 @@
 const cli = require('heroku-cli-util')
 const cmd = require('../../..').commands.find(c => c.topic === 'container' && c.command === 'release')
 const {expect} = require('chai')
-const sinon = require('sinon')
 const nock = require('nock')
 const stdMocks = require('std-mocks')
 const helpers = require('../../helpers')
 
-let sandbox
-
 describe('container release', () => {
   beforeEach(() => {
     cli.mockConsole()
-    sandbox = sinon.createSandbox()
     cli.exit.mock()
   })
   afterEach(() => {
-    sandbox.restore()
     nock.cleanAll()
   })
 

--- a/packages/container-registry-v5/test/unit/commands/release.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/release.unit.test.js
@@ -22,7 +22,7 @@ describe('container release', () => {
       .get('/apps/testapp')
       .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
 
-    return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+    return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
       .then(error => {
         expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
         api.done()
@@ -30,7 +30,7 @@ describe('container release', () => {
   })
 
   it('has no process type specified', () => {
-    return testutil.assertExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
+    return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
       .then(error => {
         expect(error.message).to.contain('Requires one or more process types')
         expect(cli.stderr).to.contain('Requires one or more process types')
@@ -256,7 +256,7 @@ describe('container release', () => {
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
 
-      return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+      return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
         .then(error => {
           expect(error.message).to.contain('Error: release command failed')
           expect(cli.stderr).to.contain('Releasing images web to testapp...')
@@ -288,7 +288,7 @@ describe('container release', () => {
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
 
-      return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+      return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
         .then(error => {
           expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content')
           expect(error.message).to.contain('Error: release command failed')
@@ -371,7 +371,7 @@ describe('container release', () => {
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
 
-      return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+      return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
         .then(error => {
           expect(error.message).to.contain('Error: release command failed')
           expect(stdMocks.flush().stdout.join('')).to.equal('')
@@ -404,7 +404,7 @@ describe('container release', () => {
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
 
-      return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+      return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
         .then(error => {
           expect(error.message).to.contain('Error: release command failed')
           expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content')

--- a/packages/container-registry-v5/test/unit/commands/release.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/release.unit.test.js
@@ -25,11 +25,11 @@ describe('container release', () => {
   it('exits when the app stack is not "container"', () => {
     let api = nock('https://api.heroku.com:443')
       .get('/apps/testapp')
-      .reply(200, {name: 'testapp', stack: {name: 'heroku-22'}})
+      .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
 
     return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
       .then(error => {
-        expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-22.')
+        expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
         api.done()
       })
   })

--- a/packages/container-registry-v5/test/unit/commands/rm.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/rm.unit.test.js
@@ -1,48 +1,73 @@
 'use strict'
-/* globals beforeEach */
+/* globals beforeEach afterEach context */
 
 const cli = require('heroku-cli-util')
 const cmd = require('../../..').commands.find(c => c.topic === 'container' && c.command === 'rm')
 const {expect} = require('chai')
 const nock = require('nock')
 const sinon = require('sinon')
+const helpers = require('../../helpers')
 
 describe('container removal', () => {
-  beforeEach(() => cli.mockConsole())
-
-  it('removes one container', () => {
-    let api = nock('https://api.heroku.com:443')
-      .patch('/apps/testapp/formation/web')
-      .reply(200, {})
-
-    return cmd.run({app: 'testapp', args: ['web'], flags: {}})
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.contain('Removing container web for testapp... done'))
-      .then(() => api.done())
+  beforeEach(() => {
+    cli.mockConsole()
+    cli.exit.mock()
+  })
+  afterEach(() => {
+    nock.cleanAll()
   })
 
-  it('removes two containers', () => {
+  it('exits when the app stack is not "container"', () => {
     let api = nock('https://api.heroku.com:443')
-      .patch('/apps/testapp/formation/web')
-      .reply(200, {})
-      .patch('/apps/testapp/formation/worker')
-      .reply(200, {})
+      .get('/apps/testapp')
+      .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
 
-    return cmd.run({app: 'testapp', args: ['web', 'worker'], flags: {}})
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.contain('Removing container web for testapp... done'))
-      .then(() => expect(cli.stderr).to.contain('Removing container worker for testapp... done'))
-      .then(() => api.done())
+    return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+      .then(error => {
+        expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
+        api.done()
+      })
+  })
+
+  context('when the app is a container app', () => {
+    let api
+    beforeEach(() => {
+      api = nock('https://api.heroku.com:443')
+        .get('/apps/testapp')
+        .reply(200, {name: 'testapp', stack: {name: 'container'}})
+    })
+    afterEach(() => api.done())
+
+    it('removes one container', () => {
+      api
+        .patch('/apps/testapp/formation/web')
+        .reply(200, {})
+
+      return cmd.run({app: 'testapp', args: ['web'], flags: {}})
+        .then(() => expect(cli.stdout).to.equal(''))
+        .then(() => expect(cli.stderr).to.contain('Removing container web for testapp... done'))
+    })
+
+    it('removes two containers', () => {
+      api
+        .patch('/apps/testapp/formation/web')
+        .reply(200, {})
+        .patch('/apps/testapp/formation/worker')
+        .reply(200, {})
+
+      return cmd.run({app: 'testapp', args: ['web', 'worker'], flags: {}})
+        .then(() => expect(cli.stdout).to.equal(''))
+        .then(() => expect(cli.stderr).to.contain('Removing container web for testapp... done'))
+        .then(() => expect(cli.stderr).to.contain('Removing container worker for testapp... done'))
+    })
   })
 
   it('requires a container to be specified', () => {
-    const sandbox = sinon.createSandbox()
-    sandbox.stub(process, 'exit')
-
-    return cmd.run({app: 'testapp', args: [], flags: {}})
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.contain('Please specify at least one target process type'))
-      .then(() => expect(process.exit.calledWith(1)).to.equal(true))
-      .finally(() => sandbox.restore())
+    return helpers.assertExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
+      .then(error => {
+        expect(error.message).to.contain('Please specify at least one target process type')
+        expect(cli.stdout).to.equal('')
+        expect(cli.stderr).to.contain('Please specify at least one target process type')
+      })
   })
 })

--- a/packages/container-registry-v5/test/unit/commands/rm.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/rm.unit.test.js
@@ -5,7 +5,6 @@ const cli = require('heroku-cli-util')
 const cmd = require('../../..').commands.find(c => c.topic === 'container' && c.command === 'rm')
 const {expect} = require('chai')
 const nock = require('nock')
-const sinon = require('sinon')
 const helpers = require('../../helpers')
 
 describe('container removal', () => {

--- a/packages/container-registry-v5/test/unit/commands/rm.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/rm.unit.test.js
@@ -5,7 +5,7 @@ const cli = require('heroku-cli-util')
 const cmd = require('../../..').commands.find(c => c.topic === 'container' && c.command === 'rm')
 const {expect} = require('chai')
 const nock = require('nock')
-const helpers = require('../../helpers')
+const testutil = require('../../testutil')
 
 describe('container removal', () => {
   beforeEach(() => {
@@ -21,7 +21,7 @@ describe('container removal', () => {
       .get('/apps/testapp')
       .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
 
-    return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+    return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
       .then(error => {
         expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
         api.done()
@@ -62,7 +62,7 @@ describe('container removal', () => {
   })
 
   it('requires a container to be specified', () => {
-    return helpers.assertExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
+    return testutil.assertExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
       .then(error => {
         expect(error.message).to.contain('Please specify at least one target process type')
         expect(cli.stdout).to.equal('')

--- a/packages/container-registry-v5/test/unit/commands/rm.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/rm.unit.test.js
@@ -23,7 +23,7 @@ describe('container removal', () => {
 
     return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
       .then(error => {
-        expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
+        expect(error.message).to.equal('This command is for Docker apps only. Run git push heroku main to deploy your testapp heroku-24 app instead.')
         api.done()
       })
   })

--- a/packages/container-registry-v5/test/unit/commands/rm.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/rm.unit.test.js
@@ -23,7 +23,7 @@ describe('container removal', () => {
 
     return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
       .then(error => {
-        expect(error.message).to.equal('This command is for Docker apps only. Run git push heroku main to deploy your testapp heroku-24 app instead.')
+        expect(error.message).to.equal('This command is for Docker apps only.')
         api.done()
       })
   })

--- a/packages/container-registry-v5/test/unit/commands/rm.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/rm.unit.test.js
@@ -21,7 +21,7 @@ describe('container removal', () => {
       .get('/apps/testapp')
       .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
 
-    return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+    return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
       .then(error => {
         expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
         api.done()
@@ -62,7 +62,7 @@ describe('container removal', () => {
   })
 
   it('requires a container to be specified', () => {
-    return testutil.assertExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
+    return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
       .then(error => {
         expect(error.message).to.contain('Please specify at least one target process type')
         expect(cli.stdout).to.equal('')

--- a/packages/container-registry-v5/test/unit/commands/run.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/run.unit.test.js
@@ -39,7 +39,7 @@ describe('container run', () => {
 
     return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
       .then(error => {
-        expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
+        expect(error.message).to.equal('This command is for Docker apps only. Run git push heroku main to deploy your testapp heroku-24 app instead.')
         api.done()
       })
   })

--- a/packages/container-registry-v5/test/unit/commands/run.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/run.unit.test.js
@@ -24,7 +24,7 @@ describe('container run', () => {
   })
 
   it('requires a process type', () => {
-    return testutil.assertExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
+    return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
       .then(error => {
         expect(error.message).to.contain('Requires one process type')
         expect(cli.stdout).to.equal('')
@@ -37,7 +37,7 @@ describe('container run', () => {
       .get('/apps/testapp')
       .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
 
-    return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+    return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
       .then(error => {
         expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
         api.done()

--- a/packages/container-registry-v5/test/unit/commands/run.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/run.unit.test.js
@@ -1,12 +1,12 @@
 'use strict'
-/* globals beforeEach afterEach */
+/* globals beforeEach afterEach context */
 
 const cli = require('heroku-cli-util')
 const cmd = require('../../..').commands.find(c => c.topic === 'container' && c.command === 'run')
 const {expect} = require('chai')
 const sinon = require('sinon')
 const nock = require('nock')
-const helpers = require('../../helpers')
+const testutil = require('../../testutil')
 
 const Sanbashi = require('../../../lib/sanbashi')
 let sandbox
@@ -24,7 +24,7 @@ describe('container run', () => {
   })
 
   it('requires a process type', () => {
-    return helpers.assertExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
+    return testutil.assertExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
       .then(error => {
         expect(error.message).to.contain('Requires one process type')
         expect(cli.stdout).to.equal('')
@@ -37,7 +37,7 @@ describe('container run', () => {
       .get('/apps/testapp')
       .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
 
-    return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+    return testutil.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
       .then(error => {
         expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
         api.done()

--- a/packages/container-registry-v5/test/unit/commands/run.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/run.unit.test.js
@@ -39,7 +39,7 @@ describe('container run', () => {
 
     return testutil.assertErrorExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
       .then(error => {
-        expect(error.message).to.equal('This command is for Docker apps only. Run git push heroku main to deploy your testapp heroku-24 app instead.')
+        expect(error.message).to.equal('This command is for Docker apps only.')
         api.done()
       })
   })

--- a/packages/container-registry-v5/test/unit/commands/run.unit.test.js
+++ b/packages/container-registry-v5/test/unit/commands/run.unit.test.js
@@ -5,6 +5,8 @@ const cli = require('heroku-cli-util')
 const cmd = require('../../..').commands.find(c => c.topic === 'container' && c.command === 'run')
 const {expect} = require('chai')
 const sinon = require('sinon')
+const nock = require('nock')
+const helpers = require('../../helpers')
 
 const Sanbashi = require('../../../lib/sanbashi')
 let sandbox
@@ -14,51 +16,76 @@ describe('container run', () => {
     cli.mockConsole()
     process.env.HEROKU_API_KEY = 'heroku_token'
     sandbox = sinon.createSandbox()
+    cli.exit.mock()
   })
-  afterEach(() => sandbox.restore())
+  afterEach(() => {
+    sandbox.restore()
+    nock.cleanAll()
+  })
 
   it('requires a process type', () => {
-    sandbox.stub(process, 'exit')
-
-    return cmd.run({app: 'testapp', args: [], flags: {}})
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.contain('Requires one process type'))
-      .then(() => expect(process.exit.calledWith(1)).to.equal(true))
+    return helpers.assertExit(1, cmd.run({app: 'testapp', args: [], flags: {}}))
+      .then(error => {
+        expect(error.message).to.contain('Requires one process type')
+        expect(cli.stdout).to.equal('')
+        expect(cli.stderr).to.contain('Requires one process type')
+      })
   })
 
-  it('runs a container', () => {
-    let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
-      .returns(['/path/to/Dockerfile'])
-    let run = sandbox.stub(Sanbashi, 'runImage')
-      .withArgs('registry.heroku.com/testapp/web', [])
+  it('exits when the app stack is not "container"', () => {
+    let api = nock('https://api.heroku.com:443')
+      .get('/apps/testapp')
+      .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
 
-    return cmd.run({app: 'testapp', args: ['web'], flags: {}})
-      .then(() => expect(cli.stdout).to.contain('Running registry.heroku.com/testapp/web'))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
-      .then(() => sandbox.assert.calledOnce(run))
+    return helpers.assertExit(1, cmd.run({app: 'testapp', args: ['web'], flags: {}}))
+      .then(error => {
+        expect(error.message).to.equal('This command is only supported for the container stack. The stack for app testapp is heroku-24.')
+        api.done()
+      })
   })
 
-  it('runs a container with a command', () => {
-    let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
-      .returns(['/path/to/Dockerfile'])
-    let run = sandbox.stub(Sanbashi, 'runImage')
-      .withArgs('registry.heroku.com/testapp/web', ['bash'])
+  context('when the app is a container app', () => {
+    let api
+    beforeEach(() => {
+      api = nock('https://api.heroku.com:443')
+        .get('/apps/testapp')
+        .reply(200, {name: 'testapp', stack: {name: 'container'}})
+    })
+    afterEach(() => api.done())
 
-    return cmd.run({app: 'testapp', args: ['web', 'bash'], flags: {}})
-      .then(() => expect(cli.stdout).to.contain('Running \'bash\' on registry.heroku.com/testapp/web'))
-      .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
-      .then(() => sandbox.assert.calledOnce(run))
-  })
+    it('runs a container', () => {
+      let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
+        .returns(['/path/to/Dockerfile'])
+      let run = sandbox.stub(Sanbashi, 'runImage')
+        .withArgs('registry.heroku.com/testapp/web', [])
 
-  it('requires a known dockerfile', () => {
-    let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
-      .returns([])
+      return cmd.run({app: 'testapp', args: ['web'], flags: {}})
+        .then(() => expect(cli.stdout).to.contain('Running registry.heroku.com/testapp/web'))
+        .then(() => sandbox.assert.calledOnce(dockerfiles))
+        .then(() => sandbox.assert.calledOnce(run))
+    })
 
-    return cmd.run({app: 'testapp', args: ['worker'], flags: {}})
-      .then(() => expect(cli.stdout, 'to be empty'))
-      .then(() => expect(cli.stderr).to.contain('No images to run'))
-      .then(() => sandbox.assert.calledOnce(dockerfiles))
+    it('runs a container with a command', () => {
+      let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
+        .returns(['/path/to/Dockerfile'])
+      let run = sandbox.stub(Sanbashi, 'runImage')
+        .withArgs('registry.heroku.com/testapp/web', ['bash'])
+
+      return cmd.run({app: 'testapp', args: ['web', 'bash'], flags: {}})
+        .then(() => expect(cli.stdout).to.contain('Running \'bash\' on registry.heroku.com/testapp/web'))
+        .then(() => expect(cli.stderr).to.equal(''))
+        .then(() => sandbox.assert.calledOnce(dockerfiles))
+        .then(() => sandbox.assert.calledOnce(run))
+    })
+
+    it('requires a known dockerfile', () => {
+      let dockerfiles = sandbox.stub(Sanbashi, 'getDockerfiles')
+        .returns([])
+
+      return cmd.run({app: 'testapp', args: ['worker'], flags: {}})
+        .then(() => expect(cli.stdout).to.equal(''))
+        .then(() => expect(cli.stderr).to.contain('No images to run'))
+        .then(() => sandbox.assert.calledOnce(dockerfiles))
+    })
   })
 })


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

Restrict container:* CLI commands to apps with stack=container

[GUS-W-15427582](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-15427582)
