### PR TITLE
chore(run): remove env flag

### DIFF
--- a/packages/cli/src/commands/run/inside.ts
+++ b/packages/cli/src/commands/run/inside.ts
@@ -19,7 +19,6 @@ export default class RunInside extends Command {
     app: flags.app({required: true}),
     remote: flags.remote(),
     'exit-code': flags.boolean({char: 'x', description: 'passthrough the exit code of the remote command'}),
-    env: flags.string({char: 'e', description: "environment variables to set (use ';' to split multiple vars)"}),
     listen: flags.boolean({description: 'listen on a local port', hidden: true}),
   }
 
@@ -37,7 +36,6 @@ export default class RunInside extends Command {
       app: flags.app,
       command: buildCommand(argv.slice(1) as string[]),
       dyno: argv[0] as string,
-      env: flags.env,
       heroku: this.heroku,
       listen: flags.listen,
     }


### PR DESCRIPTION
## Description
This PR removes the `env` flag from the `run:inside` command.

[Work Item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001ntdoxYAA/view)