### PR TITLE
fix: add short char for the team flag on spaces:transfer

### DIFF
--- a/packages/cli/src/commands/spaces/transfer.ts
+++ b/packages/cli/src/commands/spaces/transfer.ts
@@ -13,7 +13,7 @@ export default class Transfer extends Command {
 
   static flags = {
     space: flags.string({required: true, char: 's', description: 'name of space'}),
-    team: flags.string({required: true, description: 'desired owner of space'}),
+    team: flags.string({required: true, char: 't', description: 'desired owner of space'}),
   }
 
   public async run(): Promise<void> {


### PR DESCRIPTION
[Work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001vj6NdYAI/view)

Adds the char option for the team flag for the `spaces:transfer` command to be more consistent with other commands.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
