### PR TITLE
fix: fix logic for publish-docs job

### DIFF
--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -60,5 +60,5 @@ jobs:
     needs: [ get-version-channel, promote ]
     uses: ./.github/workflows/devcenter-doc-update.yml
     with:
-      isStableRelease: ${{ fromJSON(needs.get-version-channel.outputs.isStableRelease) }}
+      isStableRelease: ${{ needs.get-version-channel.outputs.isStableRelease }}
     secrets: inherit


### PR DESCRIPTION
This is a potential fix for the publish-docs job being skipped in the [9.3.0 release](https://github.com/heroku/cli/actions/runs/11022514759).


<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
