### PR TITLE
chore(cli): enable backwards compatibility syntax for addons:create

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "2.0.1",
-    "@heroku-cli/command": "^11.1.2",
+    "@heroku-cli/command": "^11.2.1",
     "@heroku-cli/notifications": "^1.2.4",
     "@heroku-cli/plugin-ps": "^8.1.7",
     "@heroku-cli/plugin-ps-exec": "^2.4.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "2.0.1",
-    "@heroku-cli/command": "^11.2.1",
+    "@heroku-cli/command": "^11.2.2",
     "@heroku-cli/notifications": "^1.2.4",
     "@heroku-cli/plugin-ps": "^8.1.7",
     "@heroku-cli/plugin-ps-exec": "^2.4.0",

--- a/packages/cli/src/commands/addons/create.ts
+++ b/packages/cli/src/commands/addons/create.ts
@@ -77,8 +77,8 @@ export default class Create extends Command {
       .filter(arg => arg !== servicePlan)
 
     if (restParse.nonExistentFlags && restParse.nonExistentFlags.length > 0) {
-      ux.log(` ${color.yellow('›')}   For example: ${color.cyan(`heroku addons:create -a ${app} ${restParse.raw[0].input} -- ${restParse.nonExistentFlags.join(' ')}`)}`)
-      ux.log(` ${color.yellow('›')}   See https://devcenter.heroku.com/changelog-items/2925 for more info.`)
+      process.stderr.write(` ${color.yellow('›')}   For example: ${color.cyan(`heroku addons:create -a ${app} ${restParse.raw[0].input} -- ${restParse.nonExistentFlags.join(' ')}`)}`)
+      process.stderr.write(` ${color.yellow('›')}   See https://devcenter.heroku.com/changelog-items/2925 for more info.\n`)
     }
 
     const config = parseConfig(argv)

--- a/packages/cli/src/commands/addons/create.ts
+++ b/packages/cli/src/commands/addons/create.ts
@@ -77,6 +77,8 @@ export default class Create extends Command {
       .filter(arg => arg !== servicePlan)
 
     if (restParse.nonExistentFlags && restParse.nonExistentFlags.length > 0) {
+      console.log('WE ARE HERE')
+      console.log('restParse.nonExistentFlags', Object.entries(restParse.nonExistentFlags))
       ux.log(` ${color.yellow('›')}   For example: ${color.cyan(`heroku addons:create -a ${app} ${restParse.raw[0].input} -- ${restParse.nonExistentFlags.join(' ')}`)}`)
       ux.log(` ${color.yellow('›')}   See https://devcenter.heroku.com/changelog-items/2925 for more info.`)
     }

--- a/packages/cli/src/commands/addons/create.ts
+++ b/packages/cli/src/commands/addons/create.ts
@@ -77,8 +77,6 @@ export default class Create extends Command {
       .filter(arg => arg !== servicePlan)
 
     if (restParse.nonExistentFlags && restParse.nonExistentFlags.length > 0) {
-      console.log('WE ARE HERE')
-      console.log('restParse.nonExistentFlags', Object.entries(restParse.nonExistentFlags))
       ux.log(` ${color.yellow('›')}   For example: ${color.cyan(`heroku addons:create -a ${app} ${restParse.raw[0].input} -- ${restParse.nonExistentFlags.join(' ')}`)}`)
       ux.log(` ${color.yellow('›')}   See https://devcenter.heroku.com/changelog-items/2925 for more info.`)
     }

--- a/packages/cli/src/commands/addons/create.ts
+++ b/packages/cli/src/commands/addons/create.ts
@@ -76,8 +76,10 @@ export default class Create extends Command {
     // oclif duplicates specified args in argv
       .filter(arg => arg !== servicePlan)
 
-    ux.log(` ${color.yellow('›')}   For example: ${color.cyan(`heroku addons:create -a ${app} ${restParse.raw[0].input} -- ${restParse.nonExistentFlags.join(' ')}`)}`)
-    ux.log(` ${color.yellow('›')}   See https://devcenter.heroku.com/changelog-items/2925 for more info.`)
+    if (restParse.nonExistentFlags && restParse.nonExistentFlags.length > 0) {
+      ux.log(` ${color.yellow('›')}   For example: ${color.cyan(`heroku addons:create -a ${app} ${restParse.raw[0].input} -- ${restParse.nonExistentFlags.join(' ')}`)}`)
+      ux.log(` ${color.yellow('›')}   See https://devcenter.heroku.com/changelog-items/2925 for more info.`)
+    }
 
     const config = parseConfig(argv)
     let addon

--- a/packages/cli/src/commands/addons/create.ts
+++ b/packages/cli/src/commands/addons/create.ts
@@ -76,6 +76,9 @@ export default class Create extends Command {
     // oclif duplicates specified args in argv
       .filter(arg => arg !== servicePlan)
 
+    ux.log(` ${color.yellow('›')}   For example: ${color.cyan(`heroku addons:create -a ${app} ${restParse.raw[0].input} -- ${restParse.nonExistentFlags.join(' ')}`)}`)
+    ux.log(` ${color.yellow('›')}   See https://devcenter.heroku.com/changelog-items/2925 for more info.`)
+
     const config = parseConfig(argv)
     let addon
     try {

--- a/packages/cli/src/commands/addons/create.ts
+++ b/packages/cli/src/commands/addons/create.ts
@@ -68,6 +68,7 @@ export default class Create extends Command {
   }
 
   public async run(): Promise<void> {
+    this.allowArbitraryFlags = true
     const {flags, args, ...restParse} = await this.parse(Create)
     const {app, name, as, wait, confirm} = flags
     const servicePlan = args['service:plan']

--- a/packages/cli/test/unit/commands/addons/create.unit.test.ts
+++ b/packages/cli/test/unit/commands/addons/create.unit.test.ts
@@ -94,8 +94,8 @@ describe('addons:create', function () {
       ])
       expect(unwrap(stderr.output)).to.contain('Warning: You’re using a deprecated syntax with the [--rollback,--follow,--foo] flag')
       expect(unwrap(stderr.output)).to.contain("Add a '--' (end of options) separator before the flags you’re passing through.")
-      expect(unwrap(stdout.output)).to.contain('For example: heroku addons:create -a myapp heroku-postgresql:standard-0 -- --rollback --follow otherdb --foo')
-      expect(unwrap(stdout.output)).to.contain('See https://devcenter.heroku.com/changelog-items/2925 for more info.')
+      expect(unwrap(stderr.output)).to.contain('For example: heroku addons:create -a myapp heroku-postgresql:standard-0 -- --rollback --follow otherdb --foo')
+      expect(unwrap(stderr.output)).to.contain('See https://devcenter.heroku.com/changelog-items/2925 for more info.')
     })
     it('creates an addon with = args', async function () {
       await runCommand(Cmd, [

--- a/packages/cli/test/unit/commands/addons/create.unit.test.ts
+++ b/packages/cli/test/unit/commands/addons/create.unit.test.ts
@@ -6,6 +6,7 @@ import * as _ from 'lodash'
 import * as sinon from 'sinon'
 import * as nock from 'nock'
 import stripAnsi = require('strip-ansi')
+import {unwrap} from '../../../helpers/utils/unwrap'
 const lolex = require('lolex')
 
 describe('addons:create', function () {
@@ -78,6 +79,23 @@ describe('addons:create', function () {
       ])
       expect(stderr.output).to.contain('Creating heroku-postgresql:standard-0 on ⬢ myapp... ~$0.139/hour (max $100/month)\n')
       expect(stdout.output).to.equal('provision message\nCreated db3-swiftly-123 as DATABASE_URL\nUse heroku addons:docs heroku-db3 to view documentation\n')
+    })
+    it('creates an add-on with proper output using old syntax with deprecation message', async function () {
+      await runCommand(Cmd, [
+        '--app',
+        'myapp',
+        '--as',
+        'mydb',
+        'heroku-postgresql:standard-0',
+        '--rollback',
+        '--follow',
+        'otherdb',
+        '--foo',
+      ])
+      expect(unwrap(stderr.output)).to.contain('Warning: You’re using a deprecated syntax with the [--rollback,--follow,--foo] flag')
+      expect(unwrap(stderr.output)).to.contain("Add a '--' (end of options) separator before the flags you’re passing through.")
+      expect(unwrap(stdout.output)).to.contain('For example: heroku addons:create -a myapp heroku-postgresql:standard-0 -- --rollback --follow otherdb --foo')
+      expect(unwrap(stdout.output)).to.contain('See https://devcenter.heroku.com/changelog-items/2925 for more info.')
     })
     it('creates an addon with = args', async function () {
       await runCommand(Cmd, [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1616,9 +1616,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@heroku-cli/command@npm:^11.1.2":
-  version: 11.1.2
-  resolution: "@heroku-cli/command@npm:11.1.2"
+"@heroku-cli/command@npm:^11.2.1":
+  version: 11.2.1
+  resolution: "@heroku-cli/command@npm:11.2.1"
   dependencies:
     "@heroku-cli/color": ^2.0.1
     "@oclif/core": ^2.16.0
@@ -1630,7 +1630,10 @@ __metadata:
     netrc-parser: ^3.1.6
     open: ^8.4.2
     uuid: ^8.3.0
-  checksum: 93565c7177efa373b9f6120ed3d71bf739c09f5557f00c599d7f2cf4e8b6c42c552d314f31059d5f8d72e339c24919c2fe69bce31a2031ce35b6ff2f6db2f189
+  peerDependencies:
+    yargs-parser: ">=18.x"
+    yargs-unparser: ^2.0.0
+  checksum: 1847acd3fabbefb8bd485ca04186aa4e293be8ed44201d5d46d0a624ccfefa523e76a4e8cc7d02cbc52d52486119a8326075fe20d2b168e633df3bd38af7ac0d
   languageName: node
   linkType: hard
 
@@ -11204,7 +11207,7 @@ __metadata:
   resolution: "heroku@workspace:packages/cli"
   dependencies:
     "@heroku-cli/color": 2.0.1
-    "@heroku-cli/command": ^11.1.2
+    "@heroku-cli/command": ^11.2.1
     "@heroku-cli/notifications": ^1.2.4
     "@heroku-cli/plugin-ps": ^8.1.7
     "@heroku-cli/plugin-ps-exec": ^2.4.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1616,9 +1616,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@heroku-cli/command@npm:^11.2.1":
-  version: 11.2.1
-  resolution: "@heroku-cli/command@npm:11.2.1"
+"@heroku-cli/command@npm:^11.2.2":
+  version: 11.2.2
+  resolution: "@heroku-cli/command@npm:11.2.2"
   dependencies:
     "@heroku-cli/color": ^2.0.1
     "@oclif/core": ^2.16.0
@@ -1633,7 +1633,7 @@ __metadata:
   peerDependencies:
     yargs-parser: ">=18.x"
     yargs-unparser: ^2.0.0
-  checksum: 1847acd3fabbefb8bd485ca04186aa4e293be8ed44201d5d46d0a624ccfefa523e76a4e8cc7d02cbc52d52486119a8326075fe20d2b168e633df3bd38af7ac0d
+  checksum: 049415c4dad3eb116b50974c75c692905fa00bf0d25d0aff466d15ea18ee97f095fda78cc2d4da5921eb207ee5937c68de46006b63f4c6dc5ae3ebdffd58be03
   languageName: node
   linkType: hard
 
@@ -11207,7 +11207,7 @@ __metadata:
   resolution: "heroku@workspace:packages/cli"
   dependencies:
     "@heroku-cli/color": 2.0.1
-    "@heroku-cli/command": ^11.2.1
+    "@heroku-cli/command": ^11.2.2
     "@heroku-cli/notifications": ^1.2.4
     "@heroku-cli/plugin-ps": ^8.1.7
     "@heroku-cli/plugin-ps-exec": ^2.4.0


### PR DESCRIPTION
## Description
This PR enables backwards compatible `v8.x.x` syntax for passing in positional arguments to the `heroku addons:create` command.

## Testing
1. Pull down branch
2. `yarn` it up
3. Confirm passing positional arguments using old `v8.x.x` syntax via
`./bin/run addons:create -a heroku-cli-test-staging  heroku-postgresql:private-0 --follow DATABASE`
4. Confirm that the addon successfully provisioned a follower database with the positional `--follow` flag
5. Confirm that the deprecation warning is also visible like so:
```
 ›   Warning: You’re using a deprecated syntax with the [--follow] flag.
 ›   Add a '--' (end of options) separator before the flags you’re passing through.
 ›   For example: heroku addons:create -a heroku-cli-test-staging heroku-postgresql:private-0 -- --follow
 ›   See https://devcenter.heroku.com/changelog-items/2925 for more info.
```
6. Once finished, remove any test provisioned addons to the aforementioned app used