### PR TITLE
fix: move tsheredoc to dependencies

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -72,6 +72,7 @@
     "strip-ansi": "^6",
     "term-img": "^4.1.0",
     "true-myth": "2.2.3",
+    "tsheredoc": "^1.0.1",
     "tslib": "1.14.1",
     "tunnel-ssh": "4.1.6",
     "urijs": "^1.19.11",
@@ -131,7 +132,6 @@
     "strip-ansi": "6.0.1",
     "tmp": "^0.2.3",
     "ts-node": "^10.9.1",
-    "tsheredoc": "^1.0.1",
     "typescript": "4.8.4"
   },
   "engines": {


### PR DESCRIPTION
[Work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001smLTWYA2/view)

Moves `tsheredoc` from devdependencies to dependencies to fix a bug in the latest alpha release.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
