### PR TITLE
fix(cli): Fix bug with git remote creation

### DIFF
--- a/packages/cli/src/lib/git/git.ts
+++ b/packages/cli/src/lib/git/git.ts
@@ -48,8 +48,8 @@ export default class Git {
     const remotes = await this.exec(['remote', '-v'])
     return remotes.split('\n')
       .map(r => r.split('\t'))
-      .find(r => r[0] === name)![1]
-      .split(' ')[0]
+      .find(r => r[0] === name)?.[1]
+      ?.split(' ')[0] ?? ''
   }
 
   url(app: string) {


### PR DESCRIPTION
[Gus WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001vh171YAA/view)

### Description

This fixes an issue where the `apps:create` emits an error if you don't have a `heroku` git remote in your current working directory. This is because `apps:create` will try to create a `heroku` git remote if you don't have one and, confusingly, there was logic in there that throws a type error when it can't find the `heroku` string in your list of remotes. I'm not sure why this wasn't causing an issue before -- we didn't change this library as part of v9. Perhaps, though, because we migrated `apps:create` to typescript/oclif, the error is surfacing in a way it didn't when it was a legacy javascript command. At any rate, as part of this fix, we no longer throw that type error, and return an empty string instead.

### Testing

1. Pull down this branch
2. Make sure you do not have `heroku` defined when you run `git remote -v`
3. Run `./bin/dev apps:create APP_NAME`
4. See that there are no errors and the command succeeds