### PR TITLE
chore: re-enable CLI command docs auto-update

### DIFF
--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -55,3 +55,10 @@ jobs:
       isStableRelease: ${{ fromJSON(needs.get-version-channel.outputs.isStableRelease) }}
       channel: ${{ needs.get-version-channel.outputs.channel }}
     secrets: inherit
+
+  publish-docs:
+    needs: [ promote ]
+    uses: ./.github/workflows/devcenter-doc-update.yml
+    with:
+      isStableRelease: ${{ fromJSON(needs.get-version-channel.outputs.isStableRelease) }}
+    secrets: inherit

--- a/.github/workflows/devcenter-doc-update.yml
+++ b/.github/workflows/devcenter-doc-update.yml
@@ -7,12 +7,36 @@ on:
 jobs:
   update-devcenter-command-docs:
     name: Update Devcenter command docs
-    runs-on: pub-hk-ubuntu-22.04-small
+    runs-on: ubuntu-latest
+    environment: SignDebian
     steps:
       - uses: actions/checkout@v3
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: yarn
+      - name: Install Ruby
+        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+        with:
+          ruby-version: '3.1'
       - name: Install package deps
         run: yarn --immutable --network-timeout 1000000
       - name: Install Devcenter CLI
         run: |
           gem install devcenter
           devcenter help
+      - name: Build CLI
+        run: yarn build
+      - name: Compile documentation and push to devcenter
+        run: |
+          cd packages/cli
+          ./scripts/postrelease/dev_center_docs
+        env:
+          HEROKU_DEB_SECRET_KEY: ${{ secrets.HEROKU_DEB_SECRET_KEY }}
+          HEROKU_DEVCENTER_API_KEY: ${{ secrets.HEROKU_DEVCENTER_API_KEY }}
+      - name: Upload md file as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: heroku-cli-commands
+          path: /tmp/heroku-cli-commands.md

--- a/.github/workflows/devcenter-doc-update.yml
+++ b/.github/workflows/devcenter-doc-update.yml
@@ -8,7 +8,6 @@ jobs:
   update-devcenter-command-docs:
     name: Update Devcenter command docs
     runs-on: ubuntu-latest
-    environment: SignDebian
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 16.x
@@ -33,7 +32,6 @@ jobs:
           cd packages/cli
           ./scripts/postrelease/dev_center_docs
         env:
-          HEROKU_DEB_SECRET_KEY: ${{ secrets.HEROKU_DEB_SECRET_KEY }}
           HEROKU_DEVCENTER_API_KEY: ${{ secrets.HEROKU_DEVCENTER_API_KEY }}
       - name: Upload md file as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/devcenter-doc-update.yml
+++ b/.github/workflows/devcenter-doc-update.yml
@@ -2,12 +2,25 @@ name: Update CLI Command DevCenter Documentation
 
 on:
   workflow_dispatch:
+    inputs:
+      isStableRelease:
+        type: boolean
+        description: Is this a stable/prod release?
+        required: true
+        default: false
   workflow_call:
+    inputs:
+      isStableRelease:
+        type: boolean
+        description: Is this a stable/prod release?
+        required: true
+        default: false
 
 jobs:
   update-devcenter-command-docs:
     name: Update Devcenter command docs
     runs-on: ubuntu-latest
+    if: fromJSON(inputs.isStableRelease)
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 16.x

--- a/scripts/postrelease/dev_center_docs
+++ b/scripts/postrelease/dev_center_docs
@@ -39,4 +39,3 @@ oclif readme --no-aliases
 grep -v "^\\* \\[\`" README.md | grep -v "^<!--" | sed "s/^## \`/### \`/g" > /tmp/heroku-cli-commands.md
 cat /tmp/heroku-cli-commands.md
 git checkout README.md
-devcenter push /tmp/heroku-cli-commands.md --trace

--- a/scripts/postrelease/dev_center_docs
+++ b/scripts/postrelease/dev_center_docs
@@ -4,7 +4,9 @@
 
 set +x
 
-if [[ -z "${CIRCLE_TAG}" ]]; then
+PACKAGE_VERSION=`node -e "console.log(require('./package.json').version)"`
+
+if [[ "${PACKAGE_VERSION}" == *"-"* ]]; then
   echo "Not on stable release, skipping devcenter docs update"
   exit
 fi
@@ -34,6 +36,7 @@ These are the help texts for each of the core Heroku CLI commands. You can also 
 <!-- commands -->
 EOF
 oclif readme --no-aliases
-grep -v "^\\* \\[\`" README.md | grep -v "^<!--" | sed "s/^## \`/### \`/g" | sed "/_See\ code\:/d" > /tmp/heroku-cli-commands.md
+grep -v "^\\* \\[\`" README.md | grep -v "^<!--" | sed "s/^## \`/### \`/g" > /tmp/heroku-cli-commands.md
+cat /tmp/heroku-cli-commands.md
 git checkout README.md
 devcenter push /tmp/heroku-cli-commands.md --trace

--- a/scripts/postrelease/dev_center_docs
+++ b/scripts/postrelease/dev_center_docs
@@ -14,7 +14,7 @@ fi
 echo "$HEROKU_DEB_SECRET_KEY" | base64 -d | gpg --import
 cat << EOF > ~/.netrc
 machine api.heroku.com
-  login me@example.com
+  login heroku-cli@salesforce.com
   password $HEROKU_DEVCENTER_API_KEY
 EOF
 chmod 0600 ~/.netrc
@@ -23,7 +23,6 @@ set -ex
 export PATH="./node_modules/.bin:./bin:$PATH"
 export COLUMNS=80
 
-yarn
 run whoami
 cat <<EOF > README.md
 ---

--- a/scripts/postrelease/dev_center_docs
+++ b/scripts/postrelease/dev_center_docs
@@ -37,3 +37,4 @@ oclif readme --no-aliases
 grep -v "^\\* \\[\`" README.md | grep -v "^<!--" | sed "s/^## \`/### \`/g" > /tmp/heroku-cli-commands.md
 cat /tmp/heroku-cli-commands.md
 git checkout README.md
+devcenter push /tmp/heroku-cli-commands.md --trace

--- a/scripts/postrelease/dev_center_docs
+++ b/scripts/postrelease/dev_center_docs
@@ -31,7 +31,7 @@ title: Heroku CLI Commands
 id: 4088
 
 
-These are the help texts for each of the core Heroku CLI commands. You can also see this text in your terminal with \`heroku help \`, \`heroku --help\`, or \`heroku -h\`.
+These are the help texts for each of the core Heroku CLI commands. You can also see this text in your terminal with heroku help, heroku --help, or heroku -h.
 
 <!-- commands -->
 EOF

--- a/scripts/postrelease/dev_center_docs
+++ b/scripts/postrelease/dev_center_docs
@@ -11,7 +11,6 @@ if [[ "${PACKAGE_VERSION}" == *"-"* ]]; then
   exit
 fi
 
-echo "$HEROKU_DEB_SECRET_KEY" | base64 -d | gpg --import
 cat << EOF > ~/.netrc
 machine api.heroku.com
   login heroku-cli@salesforce.com

--- a/scripts/postrelease/dev_center_docs
+++ b/scripts/postrelease/dev_center_docs
@@ -29,12 +29,11 @@ title: Heroku CLI Commands
 id: 4088
 
 
-These are the help texts for each of the core Heroku CLI commands. You can also see this text in your terminal with heroku help, heroku --help, or heroku -h.
+These are the help texts for each of the core Heroku CLI commands. You can also see this text in your terminal with \`heroku help\`, \`heroku --help\`, or \`heroku -h\`.
 
 <!-- commands -->
 EOF
 oclif readme --no-aliases
 grep -v "^\\* \\[\`" README.md | grep -v "^<!--" | sed "s/^## \`/### \`/g" > /tmp/heroku-cli-commands.md
-cat /tmp/heroku-cli-commands.md
 git checkout README.md
 devcenter push /tmp/heroku-cli-commands.md --trace


### PR DESCRIPTION
This PR re-enables the automation for updating the [CLI command docs](https://devcenter.heroku.com/articles/heroku-cli-commands) on Devcenter. I have tested it by [running the workflow manually](https://devcenter.heroku.com/admin/articles/diff/4088/v205..v206) and it worked great.

[Internal work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001YgOGhYAN/view)

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
