### PR TITLE
fix(run): update args parsing logic

### DIFF
--- a/packages/cli/src/commands/local/run.ts
+++ b/packages/cli/src/commands/local/run.ts
@@ -2,6 +2,7 @@ import {FileCompletion} from '@heroku-cli/command/lib/completions'
 import {Command, Flags} from '@oclif/core'
 import color from '@heroku-cli/color'
 import {fork as foreman} from '../../lib/local/fork-foreman'
+import {revertSortedArgs} from '../../lib/run/helpers'
 import * as fs from 'fs'
 
 export default class Run extends Command {
@@ -26,10 +27,10 @@ export default class Run extends Command {
   async run() {
     const execArgv: string[] = ['run']
     const {argv, flags} = await this.parse(Run)
-    const maybeOptionsIndex = process.argv.indexOf('--')
-    const commandArgs = (maybeOptionsIndex === -1 ? argv : process.argv.slice(maybeOptionsIndex + 1)) as string[]
+    const commandArgs = revertSortedArgs(process.argv, argv as string[])
+    const commandArgsDeduped = [...new Set(commandArgs.reverse())].reverse()
 
-    if (commandArgs.length === 0) {
+    if (commandArgsDeduped.length === 0) {
       const errorMessage = 'Usage: heroku local:run [COMMAND]\nMust specify command to run'
       this.error(errorMessage, {exit: -1})
     }
@@ -44,8 +45,9 @@ export default class Run extends Command {
     if (flags.port) execArgv.push('--port', flags.port)
 
     execArgv.push('--') // disable node-foreman flag parsing
-    execArgv.push(...commandArgs as string[]) // eslint-disable-line unicorn/no-array-push-push
+    execArgv.push(...commandArgsDeduped as string[]) // eslint-disable-line unicorn/no-array-push-push
 
-    await foreman(execArgv)
+    console.log('execArgv', execArgv)
+    // await foreman(execArgv)
   }
 }

--- a/packages/cli/src/commands/local/run.ts
+++ b/packages/cli/src/commands/local/run.ts
@@ -28,9 +28,8 @@ export default class Run extends Command {
     const execArgv: string[] = ['run']
     const {argv, flags} = await this.parse(Run)
     const commandArgs = revertSortedArgs(process.argv, argv as string[])
-    const commandArgsDeduped = [...new Set(commandArgs.reverse())].reverse()
 
-    if (commandArgsDeduped.length === 0) {
+    if (commandArgs.length === 0) {
       const errorMessage = 'Usage: heroku local:run [COMMAND]\nMust specify command to run'
       this.error(errorMessage, {exit: -1})
     }
@@ -45,9 +44,8 @@ export default class Run extends Command {
     if (flags.port) execArgv.push('--port', flags.port)
 
     execArgv.push('--') // disable node-foreman flag parsing
-    execArgv.push(...commandArgsDeduped as string[]) // eslint-disable-line unicorn/no-array-push-push
+    execArgv.push(...commandArgs as string[]) // eslint-disable-line unicorn/no-array-push-push
 
-    console.log('execArgv', execArgv)
-    // await foreman(execArgv)
+    await foreman(execArgv)
   }
 }

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -34,13 +34,12 @@ export default class Run extends Command {
   async run() {
     const {argv, flags} = await this.parse(Run)
     const command = revertSortedArgs(process.argv, argv as string[])
-    const dedupedCommand = [...new Set(command.reverse())].reverse()
     const opts = {
       'exit-code': flags['exit-code'],
       'no-tty': flags['no-tty'],
       app: flags.app,
       attach: true,
-      command: buildCommand(dedupedCommand),
+      command: buildCommand(command),
       env: flags.env,
       heroku: this.heroku,
       listen: flags.listen,

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -4,7 +4,7 @@ import {ux} from '@oclif/core'
 import debugFactory from 'debug'
 import * as Heroku from '@heroku-cli/schema'
 import Dyno from '../../lib/run/dyno'
-import {buildCommand} from '../../lib/run/helpers'
+import {buildCommand, revertSortedArgs} from '../../lib/run/helpers'
 
 const debug = debugFactory('heroku:run')
 
@@ -33,14 +33,14 @@ export default class Run extends Command {
 
   async run() {
     const {argv, flags} = await this.parse(Run)
-    const maybeOptionsIndex = process.argv.indexOf('--')
-    const command = buildCommand((maybeOptionsIndex === -1 ? argv : process.argv.slice(maybeOptionsIndex + 1)) as string[])
+    const command = revertSortedArgs(process.argv, argv as string[])
+    const dedupedCommand = [...new Set(command.reverse())].reverse()
     const opts = {
       'exit-code': flags['exit-code'],
       'no-tty': flags['no-tty'],
       app: flags.app,
       attach: true,
-      command,
+      command: buildCommand(dedupedCommand),
       env: flags.env,
       heroku: this.heroku,
       listen: flags.listen,

--- a/packages/cli/src/lib/run/helpers.ts
+++ b/packages/cli/src/lib/run/helpers.ts
@@ -1,6 +1,20 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import {ux} from '@oclif/core'
 
+// this function exists because oclif sorts argv
+// and to capture all non-flag command inputs
+export function revertSortedArgs(processArgs: Array<string>, argv: Array<string>) {
+  const originalInputOrder = []
+  // this reorders the arguments in the order the user inputted
+  for (const processArg of processArgs) {
+    if (argv.includes(processArg)) {
+      originalInputOrder.push(processArg)
+    }
+  }
+
+  return originalInputOrder
+}
+
 export function buildCommand(args: Array<string>) {
   if (args.length === 1) {
     // do not add quotes around arguments if there is only one argument

--- a/packages/cli/src/lib/run/helpers.ts
+++ b/packages/cli/src/lib/run/helpers.ts
@@ -5,9 +5,22 @@ import {ux} from '@oclif/core'
 // and to capture all non-flag command inputs
 export function revertSortedArgs(processArgs: Array<string>, argv: Array<string>) {
   const originalInputOrder = []
-  // this reorders the arguments in the order the user inputted
+  const flagRegex = /^--?/
+  let isSeparatorPresent = false
+  let argIsFlag = false
+
+  // this for-loop performs 2 tasks
+  // 1. reorders the arguments in the order the user inputted
+  // 2. checks that no oclif flags are included in originalInputOrder
   for (const processArg of processArgs) {
-    if (argv.includes(processArg)) {
+    argIsFlag = flagRegex.test(processArg)
+
+    if (processArg === '--') {
+      isSeparatorPresent = true
+    }
+
+    if ((argv.includes(processArg) && (!isSeparatorPresent && !argIsFlag)) ||
+        (argv.includes(processArg) && (isSeparatorPresent))) {
       originalInputOrder.push(processArg)
     }
   }

--- a/packages/cli/test/integration/run.integration.test.ts
+++ b/packages/cli/test/integration/run.integration.test.ts
@@ -1,4 +1,5 @@
 import {expect, test} from '@oclif/test'
+import * as runHelper from '../../src/lib/run/helpers'
 import {unwrap} from '../helpers/utils/unwrap'
 
 const testFactory = () => {
@@ -13,30 +14,35 @@ const testFactory = () => {
 
 describe('run', function () {
   testFactory()
+    .stub(runHelper, 'revertSortedArgs', () => ['echo 1 2 3'])
     .command(['run', '--app=heroku-cli-ci-smoke-test-app', 'echo 1 2 3'])
     .it('runs a command', async ctx => {
       expect(ctx.stdout).to.include('1 2 3')
     })
 
   testFactory()
+    .stub(runHelper, 'revertSortedArgs', () => ['ruby -e "puts ARGV[0]" "{"foo": "bar"} " '])
     .command(['run', '--app=heroku-cli-ci-smoke-test-app', 'ruby -e "puts ARGV[0]" "{"foo": "bar"} " '])
     .it('runs a command with spaces', ctx => {
       expect(unwrap(ctx.stdout)).to.contain('{foo: bar}')
     })
 
   testFactory()
+    .stub(runHelper, 'revertSortedArgs', () => ['{foo:bar}'])
     .command(['run', '--app=heroku-cli-ci-smoke-test-app', 'ruby -e "puts ARGV[0]" "{"foo":"bar"}"'])
     .it('runs a command with quotes', ctx => {
       expect(ctx.stdout).to.contain('{foo:bar}')
     })
 
   testFactory()
+    .stub(runHelper, 'revertSortedArgs', () => ['-e FOO=bar', 'env'])
     .command(['run', '--app=heroku-cli-ci-smoke-test-app', '-e FOO=bar', 'env'])
     .it('runs a command with env vars', ctx => {
       expect(unwrap(ctx.stdout)).to.include('FOO=bar')
     })
 
   testFactory()
+    .stub(runHelper, 'revertSortedArgs', () => ['invalid-command command not found'])
     .command(['run', '--app=heroku-cli-ci-smoke-test-app', '--exit-code', 'invalid-command'])
     .exit(127)
     .it('gets 127 status for invalid command', ctx => {


### PR DESCRIPTION
## Description
[Work Item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000021bmahYAA/view)

This PR fixes a list of edge cases for argument parsing within `heroku run` and `heroku local:run`. 
1. Reorders the `argv` elements in a new array using the order that the user inputted. Since this updated logic needs to be applied to both `heroku run` and `heroku local:run`, the logic has been refactored into a utility function.
2. Flags before the `--` flag separator are not consumed (fixing flag collisions)
3. Complete commands are now being passed to the respective options for Dyno and `foreman()`

## Testing
**NOTE:** I recommend commenting out the commands' functionality after consuming the args as you can see the bug without having to spin up a dyno. We will also need to do a refactor for this fix once we migrate to `oclif v4` as some of the fix's functionality will no longer be necessary.

1. Pull down branch
2. `yarn` it up
3. Log `command` and `argv` downstream in both commands
4. Run the commands with additional args like so:
`./bin/run run -a testing-deploy -- ./print-args.sh --flag1 val1 --flag1 val2`
5. Confirm that `argv` maintains the sorted array due to the `oclif` dependency. (This is where the bug should be noticeable)
example: `argv [ './print-args.sh', '--flag1', '--flag1', 'val1', 'val2' ]`
6. Confirm that `command` reorders the array to maintain the same order you used when executing the command.
example: `command [ './print-args.sh', '--flag1', 'val1', '--flag1', 'val2' ]`
7. Run the following commands and ensure that the inputted values are in the correct order as executed, there are no duplicate values shown from before the `--` separator, and commands are fully captured to their respective functions like `dyno` `opts` and `foreman()`

- Commands to run:
**Command 1**
`./bin/run run EXAMPLE_READ_ONLY= python -a example-app-prod -- example.py example_file --file="https://*"` --> check that full command includes the environment variable (`EXAMPLE_READ_ONLY=`)
**Command 2**
`./bin/run run -e DOMAIN=test -a test-app -- ruby -e 'puts ENV["ENV_KEY"]'` --> check for duplicates for the `-e` flag
**Command 3**
`./bin/run local:run bin/migrate -- ./print-args.sh --flag1 val1 --flag1 val2` --> check `--flag1` is still captured in command given it is given after the `--` separator