### PR TITLE
chore(cli): Declaratively require pipeline or app across ci:config commands

### DIFF
--- a/packages/cli/src/commands/ci/config/get.ts
+++ b/packages/cli/src/commands/ci/config/get.ts
@@ -14,9 +14,9 @@ export default class CiConfigGet extends Command {
 
   static flags = {
     help: flags.help({char: 'h'}),
-    app: flags.app({required: false}),
+    app: flags.app(),
     remote: flags.remote(),
-    pipeline: flags.pipeline({required: false}),
+    pipeline: flags.pipeline({exactlyOne: ['pipeline', 'app']}),
     shell: flags.boolean({char: 's', description: 'output config var in shell format'}),
   }
 

--- a/packages/cli/src/commands/ci/config/index.ts
+++ b/packages/cli/src/commands/ci/config/index.ts
@@ -16,10 +16,11 @@ export default class CiConfig extends Command {
   ]
 
   static flags = {
-    app: cmdFlags.string({char: 'a', description: 'app name'}),
+    app: cmdFlags.app(),
+    remote: cmdFlags.remote(),
     shell: cmdFlags.boolean({char: 's', description: 'output config vars in shell format'}),
     json: cmdFlags.boolean({description: 'output config vars in json format'}),
-    pipeline: cmdFlags.pipeline(),
+    pipeline: cmdFlags.pipeline({exactlyOne: ['pipeline', 'app']}),
   }
 
   async run() {

--- a/packages/cli/src/commands/ci/config/unset.ts
+++ b/packages/cli/src/commands/ci/config/unset.ts
@@ -14,10 +14,9 @@ export default class CiConfigUnset extends Command {
   static strict = false
 
   static flags = {
-    help: flags.help({char: 'h'}),
-    app: flags.app({required: false}),
+    app: flags.app(),
     remote: flags.remote(),
-    pipeline: flags.pipeline({required: false}),
+    pipeline: flags.pipeline({exactlyOne: ['pipeline', 'app']}),
   }
 
   async run() {

--- a/packages/cli/test/unit/commands/ci/config/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/ci/config/index.unit.test.ts
@@ -11,7 +11,7 @@ describe('ci:config', function () {
   test
     .command(['ci:config'])
     .catch(error => {
-      expect(error.message).to.contain('Required flag:  --pipeline PIPELINE or --app APP')
+      expect(error.message).to.contain('Exactly one of the following must be provided: --app, --pipeline')
     })
     .it('errors when not specifying a pipeline or an app')
 


### PR DESCRIPTION
Followup to https://github.com/heroku/cli/pull/2907

### Description

This improves consistency across our `ci:config` commands, leveraging oclif's `exactlyOne` instead of manually improvised error messaging.