### PR TITLE
fix(W-15954887): json flag yelds error for command: heroku commands -…

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,7 @@
     "@heroku/eventsource": "^1.0.7",
     "@heroku/heroku-cli-util": "^8.0.13",
     "@oclif/core": "^2.16.0",
-    "@oclif/plugin-commands": "2.2.2",
+    "@oclif/plugin-commands": "2.2.28",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-legacy": "^1.3.0",
     "@oclif/plugin-not-found": "2.3.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2954,7 +2954,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oclif/core@npm:^1.1.1, @oclif/core@npm:^1.2.0, @oclif/core@npm:^1.25.0, @oclif/core@npm:^1.26.2":
+"@oclif/core@npm:^1.1.1, @oclif/core@npm:^1.25.0, @oclif/core@npm:^1.26.2":
   version: 1.26.2
   resolution: "@oclif/core@npm:1.26.2"
   dependencies:
@@ -3290,13 +3290,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oclif/plugin-commands@npm:2.2.2":
-  version: 2.2.2
-  resolution: "@oclif/plugin-commands@npm:2.2.2"
+"@oclif/plugin-commands@npm:2.2.28":
+  version: 2.2.28
+  resolution: "@oclif/plugin-commands@npm:2.2.28"
   dependencies:
-    "@oclif/core": ^1.2.0
+    "@oclif/core": ^2.15.0
     lodash: ^4.17.11
-  checksum: ee5d6bb6fcb8c8517514d11d7e005923ceb735513697085f57b53715a970fa3fbe98919f050bcf890342d9aa0d1b0a287dad22aca1cd2471e8c00e1c712d3ac5
+  checksum: b0c8573ac3930310837656eef049c1b901cf772451561581797575f470ca20c50936a351ba77fc0255f30d878c6d30b8d34bee9d8a783449dd6b5329de106df3
   languageName: node
   linkType: hard
 
@@ -10574,7 +10574,7 @@ __metadata:
     "@heroku/eventsource": ^1.0.7
     "@heroku/heroku-cli-util": ^8.0.13
     "@oclif/core": ^2.16.0
-    "@oclif/plugin-commands": 2.2.2
+    "@oclif/plugin-commands": 2.2.28
     "@oclif/plugin-help": ^5
     "@oclif/plugin-legacy": ^1.3.0
     "@oclif/plugin-not-found": 2.3.16


### PR DESCRIPTION
This PR updates the @oclif/plugin-commands package to remedy the "MODULE NOT FOUND" error when the `--json` flag is used.

[GUS work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001tt0sMYAQ/view)