### PR TITLE
chore: add get-version-channel to needs in publish-docs job

### DIFF
--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -57,7 +57,7 @@ jobs:
     secrets: inherit
 
   publish-docs:
-    needs: [ promote ]
+    needs: [ get-version-channel, promote ]
     uses: ./.github/workflows/devcenter-doc-update.yml
     with:
       isStableRelease: ${{ fromJSON(needs.get-version-channel.outputs.isStableRelease) }}


### PR DESCRIPTION
Adds the `get-version-channel` job to the `needs` array in the `publish-docs` job.


<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
