### PR TITLE
FIx container:push --recursive behavior

### DIFF
--- a/packages/cli/src/commands/container/push.ts
+++ b/packages/cli/src/commands/container/push.ts
@@ -16,6 +16,8 @@ async function selectJobs(jobs: DockerHelper.groupedDockerJobs, processTypes: st
   if (recursive) {
     if (processTypes.length > 0) {
       filteredJobs = DockerHelper.filterByProcessType(jobs, processTypes)
+    } else {
+      filteredJobs = jobs
     }
 
     selectedJobs = await DockerHelper.chooseJobs(filteredJobs)


### PR DESCRIPTION
### Description

[Gus Item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001xSWixYAG/view)
Fixes https://github.com/heroku/cli/issues/2949

A regression was introduced in 9.0 that made `--recursive` not push any dockerfiles when process types were not provided. This fixes that bug, and adds a test for this scenario.

### Testing

1. Pull down this branch
2. Switch to a repository with a Docker-based app and multiple dockerfiles (e.g., `Dockerfile.web`, `Dockerfile.worker`)
3. Run `$PATH_TO_CLI/bin/dev --app DOCKER_APP_NAME --recursive`
4. Verify it pushes all Dockerfiles