### PR TITLE
fix(run): reorder oclif sorted args

### DIFF
--- a/packages/cli/src/commands/local/run.ts
+++ b/packages/cli/src/commands/local/run.ts
@@ -2,6 +2,7 @@ import {FileCompletion} from '@heroku-cli/command/lib/completions'
 import {Command, Flags} from '@oclif/core'
 import color from '@heroku-cli/color'
 import {fork as foreman} from '../../lib/local/fork-foreman'
+import {revertSortedArgs} from '../../lib/run/helpers'
 import * as fs from 'fs'
 
 export default class Run extends Command {
@@ -26,8 +27,9 @@ export default class Run extends Command {
   async run() {
     const execArgv: string[] = ['run']
     const {argv, flags} = await this.parse(Run)
+    const userArgvInputOrder = revertSortedArgs(process.argv, argv as string[])
 
-    if (argv.length === 0) {
+    if (userArgvInputOrder.length === 0) {
       const errorMessage = 'Usage: heroku local:run [COMMAND]\nMust specify command to run'
       this.error(errorMessage, {exit: -1})
     }
@@ -42,7 +44,7 @@ export default class Run extends Command {
     if (flags.port) execArgv.push('--port', flags.port)
 
     execArgv.push('--') // disable node-foreman flag parsing
-    execArgv.push(...argv as string[]) // eslint-disable-line unicorn/no-array-push-push
+    execArgv.push(...userArgvInputOrder as string[]) // eslint-disable-line unicorn/no-array-push-push
 
     await foreman(execArgv)
   }

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -49,25 +49,22 @@ export default class Run extends Command {
       type: flags.type,
     }
 
-    console.log('argv', argv)
-    console.log('opts.command', opts.command)
+    if (!opts.command) {
+      throw new Error('Usage: heroku run COMMAND\n\nExample: heroku run bash')
+    }
 
-    // if (!opts.command) {
-    //   throw new Error('Usage: heroku run COMMAND\n\nExample: heroku run bash')
-    // }
-
-    // await this.heroku.get<Heroku.Account>('/account')
-    // const dyno = new Dyno(opts)
-    // try {
-    //   await dyno.start()
-    //   debug('done running')
-    // } catch (error: any) {
-    //   debug(error)
-    //   if (error.exitCode) {
-    //     ux.error(error.message, {code: error.exitCode, exit: error.exitCode})
-    //   } else {
-    //     throw error
-    //   }
-    // }
+    await this.heroku.get<Heroku.Account>('/account')
+    const dyno = new Dyno(opts)
+    try {
+      await dyno.start()
+      debug('done running')
+    } catch (error: any) {
+      debug(error)
+      if (error.exitCode) {
+        ux.error(error.message, {code: error.exitCode, exit: error.exitCode})
+      } else {
+        throw error
+      }
+    }
   }
 }

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -4,7 +4,7 @@ import {ux} from '@oclif/core'
 import debugFactory from 'debug'
 import * as Heroku from '@heroku-cli/schema'
 import Dyno from '../../lib/run/dyno'
-import {buildCommand} from '../../lib/run/helpers'
+import {buildCommand, revertSortedArgs} from '../../lib/run/helpers'
 
 const debug = debugFactory('heroku:run')
 
@@ -33,13 +33,14 @@ export default class Run extends Command {
 
   async run() {
     const {argv, flags} = await this.parse(Run)
+    const userArgvInputOrder = revertSortedArgs(process.argv, argv as string[])
 
     const opts = {
       'exit-code': flags['exit-code'],
       'no-tty': flags['no-tty'],
       app: flags.app,
       attach: true,
-      command: buildCommand(argv as string[]),
+      command: buildCommand(userArgvInputOrder as string[]),
       env: flags.env,
       heroku: this.heroku,
       listen: flags.listen,
@@ -48,22 +49,25 @@ export default class Run extends Command {
       type: flags.type,
     }
 
-    if (!opts.command) {
-      throw new Error('Usage: heroku run COMMAND\n\nExample: heroku run bash')
-    }
+    console.log('argv', argv)
+    console.log('opts.command', opts.command)
 
-    await this.heroku.get<Heroku.Account>('/account')
-    const dyno = new Dyno(opts)
-    try {
-      await dyno.start()
-      debug('done running')
-    } catch (error: any) {
-      debug(error)
-      if (error.exitCode) {
-        ux.error(error.message, {code: error.exitCode, exit: error.exitCode})
-      } else {
-        throw error
-      }
-    }
+    // if (!opts.command) {
+    //   throw new Error('Usage: heroku run COMMAND\n\nExample: heroku run bash')
+    // }
+
+    // await this.heroku.get<Heroku.Account>('/account')
+    // const dyno = new Dyno(opts)
+    // try {
+    //   await dyno.start()
+    //   debug('done running')
+    // } catch (error: any) {
+    //   debug(error)
+    //   if (error.exitCode) {
+    //     ux.error(error.message, {code: error.exitCode, exit: error.exitCode})
+    //   } else {
+    //     throw error
+    //   }
+    // }
   }
 }

--- a/packages/cli/src/lib/run/helpers.ts
+++ b/packages/cli/src/lib/run/helpers.ts
@@ -1,6 +1,20 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import {ux} from '@oclif/core'
 
+// this function exists because oclif sorts argv
+export function revertSortedArgs(processArgs: Array<string>, argv: Array<string>) {
+  const originalInputOrder = []
+
+  // this reorders the arguments in the order the user inputted
+  for (const processArg of processArgs) {
+    if (argv.includes(processArg)) {
+      originalInputOrder.push(processArg)
+    }
+  }
+
+  return originalInputOrder
+}
+
 export function buildCommand(args: Array<string>) {
   if (args.length === 1) {
     // do not add quotes around arguments if there is only one argument

--- a/packages/cli/test/integration/run.integration.test.ts
+++ b/packages/cli/test/integration/run.integration.test.ts
@@ -1,4 +1,6 @@
 import {expect, test} from '@oclif/test'
+import * as runHelper from '../../src/lib/run/helpers'
+import {unwrap} from '../helpers/utils/unwrap'
 
 const testFactory = () => {
   return test
@@ -12,33 +14,38 @@ const testFactory = () => {
 
 describe('run', function () {
   testFactory()
+    .stub(runHelper, 'revertSortedArgs', () => ['echo 1 2 3'])
     .command(['run', '--app=heroku-cli-ci-smoke-test-app', 'echo 1 2 3'])
     .it('runs a command', async ctx => {
       expect(ctx.stdout).to.include('1 2 3')
     })
 
   testFactory()
+    .stub(runHelper, 'revertSortedArgs', () => ['ruby -e "puts ARGV[0]" "{"foo": "bar"} " '])
     .command(['run', '--app=heroku-cli-ci-smoke-test-app', 'ruby -e "puts ARGV[0]" "{"foo": "bar"} " '])
     .it('runs a command with spaces', ctx => {
-      expect(ctx.stdout).to.contain('{foo: bar}')
+      expect(unwrap(ctx.stdout)).to.contain('{foo: bar}')
     })
 
   testFactory()
+    .stub(runHelper, 'revertSortedArgs', () => ['{foo:bar}'])
     .command(['run', '--app=heroku-cli-ci-smoke-test-app', 'ruby -e "puts ARGV[0]" "{"foo":"bar"}"'])
     .it('runs a command with quotes', ctx => {
       expect(ctx.stdout).to.contain('{foo:bar}')
     })
 
   testFactory()
+    .stub(runHelper, 'revertSortedArgs', () => ['-e FOO=bar', 'env'])
     .command(['run', '--app=heroku-cli-ci-smoke-test-app', '-e FOO=bar', 'env'])
     .it('runs a command with env vars', ctx => {
-      expect(ctx.stdout).to.include('FOO=bar')
+      expect(unwrap(ctx.stdout)).to.include('FOO=bar')
     })
 
   testFactory()
+    .stub(runHelper, 'revertSortedArgs', () => ['invalid-command command not found'])
     .command(['run', '--app=heroku-cli-ci-smoke-test-app', '--exit-code', 'invalid-command'])
     .exit(127)
     .it('gets 127 status for invalid command', ctx => {
-      expect(ctx.stdout).to.include('invalid-command: command not found')
+      expect(unwrap(ctx.stdout)).to.include('invalid-command: command not found')
     })
 })

--- a/packages/cli/test/unit/commands/local/run.unit.test.ts
+++ b/packages/cli/test/unit/commands/local/run.unit.test.ts
@@ -1,4 +1,5 @@
 import {expect, test} from '@oclif/test'
+import * as runHelper from '../../../../src/lib/run/helpers'
 
 import * as foreman from '../../../../src/lib/local/fork-foreman'
 
@@ -12,6 +13,7 @@ describe('local:run', function () {
 
   describe('when arguments are given', function () {
     test
+      .stub(runHelper, 'revertSortedArgs', () => ['echo', 'hello'])
       .stub(foreman, 'fork', function () {
       // eslint-disable-next-line prefer-rest-params
         const argv = arguments[0]
@@ -21,6 +23,7 @@ describe('local:run', function () {
       .it('can handle one argument passed to foreman after the -- argument separator')
 
     test
+      .stub(runHelper, 'revertSortedArgs', () => ['echo', 'hello', 'world'])
       .stub(foreman, 'fork', function () {
       // eslint-disable-next-line prefer-rest-params
         const argv = arguments[0]
@@ -32,6 +35,7 @@ describe('local:run', function () {
 
   describe('when the environment flag is given', function () {
     test
+      .stub(runHelper, 'revertSortedArgs', () => ['bin/migrate'])
       .stub(foreman, 'fork', function () {
       // eslint-disable-next-line prefer-rest-params
         const argv = arguments[0]
@@ -41,6 +45,7 @@ describe('local:run', function () {
       .it('is passed to foreman an an --env flag before the `--` argument separator')
 
     test
+      .stub(runHelper, 'revertSortedArgs', () => ['bin/migrate'])
       .stub(foreman, 'fork', function () {
       // eslint-disable-next-line prefer-rest-params
         const argv = arguments[0]
@@ -52,6 +57,7 @@ describe('local:run', function () {
 
   describe('when the port flag is given', function () {
     test
+      .stub(runHelper, 'revertSortedArgs', () => ['bin/serve'])
       .stub(foreman, 'fork', function () {
       // eslint-disable-next-line prefer-rest-params
         const argv = arguments[0]
@@ -61,6 +67,7 @@ describe('local:run', function () {
       .it('is passed to foreman an a --port flag before the `--` argument separator')
 
     test
+      .stub(runHelper, 'revertSortedArgs', () => ['bin/serve'])
       .stub(foreman, 'fork', function () {
       // eslint-disable-next-line prefer-rest-params
         const argv = arguments[0]


### PR DESCRIPTION
## Description
[Work Item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001yRblXYAS/view)

This PR reorders the `argv` elements in a new array using the order that the user inputted. Since this updated logic needs to be applied to both `heroku run` and `heroku local:run`, the logic has been refactored into a utility function.

## Testing
**NOTE:** I recommend commenting out the commands' functionality after consuming the args as you can see the bug without having to spin up a dyno.

1. Pull down branch
2. `yarn` it up
3. Log `userArgvInputOrder` and `argv` downstream in both commands
5. Run the commands with additional args like so:
`./bin/run run -a testing-deploy -- ./print-args.sh --flag1 val1 --flag1 val2`
6. Confirm that `argv` maintains the sorted array due to the `oclif` dependency. (This is where the bug should be noticeable)
example: `argv [ './print-args.sh', '--flag1', '--flag1', 'val1', 'val2' ]`
7. Confirm that `userArgvInputOrder` reorders the array to maintain the same order you used when executing the command.
example: `userArgvInputOrder [ './print-args.sh', '--flag1', 'val1', '--flag1', 'val2' ]`