### PR TITLE
fix: correct error handling in matchesHelper

### DIFF
--- a/packages/cli/src/lib/addons/resolve.ts
+++ b/packages/cli/src/lib/addons/resolve.ts
@@ -158,6 +158,7 @@ resolveAddon.cache = addonResolverMap
 
 export class NotFound extends Error {
   public readonly statusCode = 404
+  public readonly id = 'not_found'
   public readonly message = 'Couldn\'t find that addon.'
 }
 

--- a/packages/cli/src/lib/pg/fetcher.ts
+++ b/packages/cli/src/lib/pg/fetcher.ts
@@ -2,12 +2,13 @@ import {APIClient} from '@heroku-cli/command'
 import type {AddOnAttachment} from '@heroku-cli/schema'
 import * as Heroku from '@heroku-cli/schema'
 import debug from 'debug'
-import {AmbiguousError, appAttachment, NotFound} from '../addons/resolve'
+import {AmbiguousError, appAttachment} from '../addons/resolve'
 import {fetchConfig} from './bastion'
 import {getConfig} from './config'
 import color from '@heroku-cli/color'
 import type {AddOnAttachmentWithConfigVarsAndPlan, AddOnWithRelatedData} from './types'
 import {bastionKeyPlan, getConfigVarName, getConnectionDetails} from './util'
+import {HTTPError} from 'http-call'
 
 const pgDebug = debug('pg')
 
@@ -48,7 +49,7 @@ export async function all(heroku: APIClient, app_id: string): Promise<AddOnWithR
   return addons
 }
 
-async function matchesHelper(heroku: APIClient, app: string, db: string, namespace?: string): Promise<{matches: AddOnAttachment[] | null, error?: AmbiguousError | NotFound}> {
+async function matchesHelper(heroku: APIClient, app: string, db: string, namespace?: string): Promise<{matches: AddOnAttachment[] | null, error?: AmbiguousError | HTTPError}> {
   debug(`fetching ${db} on ${app}`)
 
   const addonService = process.env.HEROKU_POSTGRESQL_ADDON_NAME || 'heroku-postgresql'
@@ -61,7 +62,7 @@ async function matchesHelper(heroku: APIClient, app: string, db: string, namespa
       return {matches: error.matches, error}
     }
 
-    if (error instanceof NotFound) {
+    if (error instanceof HTTPError && error.statusCode === 404 && error.body && error.body.id === 'not_found') {
       return {matches: null, error}
     }
 


### PR DESCRIPTION
This fix corrects an issue with error handling in the matchesHelper function used with the `pg:psql` command. Testing this is kind of odd, since in both cases we expect the command to fail, just at different points.

## Testing
### Original issue
To see the original issue:
1. Using the current `beta` release of the CLI (beta.0), run `DEBUG=http heroku psql NONEXISTANT_DB_NAME -a APP_NAME`
2. You should see that the first POST call to the `https://api.heroku.com/actions/addon-attachments/resolve` endpoint returns a 404 not found error and the command fails.

To see the fix:
1. Using this branch, run `yarn` and `yarn build`
2. Run `DEBUG=http ./bin/run psql NONEXISTANT_DB_NAME -a APP_NAME`
3. You should see that the first POST call to the `https://api.heroku.com/actions/addon-attachments/resolve` endpoint returns a 404 not found error, but the command doesn't fail yet. It will go on to make calls to the `config-vars` and `addon-attachments` endpoints and then fail after a few other API calls when it can't find the database.



<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
