### PR TITLE
fix(redis:cli): remove call to resolve ssh2 in bastionConnect function

### DIFF
--- a/packages/cli/src/commands/redis/cli.ts
+++ b/packages/cli/src/commands/redis/cli.ts
@@ -108,7 +108,6 @@ async function redisCLI(uri: URL, client: Writable): Promise<void> {
 async function bastionConnect(uri: URL, bastions: string, config: Record<string, unknown>, preferNativeTls: boolean) {
   const tunnel: Client = await new Promise(resolve => {
     const ssh2 = new Client()
-    resolve(ssh2)
     ssh2.once('ready', () => resolve(ssh2))
     ssh2.connect({
       host: bastions.split(',')[0],


### PR DESCRIPTION
[Work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001yRuGlYAK/view)

## Description
Using the `redis:cli` command to connect to a redis instance using the private plan was failing. This PR implements the fix suggested in #2978.

## Testing
- Create an app inside of a private space and add a Heroku Redis instance on a private plan
- Run `heroku redis:cli redis_name -a app_name` to see how the command fails
- Pull down this branch and run `yarn && yarn build`
- Run `./bin/run redis:cli redis_name -a app_name` to see the command succeed

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
