### PR TITLE
feat: add generation info to spaces:info and spaces:wait commands

### DIFF
--- a/packages/cli/src/commands/spaces/info.ts
+++ b/packages/cli/src/commands/spaces/info.ts
@@ -1,11 +1,16 @@
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
-import * as Heroku from '@heroku-cli/schema'
 import heredoc from 'tsheredoc'
 import {renderInfo} from '../../lib/spaces/spaces'
 import debug from 'debug'
+import {IncomingHttpHeaders} from 'node:http'
+import {Space, SpaceNat} from '../../lib/types/fir'
 
 const spacesDebug = debug('spaces:info')
+
+type SpaceWithOutboundIps = Space & {
+  outbound_ips?: SpaceNat
+}
 
 export default class Info extends Command {
   static topic = 'spaces'
@@ -32,15 +37,18 @@ export default class Info extends Command {
       `))
     }
 
-    let headers = {}
+    const headers: IncomingHttpHeaders = {
+      Accept: 'application/vnd.heroku+json; version=3.fir',
+    }
     if (!flags.json) {
-      headers = {'Accept-Expansion': 'region'}
+      headers['Accept-Expansion'] = 'region'
     }
 
-    const {body: space} = await this.heroku.get<Heroku.Space>(`/spaces/${spaceName}`, {headers})
+    const {body: updatedSpace} = await this.heroku.get<Space>(`/spaces/${spaceName}`, {headers})
+    const space: SpaceWithOutboundIps = updatedSpace
     if (space.state === 'allocated') {
       try {
-        const {body: outbound_ips} = await this.heroku.get<Heroku.SpaceNetworkAddressTranslation>(`/spaces/${spaceName}/nat`)
+        const {body: outbound_ips} = await this.heroku.get<SpaceNat>(`/spaces/${spaceName}/nat`, {headers: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
         space.outbound_ips = outbound_ips
       } catch (error) {
         spacesDebug(`Retrieving NAT details for the space failed with ${error}`)

--- a/packages/cli/src/commands/spaces/info.ts
+++ b/packages/cli/src/commands/spaces/info.ts
@@ -5,12 +5,9 @@ import {renderInfo} from '../../lib/spaces/spaces'
 import debug from 'debug'
 import {IncomingHttpHeaders} from 'node:http'
 import {Space, SpaceNat} from '../../lib/types/fir'
+import {SpaceWithOutboundIps} from '../../lib/types/spaces'
 
 const spacesDebug = debug('spaces:info')
-
-type SpaceWithOutboundIps = Space & {
-  outbound_ips?: SpaceNat
-}
 
 export default class Info extends Command {
   static topic = 'spaces'

--- a/packages/cli/src/commands/spaces/info.ts
+++ b/packages/cli/src/commands/spaces/info.ts
@@ -41,8 +41,7 @@ export default class Info extends Command {
       headers['Accept-Expansion'] = 'region'
     }
 
-    const {body: updatedSpace} = await this.heroku.get<Space>(`/spaces/${spaceName}`, {headers})
-    const space: SpaceWithOutboundIps = updatedSpace
+    const {body: space} = await this.heroku.get<SpaceWithOutboundIps>(`/spaces/${spaceName}`, {headers})
     if (space.state === 'allocated') {
       try {
         const {body: outbound_ips} = await this.heroku.get<SpaceNat>(`/spaces/${spaceName}/nat`, {headers: {Accept: 'application/vnd.heroku+json; version=3.fir'}})

--- a/packages/cli/src/commands/spaces/wait.ts
+++ b/packages/cli/src/commands/spaces/wait.ts
@@ -7,13 +7,10 @@ import debug from 'debug'
 import {renderInfo} from '../../lib/spaces/spaces'
 import {Notification, notify} from '@heroku-cli/notifications'
 import {IncomingHttpHeaders} from 'node:http'
-import {Space, SpaceNat} from '../../lib/types/fir'
+import {SpaceNat} from '../../lib/types/fir'
+import {SpaceWithOutboundIps} from '../../lib/types/spaces'
 
 const spacesDebug = debug('spaces:wait')
-
-type SpaceWithOutboundIps = Space & {
-  outbound_ips?: SpaceNat
-}
 
 export default class Wait extends Command {
   static topic = 'spaces'

--- a/packages/cli/src/lib/spaces/spaces.ts
+++ b/packages/cli/src/lib/spaces/spaces.ts
@@ -1,11 +1,7 @@
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
-import {Space, SpaceNat, SpaceRegion} from '../types/fir'
-
-type SpaceExpanded = Space & {
-  outbound_ips?: SpaceNat
-  region: SpaceRegion & {description?: string}
-}
+import {SpaceNat} from '../types/fir'
+import {SpaceWithOutboundIps} from '../types/spaces'
 
 export function displayShieldState(space: Heroku.Space) {
   return space.shield ? 'on' : 'off'
@@ -17,7 +13,7 @@ export function displayNat(nat?: Required<SpaceNat>) {
   return nat.sources.join(', ')
 }
 
-export function renderInfo(space: SpaceExpanded, json: boolean) {
+export function renderInfo(space: SpaceWithOutboundIps, json: boolean) {
   if (json) {
     ux.log(JSON.stringify(space, null, 2))
   } else {

--- a/packages/cli/src/lib/spaces/spaces.ts
+++ b/packages/cli/src/lib/spaces/spaces.ts
@@ -1,17 +1,23 @@
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
+import {Space, SpaceNat, SpaceRegion} from '../types/fir'
+
+type SpaceExpanded = Space & {
+  outbound_ips?: SpaceNat
+  region: SpaceRegion & {description?: string}
+}
 
 export function displayShieldState(space: Heroku.Space) {
   return space.shield ? 'on' : 'off'
 }
 
-export function displayNat(nat?: Required<Heroku.SpaceNetworkAddressTranslation>) {
+export function displayNat(nat?: Required<SpaceNat>) {
   if (!nat) return
   if (nat.state !== 'enabled') return nat.state
   return nat.sources.join(', ')
 }
 
-export function renderInfo(space: Heroku.Space, json: boolean) {
+export function renderInfo(space: SpaceExpanded, json: boolean) {
   if (json) {
     ux.log(JSON.stringify(space, null, 2))
   } else {

--- a/packages/cli/src/lib/spaces/spaces.ts
+++ b/packages/cli/src/lib/spaces/spaces.ts
@@ -26,9 +26,10 @@ export function renderInfo(space: Heroku.Space, json: boolean) {
         State: space.state,
         Shield: displayShieldState(space),
         'Outbound IPs': displayNat(space.outbound_ips),
+        Generation: space.generation,
         'Created at': space.created_at,
       },
-      ['ID', 'Team', 'Region', 'CIDR', 'Data CIDR', 'State', 'Shield', 'Outbound IPs', 'Created at'],
+      ['ID', 'Team', 'Region', 'CIDR', 'Data CIDR', 'State', 'Shield', 'Outbound IPs', 'Generation', 'Created at'],
     )
   }
 }

--- a/packages/cli/src/lib/types/spaces.d.ts
+++ b/packages/cli/src/lib/types/spaces.d.ts
@@ -1,0 +1,14 @@
+import {
+  Space,
+  Region,
+  SpaceRegion,
+  SpaceNat,
+} from './fir'
+
+export type SpaceExpanded = Omit<Space, 'region'> & {
+  region: SpaceRegion & Partial<Region>
+}
+
+export type SpaceWithOutboundIps = SpaceExpanded & {
+  outbound_ips?: SpaceNat
+}

--- a/packages/cli/test/fixtures/spaces/fixtures.ts
+++ b/packages/cli/test/fixtures/spaces/fixtures.ts
@@ -1,12 +1,14 @@
 import * as Heroku from '@heroku-cli/schema'
 import type {SpaceTopology} from '../../../src/commands/spaces/topology'
+import {SpaceWithOutboundIps} from '../../../src/lib/types/spaces'
 
-export const spaces: Record<string, Required<Heroku.Space>> = {
+export const spaces: Record<string, SpaceWithOutboundIps> = {
   'non-shield-space': {
     id: '1234',
     name: 'my-unshielded-space',
     shield: false,
     region: {
+      id: '1',
       description: 'virginia',
       name: 'us',
     },
@@ -19,6 +21,7 @@ export const spaces: Record<string, Required<Heroku.Space>> = {
     organization: {
       name: 'my-org',
     },
+    generation: 'cedar',
     created_at: '2016-01-06T03:23:13Z',
     updated_at: '2016-01-06T03:23:13Z',
   },
@@ -27,6 +30,7 @@ export const spaces: Record<string, Required<Heroku.Space>> = {
     name: 'my-shielded-space',
     shield: true,
     region: {
+      id: '1',
       description: 'virginia',
       name: 'us',
     },
@@ -39,6 +43,7 @@ export const spaces: Record<string, Required<Heroku.Space>> = {
     organization: {
       name: 'my-org',
     },
+    generation: 'cedar',
     created_at: '2016-01-06T03:23:13Z',
     updated_at: '2016-01-06T03:23:13Z',
   },
@@ -48,6 +53,7 @@ export const spaces: Record<string, Required<Heroku.Space>> = {
     name: 'my-unshielded-space',
     shield: false,
     region: {
+      id: '1',
       description: 'virginia',
       name: 'us',
     },
@@ -60,6 +66,7 @@ export const spaces: Record<string, Required<Heroku.Space>> = {
     organization: {
       name: 'my-org',
     },
+    generation: 'cedar',
     created_at: '2016-01-06T03:23:13Z',
     updated_at: '2016-01-06T03:23:13Z',
   },

--- a/packages/cli/test/unit/commands/spaces/info.unit.test.ts
+++ b/packages/cli/test/unit/commands/spaces/info.unit.test.ts
@@ -5,11 +5,11 @@ import * as nock from 'nock'
 import heredoc from 'tsheredoc'
 import expectOutput from '../../../helpers/utils/expectOutput'
 import * as fixtures from '../../../fixtures/spaces/fixtures'
-import * as Heroku from '@heroku-cli/schema'
+import {SpaceWithOutboundIps} from '../../../../src/lib/types/spaces'
 
 describe('spaces:info', function () {
-  let space: Required<Heroku.Space>
-  let shieldSpace: Required<Heroku.Space>
+  let space: SpaceWithOutboundIps
+  let shieldSpace: SpaceWithOutboundIps
 
   beforeEach(function () {
     space = fixtures.spaces['non-shield-space']
@@ -34,6 +34,7 @@ describe('spaces:info', function () {
       Data CIDR:    ${space.data_cidr}
       State:        ${space.state}
       Shield:       off
+      Generation:   ${space.generation}
       Created at:   ${space.created_at}
     `))
   })
@@ -73,6 +74,7 @@ describe('spaces:info', function () {
       State:        ${space.state}
       Shield:       off
       Outbound IPs: 123.456.789.123
+      Generation:   ${space.generation}
       Created at:   ${space.created_at}
     `))
   })
@@ -99,6 +101,7 @@ describe('spaces:info', function () {
       State:        ${space.state}
       Shield:       off
       Outbound IPs: disabled
+      Generation:   ${space.generation}
       Created at:   ${space.created_at}
     `))
   })
@@ -121,6 +124,7 @@ describe('spaces:info', function () {
       Data CIDR:    ${space.data_cidr}
       State:        ${space.state}
       Shield:       off
+      Generation:   ${space.generation}
       Created at:   ${space.created_at}
     `))
   })
@@ -143,6 +147,7 @@ describe('spaces:info', function () {
       Data CIDR:    ${shieldSpace.data_cidr}
       State:        ${shieldSpace.state}
       Shield:       on
+      Generation:   ${space.generation}
       Created at:   ${shieldSpace.created_at}
     `))
   })
@@ -164,6 +169,7 @@ describe('spaces:info', function () {
       Data CIDR:    ${space.data_cidr}
       State:        ${space.state}
       Shield:       off
+      Generation:   ${space.generation}
       Created at:   ${space.created_at}
     `))
   })

--- a/packages/cli/test/unit/commands/spaces/wait.unit.test.ts
+++ b/packages/cli/test/unit/commands/spaces/wait.unit.test.ts
@@ -7,11 +7,11 @@ import {expect} from 'chai'
 import expectOutput from '../../../helpers/utils/expectOutput'
 import * as fixtures from '../../../fixtures/spaces/fixtures'
 import * as sinon from 'sinon'
-import {Space} from '@heroku-cli/schema'
+import {SpaceWithOutboundIps} from '../../../../src/lib/types/spaces'
 
 describe('spaces:wait', function () {
-  let allocatingSpace: Required<Space>
-  let allocatedSpace: Required<Space>
+  let allocatingSpace: SpaceWithOutboundIps
+  let allocatedSpace: SpaceWithOutboundIps
   let sandbox: sinon.SinonSandbox
   let notifySpy: sinon.SinonSpy
 
@@ -56,6 +56,7 @@ describe('spaces:wait', function () {
       State:        ${allocatedSpace.state}
       Shield:       off
       Outbound IPs: 123.456.789.123
+      Generation:   ${allocatedSpace.generation}
       Created at:   ${allocatedSpace.created_at}
     `))
     expect(notifySpy.called).to.be.true
@@ -114,6 +115,7 @@ describe('spaces:wait', function () {
       Data CIDR:    ${allocatedSpace.data_cidr}
       State:        ${allocatedSpace.state}
       Shield:       off
+      Generation:   ${allocatedSpace.generation}
       Created at:   ${allocatedSpace.created_at}
     `))
     expect(notifySpy.called).to.be.true


### PR DESCRIPTION
## Description
This PR adds space generation to the output from the `spaces:info` and `spaces:wait` commands.

## Testing
- Pull down this branch locally and run `yarn && yarn build`
- Run `./bin/run spaces:info test-fir-dev-tools` and verify that the generation is included in the output
- Run `./bin/run spaces:info test-fir-dev-tools --json` and verify that the generation is included in the output
- Run `./bin/run spaces:wait test-fir-dev-tools` and verify that the generation is included in the output
- Run `./bin/run spaces:wait test-fir-dev-tools --json` and verify that the generation is included in the output

[Internal work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000020mJ3FYAU/view)

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
