### PR TITLE
fix: add ARCH=arm64 to install script

### DIFF
--- a/install-standalone.sh
+++ b/install-standalone.sh
@@ -36,6 +36,8 @@
     ARCH=x64
   elif [[ "\$ARCH" == aarch* ]]; then
     ARCH=arm
+  elif [[ "\$ARCH" == "arm64" ]]; then
+    ARCH=arm64
   else
     echoerr "unsupported arch: \$ARCH"
     exit 1


### PR DESCRIPTION
Don't know if anything else is needed here, but this fixes the issue described in #1963 where the install script doesn't work on an M1 Mac even though the tarballs exist now.