### PR TITLE
feat: add generation column to spaces command

### DIFF
--- a/packages/cli/src/commands/spaces/index.ts
+++ b/packages/cli/src/commands/spaces/index.ts
@@ -1,9 +1,9 @@
 import color from '@heroku-cli/color'
 import {Command, flags as Flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
-import {FirSpace} from '../../lib/types/fir'
+import {Space} from '../../lib/types/fir'
 
-type SpaceArray = Array<Required<FirSpace>>
+type SpaceArray = Array<Required<Space>>
 
 export default class Index extends Command {
   static topic = 'spaces'

--- a/packages/cli/src/commands/spaces/index.ts
+++ b/packages/cli/src/commands/spaces/index.ts
@@ -1,9 +1,9 @@
 import color from '@heroku-cli/color'
 import {Command, flags as Flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
-import * as Heroku from '@heroku-cli/schema'
+import {FirSpace} from '../../lib/types/fir'
 
-type SpaceArray = Array<Required<Heroku.Space>>
+type SpaceArray = Array<Required<FirSpace>>
 
 export default class Index extends Command {
   static topic = 'spaces'
@@ -16,7 +16,11 @@ export default class Index extends Command {
   public async run(): Promise<void> {
     const {flags} = await this.parse(Index)
     const {team, json} = flags
-    let {body: spaces} = await this.heroku.get<SpaceArray>('/spaces')
+    let {body: spaces} = await this.heroku.get<SpaceArray>('/spaces', {
+      headers: {
+        Accept: 'application/vnd.heroku+json; version=3.fir',
+      },
+    })
     if (team) {
       spaces = spaces.filter(s => s.team.name === team)
     }
@@ -54,6 +58,7 @@ export default class Index extends Command {
         Team: {get: space => space.team.name},
         Region: {get: space => space.region.name},
         State: {get: space => space.state},
+        Generation: {get: space => space.generation},
         createdAt: {
           header: 'Created At',
           get: space => space.created_at,

--- a/packages/cli/test/unit/commands/spaces/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/spaces/index.unit.test.ts
@@ -15,6 +15,7 @@ describe('spaces', function () {
     region: {name: 'my-region'},
     state: 'allocated',
     created_at: now.toISOString(),
+    generation: 'cedar',
   }]
 
   afterEach(function () {
@@ -30,9 +31,9 @@ describe('spaces', function () {
 
     api.done()
     expect(heredoc(stdout.output)).to.eq(heredoc`
-      Name     Team    Region    State     Created At               
-      ──────── ─────── ───────── ───────── ──────────────────────── 
-      my-space my-team my-region allocated ${now.toISOString()} 
+      Name     Team    Region    State     Generation Created At               
+      ──────── ─────── ───────── ───────── ────────── ──────────────────────── 
+      my-space my-team my-region allocated cedar      ${now.toISOString()} 
     `)
   })
 
@@ -55,15 +56,17 @@ describe('spaces', function () {
         team: {name: 'other-team'},
         region: {name: 'my-region'},
         state: 'allocated',
-        created_at: now.toISOString()}]))
+        created_at: now.toISOString(),
+        generation: 'cedar',
+      }]))
 
     await runCommand(Cmd, ['--team', 'my-team'])
 
     api.done()
     expect(heredoc(stdout.output)).to.eq(heredoc`
-      Name     Team    Region    State     Created At               
-      ──────── ─────── ───────── ───────── ──────────────────────── 
-      my-space my-team my-region allocated ${now.toISOString()} 
+      Name     Team    Region    State     Generation Created At               
+      ──────── ─────── ───────── ───────── ────────── ──────────────────────── 
+      my-space my-team my-region allocated cedar      ${now.toISOString()} 
     `)
   })
 


### PR DESCRIPTION
## Description
Adds a "Generation" column to the spaces table that indicates which generation a space belongs to (fir, cedar, ...)

## Testing
1. Pull down this branch locally and run `yarn && yarn build`.
2. Run `./bin/run heroku spaces`. You should get a table with a listing of available spaces. The second-to-last column should be titled "Generation" and it should indicate which generation your spaces belong to.

[Internal work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000020r00vYAA/view)

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
