### PR TITLE
fix(cli): fix missing dockerfile error

### DIFF
--- a/packages/cli/src/commands/container/push.ts
+++ b/packages/cli/src/commands/container/push.ts
@@ -79,11 +79,6 @@ export default class Push extends Command {
     const jobs = await selectJobs(possibleJobs, processTypes as string[], recursive)
 
     if (jobs.length === 0) {
-      if (processTypes.length > 0) {
-        for (const processType of processTypes) {
-          ux.warn(`Dockerfile.${processType} not found`)
-        }
-      }
       ux.error('No images to push', {exit: 1})
     }
 

--- a/packages/cli/src/commands/container/push.ts
+++ b/packages/cli/src/commands/container/push.ts
@@ -79,6 +79,11 @@ export default class Push extends Command {
     const jobs = await selectJobs(possibleJobs, processTypes as string[], recursive)
 
     if (jobs.length === 0) {
+      if (processTypes.length > 0) {
+        for (const processType of processTypes) {
+          ux.warn(`Dockerfile.${processType} not found`)
+        }
+      }
       ux.error('No images to push', {exit: 1})
     }
 

--- a/packages/cli/src/lib/container/docker_helper.ts
+++ b/packages/cli/src/lib/container/docker_helper.ts
@@ -4,6 +4,7 @@ import * as glob from 'glob'
 import * as Path from 'path'
 import * as inquirer from 'inquirer'
 import * as os from 'os'
+import {ux} from '@oclif/core'
 
 const DOCKERFILE_REGEX = /\bDockerfile(.\w*)?$/
 
@@ -140,6 +141,11 @@ export const chooseJobs = async function (jobs: groupedDockerJobs) {
   for (const processType in jobs) {
     if (Object.prototype.hasOwnProperty.call(jobs, processType)) {
       const group = jobs[processType]
+      if (group === undefined) {
+        ux.warn(`Dockerfile.${processType} not found`)
+        continue
+      }
+
       if (group.length > 1) {
         const prompt = [{
           type: 'list',


### PR DESCRIPTION
Fixes https://github.com/heroku/cli/issues/1420

### Description

This resolves a bug where if you specify multiple process types in `container:push --recursive` and one of those dockerfiles doesn't actually exist, you get a bad error.

### Testing

1. Pull down this branch and `yarn build`
2. Go to a directory where a docker-based app is set up
3. Have `Dockerfile.web` in the directory, but not `Dockerfile.worker`
4. run `$CLI_PATH/bin/run container:push web worker --recursive`
5. See warning message instead of error