### PR TITLE
fix: update spaces:vpn commands to improve consistency in args and flags

### DIFF
--- a/packages/cli/src/commands/spaces/vpn/config.ts
+++ b/packages/cli/src/commands/spaces/vpn/config.ts
@@ -18,7 +18,7 @@ export default class Config extends Command {
   `)
 
   static example = heredoc(`
-    $ heroku spaces:vpn:config --space my-space vpn-connection-name
+    $ heroku spaces:vpn:config vpn-connection-name --space my-space
     === vpn-connection-name VPN Tunnels
      VPN Tunnel Customer Gateway VPN Gateway    Pre-shared Key Routable Subnets IKE Version
      ────────── ──────────────── ────────────── ────────────── ──────────────── ───────────

--- a/packages/cli/src/commands/spaces/vpn/connect.ts
+++ b/packages/cli/src/commands/spaces/vpn/connect.ts
@@ -12,7 +12,7 @@ export default class Connect extends Command {
     The connection is established over the public Internet but all traffic is encrypted using IPSec.
   `
   static examples = [heredoc`
-    $ heroku spaces:vpn:connect --name office --ip 35.161.69.30 --cidrs 172.16.0.0/16,10.0.0.0/24 --space my-space
+    $ heroku spaces:vpn:connect vpn-connection-name --ip 35.161.69.30 --cidrs 172.16.0.0/16,10.0.0.0/24 --space my-space
     Creating VPN Connection in space my-space... done
     ▸    Use spaces:vpn:wait to track allocation.
   `]
@@ -24,7 +24,10 @@ export default class Connect extends Command {
   }
 
   static args = {
-    name: Args.string({required: true}),
+    name: Args.string({
+      required: true,
+      description: 'name or id of the VPN connection to retrieve config from',
+    }),
   }
 
   public async run(): Promise<void> {

--- a/packages/cli/src/commands/spaces/vpn/connect.ts
+++ b/packages/cli/src/commands/spaces/vpn/connect.ts
@@ -26,7 +26,7 @@ export default class Connect extends Command {
   static args = {
     name: Args.string({
       required: true,
-      description: 'name or id of the VPN connection to retrieve config from',
+      description: 'name or id of the VPN connection to create',
     }),
   }
 

--- a/packages/cli/src/commands/spaces/vpn/destroy.ts
+++ b/packages/cli/src/commands/spaces/vpn/destroy.ts
@@ -18,7 +18,10 @@ export default class Destroy extends Command {
   }
 
   static args = {
-    name: Args.string({description: 'name of the VPN connection to destroy', required: true}),
+    name: Args.string({
+      required: true,
+      description: 'name or id of the VPN connection to retrieve config from',
+    }),
   }
 
   public async run(): Promise<void> {

--- a/packages/cli/src/commands/spaces/vpn/destroy.ts
+++ b/packages/cli/src/commands/spaces/vpn/destroy.ts
@@ -20,7 +20,7 @@ export default class Destroy extends Command {
   static args = {
     name: Args.string({
       required: true,
-      description: 'name or id of the VPN connection to retrieve config from',
+      description: 'name or id of the VPN connection to destroy',
     }),
   }
 

--- a/packages/cli/src/commands/spaces/vpn/info.ts
+++ b/packages/cli/src/commands/spaces/vpn/info.ts
@@ -8,7 +8,7 @@ export default class Info extends Command {
   static topic = 'spaces';
   static description = 'display the information for VPN';
   static example = heredoc(`
-    $ heroku spaces:vpn:info --space my-space vpn-connection-name
+    $ heroku spaces:vpn:info vpn-connection-name --space my-space
     === vpn-connection-name VPN Tunnel Info
     Name:           vpn-connection-name
     ID:             123456789012

--- a/packages/cli/src/commands/spaces/vpn/update.ts
+++ b/packages/cli/src/commands/spaces/vpn/update.ts
@@ -23,7 +23,7 @@ export default class Update extends Command {
   static args = {
     name: Args.string({
       required: true,
-      description: 'name or id of the VPN connection to retrieve config from',
+      description: 'name or id of the VPN connection to update',
     }),
   }
 

--- a/packages/cli/src/commands/spaces/vpn/update.ts
+++ b/packages/cli/src/commands/spaces/vpn/update.ts
@@ -17,11 +17,14 @@ export default class Update extends Command {
   }
 
   static example = heredoc`
-    $ heroku spaces:vpn:update office --space my-space --cidrs 172.16.0.0/16,10.0.0.0/24
+    $ heroku spaces:vpn:update vpn-connection-name --space my-space --cidrs 172.16.0.0/16,10.0.0.0/24
     Updating VPN Connection in space my-space... done
   `
   static args = {
-    name: Args.string({required: true}),
+    name: Args.string({
+      required: true,
+      description: 'name or id of the VPN connection to retrieve config from',
+    }),
   }
 
   public async run(): Promise<void> {

--- a/packages/cli/src/commands/spaces/vpn/wait.ts
+++ b/packages/cli/src/commands/spaces/vpn/wait.ts
@@ -32,7 +32,7 @@ export default class Wait extends Command {
 
     static args = {
       name: Args.string({
-        description: 'name or id of the VPN connection to get info from',
+        description: 'name or id of the VPN connection you are waiting on for allocation.',
         required: true,
       }),
     }

--- a/packages/cli/src/commands/spaces/vpn/wait.ts
+++ b/packages/cli/src/commands/spaces/vpn/wait.ts
@@ -1,8 +1,9 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
-import {ux} from '@oclif/core'
+import {Args, ux} from '@oclif/core'
 import * as Heroku from '@heroku-cli/schema'
 import {displayVPNConfigInfo} from '../../../lib/spaces/vpn-connections'
+import heredoc from 'tsheredoc'
 
 const wait = (ms: number) => new Promise(resolve => {
   setTimeout(resolve, ms)
@@ -11,17 +12,35 @@ const wait = (ms: number) => new Promise(resolve => {
 export default class Wait extends Command {
     static topic = 'spaces';
     static description = 'wait for VPN Connection to be created';
+    static examples = [heredoc`
+      $ heroku spaces:vpn:wait vpn-connection-name --space my-space
+      Waiting for VPN Connection vpn-connection-name to allocate... done
+      === my-space VPN Tunnels
+
+     VPN Tunnel Customer Gateway VPN Gateway    Pre-shared Key Routable Subnets IKE Version
+     ────────── ──────────────── ────────────── ────────────── ──────────────── ───────────
+     Tunnel 1    104.196.121.200   35.171.237.136  abcdef12345     10.0.0.0/16       1
+     Tunnel 2    104.196.121.200   52.44.7.216     fedcba54321     10.0.0.0/16       1
+    `]
+
     static flags = {
       space: flags.string({char: 's', description: 'space the vpn connection belongs to', required: true}),
-      name: flags.string({char: 'n', description: 'name or id of the vpn connection to wait for', required: true}),
       json: flags.boolean({description: 'output in json format'}),
       interval: flags.string({char: 'i', description: 'seconds to wait between poll intervals'}),
       timeout: flags.string({char: 't', description: 'maximum number of seconds to wait'}),
-    };
+    }
+
+    static args = {
+      name: Args.string({
+        description: 'name or id of the VPN connection to get info from',
+        required: true,
+      }),
+    }
 
     public async run(): Promise<void> {
-      const {flags} = await this.parse(Wait)
-      const {name, space, json} = flags
+      const {flags, args} = await this.parse(Wait)
+      const {space, json} = flags
+      const {name} = args
       const interval = (flags.interval ? Number.parseInt(flags.interval, 10) : 10) * 1000
       const timeout = (flags.timeout ? Number.parseInt(flags.timeout, 10) : 20 * 60) * 1000
       const deadline = new Date(Date.now() + timeout)

--- a/packages/cli/test/unit/commands/spaces/vpn/wait.unit.test.ts
+++ b/packages/cli/test/unit/commands/spaces/vpn/wait.unit.test.ts
@@ -79,10 +79,9 @@ describe('spaces:vpn:wait', function () {
 
     try {
       await runCommand(Cmd, [
+        'vpn-connection-name-wait',
         '--space',
         'my-space',
-        '--name',
-        'vpn-connection-name-wait',
         '--interval',
         '0',
       ])
@@ -184,10 +183,9 @@ describe('spaces:vpn:wait', function () {
         ],
       })
     await runCommand(Cmd, [
+      'vpn-connection-name-wait',
       '--space',
       'my-space',
-      '--name',
-      'vpn-connection-name-wait',
       '--interval',
       '0',
     ])
@@ -217,10 +215,9 @@ describe('spaces:vpn:wait', function () {
       })
 
     await runCommand(Cmd, [
+      'vpn-connection-allocated',
       '--space',
       'my-space',
-      '--name',
-      'vpn-connection-allocated',
       '--interval',
       '0',
     ])


### PR DESCRIPTION
[Work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001vSuraYAC/view)

## Description
This PR updates the `spaces:vpn` commands to improve consistency. All of these commands (except`connections`) should require an arg for the name of the vpn connection and _not_ a `--name` flag. This PR also contains updates to the example documentation for these commands that reflects this change and improves consistency.

## Testing
- Pull down this branch and run `yarn install` and `yarn build`
- Create a vpn connection for a test space (use the instructions from https://github.com/heroku/cli/pull/2873)
- Run `./bin/run spaces:vpn:wait VPN-CONNECTION-NAME -s SPACE-NAME`
- If you run `./bin/run spaces:vpn:wait -n VPN-CONNECTION-NAME -s SPACE-NAME` you should get an error message about the `-n` flag.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
