### PR TITLE
chore: separate unit testing and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: yarn
       - run: yarn --immutable --network-timeout 1000000
-      - run: yarn test
+      - name: unit tests
+        run: yarn test
+      - name: linting
+        run: yarn lint
 
   integration:
     runs-on: ${{ matrix.os }}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "scripts": {
     "build": "lerna run prepack --concurrency 4",
     "test": "lerna run test --concurrency 4",
+    "lint": "lerna run lint --concurrency 4",
     "version": "cp packages/cli/CHANGELOG.md CHANGELOG.md && git add CHANGELOG.md",
     "cleanNodeModules": "rm -rf ./packages/*/node_modules && rm -rf ./node_modules && rm -rf ./.yarn/cache"
   },

--- a/packages/addons-v5/package.json
+++ b/packages/addons-v5/package.json
@@ -62,7 +62,7 @@
     "posttest": "yarn lint",
     "prepack": "oclif manifest",
     "release": "np",
-    "test": "mocha --forbid-only \"test/**/*.unit.test.js\"  && yarn lint",
+    "test": "mocha --forbid-only \"test/**/*.unit.test.js\"",
     "version": "oclif readme && git add README.md"
   }
 }

--- a/packages/apps-v5/package.json
+++ b/packages/apps-v5/package.json
@@ -77,7 +77,7 @@
     "lint": "eslint . --ext .js --config ../../.eslintrc --ignore-path ../../.eslintignore",
     "postpublish": "rm oclif.manifest.json",
     "prepack": "oclif manifest",
-    "test": "nyc --extension .js mocha --forbid-only \"test/**/*.unit.test.js\" && yarn lint",
+    "test": "nyc --extension .js mocha --forbid-only \"test/**/*.unit.test.js\"",
     "version": "oclif readme && git add README.md"
   }
 }

--- a/packages/certs-v5/package.json
+++ b/packages/certs-v5/package.json
@@ -62,7 +62,7 @@
     "lint": "eslint . --ext .js --config ../../.eslintrc --ignore-path ../../.eslintignore",
     "postpublish": "rm oclif.manifest.json",
     "prepack": "oclif manifest",
-    "test": "nyc mocha --forbid-only \"test/**/*.unit.test.js\" && yarn lint",
+    "test": "nyc mocha --forbid-only \"test/**/*.unit.test.js\"",
     "version": "oclif readme && git add README.md"
   }
 }

--- a/packages/ci-v5/package.json
+++ b/packages/ci-v5/package.json
@@ -66,7 +66,7 @@
     "lint": "eslint . --ext .js --config ../../.eslintrc --ignore-path ../../.eslintignore",
     "postpublish": "rm oclif.manifest.json",
     "prepack": "oclif manifest",
-    "test": "nyc mocha --forbid-only  && yarn lint",
+    "test": "nyc mocha --forbid-only",
     "version": "oclif readme && git add README.md"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -349,13 +349,12 @@
     "build": "rm -rf lib && tsc",
     "lint": "eslint . --ext .ts --config ../../.eslintrc --ignore-path ../../.eslintignore-lib",
     "postpublish": "rm -f oclif.manifest.json",
-    "posttest": "yarn lint",
     "prepack": "yarn run build && oclif manifest",
     "pretest": "tsc -p test --noEmit && cd ../.. && yarn build",
     "test:acceptance": "yarn pretest && mocha --forbid-only \"test/**/*.acceptance.test.ts\" && node ./bin/bats-test-runner",
     "test:integration": "yarn pretest && mocha --forbid-only \"test/**/*.integration.test.ts\"",
     "test:smoke": "yarn pretest && mocha --forbid-only \"test/**/smoke.acceptance.test.ts\"",
-    "test": "yarn pretest && nyc mocha --forbid-only \"test/**/*.unit.test.ts\" && yarn posttest",
+    "test": "yarn pretest && nyc mocha --forbid-only \"test/**/*.unit.test.ts\"",
     "version": "oclif readme --multi && git add README.md ../../docs"
   },
   "types": "lib/index.d.ts"

--- a/packages/container-registry-v5/package.json
+++ b/packages/container-registry-v5/package.json
@@ -64,7 +64,7 @@
     "lint": "eslint . --ext .js --config ../../.eslintrc --ignore-path ../../.eslintignore",
     "postpublish": "rm oclif.manifest.json",
     "prepack": "oclif manifest",
-    "test": "cross-env TZ=utc nyc mocha --forbid-only \"test/**/*.unit.test.js\" && yarn lint",
+    "test": "cross-env TZ=utc nyc mocha --forbid-only \"test/**/*.unit.test.js\"",
     "version": "oclif readme && git add README.md"
   },
   "topic": "container"

--- a/packages/oauth-v5/package.json
+++ b/packages/oauth-v5/package.json
@@ -61,7 +61,7 @@
     "lint": "eslint . --ext .js --config ../../.eslintrc --ignore-path ../../.eslintignore",
     "postpublish": "rm oclif.manifest.json",
     "prepack": "oclif manifest",
-    "test": "cross-env TZ=UTC nyc mocha --forbid-only \"test/**/*.unit.test.js\" && yarn lint",
+    "test": "cross-env TZ=UTC nyc mocha --forbid-only \"test/**/*.unit.test.js\"",
     "version": "oclif readme && git add README.md"
   }
 }

--- a/packages/orgs-v5/package.json
+++ b/packages/orgs-v5/package.json
@@ -78,7 +78,7 @@
     "lint": "eslint . --ext .js --config ../../.eslintrc --ignore-path ../../.eslintignore",
     "postpublish": "rm oclif.manifest.json",
     "prepack": "oclif manifest",
-    "test": "nyc mocha ./test/**/*.unit.test.js && yarn lint",
+    "test": "nyc mocha ./test/**/*.unit.test.js",
     "test:integration": "mocha './test/**/*.integration.test.js'",
     "version": "oclif readme && git add README.md"
   }

--- a/packages/pg-v5/package.json
+++ b/packages/pg-v5/package.json
@@ -69,7 +69,7 @@
     "postpublish": "rm oclif.manifest.json",
     "prepack": "oclif manifest",
     "release": "np",
-    "test": "cross-env TZ=utc nyc mocha --forbid-only \"test/**/*.unit.test.js\" && yarn lint",
+    "test": "cross-env TZ=utc nyc mocha --forbid-only \"test/**/*.unit.test.js\"",
     "version": "oclif readme && git add README.md"
   }
 }

--- a/packages/redis-v5/package.json
+++ b/packages/redis-v5/package.json
@@ -56,7 +56,7 @@
     "lint": "eslint . --ext .js --config ../../.eslintrc --ignore-path ../../.eslintignore",
     "postpublish": "rm oclif.manifest.json",
     "prepack": "oclif manifest",
-    "test": "nyc mocha --forbid-only \"test/**/*.unit.test.js\" && yarn lint",
+    "test": "nyc mocha --forbid-only \"test/**/*.unit.test.js\"",
     "version": "oclif readme && git add README.md"
   }
 }

--- a/packages/run-v5/package.json
+++ b/packages/run-v5/package.json
@@ -73,7 +73,7 @@
     "lint": "eslint . --ext .js --config ../../.eslintrc --ignore-path ../../.eslintignore",
     "postpack": "rm oclif.manifest.json",
     "prepack": "oclif manifest",
-    "test": "nyc --extension .js mocha \"test/**/*.unit.test.js\" && yarn lint",
+    "test": "nyc --extension .js mocha \"test/**/*.unit.test.js\"",
     "version": "oclif readme && git add README.md"
   }
 }

--- a/packages/spaces/package.json
+++ b/packages/spaces/package.json
@@ -58,7 +58,7 @@
     "lint": "eslint . --ext .js --config ../../.eslintrc --ignore-path ../../.eslintignore",
     "postpublish": "rm oclif.manifest.json",
     "prepack": "oclif manifest",
-    "test": "nyc mocha --forbid-only \"test/**/*.unit.test.js\" && yarn lint",
+    "test": "nyc mocha --forbid-only \"test/**/*.unit.test.js\"",
     "version": "oclif readme && git add README.md"
   }
 }


### PR DESCRIPTION
Separates our unit testing and linting scripts so that linting errors become more obvious in CI.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
