### PR TITLE
fix: remove 'needs' from cache-invalidation

### DIFF
--- a/.github/workflows/cache-invalidation.yml
+++ b/.github/workflows/cache-invalidation.yml
@@ -5,7 +5,6 @@ on:
 
 jobs:
   invalidate-cdn-cache:
-    needs: [ promote ]
     runs-on: ubuntu-latest
     env:
       CLOUDFRONT_DISTRIBUTION: ${{ secrets.CLOUDFRONT_DISTRIBUTION }}


### PR DESCRIPTION
Removes unneeded line from cache-invalidation workflow.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
