### PR TITLE
feat(cli) created pg setting for log min error statements

### DIFF
--- a/packages/cli/src/commands/pg/settings/log-min-error-statement.ts
+++ b/packages/cli/src/commands/pg/settings/log-min-error-statement.ts
@@ -1,0 +1,27 @@
+import {Args} from '@oclif/core'
+import heredoc from 'tsheredoc'
+import {PGSettingsCommand} from '../../../lib/pg/setter'
+import type {Setting, SettingKey} from '../../../lib/pg/types'
+
+export default class LogMinErrorStatement extends PGSettingsCommand {
+  static description = heredoc(`
+    log-min-error-statement controls the logging of SQL statements that cause an error at a specified severity level.
+    This setting is useful to prevent logging SQL queries that might contain sensitive information.
+    Use this setting to prevent logging SQL queries that contain sensitive information. Default is "error".
+  `)
+
+  static args = {
+    database: Args.string(),
+    value: Args.string({options: ['error', 'log', 'fatal', 'panic']}),
+  }
+
+  protected settingKey: SettingKey = 'log_min_error_statement'
+
+  protected convertValue(val: string): string {
+    return val
+  }
+
+  protected explain(setting: Setting<string>) {
+    return setting.values[setting.value]
+  }
+}

--- a/packages/cli/src/lib/pg/types.ts
+++ b/packages/cli/src/lib/pg/types.ts
@@ -210,6 +210,7 @@ export type SettingKey =
   'log_lock_waits'
   | 'log_connections'
   | 'log_min_duration_statement'
+  | 'log_min_error_statement'
   | 'log_statement'
   | 'track_functions'
   | 'pgbouncer_max_client_conn'

--- a/packages/cli/test/unit/commands/pg/settings/log-min-error-statement.test.ts
+++ b/packages/cli/test/unit/commands/pg/settings/log-min-error-statement.test.ts
@@ -1,0 +1,47 @@
+import {expect} from '@oclif/test'
+import * as nock from 'nock'
+import {stdout} from 'stdout-stderr'
+import heredoc from 'tsheredoc'
+import runCommand from '../../../../helpers/runCommand'
+import Cmd from '../../../../../src/commands/pg/settings/log-min-error-statement'
+import * as fixtures from '../../../../fixtures/addons/fixtures'
+
+describe('pg:settings:log-min-error-statement', function () {
+  const addon = fixtures.addons['dwh-db']
+
+  beforeEach(function () {
+    nock('https://api.heroku.com')
+      .post('/actions/addons/resolve', {
+        app: 'myapp',
+        addon: 'test-database',
+      }).reply(200, [addon])
+  })
+
+  afterEach(function () {
+    nock.cleanAll()
+  })
+
+  it('shows settings for log_min_error_statement', async function () {
+    nock('https://api.data.heroku.com')
+      .get(`/postgres/v0/databases/${addon.id}/config`)
+      .reply(200, {
+        log_min_error_statement: {
+          value: 'error',
+          desc: 'Specify the minimum severity level of SQL errors to be logged.',
+          default: 'error',
+          values: {
+            error: 'Logs all ERROR, LOG, FATAL, and PANIC level messages. (Default)',
+            log: 'Logs all LOG, FATAL, and PANIC level messages.',
+            fatal: 'Logs all FATAL and PANIC level messages.',
+            panic: 'Logs only PANIC level messages.',
+          },
+        },
+      })
+
+    await runCommand(Cmd, ['--app', 'myapp', 'test-database'])
+    expect(stdout.output).to.equal(heredoc(`
+      log-min-error-statement is set to error for ${addon.name}.
+      Logs all ERROR, LOG, FATAL, and PANIC level messages. (Default)
+    `))
+  })
+})


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

- CX Doc: https://docs.google.com/document/d/1qqqHjoFLrI2spkfjl8BTKEd0L49IBYuHlr3R3Cc5-oM/edit?pli=1#heading=h.2ac9dp6vi2kc
- GUS: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001zR98CYAS/view

## No option
```
🕙[ 13:15:59 ] ➜ bin/run pg:settings:log-min-error-statement postgresql-dbright-crystalline-65397 -a brahyt-dev

log-min-error-statement is set to error for postgresql-dbright-crystalline-65397.
Logs all ERROR, LOG, FATAL, and PANIC level messages. (Default)
```

## set panic
```
🕙[ 13:16:06 ] ➜ bin/run pg:settings:log-min-error-statement postgresql-dbright-crystalline-65397 panic -a brahyt-dev

log-min-error-statement has been set to panic for postgresql-dbright-crystalline-65397.
Logs only PANIC level messages.
----psql----
dfmiscmbm6bodf=> select 1/0;
ERROR:  division by zero
dfmiscmbm6bodf=> select 1/0;
ERROR:  division by zero
dfmiscmbm6bodf=> select 1/0;
ERROR:  division by zero
----psql----

----heroku logs----
2024-08-26T20:18:43.000000+00:00 app[postgres.2487360]: [DBRIGHT_WHITE] [65-1]  sql_error_code = 22012 time_ms = "2024-08-26 20:18:43.325 UTC" pid="2539221" proc_start_time="2024-08-26 20:14:17 UTC" session_id="66cce219.26bed5" vtid="5/4552982" tid="0" log_line="21" database="dfmiscmbm6bodf" connection_source="13.110.54.12(17504)" user="u9ugv49trmjt9a" application_name="psql" ERROR:  division by zero
2024-08-26T20:18:43.000000+00:00 app[postgres.2487360]: [DBRIGHT_WHITE] [66-1]  sql_error_code = 22012 time_ms = "2024-08-26 20:18:43.598 UTC" pid="2539221" proc_start_time="2024-08-26 20:14:17 UTC" session_id="66cce219.26bed5" vtid="5/4552983" tid="0" log_line="22" database="dfmiscmbm6bodf" connection_source="13.110.54.12(17504)" user="u9ugv49trmjt9a" application_name="psql" ERROR:  division by zero
2024-08-26T20:18:43.000000+00:00 app[postgres.2487360]: [DBRIGHT_WHITE] [67-1]  sql_error_code = 22012 time_ms = "2024-08-26 20:18:43.841 UTC" pid="2539221" proc_start_time="2024-08-26 20:14:17 UTC" session_id="66cce219.26bed5" vtid="5/4552984" tid="0" log_line="23" database="dfmiscmbm6bodf" connection_source="13.110.54.12(17504)" user="u9ugv49trmjt9a" application_name="psql" ERROR:  division by zero
----heroku logs----
```

## set error
```
🕙[ 13:18:12 ] ➜ bin/run pg:settings:log-min-error-statement postgresql-dbright-crystalline-65397 error -a brahyt-dev

log-min-error-statement has been set to error for postgresql-dbright-crystalline-65397.
Logs all ERROR, LOG, FATAL, and PANIC level messages. (Default)

----psql----
dfmiscmbm6bodf=> select 1/0;
ERROR:  division by zero
dfmiscmbm6bodf=> select 1/0;
ERROR:  division by zero
dfmiscmbm6bodf=> select 1/0;
ERROR:  division by zero
----

----heroku logs----
2024-08-26T20:20:32.000000+00:00 app[postgres.2487360]: [DBRIGHT_WHITE] [73-1]  sql_error_code = 22012 time_ms = "2024-08-26 20:20:32.224 UTC" pid="2539221" proc_start_time="2024-08-26 20:14:17 UTC" session_id="66cce219.26bed5" vtid="5/4552990" tid="0" log_line="30" database="dfmiscmbm6bodf" connection_source="13.110.54.12(17504)" user="u9ugv49trmjt9a" application_name="psql" ERROR:  division by zero
2024-08-26T20:20:32.000000+00:00 app[postgres.2487360]: [DBRIGHT_WHITE] [73-2]  sql_error_code = 22012 time_ms = "2024-08-26 20:20:32.224 UTC" pid="2539221" proc_start_time="2024-08-26 20:14:17 UTC" session_id="66cce219.26bed5" vtid="5/4552990" tid="0" log_line="31" database="dfmiscmbm6bodf" connection_source="13.110.54.12(17504)" user="u9ugv49trmjt9a" application_name="psql" STATEMENT:  select 1/0;
2024-08-26T20:20:32.000000+00:00 app[postgres.2487360]: [DBRIGHT_WHITE] [74-1]  sql_error_code = 22012 time_ms = "2024-08-26 20:20:32.591 UTC" pid="2539221" proc_start_time="2024-08-26 20:14:17 UTC" session_id="66cce219.26bed5" vtid="5/4552991" tid="0" log_line="32" database="dfmiscmbm6bodf" connection_source="13.110.54.12(17504)" user="u9ugv49trmjt9a" application_name="psql" ERROR:  division by zero
2024-08-26T20:20:32.000000+00:00 app[postgres.2487360]: [DBRIGHT_WHITE] [74-2]  sql_error_code = 22012 time_ms = "2024-08-26 20:20:32.591 UTC" pid="2539221" proc_start_time="2024-08-26 20:14:17 UTC" session_id="66cce219.26bed5" vtid="5/4552991" tid="0" log_line="33" database="dfmiscmbm6bodf" connection_source="13.110.54.12(17504)" user="u9ugv49trmjt9a" application_name="psql" STATEMENT:  select 1/0;
2024-08-26T20:20:32.000000+00:00 app[postgres.2487360]: [DBRIGHT_WHITE] [75-1]  sql_error_code = 22012 time_ms = "2024-08-26 20:20:32.990 UTC" pid="2539221" proc_start_time="2024-08-26 20:14:17 UTC" session_id="66cce219.26bed5" vtid="5/4552992" tid="0" log_line="34" database="dfmiscmbm6bodf" connection_source="13.110.54.12(17504)" user="u9ugv49trmjt9a" application_name="psql" ERROR:  division by zero
2024-08-26T20:20:32.000000+00:00 app[postgres.2487360]: [DBRIGHT_WHITE] [75-2]  sql_error_code = 22012 time_ms = "2024-08-26 20:20:32.990 UTC" pid="2539221" proc_start_time="2024-08-26 20:14:17 UTC" session_id="66cce219.26bed5" vtid="5/4552992" tid="0" log_line="35" database="dfmiscmbm6bodf" connection_source="13.110.54.12(17504)" user="u9ugv49trmjt9a" application_name="psql" STATEMENT:  select 1/0;
----heroku logs----
```

## help
```
🕙[ 13:18:02 ] ❯ bin/run pg:settings:log-min-error-statement postgresql-dbright-crystalline-65397 -h -a brahyt-dev

log_min_error_statement controls the logging of SQL statements that cause an error of at least the specified severity level.

USAGE
  $ heroku pg:settings:log-min-error-statement [DATABASE] [VALUE] -a <value> [-r <value>]

FLAGS
  -a, --app=<value>     (required) app to run command against
  -r, --remote=<value>  git remote of app to use

DESCRIPTION
  log_min_error_statement controls the logging of SQL statements that cause an error of at least the specified severity level.
  This setting is useful to prevent logging SQL queries that might contain sensitive information.
  The valid values for log_min_error_statement are: error, log, fatal and panic.
```

## 