### PR TITLE
fix(W-16441506): redis:cli command not working for private redis inst…

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -375,6 +375,7 @@
   "repository": "heroku/cli",
   "scripts": {
     "build": "rm -rf lib && tsc",
+    "build:dev": "rm -rf lib && tsc --sourcemap",
     "lint": "eslint . --ext .ts --config ../../.eslintrc --ignore-path ../../.eslintignore-lib",
     "postpublish": "rm -f oclif.manifest.json",
     "prepack": "yarn run build && oclif manifest",

--- a/packages/cli/src/commands/redis/cli.ts
+++ b/packages/cli/src/commands/redis/cli.ts
@@ -117,7 +117,7 @@ async function bastionConnect(uri: URL, bastions: string, config: Record<string,
     })
   })
   const localPort = await portfinder.getPortPromise({startPort: 49152, stopPort: 65535})
-  const stream: Duplex = await promisify(tunnel.forwardOut)('localhost', localPort, uri.hostname, Number.parseInt(uri.port, 10))
+  const stream: Duplex = await promisify(tunnel.forwardOut.bind(tunnel))('localhost', localPort, uri.hostname, Number.parseInt(uri.port, 10))
 
   let client: Duplex = stream
   if (preferNativeTls) {


### PR DESCRIPTION
This PR fixes a scope issue that prevented the `ssh2` library from accessing `this`. 

Testing this PR follows the standard instructions for connecting to a Redis Database. 

1. `heroku redis:cli -a <your_app> <your_redis_database_name>`