### PR TITLE
fix(cli): Change to require either app or pipeline

### DIFF
--- a/packages/cli/src/commands/ci/config/set.ts
+++ b/packages/cli/src/commands/ci/config/set.ts
@@ -27,7 +27,7 @@ export default class CiConfigSet extends Command {
   static flags = {
     app: flags.app(),
     remote: flags.remote(),
-    pipeline: flags.pipeline({required: true}),
+    pipeline: flags.pipeline({exactlyOne: ['pipeline', 'app']}),
   }
 
   static strict = false

--- a/packages/cli/test/unit/commands/ci/config/set.unit.test.ts
+++ b/packages/cli/test/unit/commands/ci/config/set.unit.test.ts
@@ -29,4 +29,12 @@ describe('heroku ci:config:set', function () {
       expect(error.message).to.equal('Usage: heroku ci:config:set KEY1 [KEY2 ...]\nMust specify KEY to set.')
     })
     .it('errors with example of valid args')
+
+  test
+    .stderr()
+    .command(['ci:config:set', '--', `${key}=${value}`])
+    .catch(error => {
+      expect(error.message).to.include('Exactly one of the following must be provided: --app, --pipeline')
+    })
+    .it('errors with explanation of required flags')
 })


### PR DESCRIPTION
[GUS WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001vT9ipYAC/view)

During oclif migration we added a pipeline flag requirement to `ci:config:set`. However, the command actually accepts `--pipeline` _or_ `--app` and manually errors if provided neither: https://github.com/heroku/cli/blob/prerelease/9.0.0-alpha/packages/cli/src/lib/ci/pipelines.ts#L45 .. I elected to move up that requirement to be declaratively defined with the flag using oclif's `exactlyOne`. This ensures consistent error messaging. We probably should update other commands to do this as well.

### Testing
1. pull down branch
2. Run `bin/dev ci:config:set` without providing `--app` or `--pipeline`
3. Run  `bin/dev ci:config:set` providing `--app`
4. Run `bin/dev ci:config:set` providing `--pipeline`