### PR TITLE
Fix(run): arguments are incorrectly gathered leading to duplicates

### DIFF
--- a/packages/cli/src/commands/local/run.ts
+++ b/packages/cli/src/commands/local/run.ts
@@ -2,7 +2,6 @@ import {FileCompletion} from '@heroku-cli/command/lib/completions'
 import {Command, Flags} from '@oclif/core'
 import color from '@heroku-cli/color'
 import {fork as foreman} from '../../lib/local/fork-foreman'
-import {revertSortedArgs} from '../../lib/run/helpers'
 import * as fs from 'fs'
 
 export default class Run extends Command {
@@ -27,9 +26,10 @@ export default class Run extends Command {
   async run() {
     const execArgv: string[] = ['run']
     const {argv, flags} = await this.parse(Run)
-    const userArgvInputOrder = revertSortedArgs(process.argv, argv as string[])
+    const maybeOptionsIndex = process.argv.indexOf('--')
+    const commandArgs = (maybeOptionsIndex === -1 ? argv : process.argv.slice(maybeOptionsIndex + 1)) as string[]
 
-    if (userArgvInputOrder.length === 0) {
+    if (commandArgs.length === 0) {
       const errorMessage = 'Usage: heroku local:run [COMMAND]\nMust specify command to run'
       this.error(errorMessage, {exit: -1})
     }
@@ -44,7 +44,7 @@ export default class Run extends Command {
     if (flags.port) execArgv.push('--port', flags.port)
 
     execArgv.push('--') // disable node-foreman flag parsing
-    execArgv.push(...userArgvInputOrder as string[]) // eslint-disable-line unicorn/no-array-push-push
+    execArgv.push(...commandArgs as string[]) // eslint-disable-line unicorn/no-array-push-push
 
     await foreman(execArgv)
   }

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -4,7 +4,7 @@ import {ux} from '@oclif/core'
 import debugFactory from 'debug'
 import * as Heroku from '@heroku-cli/schema'
 import Dyno from '../../lib/run/dyno'
-import {buildCommand, revertSortedArgs} from '../../lib/run/helpers'
+import {buildCommand} from '../../lib/run/helpers'
 
 const debug = debugFactory('heroku:run')
 
@@ -33,14 +33,14 @@ export default class Run extends Command {
 
   async run() {
     const {argv, flags} = await this.parse(Run)
-    const userArgvInputOrder = revertSortedArgs(process.argv, argv as string[])
-
+    const maybeOptionsIndex = process.argv.indexOf('--')
+    const command = buildCommand((maybeOptionsIndex === -1 ? argv : process.argv.slice(maybeOptionsIndex + 1)) as string[])
     const opts = {
       'exit-code': flags['exit-code'],
       'no-tty': flags['no-tty'],
       app: flags.app,
       attach: true,
-      command: buildCommand(userArgvInputOrder as string[]),
+      command,
       env: flags.env,
       heroku: this.heroku,
       listen: flags.listen,

--- a/packages/cli/src/lib/run/helpers.ts
+++ b/packages/cli/src/lib/run/helpers.ts
@@ -1,20 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import {ux} from '@oclif/core'
 
-// this function exists because oclif sorts argv
-export function revertSortedArgs(processArgs: Array<string>, argv: Array<string>) {
-  const originalInputOrder = []
-
-  // this reorders the arguments in the order the user inputted
-  for (const processArg of processArgs) {
-    if (argv.includes(processArg)) {
-      originalInputOrder.push(processArg)
-    }
-  }
-
-  return originalInputOrder
-}
-
 export function buildCommand(args: Array<string>) {
   if (args.length === 1) {
     // do not add quotes around arguments if there is only one argument

--- a/packages/cli/test/integration/run.integration.test.ts
+++ b/packages/cli/test/integration/run.integration.test.ts
@@ -1,5 +1,4 @@
 import {expect, test} from '@oclif/test'
-import * as runHelper from '../../src/lib/run/helpers'
 import {unwrap} from '../helpers/utils/unwrap'
 
 const testFactory = () => {
@@ -14,35 +13,30 @@ const testFactory = () => {
 
 describe('run', function () {
   testFactory()
-    .stub(runHelper, 'revertSortedArgs', () => ['echo 1 2 3'])
     .command(['run', '--app=heroku-cli-ci-smoke-test-app', 'echo 1 2 3'])
     .it('runs a command', async ctx => {
       expect(ctx.stdout).to.include('1 2 3')
     })
 
   testFactory()
-    .stub(runHelper, 'revertSortedArgs', () => ['ruby -e "puts ARGV[0]" "{"foo": "bar"} " '])
     .command(['run', '--app=heroku-cli-ci-smoke-test-app', 'ruby -e "puts ARGV[0]" "{"foo": "bar"} " '])
     .it('runs a command with spaces', ctx => {
       expect(unwrap(ctx.stdout)).to.contain('{foo: bar}')
     })
 
   testFactory()
-    .stub(runHelper, 'revertSortedArgs', () => ['{foo:bar}'])
     .command(['run', '--app=heroku-cli-ci-smoke-test-app', 'ruby -e "puts ARGV[0]" "{"foo":"bar"}"'])
     .it('runs a command with quotes', ctx => {
       expect(ctx.stdout).to.contain('{foo:bar}')
     })
 
   testFactory()
-    .stub(runHelper, 'revertSortedArgs', () => ['-e FOO=bar', 'env'])
     .command(['run', '--app=heroku-cli-ci-smoke-test-app', '-e FOO=bar', 'env'])
     .it('runs a command with env vars', ctx => {
       expect(unwrap(ctx.stdout)).to.include('FOO=bar')
     })
 
   testFactory()
-    .stub(runHelper, 'revertSortedArgs', () => ['invalid-command command not found'])
     .command(['run', '--app=heroku-cli-ci-smoke-test-app', '--exit-code', 'invalid-command'])
     .exit(127)
     .it('gets 127 status for invalid command', ctx => {


### PR DESCRIPTION
This PR fixes and issue with the `run` command where arguments after the `--` which collide with the command flag names are duplicated leading to errors.

e.g. `heroku run -e DOMAIN=test -- ruby -e 'puts ENV["ENV_KEY"]'` <-- '-e' is a collision with the command flag alias for `env` and is duplicated and sent to the Dyno by mistake.

**NOTE**: Reverting the sorted args is no longer needed since a direct slice from the `process.argv` is performed. This operation has been removed.