### PR TITLE
feat(cli) created pg setting auto explain format

### DIFF
--- a/packages/cli/src/commands/pg/settings/auto-explain/log-format.ts
+++ b/packages/cli/src/commands/pg/settings/auto-explain/log-format.ts
@@ -1,0 +1,27 @@
+import {Args} from '@oclif/core'
+import {PGSettingsCommand} from '../../../../lib/pg/setter'
+import {Setting, SettingKey} from '../../../../lib/pg/types'
+import heredoc from 'tsheredoc'
+
+export default class LogFormat extends PGSettingsCommand {
+  static topic = 'pg'
+  static description = heredoc(`
+    Selects the EXPLAIN output format to be used.
+    The allowed values are text, xml, json, and yaml. The default is text.
+  `)
+
+  static args = {
+    database: Args.string(),
+    value: Args.string({options: ['text', 'json', 'yaml', 'xml']}),
+  }
+
+  protected settingKey: SettingKey = 'auto_explain.log_format'
+
+  protected explain(setting: Setting<string>) {
+    return `Auto explain log output will log in ${setting.value} format.`
+  }
+
+  protected convertValue(val: string): string {
+    return val
+  }
+}

--- a/packages/cli/src/commands/pg/settings/auto-explain/log-format.ts
+++ b/packages/cli/src/commands/pg/settings/auto-explain/log-format.ts
@@ -4,7 +4,6 @@ import {Setting, SettingKey} from '../../../../lib/pg/types'
 import heredoc from 'tsheredoc'
 
 export default class LogFormat extends PGSettingsCommand {
-  static topic = 'pg'
   static description = heredoc(`
     selects the EXPLAIN output format to be used
     The allowed values are text, xml, json, and yaml. The default is text.

--- a/packages/cli/src/commands/pg/settings/auto-explain/log-format.ts
+++ b/packages/cli/src/commands/pg/settings/auto-explain/log-format.ts
@@ -6,7 +6,7 @@ import heredoc from 'tsheredoc'
 export default class LogFormat extends PGSettingsCommand {
   static topic = 'pg'
   static description = heredoc(`
-    Selects the EXPLAIN output format to be used.
+    selects the EXPLAIN output format to be used
     The allowed values are text, xml, json, and yaml. The default is text.
   `)
 

--- a/packages/cli/src/lib/pg/types.ts
+++ b/packages/cli/src/lib/pg/types.ts
@@ -222,6 +222,7 @@ export type SettingKey =
   | 'auto_explain.log_buffers'
   | 'auto_explain.log_verbose'
   | 'auto_explain.log_nested_statements'
+  | 'auto_explain.log_format'
 export type Setting<T> = {
   value: T
   values: Record<string, string>

--- a/packages/cli/test/unit/commands/pg/settings/auto-explain/log-format.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/settings/auto-explain/log-format.unit.test.ts
@@ -1,0 +1,40 @@
+
+import {expect} from '@oclif/test'
+import * as nock from 'nock'
+import {stdout} from 'stdout-stderr'
+import heredoc from 'tsheredoc'
+import runCommand from '../../../../../helpers/runCommand'
+import Cmd from '../../../../../../src/commands/pg/settings/auto-explain/log-format'
+import * as fixtures from '../../../../../fixtures/addons/fixtures'
+
+describe('pg:settings:auto-explain:log-format', function () {
+  const addon = fixtures.addons['dwh-db']
+  let api: nock.Scope
+
+  beforeEach(function () {
+    api = nock('https://api.heroku.com')
+      .post('/actions/addons/resolve', {
+        app: 'myapp',
+        addon: 'test-database',
+      }).reply(200, [addon])
+  })
+
+  afterEach(function () {
+    nock.cleanAll()
+  })
+
+  it('updates settings for auto_explain.log_format with value', async function () {
+    const pg = nock('https://api.data.heroku.com')
+      .patch(`/postgres/v0/databases/${addon.id}/config`).reply(200, {'auto_explain.log_format': {value: 'json'}})
+
+    await runCommand(Cmd, ['--app', 'myapp', 'test-database', 'json'])
+
+    api.done()
+    pg.done()
+
+    expect(stdout.output).to.equal(heredoc(`
+      auto-explain.log-format has been set to json for ${addon.name}.
+      Auto explain log output will log in json format.
+    `))
+  })
+})


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

GUS item: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001yRu4CYAS/view

This change will allow the customer to set the auto explain format. To be released with work specified in https://salesforce.quip.com/LKrbARg3mg1g with an announcement. 

- CX Doc: https://docs.google.com/document/d/1qqqHjoFLrI2spkfjl8BTKEd0L49IBYuHlr3R3Cc5-oM/edit?pli=1#heading=h.2ac9dp6vi2kc


## set text
```
🕙[ 12:34:41 ] ❯ bin/run pg:settings:auto-explain:log-format postgresql-dbright-crystalline-65397 text -a brahyt-dev
auto-explain.log-format has been set to text for postgresql-dbright-crystalline-65397.
Auto explain log output will log in text format.


2024-08-26T19:36:22.000000+00:00 app[postgres.3188942]: [DBRIGHT_WHITE] [40-2]  Query Text: SELECT setting FROM pg_settings WHERE name = 'data_checksums'
2024-08-26T19:36:22.000000+00:00 app[postgres.3188942]: [DBRIGHT_WHITE] [40-3]  Function Scan on pg_catalog.pg_show_all_settings a  (cost=0.00..3.50 rows=5 width=32) (actual time=3.281..3.320 rows=1 loops=1)
2024-08-26T19:36:22.000000+00:00 app[postgres.3188942]: [DBRIGHT_WHITE] [40-4]    Output: a.setting
2024-08-26T19:36:22.000000+00:00 app[postgres.3188942]: [DBRIGHT_WHITE] [40-5]    Function Call: pg_show_all_settings()
2024-08-26T19:36:22.000000+00:00 app[postgres.3188942]: [DBRIGHT_WHITE] [40-6]    Filter: (a.name = 'data_checksums'::text)
2024-08-26T19:36:22.000000+00:00 app[postgres.3188942]: [DBRIGHT_WHITE] [40-7]    Rows Removed by Filter: 383
2024-08-26T19:36:22.000000+00:00 app[postgres.3188942]: [DBRIGHT_WHITE] [40-8]  Query Identifier: 2247467723989480173
```
## set json
```
🕙[ 12:34:49 ] ➜ bin/run pg:settings:auto-explain:log-format postgresql-dbright-crystalline-65397 json -a brahyt-dev
auto-explain.log-format has been set to json for postgresql-dbright-crystalline-65397.
Auto explain log output will log in json format.

2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-2]  {
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-3]    "Query Text": "SELECT setting FROM pg_settings WHERE name = 'data_checksums'",
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-4]    "Plan": {
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-5]      "Node Type": "Function Scan",
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-6]      "Parallel Aware": false,
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-7]      "Async Capable": false,
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-8]      "Function Name": "pg_show_all_settings",
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-9]      "Schema": "pg_catalog",
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-10]             "Alias": "a",
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-11]             "Startup Cost": 0.00,
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-12]             "Total Cost": 3.50,
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-13]             "Plan Rows": 5,
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-14]             "Plan Width": 32,
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-15]             "Actual Startup Time": 2.575,
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-16]             "Actual Total Time": 2.993,
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-17]             "Actual Rows": 1,
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-18]             "Actual Loops": 1,
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-19]             "Output": ["a.setting"],
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-20]             "Function Call": "pg_show_all_settings()",
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-21]             "Filter": "(a.name = 'data_checksums'::text)",
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-22]             "Rows Removed by Filter": 383
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-23]           },
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-24]           "Query Identifier": 2247467723989480173
2024-08-26T19:52:23.000000+00:00 app[postgres.3190672]: [DBRIGHT_WHITE] [42-25]         }
```

## set no option
```
🕙[ 12:52:34 ] ➜ bin/run pg:settings:auto-explain:log-format postgresql-dbright-crystalline-65397 -a brahyt-dev
auto-explain.log-format is set to json for postgresql-dbright-crystalline-65397.
Auto explain log output will log in json format.
```

## set wrong option
```
🕙[ 12:52:59 ] ➜ bin/run pg:settings:auto-explain:log-format postgresql-dbright-crystalline-65397 nope -a brahyt-dev
 ›   Error: Expected nope to be one of: text, json, yaml, xml
 ›   See more help with --help
```

## help
```
🕙[ 12:53:35 ] ❯ bin/run pg:settings:auto-explain:log-format postgresql-dbright-crystalline-65397 -h -a brahyt-dev
Selects the EXPLAIN output format to be used.

USAGE
  $ heroku pg:settings:auto-explain:log-format [DATABASE] [VALUE] -a <value> [-r <value>]

FLAGS
  -a, --app=<value>     (required) app to run command against
  -r, --remote=<value>  git remote of app to use

DESCRIPTION
  Selects the EXPLAIN output format to be used.
  The allowed values are text, xml, json, and yaml. The default is text.

```
