### PR TITLE
feat(cli) add explain postgres data connectors setting

### DIFF
--- a/packages/cli/src/commands/pg/settings/explain-data-connector-details.ts
+++ b/packages/cli/src/commands/pg/settings/explain-data-connector-details.ts
@@ -5,9 +5,8 @@ import {type BooleanAsString, booleanConverter, PGSettingsCommand} from '../../.
 import type {Setting, SettingKey} from '../../../lib/pg/types'
 
 export default class ExplainDataConnectorDetails extends PGSettingsCommand {
-  static topic = 'pg'
   static description = heredoc(`
-  Displays stats on replication slots on your database. The default value is "off".
+  displays stats on replication slots on your database, the default value is "off"
   `)
 
   static flags = {

--- a/packages/cli/src/commands/pg/settings/explain-data-connector-details.ts
+++ b/packages/cli/src/commands/pg/settings/explain-data-connector-details.ts
@@ -1,0 +1,36 @@
+import {flags} from '@heroku-cli/command'
+import {Args} from '@oclif/core'
+import heredoc from 'tsheredoc'
+import {type BooleanAsString, booleanConverter, PGSettingsCommand} from '../../../lib/pg/setter'
+import type {Setting, SettingKey} from '../../../lib/pg/types'
+
+export default class ExplainDataConnectorDetails extends PGSettingsCommand {
+  static topic = 'pg'
+  static description = heredoc(`
+  Displays stats on replication slots on your database. The default value is "off".
+  `)
+
+  static flags = {
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+  }
+
+  static args = {
+    database: Args.string(),
+    value: Args.string(),
+  }
+
+  protected settingKey:SettingKey = 'explain_data_connector_details'
+
+  protected convertValue(val: BooleanAsString): boolean {
+    return booleanConverter(val)
+  }
+
+  protected explain(setting: Setting<boolean>): string {
+    if (setting?.value) {
+      return 'Data replication slot details will be logged.'
+    }
+
+    return 'Data replication slot details will no longer be logged.'
+  }
+}

--- a/packages/cli/src/lib/pg/types.ts
+++ b/packages/cli/src/lib/pg/types.ts
@@ -215,6 +215,7 @@ export type SettingKey =
   | 'pgbouncer_max_client_conn'
   | 'pg_bouncer_max_db_conns'
   | 'pg_bouncer_default_pool_size'
+  | 'explain_data_connector_details'
   | 'auto_explain'
   | 'auto_explain.log_min_duration'
   | 'auto_explain.log_analyze'

--- a/packages/cli/test/unit/commands/pg/settings/explain-data-connector-details.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/settings/explain-data-connector-details.unit.test.ts
@@ -1,0 +1,43 @@
+import {expect} from '@oclif/test'
+import * as nock from 'nock'
+import {stdout} from 'stdout-stderr'
+import heredoc from 'tsheredoc'
+import runCommand from '../../../../helpers/runCommand'
+import Cmd from '../../../../../src/commands/pg/settings/explain-data-connector-details'
+import * as fixtures from '../../../../fixtures/addons/fixtures'
+
+describe('pg:explain-data-connector-details', function () {
+  const addon = fixtures.addons['dwh-db']
+
+  beforeEach(function () {
+    nock('https://api.heroku.com')
+      .post('/actions/addons/resolve', {
+        app: 'myapp',
+        addon: 'test-database',
+      }).reply(200, [addon])
+  })
+
+  afterEach(function () {
+    nock.cleanAll()
+  })
+
+  it('turns on explain-data-connector-details option', async function () {
+    nock('https://api.data.heroku.com')
+      .get(`/postgres/v0/databases/${addon.id}/config`).reply(200, {explain_data_connector_details: {value: 'on'}})
+    await runCommand(Cmd, ['--app', 'myapp', 'test-database'])
+    expect(stdout.output).to.equal(heredoc(`
+      explain-data-connector-details is set to on for ${addon.name}.
+      Data replication slot details will be logged.
+    `))
+  })
+
+  it('turns off explain-data-connector-details option', async function () {
+    nock('https://api.data.heroku.com')
+      .get(`/postgres/v0/databases/${addon.id}/config`).reply(200, {explain_data_connector_details: {value: ''}})
+    await runCommand(Cmd, ['--app', 'myapp', 'test-database'])
+    expect(stdout.output).to.equal(heredoc(`
+      explain-data-connector-details is set to  for ${addon.name}.
+      Data replication slot details will no longer be logged.
+    `))
+  })
+})


### PR DESCRIPTION
<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
- [x] CX verbiage
- CX Doc: https://docs.google.com/document/d/1qqqHjoFLrI2spkfjl8BTKEd0L49IBYuHlr3R3Cc5-oM/edit?pli=1#heading=h.2ac9dp6vi2kc
- GUS: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000020B0xzYAC/view
## help
```
🕙[ 14:05:55 ] ➜ bin/run pg:settings:explain-data-connector-details postgresql-dbright-lively-63921 -h -a brahyt-dev-private
UNICORN, do things

USAGE
  $ heroku pg:settings:explain-data-connector-details [DATABASE] [VALUE] -a <value> [-r <value>]

FLAGS
  -a, --app=<value>     (required) app to run command against
  -r, --remote=<value>  git remote of app to use

DESCRIPTION
  UNICORN, do things
```

## set on
```
🕙[ 14:05:32 ] ➜ bin/run pg:settings:explain-data-connector-details postgresql-dbright-lively-63921 on -a brahyt-dev-private
explain-data-connector-details has been set to true for postgresql-dbright-lively-63921.
SETTING ON DOES THINGS
```

```
2024-08-26T21:06:46.000000+00:00 app[heroku-postgres-replication-slot]: addon=polite-connector-37391 sample#spill_bytes=0 sample#spill_count=0 sample#spill_txns=0 sample#stats_reset_time=0001-01-01T00:00:00Z sample#stream_bytes=0 sample#stream_count=0 sample#stream_txns=0 sample#total_bytes=36835796 sample#total_txns=120160
```

## set off
```
🕙[ 14:06:52 ] ➜ bin/run pg:settings:explain-data-connector-details postgresql-dbright-lively-63921 off -a brahyt-dev-private
explain-data-connector-details has been set to false for postgresql-dbright-lively-63921.
SETTING OFF DOES THINGS
```
no logs for connector details

## pg settings help index
```
🕙[ 14:08:46 ] ➜ bin/run pg:settings -h
show your current database settings

USAGE
  $ heroku pg:settings [DATABASE] -a <value> [-r <value>]

FLAGS
  -a, --app=<value>     (required) app to run command against
  -r, --remote=<value>  git remote of app to use

DESCRIPTION
  show your current database settings

TOPICS
  pg:settings:auto-explain  Automatically log execution plans of queries without running EXPLAIN by hand.

COMMANDS
  pg:settings:auto-explain                    Automatically log execution plans of queries without running EXPLAIN by hand.
  pg:settings:explain-data-connector-details  UNICORN, do things
  pg:settings:log-connections                 Controls whether a log message is produced when a login attempt is made. Default is true.
  pg:settings:log-lock-waits                  Controls whether a log message is produced when a session waits longer than the deadlock_timeout to acquire a lock. deadlock_timeout is set to 1
                                              second
  pg:settings:log-min-duration-statement      The duration of each completed statement will be logged if the statement completes after the time specified by VALUE.
  pg:settings:log-statement                   log_statement controls which SQL statements are logged.
  pg:settings:track-functions                 track_functions controls tracking of function call counts and time used. Default is none.
```