### PR TITLE
fix(container): Error out `container:push` command if not `container` stack

### DIFF
--- a/packages/cli/src/commands/container/pull.ts
+++ b/packages/cli/src/commands/container/pull.ts
@@ -1,8 +1,10 @@
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
 import * as DockerHelper from '../../lib/container/docker_helper'
+import * as helpers from '../../lib/container/helpers'
 import {debug} from '../../lib/container/debug'
 import color from '@heroku-cli/color'
+import * as Heroku from '@heroku-cli/schema'
 
 export default class Pull extends Command {
   static topic = 'container'
@@ -28,6 +30,9 @@ export default class Pull extends Command {
     if (argv.length === 0) {
       this.error(`Error: Requires one or more process types\n${Pull.example}`)
     }
+
+    const {body: appBody} = await this.heroku.get<Heroku.App>(`/apps/${app}`)
+    helpers.ensureContainerStack(appBody, 'pull')
 
     const herokuHost = process.env.HEROKU_HOST || 'heroku.com'
     const registry = `registry.${herokuHost}`

--- a/packages/cli/src/commands/container/push.ts
+++ b/packages/cli/src/commands/container/push.ts
@@ -1,7 +1,9 @@
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
 import * as DockerHelper from '../../lib/container/docker_helper'
+import * as helpers from '../../lib/container/helpers'
 import {debug} from '../../lib/container/debug'
+import * as Heroku from '@heroku-cli/schema'
 
 async function selectJobs(jobs: DockerHelper.groupedDockerJobs, processTypes: string[], recursive: boolean) {
   let filteredJobs: DockerHelper.groupedDockerJobs = {}
@@ -65,7 +67,8 @@ export default class Push extends Command {
       ux.error('Requires exactly one target process type, or --recursive option', {exit: 1})
     }
 
-    await this.heroku.get(`/apps/${app}`)
+    const {body: appBody} = await this.heroku.get<Heroku.App>(`/apps/${app}`)
+    helpers.ensureContainerStack(appBody, 'push')
 
     const herokuHost = process.env.HEROKU_HOST || 'heroku.com'
     const registry = `registry.${herokuHost}`

--- a/packages/cli/src/commands/container/release.ts
+++ b/packages/cli/src/commands/container/release.ts
@@ -4,6 +4,7 @@ import {ux} from '@oclif/core'
 import * as Heroku from '@heroku-cli/schema'
 import {debug} from '../../lib/container/debug'
 import {streamer} from '../../lib/container/streamer'
+import * as helpers from '../../lib/container/helpers'
 
 type ImageResponse = {
   schemaVersion: number,
@@ -44,7 +45,8 @@ export default class ContainerRelease extends Command {
       debug.enabled = true
     }
 
-    await this.heroku.get(`/apps/${app}`)
+    const {body: appBody} = await this.heroku.get<Heroku.App>(`/apps/${app}`)
+    helpers.ensureContainerStack(appBody, 'push')
 
     const herokuHost: string = process.env.HEROKU_HOST || 'heroku.com'
     const updateData: any[] = []

--- a/packages/cli/src/commands/container/release.ts
+++ b/packages/cli/src/commands/container/release.ts
@@ -46,7 +46,7 @@ export default class ContainerRelease extends Command {
     }
 
     const {body: appBody} = await this.heroku.get<Heroku.App>(`/apps/${app}`)
-    helpers.ensureContainerStack(appBody, 'push')
+    helpers.ensureContainerStack(appBody, 'release')
 
     const herokuHost: string = process.env.HEROKU_HOST || 'heroku.com'
     const updateData: any[] = []

--- a/packages/cli/src/commands/container/rm.ts
+++ b/packages/cli/src/commands/container/rm.ts
@@ -28,7 +28,7 @@ export default class Rm extends Command {
     }
 
     const {body: appBody} = await this.heroku.get<Heroku.App>(`/apps/${app}`)
-    helpers.ensureContainerStack(appBody, 'push')
+    helpers.ensureContainerStack(appBody, 'rm')
 
     for (const process of argv as string[]) {
       ux.action.start(`Removing container ${process} for ${color.app(app)}`)

--- a/packages/cli/src/commands/container/rm.ts
+++ b/packages/cli/src/commands/container/rm.ts
@@ -1,6 +1,8 @@
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
 import color from '@heroku-cli/color'
+import * as helpers from '../../lib/container/helpers'
+import * as Heroku from '@heroku-cli/schema'
 
 export default class Rm extends Command {
   static topic = 'container'
@@ -24,6 +26,9 @@ export default class Rm extends Command {
     if (argv.length === 0) {
       this.error(`Error: Requires one or more process types\n${Rm.example}`)
     }
+
+    const {body: appBody} = await this.heroku.get<Heroku.App>(`/apps/${app}`)
+    helpers.ensureContainerStack(appBody, 'push')
 
     for (const process of argv as string[]) {
       ux.action.start(`Removing container ${process} for ${color.app(app)}`)

--- a/packages/cli/src/commands/container/run.ts
+++ b/packages/cli/src/commands/container/run.ts
@@ -1,8 +1,10 @@
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
 import * as DockerHelper from '../../lib/container/docker_helper'
+import * as helpers from '../../lib/container/helpers'
 import {debug} from '../../lib/container/debug'
 import color from '@heroku-cli/color'
+import * as Heroku from '@heroku-cli/schema'
 
 export default class Run extends Command {
   static topic = 'container'
@@ -33,6 +35,9 @@ export default class Run extends Command {
     if (verbose) {
       debug.enabled = true
     }
+
+    const {body: appBody} = await this.heroku.get<Heroku.App>(`/apps/${app}`)
+    helpers.ensureContainerStack(appBody, 'push')
 
     const processType = argv.shift() as string
     const command: string = argv.join(' ')

--- a/packages/cli/src/commands/container/run.ts
+++ b/packages/cli/src/commands/container/run.ts
@@ -37,7 +37,7 @@ export default class Run extends Command {
     }
 
     const {body: appBody} = await this.heroku.get<Heroku.App>(`/apps/${app}`)
-    helpers.ensureContainerStack(appBody, 'push')
+    helpers.ensureContainerStack(appBody, 'run')
 
     const processType = argv.shift() as string
     const command: string = argv.join(' ')

--- a/packages/cli/src/lib/container/helpers.ts
+++ b/packages/cli/src/lib/container/helpers.ts
@@ -14,10 +14,10 @@ const stackLabelMap: { [key: string]: string} = {
  */
 export function ensureContainerStack(app: Heroku.App, cmd: string): void {
   if (app.stack?.name !== 'container') {
-    const appLabel = app.stack?.name ? stackLabelMap[app.stack.name] : app.stack?.name
+    const appLabel = (app.stack?.name && stackLabelMap[app.stack.name]) || app.stack?.name
     let message = 'This command is for Docker apps only.'
     if (['push', 'release'].includes(cmd)) {
-      message += ` Run ${color.cyan('git push heroku main')} to deploy your ${color.cyan(app.name)} ${color.cyan(appLabel)}`
+      message += ` Run ${color.cyan('git push heroku main')} to deploy your ${color.cyan(app.name)} ${color.cyan(appLabel)} app instead.`
     }
 
     ux.error(message, {exit: 1})

--- a/packages/cli/src/lib/container/helpers.ts
+++ b/packages/cli/src/lib/container/helpers.ts
@@ -1,0 +1,25 @@
+import color from '@heroku-cli/color'
+import * as Heroku from '@heroku-cli/schema'
+import {ux} from '@oclif/core'
+
+const stackLabelMap: { [key: string]: string} = {
+  cnb: 'Cloud Native Buildpack',
+}
+
+/**
+ * Ensure that the given app is a container app.
+ * @param app {Heroku.App} heroku app
+ * @param cmd {String} command name
+ * @returns {null} null
+ */
+export function ensureContainerStack(app: Heroku.App, cmd: string): void {
+  if (app.stack?.name !== 'container') {
+    const appLabel = app.stack?.name ? stackLabelMap[app.stack.name] : app.stack?.name
+    let message = 'This command is for Docker apps only.'
+    if (['push', 'release'].includes(cmd)) {
+      message += ` Run ${color.cyan('git push heroku main')} to deploy your ${color.cyan(app.name)} ${color.cyan(appLabel)}`
+    }
+
+    ux.error(message, {exit: 1})
+  }
+}

--- a/packages/cli/test/unit/commands/container/pull.unit.test.ts
+++ b/packages/cli/test/unit/commands/container/pull.unit.test.ts
@@ -30,6 +30,7 @@ describe('container pull', function () {
   })
 
   it('exits when the app stack is not container', async function () {
+    let error
     const api = nock('https://api.heroku.com:443')
       .get('/apps/testapp')
       .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
@@ -37,11 +38,13 @@ describe('container pull', function () {
       '--app',
       'testapp',
       'web',
-    ]).catch((error: any) => {
-      const {message, oclif} = error as CLIError
-      expect(message).to.equal('This command is for Docker apps only.')
-      expect(oclif.exit).to.equal(1)
+    ]).catch((error_: any) => {
+      error = error_
     })
+    const {message, oclif} = error as unknown as CLIError
+    expect(message).to.equal('This command is for Docker apps only.')
+    expect(oclif.exit).to.equal(1)
+
     expect(stdout.output).to.equal('')
     api.done()
   })

--- a/packages/cli/test/unit/commands/container/push.unit.test.ts
+++ b/packages/cli/test/unit/commands/container/push.unit.test.ts
@@ -6,207 +6,209 @@ import * as sinon from 'sinon'
 import * as DockerHelper from '../../../../src/lib/container/docker_helper'
 import * as nock from 'nock'
 import {CLIError} from '@oclif/core/lib/errors'
+import color from '@heroku-cli/color'
 
 const sandbox = sinon.createSandbox()
 
 describe('container push', function () {
+  let api: nock.Scope
+
+  beforeEach(function () {
+    api = nock('https://api.heroku.com:443')
+    return nock.cleanAll()
+  })
+
   afterEach(function () {
+    api.done()
     return sandbox.restore()
   })
 
-  it('gets a build error', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-    const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
-      .returns(['/path/to/Dockerfile'])
-    const build = sandbox.stub(DockerHelper, 'buildImage')
-      .throws()
+  context('when the app stack is not "container"', function () {
+    beforeEach(function () {
+      api
+        .get('/apps/testapp')
+        .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
+    })
 
-    try {
+    it('exits', async function () {
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+      ]).catch((error: any) => {
+        const {message, oclif} = error as CLIError
+        expect(message).to.equal(`This command is for Docker apps only. Run ${color.cyan('git push heroku main')} to deploy your ${color.cyan('testapp')} ${color.cyan('heroku-24')} app instead.`)
+        expect(oclif.exit).to.equal(1)
+      })
+    })
+  })
+
+  context('when the app is a container app', function () {
+    beforeEach(function () {
+      api
+        .get('/apps/testapp')
+        .reply(200, {name: 'testapp', stack: {name: 'container'}})
+    })
+
+    it('gets a build error', async function () {
+      const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
+        .returns(['/path/to/Dockerfile'])
+      const build = sandbox.stub(DockerHelper, 'buildImage')
+        .throws()
+
+      try {
+        await runCommand(Cmd, [
+          '--app',
+          'testapp',
+          'web',
+        ])
+      } catch (error) {
+        const {message, oclif} = error as CLIError
+        expect(message).to.contain('docker build exited with Error: Error')
+        expect(oclif.exit).to.equal(1)
+      }
+
+      expect(stdout.output).to.contain('Building web (/path/to/Dockerfile)')
+      sandbox.assert.calledOnce(dockerfiles)
+      sandbox.assert.calledOnce(build)
+    })
+
+    it('gets a push error', async function () {
+      const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
+        .returns(['/path/to/Dockerfile'])
+      const build = sandbox.stub(DockerHelper, 'buildImage')
+      const push = sandbox.stub(DockerHelper, 'pushImage')
+        .throws()
+
+      try {
+        await runCommand(Cmd, [
+          '--app',
+          'testapp',
+          'web',
+        ])
+      } catch (error) {
+        const {message, oclif} = error as CLIError
+        expect(message).to.contain('docker push exited with Error: Error')
+        expect(oclif.exit).to.equal(1)
+      }
+
+      expect(stdout.output).to.contain('Building web (/path/to/Dockerfile)')
+      sandbox.assert.calledOnce(dockerfiles)
+      sandbox.assert.calledOnce(build)
+      sandbox.assert.calledOnce(push)
+    })
+
+    it('pushes to the docker registry', async function () {
+      const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
+        .returns(['/path/to/Dockerfile'])
+      const build = sandbox.stub(DockerHelper, 'buildImage')
+        .withArgs('/path/to/Dockerfile', 'registry.heroku.com/testapp/web', [])
+      const push = sandbox.stub(DockerHelper, 'pushImage')
+        .withArgs('registry.heroku.com/testapp/web')
+
       await runCommand(Cmd, [
         '--app',
         'testapp',
         'web',
       ])
-    } catch (error) {
-      const {message, oclif} = error as CLIError
-      expect(message).to.contain('docker build exited with Error: Error')
-      expect(oclif.exit).to.equal(1)
-    }
 
-    api.done()
+      expect(stdout.output).to.contain('Building web (/path/to/Dockerfile)')
+      expect(stdout.output).to.contain('Pushing web (/path/to/Dockerfile)')
+      sandbox.assert.calledOnce(dockerfiles)
+      sandbox.assert.calledOnce(build)
+      sandbox.assert.calledOnce(push)
+    })
 
-    expect(stdout.output).to.contain('Building web (/path/to/Dockerfile)')
-    sandbox.assert.calledOnce(dockerfiles)
-    sandbox.assert.calledOnce(build)
-  })
+    it('pushes the standard dockerfile to non-web', async function () {
+      const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
+        .returns(['/path/to/Dockerfile'])
+      const build = sandbox.stub(DockerHelper, 'buildImage')
+        .withArgs('/path/to/Dockerfile', 'registry.heroku.com/testapp/worker', [])
+      const push = sandbox.stub(DockerHelper, 'pushImage')
+        .withArgs('registry.heroku.com/testapp/worker')
 
-  it('gets a push error', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-    const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
-      .returns(['/path/to/Dockerfile'])
-    const build = sandbox.stub(DockerHelper, 'buildImage')
-    const push = sandbox.stub(DockerHelper, 'pushImage')
-      .throws()
-
-    try {
       await runCommand(Cmd, [
         '--app',
         'testapp',
-        'web',
+        'worker',
       ])
-    } catch (error) {
-      const {message, oclif} = error as CLIError
-      expect(message).to.contain('docker push exited with Error: Error')
-      expect(oclif.exit).to.equal(1)
-    }
 
-    api.done()
+      expect(stdout.output).to.contain('Building worker (/path/to/Dockerfile)')
+      expect(stdout.output).to.contain('Pushing worker (/path/to/Dockerfile)')
+      sandbox.assert.calledOnce(dockerfiles)
+      sandbox.assert.calledOnce(build)
+      sandbox.assert.calledOnce(push)
+    })
 
-    expect(stdout.output).to.contain('Building web (/path/to/Dockerfile)')
-    sandbox.assert.calledOnce(dockerfiles)
-    sandbox.assert.calledOnce(build)
-    sandbox.assert.calledOnce(push)
-  })
+    it('pushes several dockerfiles recursively', async function () {
+      const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
+        .returns(['/path/to/Dockerfile.web', '/path/to/Dockerfile.worker'])
+      const build = sandbox.stub(DockerHelper, 'buildImage')
+      build.withArgs('/path/to/Dockerfile.web', 'registry.heroku.com/testapp/web', [])
+      build.withArgs('/path/to/Dockerfile.worker', 'registry.heroku.com/testapp/worker', [])
+      const push = sandbox.stub(DockerHelper, 'pushImage')
+      push.withArgs('registry.heroku.com/testapp/web')
+      push.withArgs('registry.heroku.com/testapp/worker')
 
-  it('pushes to the docker registry', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-    const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
-      .returns(['/path/to/Dockerfile'])
-    const build = sandbox.stub(DockerHelper, 'buildImage')
-      .withArgs('/path/to/Dockerfile', 'registry.heroku.com/testapp/web', [])
-    const push = sandbox.stub(DockerHelper, 'pushImage')
-      .withArgs('registry.heroku.com/testapp/web')
-
-    await runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'web',
-    ])
-
-    api.done()
-
-    expect(stdout.output).to.contain('Building web (/path/to/Dockerfile)')
-    expect(stdout.output).to.contain('Pushing web (/path/to/Dockerfile)')
-    sandbox.assert.calledOnce(dockerfiles)
-    sandbox.assert.calledOnce(build)
-    sandbox.assert.calledOnce(push)
-  })
-
-  it('pushes the standard dockerfile to non-web', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-    const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
-      .returns(['/path/to/Dockerfile'])
-    const build = sandbox.stub(DockerHelper, 'buildImage')
-      .withArgs('/path/to/Dockerfile', 'registry.heroku.com/testapp/worker', [])
-    const push = sandbox.stub(DockerHelper, 'pushImage')
-      .withArgs('registry.heroku.com/testapp/worker')
-
-    await runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'worker',
-    ])
-
-    api.done()
-
-    expect(stdout.output).to.contain('Building worker (/path/to/Dockerfile)')
-    expect(stdout.output).to.contain('Pushing worker (/path/to/Dockerfile)')
-    sandbox.assert.calledOnce(dockerfiles)
-    sandbox.assert.calledOnce(build)
-    sandbox.assert.calledOnce(push)
-  })
-
-  it('pushes several dockerfiles recursively', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-    const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
-      .returns(['/path/to/Dockerfile.web', '/path/to/Dockerfile.worker'])
-    const build = sandbox.stub(DockerHelper, 'buildImage')
-    build.withArgs('/path/to/Dockerfile.web', 'registry.heroku.com/testapp/web', [])
-    build.withArgs('/path/to/Dockerfile.worker', 'registry.heroku.com/testapp/worker', [])
-    const push = sandbox.stub(DockerHelper, 'pushImage')
-    push.withArgs('registry.heroku.com/testapp/web')
-    push.withArgs('registry.heroku.com/testapp/worker')
-
-    await runCommand(Cmd, [
-      '--app',
-      'testapp',
-      '--recursive',
-      'web',
-      'worker',
-    ])
-
-    api.done()
-
-    expect(stdout.output).to.contain('Building web (/path/to/Dockerfile.web)')
-    expect(stdout.output).to.contain('Building worker (/path/to/Dockerfile.worker)')
-    expect(stdout.output).to.contain('Pushing web (/path/to/Dockerfile.web)')
-    expect(stdout.output).to.contain('Pushing worker (/path/to/Dockerfile.worker)')
-    sandbox.assert.calledOnce(dockerfiles)
-    sandbox.assert.calledTwice(build)
-    sandbox.assert.calledTwice(push)
-  })
-
-  it('builds with custom context path and pushes to the docker registry', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-    const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
-      .returns(['/path/to/Dockerfile'])
-    const build = sandbox.stub(DockerHelper, 'buildImage')
-      .withArgs('/path/to/Dockerfile', 'registry.heroku.com/testapp/web', [], '/custom/context/path')
-    const push = sandbox.stub(DockerHelper, 'pushImage')
-      .withArgs('registry.heroku.com/testapp/web')
-
-    await runCommand(Cmd, [
-      '--app',
-      'testapp',
-      '--context-path',
-      '/custom/context/path',
-      'web',
-    ])
-
-    api.done()
-
-    expect(stdout.output).to.contain('Building web (/path/to/Dockerfile)')
-    expect(stdout.output).to.contain('Pushing web (/path/to/Dockerfile)')
-    sandbox.assert.calledOnce(dockerfiles)
-    sandbox.assert.calledOnce(build)
-    sandbox.assert.calledOnce(push)
-  })
-
-  it('does not find an image to push', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-    const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
-      .returns([])
-
-    try {
       await runCommand(Cmd, [
         '--app',
         'testapp',
+        '--recursive',
+        'web',
+        'worker',
+      ])
+
+      expect(stdout.output).to.contain('Building web (/path/to/Dockerfile.web)')
+      expect(stdout.output).to.contain('Building worker (/path/to/Dockerfile.worker)')
+      expect(stdout.output).to.contain('Pushing web (/path/to/Dockerfile.web)')
+      expect(stdout.output).to.contain('Pushing worker (/path/to/Dockerfile.worker)')
+      sandbox.assert.calledOnce(dockerfiles)
+      sandbox.assert.calledTwice(build)
+      sandbox.assert.calledTwice(push)
+    })
+
+    it('builds with custom context path and pushes to the docker registry', async function () {
+      const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
+        .returns(['/path/to/Dockerfile'])
+      const build = sandbox.stub(DockerHelper, 'buildImage')
+        .withArgs('/path/to/Dockerfile', 'registry.heroku.com/testapp/web', [], '/custom/context/path')
+      const push = sandbox.stub(DockerHelper, 'pushImage')
+        .withArgs('registry.heroku.com/testapp/web')
+
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        '--context-path',
+        '/custom/context/path',
         'web',
       ])
-    } catch (error) {
-      const {message, oclif} = error as CLIError
-      expect(message).to.contain('No images to push')
-      expect(oclif.exit).to.equal(1)
-    }
 
-    api.done()
+      expect(stdout.output).to.contain('Building web (/path/to/Dockerfile)')
+      expect(stdout.output).to.contain('Pushing web (/path/to/Dockerfile)')
+      sandbox.assert.calledOnce(dockerfiles)
+      sandbox.assert.calledOnce(build)
+      sandbox.assert.calledOnce(push)
+    })
 
-    expect(stdout.output, 'to be empty')
-    sandbox.assert.calledOnce(dockerfiles)
+    it('does not find an image to push', async function () {
+      const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
+        .returns([])
+
+      try {
+        await runCommand(Cmd, [
+          '--app',
+          'testapp',
+          'web',
+        ])
+      } catch (error) {
+        const {message, oclif} = error as CLIError
+        expect(message).to.contain('No images to push')
+        expect(oclif.exit).to.equal(1)
+      }
+
+      expect(stdout.output, 'to be empty')
+      sandbox.assert.calledOnce(dockerfiles)
+    })
   })
 
   it('requires a process type if we are not recursive', async function () {

--- a/packages/cli/test/unit/commands/container/release.unit.test.ts
+++ b/packages/cli/test/unit/commands/container/release.unit.test.ts
@@ -5,514 +5,519 @@ import {expect} from 'chai'
 import * as sinon from 'sinon'
 import * as nock from 'nock'
 import stdMocks = require('std-mocks')
+import {CLIError} from '@oclif/core/lib/errors'
+import color from '@heroku-cli/color'
 
 let sandbox: { restore: () => void; stub: (arg0: NodeJS.Process, arg1: string) => void }
 
 describe('container release', function () {
+  let api: nock.Scope
+
   beforeEach(function () {
+    api = nock('https://api.heroku.com:443')
     sandbox = sinon.createSandbox()
   })
 
   afterEach(function () {
+    api.done()
     return sandbox.restore()
   })
 
   it('has no process type specified', async function () {
+    let error
     await runCommand(Cmd, [
       '--app',
       'testapp',
-    ])
-      .catch((error:any) => {
-        expect(error.message).to.contain('Requires one or more process types')
-        expect(stdout.output, 'to be empty')
-      })
+    ]).catch((error_: any) => {
+      error = error_
+    })
+    const {message} = error as unknown as CLIError
+    expect(message).to.contain('Requires one or more process types')
+    expect(stdout.output).to.equal('')
   })
 
-  it('releases a single process type, no previous release', async function () {
-    const api = nock('https://api.heroku.com:443')
+  it('exits when the app stack is not "container"', async function () {
+    let error
+    api
       .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-      .patch('/apps/testapp/formation', {
-        updates: [
-          {type: 'web', docker_image: 'image_id'},
-        ],
-      })
-      .reply(200, {})
-      .get('/apps/testapp/releases')
-      .reply(200, [])
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'release_id'}])
-    const registry = nock('https://registry.heroku.com:443')
-      .get('/v2/testapp/web/manifests/latest')
-      .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
+      .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
     await runCommand(Cmd, [
       '--app',
       'testapp',
       'web',
-    ])
-    expect(stderr.output).to.contain('Releasing images web to testapp... done')
-    expect(stdout.output, 'to be empty')
-    api.done()
-    registry.done()
+    ]).catch((error_: any) => {
+      error = error_
+    })
+
+    const {message, oclif} = error as unknown as CLIError
+    expect(message).to.equal(`This command is for Docker apps only. Run ${color.cyan('git push heroku main')} to deploy your ${color.cyan('testapp')} ${color.cyan('heroku-24')} app instead.`)
+    expect(oclif.exit).to.equal(1)
   })
 
-  it('releases a single process type, with a previous release', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-      .patch('/apps/testapp/formation', {
-        updates: [
-          {type: 'web', docker_image: 'image_id'},
-        ],
-      })
-      .reply(200, {})
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'old_release_id'}])
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'release_id'}])
-    const registry = nock('https://registry.heroku.com:443')
-      .get('/v2/testapp/web/manifests/latest')
-      .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
-    await runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'web',
-    ])
-    expect(stderr.output).to.contain('Releasing images web to testapp... done')
-    expect(stdout.output, 'to be empty')
-    api.done()
-    registry.done()
-  })
+  context('when the app is a container app', function () {
+    let registry: nock.Scope
+    beforeEach(function () {
+      api
+        .get('/apps/testapp')
+        .reply(200, {name: 'testapp', stack: {name: 'container'}})
+      registry = nock('https://registry.heroku.com:443')
+    })
 
-  it('retrieves data from a v1 schema version, no previous release', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-      .patch('/apps/testapp/formation', {
-        updates: [
-          {type: 'web', docker_image: 'image_id'},
-        ],
-      })
-      .reply(200, {})
-      .get('/apps/testapp/releases')
-      .reply(200, [])
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'release_id', status: 'succeeded'}])
-    const registry = nock('https://registry.heroku.com:443')
-      .get('/v2/testapp/web/manifests/latest')
-      .reply(200, {schemaVersion: 1, history: [{v1Compatibility: '{"id":"image_id"}'}]})
-    await runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'web',
-    ])
-    expect(stderr.output).to.contain('Releasing images web to testapp... done')
-    expect(stdout.output, 'to be empty')
-    api.done()
-    registry.done()
-  })
+    afterEach(function () {})
 
-  it('retrieves data from a v1 schema version, with a previous release', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-      .patch('/apps/testapp/formation', {
-        updates: [
-          {type: 'web', docker_image: 'image_id'},
-        ],
-      })
-      .reply(200, {})
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'release_id', status: 'succeeded'}])
-    const registry = nock('https://registry.heroku.com:443')
-      .get('/v2/testapp/web/manifests/latest')
-      .reply(200, {schemaVersion: 1, history: [{v1Compatibility: '{"id":"image_id"}'}]})
-    await runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'web',
-    ])
-    expect(stderr.output).to.contain('Releasing images web to testapp... done')
-    expect(stdout.output, 'to be empty')
-    api.done()
-    registry.done()
-  })
+    it('releases a single process type, no previous release', async function () {
+      api
+        .patch('/apps/testapp/formation', {
+          updates: [
+            {type: 'web', docker_image: 'image_id'},
+          ],
+        })
+        .reply(200, {})
+        .get('/apps/testapp/releases')
+        .reply(200, [])
+        .get('/apps/testapp/releases')
+        .reply(200, [{id: 'release_id'}])
+      registry
+        .get('/v2/testapp/web/manifests/latest')
+        .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+      ])
+      expect(stderr.output).to.contain('Releasing images web to testapp... done')
+      expect(stdout.output).to.equal('')
+    })
 
-  it('releases multiple process types, no previous release', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-      .patch('/apps/testapp/formation', {
-        updates: [
-          {type: 'web', docker_image: 'web_image_id'}, {type: 'worker', docker_image: 'worker_image_id'},
-        ],
-      })
-      .reply(200, {})
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'release_id', status: 'succeeded'}])
-    const registry = nock('https://registry.heroku.com:443')
-      .get('/v2/testapp/web/manifests/latest')
-      .reply(200, {schemaVersion: 2, config: {digest: 'web_image_id'}})
-      .get('/v2/testapp/worker/manifests/latest')
-      .reply(200, {schemaVersion: 2, config: {digest: 'worker_image_id'}})
-    await runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'web',
-      'worker',
-    ])
-    expect(stderr.output).to.contain('Releasing images web,worker to testapp... done')
-    expect(stdout.output, 'to be empty')
-    api.done()
-    registry.done()
-  })
+    it('releases a single process type, with a previous release', async function () {
+      api
+        .patch('/apps/testapp/formation', {
+          updates: [
+            {type: 'web', docker_image: 'image_id'},
+          ],
+        })
+        .reply(200, {})
+        .get('/apps/testapp/releases')
+        .reply(200, [{id: 'old_release_id'}])
+        .get('/apps/testapp/releases')
+        .reply(200, [{id: 'release_id'}])
+      registry
+        .get('/v2/testapp/web/manifests/latest')
+        .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+      ])
+      expect(stderr.output).to.contain('Releasing images web to testapp... done')
+      expect(stdout.output).to.equal('')
+    })
 
-  it('releases multiple process types, with a previous release', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-      .patch('/apps/testapp/formation', {
-        updates: [
-          {type: 'web', docker_image: 'web_image_id'}, {type: 'worker', docker_image: 'worker_image_id'},
-        ],
-      })
-      .reply(200, {})
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'release_id', status: 'succeeded'}])
-    const registry = nock('https://registry.heroku.com:443')
-      .get('/v2/testapp/web/manifests/latest')
-      .reply(200, {schemaVersion: 2, config: {digest: 'web_image_id'}})
-      .get('/v2/testapp/worker/manifests/latest')
-      .reply(200, {schemaVersion: 2, config: {digest: 'worker_image_id'}})
-    await runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'web',
-      'worker',
-    ])
-    expect(stderr.output).to.contain('Releasing images web,worker to testapp... done')
-    expect(stdout.output, 'to be empty')
-    api.done()
-    registry.done()
-  })
+    it('retrieves data from a v1 schema version, no previous release', async function () {
+      api
+        .patch('/apps/testapp/formation', {
+          updates: [
+            {type: 'web', docker_image: 'image_id'},
+          ],
+        })
+        .reply(200, {})
+        .get('/apps/testapp/releases')
+        .reply(200, [])
+        .get('/apps/testapp/releases')
+        .reply(200, [{id: 'release_id', status: 'succeeded'}])
+      registry
+        .get('/v2/testapp/web/manifests/latest')
+        .reply(200, {schemaVersion: 1, history: [{v1Compatibility: '{"id":"image_id"}'}]})
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+      ])
+      expect(stderr.output).to.contain('Releasing images web to testapp... done')
+      expect(stdout.output).to.equal('')
+    })
 
-  it('releases with previous release and immediately successful release phase', function () {
-    stdMocks.use()
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-      .patch('/apps/testapp/formation', {
-        updates: [
-          {type: 'web', docker_image: 'image_id'},
-        ],
-      })
-      .reply(200, {})
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'release_id', status: 'succeeded'}])
-    const registry = nock('https://registry.heroku.com:443')
-      .get('/v2/testapp/web/manifests/latest')
-      .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
-    return runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'web',
-    ])
-      .then(() => expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content'))
-      .then(() => expect(stderr.output).to.contain('Runnning release command...'))
-      .then(() => expect(stdout.output, 'to be empty'))
-      .then(() => api.done())
-      .then(() => registry.done())
-      .then(() => stdMocks.restore())
-      .catch(() => stdMocks.restore())
-  })
+    it('retrieves data from a v1 schema version, with a previous release', async function () {
+      api
+        .patch('/apps/testapp/formation', {
+          updates: [
+            {type: 'web', docker_image: 'image_id'},
+          ],
+        })
+        .reply(200, {})
+        .get('/apps/testapp/releases')
+        .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
+        .get('/apps/testapp/releases')
+        .reply(200, [{id: 'release_id', status: 'succeeded'}])
+      registry
+        .get('/v2/testapp/web/manifests/latest')
+        .reply(200, {schemaVersion: 1, history: [{v1Compatibility: '{"id":"image_id"}'}]})
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+      ])
+      expect(stderr.output).to.contain('Releasing images web to testapp... done')
+      expect(stdout.output).to.equal('')
+    })
 
-  it('releases with previous release and pending then successful release phase', function () {
-    stdMocks.use()
-    const busl = nock('https://busl.test:443')
-      .get('/streams/release.log')
-      .reply(200, 'Release Output Content')
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-      .patch('/apps/testapp/formation', {
-        updates: [
-          {type: 'web', docker_image: 'image_id'},
-        ],
-      })
-      .reply(200, {})
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'old_release_id', status: 'failed'}])
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'release_id', output_stream_url: 'https://busl.test/streams/release.log', status: 'pending'}])
-      .get('/apps/testapp/releases/release_id')
-      .reply(200, [{status: 'succeeded'}])
-    const registry = nock('https://registry.heroku.com:443')
-      .get('/v2/testapp/web/manifests/latest')
-      .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
-    return runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'web',
-    ])
-      .then(() => expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content'))
-      .then(() => expect(stderr.output).to.contain('Runnning release command...'))
-      .then(() => expect(stdout.output, 'to be empty'))
-      .then(() => api.done())
-      .then(() => registry.done())
-      .then(() => busl.done())
-      .then(() => stdMocks.restore())
-      .catch(() => stdMocks.restore())
-  })
+    it('releases multiple process types, no previous release', async function () {
+      api
+        .patch('/apps/testapp/formation', {
+          updates: [
+            {type: 'web', docker_image: 'web_image_id'}, {type: 'worker', docker_image: 'worker_image_id'},
+          ],
+        })
+        .reply(200, {})
+        .get('/apps/testapp/releases')
+        .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
+        .get('/apps/testapp/releases')
+        .reply(200, [{id: 'release_id', status: 'succeeded'}])
+      registry
+        .get('/v2/testapp/web/manifests/latest')
+        .reply(200, {schemaVersion: 2, config: {digest: 'web_image_id'}})
+        .get('/v2/testapp/worker/manifests/latest')
+        .reply(200, {schemaVersion: 2, config: {digest: 'worker_image_id'}})
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+        'worker',
+      ])
+      expect(stderr.output).to.contain('Releasing images web,worker to testapp... done')
+      expect(stdout.output).to.equal('')
+    })
 
-  it('releases with previous release and immediately failed release phase', function () {
-    sandbox.stub(process, 'exit')
-    stdMocks.use()
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-      .patch('/apps/testapp/formation', {
-        updates: [
-          {type: 'web', docker_image: 'image_id'},
-        ],
-      })
-      .reply(200, {})
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'release_id', status: 'failed'}])
-    const registry = nock('https://registry.heroku.com:443')
-      .get('/v2/testapp/web/manifests/latest')
-      .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
-    return runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'web',
-    ])
-      .then(() => expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content'))
-      .then(() => expect(stderr.output).to.contain('Runnning release command...'))
-      .then(() => expect(stderr.output).to.contain('Error: release command failed'))
-      .then(() => expect(stdout.output, 'to be empty'))
-      .then(() => api.done())
-      .then(() => registry.done())
-      .then(() => stdMocks.restore())
-      .catch(() => stdMocks.restore())
-  })
+    it('releases multiple process types, with a previous release', async function () {
+      api
+        .patch('/apps/testapp/formation', {
+          updates: [
+            {type: 'web', docker_image: 'web_image_id'}, {type: 'worker', docker_image: 'worker_image_id'},
+          ],
+        })
+        .reply(200, {})
+        .get('/apps/testapp/releases')
+        .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
+        .get('/apps/testapp/releases')
+        .reply(200, [{id: 'release_id', status: 'succeeded'}])
+      registry
+        .get('/v2/testapp/web/manifests/latest')
+        .reply(200, {schemaVersion: 2, config: {digest: 'web_image_id'}})
+        .get('/v2/testapp/worker/manifests/latest')
+        .reply(200, {schemaVersion: 2, config: {digest: 'worker_image_id'}})
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+        'worker',
+      ])
+      expect(stderr.output).to.contain('Releasing images web,worker to testapp... done')
+      expect(stdout.output).to.equal('')
+    })
 
-  it('releases with previous release and pending then failed release phase', function () {
-    sandbox.stub(process, 'exit')
-    stdMocks.use()
-    const busl = nock('https://busl.test:443')
-      .get('/streams/release.log')
-      .reply(200, 'Release Output Content')
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-      .patch('/apps/testapp/formation', {
-        updates: [
-          {type: 'web', docker_image: 'image_id'},
-        ],
-      })
-      .reply(200, {})
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'release_id', output_stream_url: 'https://busl.test/streams/release.log', status: 'pending'}])
-      .get('/apps/testapp/releases/release_id')
-      .reply(200, [{status: 'failed'}])
-    const registry = nock('https://registry.heroku.com:443')
-      .get('/v2/testapp/web/manifests/latest')
-      .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
-    return runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'web',
-    ])
-      .then(() => expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content'))
-      .then(() => expect(stderr.output).to.contain('Runnning release command...'))
-      .then(() => expect(stderr.output).to.contain('Error: release command failed'))
-      .then(() => expect(stdout.output, 'to be empty'))
-      .then(() => api.done())
-      .then(() => registry.done())
-      .then(() => busl.done())
-      .then(() => stdMocks.restore())
-      .catch(() => stdMocks.restore())
-  })
+    it('releases with previous release and immediately successful release phase', async function () {
+      api
+        .patch('/apps/testapp/formation', {
+          updates: [
+            {type: 'web', docker_image: 'image_id'},
+          ],
+        })
+        .reply(200, {})
+        .get('/apps/testapp/releases')
+        .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
+        .get('/apps/testapp/releases')
+        .reply(200, [{id: 'release_id', status: 'succeeded'}])
+      registry
+        .get('/v2/testapp/web/manifests/latest')
+        .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+      ])
+      expect(stdout.output).to.equal('')
+      expect(stderr.output).to.contain('Releasing images web to testapp... done')
+    })
 
-  it('releases with no previous release and immediately successful release phase', function () {
-    stdMocks.use()
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-      .patch('/apps/testapp/formation', {
-        updates: [
-          {type: 'web', docker_image: 'image_id'},
-        ],
-      })
-      .reply(200, {})
-      .get('/apps/testapp/releases')
-      .reply(200, [{status: 'succeeded'}])
-    const registry = nock('https://registry.heroku.com:443')
-      .get('/v2/testapp/web/manifests/latest')
-      .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
-    return runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'web',
-    ])
-      .then(() => expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content'))
-      .then(() => expect(stderr.output).to.contain('Runnning release command...'))
-      .then(() => expect(stdout.output, 'to be empty'))
-      .then(() => api.done())
-      .then(() => registry.done())
-      .then(() => stdMocks.restore())
-      .catch(() => stdMocks.restore())
-  })
+    it('releases with previous release and pending then successful release phase', async function () {
+      stdMocks.use()
+      const busl = nock('https://busl.test:443')
+        .get('/streams/release.log')
+        .reply(200, 'Release Output Content')
+      api
+        .patch('/apps/testapp/formation', {
+          updates: [
+            {type: 'web', docker_image: 'image_id'},
+          ],
+        })
+        .reply(200, {})
+        .get('/apps/testapp/releases')
+        .reply(200, [{id: 'old_release_id', status: 'failed'}])
+        .get('/apps/testapp/releases')
+        .reply(200, [{
+          id: 'release_id',
+          output_stream_url: 'https://busl.test/streams/release.log',
+          status: 'pending',
+        }])
+        .get('/apps/testapp/releases/release_id')
+        .reply(200, [{status: 'succeeded'}])
+      registry
+        .get('/v2/testapp/web/manifests/latest')
+        .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
 
-  it('releases with no previous release and pending then successful release phase', function () {
-    stdMocks.use()
-    const busl = nock('https://busl.test:443')
-      .get('/streams/release.log')
-      .reply(200, 'Release Output Content')
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-      .patch('/apps/testapp/formation', {
-        updates: [
-          {type: 'web', docker_image: 'image_id'},
-        ],
-      })
-      .reply(200, {})
-      .get('/apps/testapp/releases')
-      .reply(200, [])
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'release_id', output_stream_url: 'https://busl.test/streams/release.log', status: 'pending'}])
-      .get('/apps/testapp/releases/release_id')
-      .reply(200, [{status: 'succeeded'}])
-    const registry = nock('https://registry.heroku.com:443')
-      .get('/v2/testapp/web/manifests/latest')
-      .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
-    return runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'web',
-    ])
-      .then(() => expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content'))
-      .then(() => expect(stderr.output).to.contain('Runnning release command...'))
-      .then(() => expect(stdout.output, 'to be empty'))
-      .then(() => api.done())
-      .then(() => registry.done())
-      .then(() => busl.done())
-      .then(() => stdMocks.restore())
-      .catch(() => stdMocks.restore())
-  })
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+      ])
 
-  it('releases with no previous release and immediately failed release phase', function () {
-    sandbox.stub(process, 'exit')
-    stdMocks.use()
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-      .patch('/apps/testapp/formation', {
-        updates: [
-          {type: 'web', docker_image: 'image_id'},
-        ],
-      })
-      .reply(200, {})
-      .get('/apps/testapp/releases')
-      .reply(200, [])
-      .get('/apps/testapp/releases')
-      .reply(200, [{status: 'failed'}])
-    const registry = nock('https://registry.heroku.com:443')
-      .get('/v2/testapp/web/manifests/latest')
-      .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
-    return runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'web',
-    ])
-      .then(() => expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content'))
-      .then(() => expect(stderr.output).to.contain('Runnning release command...'))
-      .then(() => expect(stderr.output).to.contain('Error: release command failed'))
-      .then(() => expect(stdout.output, 'to be empty'))
-      .then(() => api.done())
-      .then(() => registry.done())
-      .then(() => stdMocks.restore())
-      .catch(() => stdMocks.restore())
-  })
+      expect(stdout.output).to.contain('Running release command...')
+      expect(stdout.output).to.contain('Release Output Content')
+      expect(stderr.output).to.contain('Releasing images web to testapp...')
 
-  it('releases with no previous release and pending then failed release phase', function () {
-    sandbox.stub(process, 'exit')
-    stdMocks.use()
-    const busl = nock('https://busl.test:443')
-      .get('/streams/release.log')
-      .reply(200, 'Release Output Content')
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-      .patch('/apps/testapp/formation', {
-        updates: [
-          {type: 'web', docker_image: 'image_id'},
-        ],
-      })
-      .reply(200, {})
-      .get('/apps/testapp/releases')
-      .reply(200, [])
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'release_id', output_stream_url: 'https://busl.test/streams/release.log', status: 'pending'}])
-      .get('/apps/testapp/releases/release_id')
-      .reply(200, [{status: 'failed'}])
-    const registry = nock('https://registry.heroku.com:443')
-      .get('/v2/testapp/web/manifests/latest')
-      .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
-    return runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'web',
-    ])
-      .then(() => expect(stdMocks.flush().stdout.join('')).to.equal('Release Output Content'))
-      .then(() => expect(stderr.output).to.contain('Runnning release command...'))
-      .then(() => expect(stderr.output).to.contain('Error: release command failed'))
-      .then(() => expect(stdout.output, 'to be empty'))
-      .then(() => api.done())
-      .then(() => registry.done())
-      .then(() => busl.done())
-      .then(() => stdMocks.restore())
-      .catch(() => stdMocks.restore())
-  })
+      busl.done()
+    })
 
-  it('has release phase but no new release', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp'})
-      .patch('/apps/testapp/formation', {
-        updates: [
-          {type: 'web', docker_image: 'image_id'},
-        ],
+    it('releases with previous release and immediately failed release phase', async function () {
+      let error
+      api
+        .patch('/apps/testapp/formation', {
+          updates: [
+            {type: 'web', docker_image: 'image_id'},
+          ],
+        })
+        .reply(200, {})
+        .get('/apps/testapp/releases')
+        .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
+        .get('/apps/testapp/releases')
+        .reply(200, [{id: 'release_id', status: 'failed'}])
+      registry
+        .get('/v2/testapp/web/manifests/latest')
+        .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
+
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+      ]).catch((error_: any) => {
+        error = error_
       })
-      .reply(200, {})
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
-      .get('/apps/testapp/releases')
-      .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
-    const registry = nock('https://registry.heroku.com:443')
-      .get('/v2/testapp/web/manifests/latest')
-      .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
-    await runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'web',
-    ])
-    expect(stderr.output).to.not.contain('Running release command...')
-    expect(stdout.output, 'to be empty')
-    api.done()
-    registry.done()
+
+      const {message, oclif} = error as unknown as CLIError
+      expect(message).to.equal('Error: release command failed')
+      expect(oclif.exit).to.equal(1)
+
+      expect(stderr.output).to.contain('Releasing images web to testapp...')
+      expect(stdout.output).to.equal('')
+    })
+
+    it('releases with previous release and pending then failed release phase', async function () {
+      let error
+      const busl = nock('https://busl.test:443')
+        .get('/streams/release.log')
+        .reply(200, 'Release Output Content')
+      api
+        .patch('/apps/testapp/formation', {
+          updates: [
+            {type: 'web', docker_image: 'image_id'},
+          ],
+        })
+        .reply(200, {})
+        .get('/apps/testapp/releases')
+        .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
+        .get('/apps/testapp/releases')
+        .reply(200, [{
+          id: 'release_id',
+          output_stream_url: 'https://busl.test/streams/release.log',
+          status: 'pending',
+        }])
+        .get('/apps/testapp/releases/release_id')
+        .reply(200, {status: 'failed'})
+      registry
+        .get('/v2/testapp/web/manifests/latest')
+        .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
+
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+      ]).catch((error_: any) => {
+        error = error_
+      })
+
+      const {message, oclif} = error as unknown as CLIError
+      expect(message).to.equal('Error: release command failed')
+      expect(oclif.exit).to.equal(1)
+
+      expect(stdout.output).to.contain('Running release command...')
+      expect(stdout.output).to.contain('Release Output Content')
+      expect(stderr.output).to.contain('Releasing images web to testapp...')
+
+      busl.done()
+    })
+
+    it('releases with no previous release and immediately successful release phase', async function () {
+      api
+        .patch('/apps/testapp/formation', {
+          updates: [
+            {type: 'web', docker_image: 'image_id'},
+          ],
+        })
+        .reply(200, {})
+        .get('/apps/testapp/releases')
+        .reply(200, [])
+        .get('/apps/testapp/releases')
+        .reply(200, [{status: 'succeeded'}])
+      registry
+        .get('/v2/testapp/web/manifests/latest')
+        .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
+
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+      ])
+
+      expect(stderr.output).to.contain('Releasing images web to testapp... done')
+    })
+
+    it('releases with no previous release and pending then successful release phase', async function () {
+      const busl = nock('https://busl.test:443')
+        .get('/streams/release.log')
+        .reply(200, 'Release Output Content')
+      api
+        .patch('/apps/testapp/formation', {
+          updates: [
+            {type: 'web', docker_image: 'image_id'},
+          ],
+        })
+        .reply(200, {})
+        .get('/apps/testapp/releases')
+        .reply(200, [])
+        .get('/apps/testapp/releases')
+        .reply(200, [{
+          id: 'release_id',
+          output_stream_url: 'https://busl.test/streams/release.log',
+          status: 'pending',
+        }])
+        .get('/apps/testapp/releases/release_id')
+        .reply(200, [{status: 'succeeded'}])
+      registry
+        .get('/v2/testapp/web/manifests/latest')
+        .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
+
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+      ])
+
+      expect(stdout.output).to.contain('Running release command...')
+      expect(stdout.output).to.contain('Release Output Content')
+      expect(stderr.output).to.contain('Releasing images web to testapp...')
+
+      busl.done()
+    })
+
+    it('releases with no previous release and immediately failed release phase', async function () {
+      let error
+      api
+        .patch('/apps/testapp/formation', {
+          updates: [
+            {type: 'web', docker_image: 'image_id'},
+          ],
+        })
+        .reply(200, {})
+        .get('/apps/testapp/releases')
+        .reply(200, [])
+        .get('/apps/testapp/releases')
+        .reply(200, [{status: 'failed'}])
+      registry
+        .get('/v2/testapp/web/manifests/latest')
+        .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
+
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+      ]).catch((error_: any) => {
+        error = error_
+      })
+
+      const {message, oclif} = error as unknown as CLIError
+      expect(message).to.equal('Error: release command failed')
+      expect(oclif.exit).to.equal(1)
+
+      expect(stderr.output).to.contain('Releasing images web to testapp... done')
+    })
+
+    it('releases with no previous release and pending then failed release phase', async function () {
+      let error
+      const busl = nock('https://busl.test:443')
+        .get('/streams/release.log')
+        .reply(200, 'Release Output Content')
+      api
+        .patch('/apps/testapp/formation', {
+          updates: [
+            {type: 'web', docker_image: 'image_id'},
+          ],
+        })
+        .reply(200, {})
+        .get('/apps/testapp/releases')
+        .reply(200, [])
+        .get('/apps/testapp/releases')
+        .reply(200, [{
+          id: 'release_id',
+          output_stream_url: 'https://busl.test/streams/release.log',
+          status: 'pending',
+        }])
+        .get('/apps/testapp/releases/release_id')
+        .reply(200, {status: 'failed'})
+      registry
+        .get('/v2/testapp/web/manifests/latest')
+        .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
+
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+      ]).catch((error_: any) => {
+        error = error_
+      })
+
+      const {message, oclif} = error as unknown as CLIError
+      expect(message).to.equal('Error: release command failed')
+      expect(oclif.exit).to.equal(1)
+
+      expect(stdout.output).to.contain('Running release command...')
+      expect(stdout.output).to.contain('Release Output Content')
+      expect(stderr.output).to.contain('Releasing images web to testapp...')
+
+      busl.done()
+    })
+
+    it('has release phase but no new release', async function () {
+      api
+        .patch('/apps/testapp/formation', {
+          updates: [
+            {type: 'web', docker_image: 'image_id'},
+          ],
+        })
+        .reply(200, {})
+        .get('/apps/testapp/releases')
+        .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
+        .get('/apps/testapp/releases')
+        .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
+      registry
+        .get('/v2/testapp/web/manifests/latest')
+        .reply(200, {schemaVersion: 2, config: {digest: 'image_id'}})
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+      ])
+      expect(stderr.output).to.not.contain('Running release command...')
+      expect(stdout.output).to.equal('')
+    })
   })
 })

--- a/packages/cli/test/unit/commands/container/rm.unit.test.ts
+++ b/packages/cli/test/unit/commands/container/rm.unit.test.ts
@@ -4,52 +4,91 @@ import runCommand from '../../../helpers/runCommand'
 import expectOutput from '../../../helpers/utils/expectOutput'
 import * as nock from 'nock'
 import {expect} from 'chai'
+import {CLIError} from '@oclif/core/lib/errors'
 
 describe('container removal', function () {
-  it('removes one container', async function () {
-    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.docker-releases'}})
-      .patch('/apps/testapp/formation/web')
-      .reply(200, {})
-    await runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'web',
-    ])
-    expectOutput(stdout.output, '')
-    expectOutput(stderr.output, `
-Removing container web for ⬢ testapp...
-Removing container web for ⬢ testapp... done
-`)
+  let api: nock.Scope
+
+  beforeEach(function () {
+    api = nock('https://api.heroku.com:443')
   })
 
-  it('removes two containers', async function () {
-    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.docker-releases'}})
-      .patch('/apps/testapp/formation/web')
-      .reply(200, {})
-      .patch('/apps/testapp/formation/worker')
-      .reply(200, {})
-    await runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'web',
-      'worker',
-    ])
-    expectOutput(stdout.output, '')
-    expectOutput(stderr.output, `
-Removing container web for ⬢ testapp...
-Removing container web for ⬢ testapp... done
-Removing container worker for ⬢ testapp...
-Removing container worker for ⬢ testapp... done
-`)
+  afterEach(function () {
+    api.done()
   })
 
   it('requires a container to be specified', async function () {
+    let error
     await runCommand(Cmd, [
       '--app',
       'testapp',
-    ]).catch((error: any) => {
-      expect(error.message).to.contain('Requires one or more process types')
+    ]).catch((error_: any) => {
+      error = error_
     })
+    const {message} = error as unknown as CLIError
+    expect(message).to.contain('Requires one or more process types')
     expectOutput(stdout.output, '')
+  })
+
+  it('exits when the app stack is not "container"', async function () {
+    let error
+    api
+      .get('/apps/testapp')
+      .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
+    await runCommand(Cmd, [
+      '--app',
+      'testapp',
+      'web',
+    ]).catch((error_: any) => {
+      error = error_
+    })
+    const {message, oclif} = error as unknown as CLIError
+    expect(message).to.equal('This command is for Docker apps only.')
+    expect(oclif.exit).to.equal(1)
+    expectOutput(stdout.output, '')
+  })
+
+  context('when the app is a container app', function () {
+    let apiV3DockerRelease: nock.Scope
+
+    beforeEach(function () {
+      api
+        .get('/apps/testapp')
+        .reply(200, {name: 'testapp', stack: {name: 'container'}})
+      apiV3DockerRelease = nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.docker-releases'}})
+    })
+    afterEach(function () {
+      apiV3DockerRelease.done()
+    })
+
+    it('removes one container', async function () {
+      apiV3DockerRelease
+        .patch('/apps/testapp/formation/web')
+        .reply(200, {})
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+      ])
+      expectOutput(stdout.output, '')
+      expect(stderr.output).to.contain('Removing container web for ⬢ testapp... done')
+    })
+
+    it('removes two containers', async function () {
+      apiV3DockerRelease
+        .patch('/apps/testapp/formation/web')
+        .reply(200, {})
+        .patch('/apps/testapp/formation/worker')
+        .reply(200, {})
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+        'worker',
+      ])
+      expectOutput(stdout.output, '')
+      expect(stderr.output).to.contain('Removing container web for ⬢ testapp... done')
+      expect(stderr.output).to.contain('Removing container worker for ⬢ testapp... done')
+    })
   })
 })

--- a/packages/cli/test/unit/commands/container/run.unit.test.ts
+++ b/packages/cli/test/unit/commands/container/run.unit.test.ts
@@ -5,74 +5,107 @@ import * as sinon from 'sinon'
 import {expect} from 'chai'
 import * as DockerHelper from '../../../../src/lib/container/docker_helper'
 import expectOutput from '../../../helpers/utils/expectOutput'
+import {CLIError} from '@oclif/core/lib/errors'
+import * as nock from 'nock'
 
 describe('container run', function () {
+  let api: nock.Scope
   let sandbox: sinon.SinonSandbox
 
   beforeEach(function () {
+    api = nock('https://api.heroku.com:443')
     process.env.HEROKU_API_KEY = 'heroku_token'
     sandbox = sinon.createSandbox()
   })
 
   afterEach(function () {
+    api.done()
     return sandbox.restore()
   })
 
   it('requires a process type', async function () {
+    let error
     await runCommand(Cmd, [
       '--app',
       'testapp',
-    ]).catch(error => {
-      const {message} = error as {message: string}
-      expect(message).to.contain('Requires one process type')
-      expect(stdout.output, 'to be empty')
+    ]).catch(error_ => {
+      error = error_
     })
+    const {message} = error as unknown as CLIError
+    expect(message).to.contain('Requires one process type')
+    expect(stdout.output).to.equal('')
   })
 
-  it('runs a container', async function () {
-    const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
-      .returns(['/path/to/Dockerfile'])
-    const run = sandbox.stub(DockerHelper, 'runImage')
-      .withArgs('registry.heroku.com/testapp/web', '', 5000)
+  it('exits when the app stack is not "container"', async function () {
+    let error
+    api
+      .get('/apps/testapp')
+      .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
     await runCommand(Cmd, [
       '--app',
       'testapp',
       'web',
-    ])
-    expectOutput(stdout.output, '=== Running registry.heroku.com/testapp/web')
-    expectOutput(stderr.output, '')
-    sandbox.assert.calledOnce(dockerfiles)
-    sandbox.assert.calledOnce(run)
+    ]).catch(error_ => {
+      error = error_
+    })
+    const {message, oclif} = error as unknown as CLIError
+    expect(message).to.equal('This command is for Docker apps only.')
+    expect(oclif.exit).to.equal(1)
+    expectOutput(stdout.output, '')
   })
 
-  it('runs a container with a command', async function () {
-    const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
-      .returns(['/path/to/Dockerfile'])
-    const run = sandbox.stub(DockerHelper, 'runImage')
-      .withArgs('registry.heroku.com/testapp/web', 'bash', 5000)
-    await runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'web',
-      'bash',
-    ])
-    expectOutput(stdout.output, '=== Running \'bash\' on registry.heroku.com/testapp/web')
-    expectOutput(stderr.output, '')
-    sandbox.assert.calledOnce(dockerfiles)
-    sandbox.assert.calledOnce(run)
-  })
+  context('when the app is a container app', function () {
+    beforeEach(function () {
+      api
+        .get('/apps/testapp')
+        .reply(200, {name: 'testapp', stack: {name: 'container'}})
+    })
 
-  it('requires a known dockerfile', async function () {
-    const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
-      .returns([])
-    await runCommand(Cmd, [
-      '--app',
-      'testapp',
-      'worker',
-    ]).catch((error: any) => {
-      expect(error.message).to.contain('No images to run')
-      expect(stdout.output, 'to be empty')
+    it('runs a container', async function () {
+      const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
+        .returns(['/path/to/Dockerfile'])
+      const run = sandbox.stub(DockerHelper, 'runImage')
+        .withArgs('registry.heroku.com/testapp/web', '', 5000)
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+      ])
+      expectOutput(stdout.output, '=== Running registry.heroku.com/testapp/web')
+      expectOutput(stderr.output, '')
       sandbox.assert.calledOnce(dockerfiles)
+      sandbox.assert.calledOnce(run)
+    })
+
+    it('runs a container with a command', async function () {
+      const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
+        .returns(['/path/to/Dockerfile'])
+      const run = sandbox.stub(DockerHelper, 'runImage')
+        .withArgs('registry.heroku.com/testapp/web', 'bash', 5000)
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'web',
+        'bash',
+      ])
+      expectOutput(stdout.output, '=== Running \'bash\' on registry.heroku.com/testapp/web')
+      expectOutput(stderr.output, '')
+      sandbox.assert.calledOnce(dockerfiles)
+      sandbox.assert.calledOnce(run)
+    })
+
+    it('requires a known dockerfile', async function () {
+      const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
+        .returns([])
+      await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        'worker',
+      ]).catch((error: any) => {
+        expect(error.message).to.contain('No images to run')
+        expect(stdout.output).to.equal('')
+        sandbox.assert.calledOnce(dockerfiles)
+      })
     })
   })
 })

--- a/packages/cli/test/unit/commands/releases/info.unit.test.ts
+++ b/packages/cli/test/unit/commands/releases/info.unit.test.ts
@@ -30,7 +30,6 @@ describe('releases:info', function () {
       'myapp',
     ])
       .then(() => expect(stdout.output).to.equal(`=== Release v10\n\nAdd-ons: addon1\n         addon2\nBy:      foo@foo.com\nChange:  something changed\nWhen:    ${d.toISOString()}\n\n=== v10 Config vars\n\nBAR: bar\nFOO: foo\n`))
-      .then(() => expect(stderr.output, 'to be empty'))
       .then(() => api.done())
   })
 
@@ -46,7 +45,6 @@ describe('releases:info', function () {
       '--shell',
     ])
       .then(() => expect(stdout.output).to.equal(`=== Release v10\n\nAdd-ons: addon1\n         addon2\nBy:      foo@foo.com\nChange:  something changed\nWhen:    ${d.toISOString()}\n\n=== v10 Config vars\n\nFOO=foo\nBAR=bar\n`))
-      .then(() => expect(stderr.output, 'to be empty'))
       .then(() => api.done())
   })
 
@@ -62,7 +60,6 @@ describe('releases:info', function () {
       'v10',
     ])
       .then(() => expect(stdout.output).to.equal(`=== Release v10\n\nAdd-ons: addon1\n         addon2\nBy:      foo@foo.com\nChange:  something changed\nWhen:    ${d.toISOString()}\n\n=== v10 Config vars\n\nBAR: bar\nFOO: foo\n`))
-      .then(() => expect(stderr.output, 'to be empty'))
       .then(() => api.done())
   })
 
@@ -77,7 +74,6 @@ describe('releases:info', function () {
       'v10',
     ])
       .then(() => expect(stdout.output).to.contain('"version": 10'))
-      .then(() => expect(stderr.output, 'to be empty'))
       .then(() => api.done())
   })
 
@@ -94,7 +90,6 @@ describe('releases:info', function () {
       'myapp',
     ])
       .then(() => expect(stdout.output).to.equal(`=== Release v10\n\nBy:      foo@foo.com\nChange:  something changed (release command failed)\nWhen:    ${d.toISOString()}\n\n=== v10 Config vars\n\nBAR: bar\nFOO: foo\n`))
-      .then(() => expect(stderr.output, 'to be empty'))
       .then(() => api.done())
   })
 
@@ -111,7 +106,6 @@ describe('releases:info', function () {
       'myapp',
     ])
       .then(() => expect(stdout.output).to.equal(`=== Release v10\n\nAdd-ons: addon1\n         addon2\nBy:      foo@foo.com\nChange:  something changed (release command executing)\nWhen:    ${d.toISOString()}\n\n=== v10 Config vars\n\nBAR: bar\nFOO: foo\n`))
-      .then(() => expect(stderr.output, 'to be empty'))
       .then(() => api.done())
   })
 })


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
Restrict container:* CLI commands to apps with stack=container

[GUS-W-15427582](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-15427582)