### PR TITLE
Allow `app.build_stack` to be `container` for `ensureContainerStack`

### DIFF
--- a/packages/cli/src/lib/container/helpers.ts
+++ b/packages/cli/src/lib/container/helpers.ts
@@ -21,7 +21,7 @@ export function ensureContainerStack(app: Heroku.App, cmd: string): void {
   if (buildStack !== allowedStack && appStack !== allowedStack) {
     let message = 'This command is for Docker apps only.'
     if (['push', 'release'].includes(cmd)) {
-      message += ` Run ${color.cyan('git push heroku main')} to deploy your ${color.cyan(app.name)} ${color.cyan(appStack)} app instead.`
+      message += `Switch stacks by running ${color.cmd('heroku stack:set container')}. Or, to deploy ${color.app(app.name)} with ${color.yellow(appStack)}, run ${color.cmd('git push heroku main')} instead.`
     }
 
     ux.error(message, {exit: 1})

--- a/packages/cli/src/lib/container/helpers.ts
+++ b/packages/cli/src/lib/container/helpers.ts
@@ -21,7 +21,7 @@ export function ensureContainerStack(app: Heroku.App, cmd: string): void {
   if (buildStack !== allowedStack && appStack !== allowedStack) {
     let message = 'This command is for Docker apps only.'
     if (['push', 'release'].includes(cmd)) {
-      message += `Switch stacks by running ${color.cmd('heroku stack:set container')}. Or, to deploy ${color.app(app.name)} with ${color.yellow(appStack)}, run ${color.cmd('git push heroku main')} instead.`
+      message += ` Switch stacks by running ${color.cmd('heroku stack:set container')}. Or, to deploy ${color.app(app.name)} with ${color.yellow(appStack)}, run ${color.cmd('git push heroku main')} instead.`
     }
 
     ux.error(message, {exit: 1})

--- a/packages/cli/src/lib/container/helpers.ts
+++ b/packages/cli/src/lib/container/helpers.ts
@@ -13,11 +13,15 @@ const stackLabelMap: { [key: string]: string} = {
  * @returns {null} null
  */
 export function ensureContainerStack(app: Heroku.App, cmd: string): void {
-  if (app.stack?.name !== 'container') {
-    const appLabel = (app.stack?.name && stackLabelMap[app.stack.name]) || app.stack?.name
+  const buildStack = app.build_stack?.name
+  const appStack = app.stack?.name
+  const allowedStack = 'container'
+
+  // either can be container stack and are allowed
+  if (buildStack !== allowedStack && appStack !== allowedStack) {
     let message = 'This command is for Docker apps only.'
     if (['push', 'release'].includes(cmd)) {
-      message += ` Run ${color.cyan('git push heroku main')} to deploy your ${color.cyan(app.name)} ${color.cyan(appLabel)} app instead.`
+      message += ` Run ${color.cyan('git push heroku main')} to deploy your ${color.cyan(app.name)} ${color.cyan(appStack)} app instead.`
     }
 
     ux.error(message, {exit: 1})

--- a/packages/cli/test/unit/commands/container/push.unit.test.ts
+++ b/packages/cli/test/unit/commands/container/push.unit.test.ts
@@ -45,7 +45,7 @@ describe('container push', function () {
     })
   })
 
-  context('when the app build_stack is container', function() {
+  context('when the app build_stack is container', function () {
     beforeEach(function () {
       api
         .get('/apps/testapp')

--- a/packages/cli/test/unit/commands/container/push.unit.test.ts
+++ b/packages/cli/test/unit/commands/container/push.unit.test.ts
@@ -40,7 +40,7 @@ describe('container push', function () {
         error = error_
       })
       const {message, oclif} = error as unknown as CLIError
-      expect(message).to.equal(`This command is for Docker apps only. Run ${color.cyan('git push heroku main')} to deploy your ${color.cyan('testapp')} ${color.cyan('heroku-24')} app instead.`)
+      expect(message).to.equal(`This command is for Docker apps only. Switch stacks by running ${color.cmd('heroku stack:set container')}. Or, to deploy ${color.app('testapp')} with ${color.yellow('heroku-24')}, run ${color.cmd('git push heroku main')} instead.`)
       expect(oclif.exit).to.equal(1)
     })
   })

--- a/packages/cli/test/unit/commands/container/release.unit.test.ts
+++ b/packages/cli/test/unit/commands/container/release.unit.test.ts
@@ -50,7 +50,7 @@ describe('container release', function () {
     })
 
     const {message, oclif} = error as unknown as CLIError
-    expect(message).to.equal(`This command is for Docker apps only. Run ${color.cyan('git push heroku main')} to deploy your ${color.cyan('testapp')} ${color.cyan('heroku-24')} app instead.`)
+    expect(message).to.equal(`This command is for Docker apps only. Switch stacks by running ${color.cmd('heroku stack:set container')}. Or, to deploy ${color.app('testapp')} with ${color.yellow('heroku-24')}, run ${color.cmd('git push heroku main')} instead.`)
     expect(oclif.exit).to.equal(1)
   })
 


### PR DESCRIPTION
When migrating from  a non-container stack to a container stack, the `app.build_stack` is set to `container`. This situation should be allowed in `ensureContainerStack` to avoid an error when `container:*` commands are run.

This should fix https://github.com/heroku/cli/issues/2951
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
