### PR TITLE
fix: use linux/amd64 platform only for m1/m2 macs (arm64)

### DIFF
--- a/packages/cli/src/commands/container/push.ts
+++ b/packages/cli/src/commands/container/push.ts
@@ -92,7 +92,13 @@ export default class Push extends Command {
           ux.styledHeader(`Building ${job.name} (${job.dockerfile})`)
         }
 
-        await DockerHelper.buildImage(job.dockerfile, job.resource, buildArgs, contextPath)
+        await DockerHelper.buildImage({
+          dockerfile: job.dockerfile,
+          resource: job.resource,
+          buildArgs,
+          path: contextPath,
+          arch: this.config.arch,
+        })
       }
     } catch (error) {
       ux.error(`docker build exited with ${error}`, {exit: 1})

--- a/packages/cli/src/lib/container/docker_helper.ts
+++ b/packages/cli/src/lib/container/docker_helper.ts
@@ -174,7 +174,8 @@ type BuildImageParams = {
 export const buildImage = async function ({dockerfile, resource, buildArgs, path, arch}: BuildImageParams) {
   const cwd = path || Path.dirname(dockerfile)
   const args = ['build', '-f', dockerfile, '-t', resource]
-  // allows for pushing docker build from m1/m2 Macs
+  // Older Docker versions don't allow for this flag, but we are
+  // adding it here when necessary to allow for pushing a docker build from m1/m2 Macs.
   if (arch === 'arm64') args.push('--platform', 'linux/amd64')
 
   for (const element of buildArgs) {

--- a/packages/cli/src/lib/container/docker_helper.ts
+++ b/packages/cli/src/lib/container/docker_helper.ts
@@ -163,9 +163,19 @@ export const chooseJobs = async function (jobs: groupedDockerJobs) {
   return chosenJobs
 }
 
-export const buildImage = async function (dockerfile: string, resource: string, buildArgs: string[], path?: string) {
+type BuildImageParams = {
+  dockerfile: string,
+  resource: string,
+  buildArgs: string[],
+  path?: string,
+  arch?: string,
+}
+
+export const buildImage = async function ({dockerfile, resource, buildArgs, path, arch}: BuildImageParams) {
   const cwd = path || Path.dirname(dockerfile)
-  const args = ['build', '-f', dockerfile, '-t', resource, '--platform', 'linux/amd64']
+  const args = ['build', '-f', dockerfile, '-t', resource]
+  // allows for pushing docker build from m1/m2 Macs
+  if (arch === 'arm64') args.push('--platform', 'linux/amd64')
 
   for (const element of buildArgs) {
     if (element.length > 0) {

--- a/packages/cli/test/unit/commands/container/push.unit.test.ts
+++ b/packages/cli/test/unit/commands/container/push.unit.test.ts
@@ -56,7 +56,6 @@ describe('container push', function () {
       const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
         .returns(['/path/to/Dockerfile'])
       const build = sandbox.stub(DockerHelper, 'buildImage')
-        .withArgs('/path/to/Dockerfile', 'registry.heroku.com/testapp/web', [])
       const push = sandbox.stub(DockerHelper, 'pushImage')
         .withArgs('registry.heroku.com/testapp/web')
 
@@ -70,6 +69,8 @@ describe('container push', function () {
       expect(stdout.output).to.contain('Pushing web (/path/to/Dockerfile)')
       sandbox.assert.calledOnce(dockerfiles)
       sandbox.assert.calledOnce(build)
+      expect(build.getCall(0).args[0].dockerfile).to.equal('/path/to/Dockerfile')
+      expect(build.getCall(0).args[0].resource).to.equal('registry.heroku.com/testapp/web')
       sandbox.assert.calledOnce(push)
     })
   })
@@ -133,7 +134,6 @@ describe('container push', function () {
       const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
         .returns(['/path/to/Dockerfile'])
       const build = sandbox.stub(DockerHelper, 'buildImage')
-        .withArgs('/path/to/Dockerfile', 'registry.heroku.com/testapp/web', [])
       const push = sandbox.stub(DockerHelper, 'pushImage')
         .withArgs('registry.heroku.com/testapp/web')
 
@@ -147,6 +147,8 @@ describe('container push', function () {
       expect(stdout.output).to.contain('Pushing web (/path/to/Dockerfile)')
       sandbox.assert.calledOnce(dockerfiles)
       sandbox.assert.calledOnce(build)
+      expect(build.getCall(0).args[0].dockerfile).to.equal('/path/to/Dockerfile')
+      expect(build.getCall(0).args[0].resource).to.equal('registry.heroku.com/testapp/web')
       sandbox.assert.calledOnce(push)
     })
 
@@ -154,7 +156,6 @@ describe('container push', function () {
       const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
         .returns(['/path/to/Dockerfile'])
       const build = sandbox.stub(DockerHelper, 'buildImage')
-        .withArgs('/path/to/Dockerfile', 'registry.heroku.com/testapp/worker', [])
       const push = sandbox.stub(DockerHelper, 'pushImage')
         .withArgs('registry.heroku.com/testapp/worker')
 
@@ -168,6 +169,8 @@ describe('container push', function () {
       expect(stdout.output).to.contain('Pushing worker (/path/to/Dockerfile)')
       sandbox.assert.calledOnce(dockerfiles)
       sandbox.assert.calledOnce(build)
+      expect(build.getCall(0).args[0].dockerfile).to.equal('/path/to/Dockerfile')
+      expect(build.getCall(0).args[0].resource).to.equal('registry.heroku.com/testapp/worker')
       sandbox.assert.calledOnce(push)
     })
 
@@ -175,8 +178,6 @@ describe('container push', function () {
       const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
         .returns(['/path/to/Dockerfile.web', '/path/to/Dockerfile.worker'])
       const build = sandbox.stub(DockerHelper, 'buildImage')
-      build.withArgs('/path/to/Dockerfile.web', 'registry.heroku.com/testapp/web', [])
-      build.withArgs('/path/to/Dockerfile.worker', 'registry.heroku.com/testapp/worker', [])
       const push = sandbox.stub(DockerHelper, 'pushImage')
       push.withArgs('registry.heroku.com/testapp/web')
       push.withArgs('registry.heroku.com/testapp/worker')
@@ -195,6 +196,8 @@ describe('container push', function () {
       expect(stdout.output).to.contain('Pushing worker (/path/to/Dockerfile.worker)')
       sandbox.assert.calledOnce(dockerfiles)
       sandbox.assert.calledTwice(build)
+      expect(build.getCall(0).args[0].dockerfile).to.equal('/path/to/Dockerfile.web')
+      expect(build.getCall(1).args[0].dockerfile).to.equal('/path/to/Dockerfile.worker')
       sandbox.assert.calledTwice(push)
     })
 
@@ -202,8 +205,6 @@ describe('container push', function () {
       const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
         .returns(['/path/to/Dockerfile.web', '/path/to/Dockerfile.worker'])
       const build = sandbox.stub(DockerHelper, 'buildImage')
-      build.withArgs('/path/to/Dockerfile.web', 'registry.heroku.com/testapp/web', [])
-      build.withArgs('/path/to/Dockerfile.worker', 'registry.heroku.com/testapp/worker', [])
       const push = sandbox.stub(DockerHelper, 'pushImage')
       push.withArgs('registry.heroku.com/testapp/web')
       push.withArgs('registry.heroku.com/testapp/worker')
@@ -220,6 +221,8 @@ describe('container push', function () {
       expect(stdout.output).to.contain('Pushing worker (/path/to/Dockerfile.worker)')
       sandbox.assert.calledOnce(dockerfiles)
       sandbox.assert.calledTwice(build)
+      expect(build.getCall(0).args[0].dockerfile).to.equal('/path/to/Dockerfile.web')
+      expect(build.getCall(1).args[0].dockerfile).to.equal('/path/to/Dockerfile.worker')
       sandbox.assert.calledTwice(push)
     })
 
@@ -227,7 +230,6 @@ describe('container push', function () {
       const dockerfiles = sandbox.stub(DockerHelper, 'getDockerfiles')
         .returns(['/path/to/Dockerfile'])
       const build = sandbox.stub(DockerHelper, 'buildImage')
-        .withArgs('/path/to/Dockerfile', 'registry.heroku.com/testapp/web', [], '/custom/context/path')
       const push = sandbox.stub(DockerHelper, 'pushImage')
         .withArgs('registry.heroku.com/testapp/web')
 
@@ -239,10 +241,15 @@ describe('container push', function () {
         'web',
       ])
 
+      const buildCallArgs = build.getCall(0).args[0]
+
       expect(stdout.output).to.contain('Building web (/path/to/Dockerfile)')
       expect(stdout.output).to.contain('Pushing web (/path/to/Dockerfile)')
       sandbox.assert.calledOnce(dockerfiles)
       sandbox.assert.calledOnce(build)
+      expect(buildCallArgs.dockerfile).to.equal('/path/to/Dockerfile')
+      expect(buildCallArgs.resource).to.equal('registry.heroku.com/testapp/web')
+      expect(buildCallArgs.path).to.equal('/custom/context/path')
       sandbox.assert.calledOnce(push)
     })
 

--- a/packages/cli/test/unit/lib/container/docker_helper.unit.test.ts
+++ b/packages/cli/test/unit/lib/container/docker_helper.unit.test.ts
@@ -215,4 +215,57 @@ describe('DockerHelper', function () {
       expect(eventStub.calledOnce).to.equal(true)
     })
   })
+
+  describe('.buildImage', function () {
+    const sandbox = sinon.createSandbox()
+
+    afterEach(function () {
+      return sandbox.restore()
+    })
+
+    it('does not include the platform flag when the arch is not arm64', async function () {
+      const argsArray = [
+        'build',
+        '-f',
+        'dockerfile',
+        '-t',
+        'registry.heroku.com/test-app/web',
+        '.',
+      ]
+
+      const eventStub = sandbox.stub(childProcess, 'spawn').callsFake(eventMock)
+
+      await DockerHelper.buildImage({
+        dockerfile: 'dockerfile',
+        resource: 'registry.heroku.com/test-app/web',
+        buildArgs: [],
+      })
+      const options = eventStub.getCall(0).args[2]
+      console.log(eventStub.getCall(0).args)
+      expect(eventStub.calledWith('docker', argsArray, options)).to.equal(true)
+    })
+
+    it('includes the platform flag when arch is arm64 (m1/m2 Macs)', async function () {
+      const argsArray = [
+        'build',
+        '-f',
+        'dockerfile',
+        '-t',
+        'registry.heroku.com/test-app/web',
+        '--platform',
+        'linux/amd64',
+        '.',
+      ]
+      const eventStub = sandbox.stub(childProcess, 'spawn').callsFake(eventMock)
+
+      await DockerHelper.buildImage({
+        dockerfile: 'dockerfile',
+        resource: 'registry.heroku.com/test-app/web',
+        buildArgs: [],
+        arch: 'arm64',
+      })
+      const options = eventStub.getCall(0).args[2]
+      expect(eventStub.calledWith('docker', argsArray, options)).to.equal(true)
+    })
+  })
 })


### PR DESCRIPTION
## Description
When we migrated the `container:push` command to oclif/core, we added a `--platform` flag that would be passed to Docker. We set it to equal `linux/amd64` because that would allow users using m1 or m2 Macs to push builds to Docker. However, that is causing problems for our users with older Docker applications that don't accept the `--platform` flag (#2967).

This PR adds logic that checks the user's architecture and then only adds the `--platform` flag if the architecture is `arm64`.

## Testing
Tests require to have a valid Dockerfile to build images, you can use the example app from [this Devcenter article](https://devcenter.heroku.com/articles/container-registry-and-runtime), but the Dockerfile might require a change on the dependencies installation command, adding the flag --break-system-packages to the pip3 install command.

- Pull down this branch and run `yarn && yarn build`
- Navigate to the directory where your Dockerfile lives
- Start Docker if you haven't already
- Run `<path_to_cli>/bin/run container:login` to login
- Run `<path_to_cli>/bin/run container:push`. You may have to add a `web` or `worker` arg depending on your Dockerfile.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
