### PR TITLE
fix(cli): add missing space char shortcut

### DIFF
--- a/packages/cli/src/commands/spaces/transfer.ts
+++ b/packages/cli/src/commands/spaces/transfer.ts
@@ -12,7 +12,7 @@ export default class Transfer extends Command {
   `)]
 
   static flags = {
-    space: flags.string({required: true, description: 'name of space'}),
+    space: flags.string({required: true, char: 's', description: 'name of space'}),
     team: flags.string({required: true, description: 'desired owner of space'}),
   }
 

--- a/packages/cli/src/commands/spaces/trusted-ips/remove.ts
+++ b/packages/cli/src/commands/spaces/trusted-ips/remove.ts
@@ -17,7 +17,7 @@ export default class Remove extends Command {
         `)]
 
   static flags = {
-    space: flags.string({optional: false, description: 'space to remove rule from'}),
+    space: flags.string({required: true, char: 's', description: 'space to remove rule from'}),
     confirm: flags.string({description: 'set to space name to bypass confirm prompt'}),
   }
 


### PR DESCRIPTION
[Gus WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001vTP5GYAW/view)

### Description

This adds the missing `s` shortcut for a couple `space` commands.

### Testing

1) Pull down branch
2) Run `bin/dev spaces:trusted-ips:remove -s pretend-space pretend-source`
3) Verify -s works as an alternative to `--space` (it's not necessary for it to be a real space, the error message referencing the space is confirmation enough)
