### PR TITLE
chore: add separate workflow for cache invalidation

### DIFF
--- a/.github/workflows/cache-invalidation.yml
+++ b/.github/workflows/cache-invalidation.yml
@@ -1,0 +1,21 @@
+name: Invalidate CDN cache
+
+on:
+  [workflow_call, workflow_dispatch]
+
+jobs:
+  invalidate-cdn-cache:
+    needs: [ promote ]
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFRONT_DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_EC2_METADATA_DISABLED: true
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y awscli
+          aws configure set preview.cloudfront true
+      - run: ./scripts/postrelease/invalidate_cdn_cache

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -44,20 +44,10 @@ jobs:
 
   ## POST release jobs
   invalidate-cdn-cache:
+    name: Invalidate CDN cache
     needs: [ promote ]
-    runs-on: ubuntu-latest
-    env:
-      CLOUDFRONT_DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_EC2_METADATA_DISABLED: true
-    steps:
-      - uses: actions/checkout@v3
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -y awscli
-          aws configure set preview.cloudfront true
-      - run: ./scripts/postrelease/invalidate_cdn_cache
+    uses: ./.github/workflows/cache-invalidation.yml
+    secrets: inherit
 
   release-homebrew:
     needs: [ invalidate-cdn-cache ]

--- a/.github/workflows/promote-windows.yml
+++ b/.github/workflows/promote-windows.yml
@@ -48,3 +48,9 @@ jobs:
           SHA=$(npm view heroku@${{ inputs.version }} --json | jq -r '.gitHead[0:7]')
           yarn oclif promote --win --root="./packages/cli" --sha="$SHA" --indexes --version=${{ inputs.version }} --channel=${{ fromJSON(inputs.isStableRelease) && 'stable' || env.prerelease-channel }}
         shell: bash
+
+  invalidate-cdn-cache:
+    name: Invalidate CDN cache
+    needs: [ promote ]
+    uses: ./.github/workflows/cache-invalidation.yml
+    secrets: inherit


### PR DESCRIPTION
This PR moves the cache invalidation job from the promote-release workflow into its own file and allows it to be called both as part of other workflows and independently. Then in adds references to this workflow in the promote-release workflow and the promote-windows workflow.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
