### PR TITLE
Add telemetry remove command

### DIFF
--- a/packages/cli/src/commands/telemetry/remove.ts
+++ b/packages/cli/src/commands/telemetry/remove.ts
@@ -33,7 +33,7 @@ export default class Remove extends Command {
       ux.action.start(`Removing all telemetry drains from app ${app}`)
       const {body: telemetryDrains} = await this.heroku.get<TelemetryDrain[]>(`/apps/${app}/telemetry-drains`, {
         headers: {
-          Accept: 'application/vnd.heroku+json; version=3.fir',
+          Accept: 'application/vnd.heroku+json; version=3.sdk',
         },
       })
 
@@ -44,7 +44,7 @@ export default class Remove extends Command {
       ux.action.start(`Removing all telemetry drains from space ${space}`)
       const {body: telemetryDrains} = await this.heroku.get<TelemetryDrain[]>(`/spaces/${space}/telemetry-drains`, {
         headers: {
-          Accept: 'application/vnd.heroku+json; version=3.fir',
+          Accept: 'application/vnd.heroku+json; version=3.sdk',
         },
       })
 
@@ -59,7 +59,7 @@ export default class Remove extends Command {
   protected async removeDrain(telemetry_drain_id: string) {
     const {body: telemetryDrain} = await this.heroku.delete<TelemetryDrain>(`/telemetry-drains/${telemetry_drain_id}`, {
       headers: {
-        Accept: 'application/vnd.heroku+json; version=3.fir',
+        Accept: 'application/vnd.heroku+json; version=3.sdk',
       },
     })
     return telemetryDrain

--- a/packages/cli/src/commands/telemetry/remove.ts
+++ b/packages/cli/src/commands/telemetry/remove.ts
@@ -1,31 +1,67 @@
-import {Command} from '@heroku-cli/command'
+import {flags, Command} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 import {TelemetryDrain} from '../../lib/types/telemetry'
+import heredoc from 'tsheredoc'
 
 export default class Remove extends Command {
   static topic = 'telemetry'
   static description = 'remove a telemetry drain'
   static args = {
-    telemetry_drain_id: Args.string({required: true, description: 'ID of the drain to remove'}),
-  };
+    telemetry_drain_id: Args.string({description: 'ID of the drain to remove'}),
+  }
+
+  static flags = {
+    app: flags.app({description: 'name of the app to remove all drains from'}),
+    space: flags.string({char: 's', description: 'name of the space to remove all drains from'}),
+  }
 
   public async run(): Promise<void> {
-    const {args} = await this.parse(Remove)
+    const {args, flags} = await this.parse(Remove)
+    const {app, space} = flags
     const {telemetry_drain_id} = args
-    const {body: telemetryDrain} =  await this.heroku.get<TelemetryDrain>(`/telemetry-drains/${telemetry_drain_id}`, {
-      headers: {
-        Accept: 'application/vnd.heroku+json; version=3.fir',
-      },
-    })
+    if (!(app || space || telemetry_drain_id)) {
+      ux.error(heredoc(`
+        Requires either --app or --space or a TELEMETRY_DRAIN_ID to be provided.
+        See more help with --help
+      `))
+    }
 
-    ux.action.start(`Removing telemetry drain ${telemetry_drain_id}, which was configured for ${telemetryDrain.owner.type} ${telemetryDrain.owner.name}`)
+    if (telemetry_drain_id) {
+      const telemetryDrain = await this.removeDrain(telemetry_drain_id)
+      ux.action.start(`Removing telemetry drain ${telemetry_drain_id}, which was configured for ${telemetryDrain.owner.type} ${telemetryDrain.owner.name}`)
+    } else if (app) {
+      ux.action.start(`Removing all telemetry drains from app ${app}`)
+      const {body: telemetryDrains} = await this.heroku.get<TelemetryDrain[]>(`/apps/${app}/telemetry-drains`, {
+        headers: {
+          Accept: 'application/vnd.heroku+json; version=3.fir',
+        },
+      })
 
-    await this.heroku.delete<TelemetryDrain>(`/telemetry-drains/${telemetry_drain_id}`, {
-      headers: {
-        Accept: 'application/vnd.heroku+json; version=3.fir',
-      },
-    })
+      for (const telemetryDrain of telemetryDrains) {
+        await this.removeDrain(telemetryDrain.id)
+      }
+    } else if (space) {
+      ux.action.start(`Removing all telemetry drains from space ${space}`)
+      const {body: telemetryDrains} = await this.heroku.get<TelemetryDrain[]>(`/spaces/${space}/telemetry-drains`, {
+        headers: {
+          Accept: 'application/vnd.heroku+json; version=3.fir',
+        },
+      })
+
+      for (const telemetryDrain of telemetryDrains) {
+        await this.removeDrain(telemetryDrain.id)
+      }
+    }
 
     ux.action.stop()
+  }
+
+  protected async removeDrain(telemetry_drain_id: string) {
+    const {body: telemetryDrain} = await this.heroku.delete<TelemetryDrain>(`/telemetry-drains/${telemetry_drain_id}`, {
+      headers: {
+        Accept: 'application/vnd.heroku+json; version=3.fir',
+      },
+    })
+    return telemetryDrain
   }
 }

--- a/packages/cli/src/commands/telemetry/remove.ts
+++ b/packages/cli/src/commands/telemetry/remove.ts
@@ -1,0 +1,31 @@
+import {Command} from '@heroku-cli/command'
+import {Args, ux} from '@oclif/core'
+import {TelemetryDrain} from '../../lib/types/telemetry'
+
+export default class Remove extends Command {
+  static topic = 'telemetry'
+  static description = 'remove a telemetry drain'
+  static args = {
+    telemetry_drain_id: Args.string({required: true, description: 'ID of the drain to remove'}),
+  };
+
+  public async run(): Promise<void> {
+    const {args} = await this.parse(Remove)
+    const {telemetry_drain_id} = args
+    const {body: telemetryDrain} =  await this.heroku.get<TelemetryDrain>(`/telemetry-drains/${telemetry_drain_id}`, {
+      headers: {
+        Accept: 'application/vnd.heroku+json; version=3.fir',
+      },
+    })
+
+    ux.action.start(`Removing telemetry drain ${telemetry_drain_id}, which was configured for ${telemetryDrain.owner.type} ${telemetryDrain.owner.name}`)
+
+    await this.heroku.delete<TelemetryDrain>(`/telemetry-drains/${telemetry_drain_id}`, {
+      headers: {
+        Accept: 'application/vnd.heroku+json; version=3.fir',
+      },
+    })
+
+    ux.action.stop()
+  }
+}

--- a/packages/cli/test/unit/commands/telemetry/remove.unit.test.ts
+++ b/packages/cli/test/unit/commands/telemetry/remove.unit.test.ts
@@ -5,60 +5,20 @@ import * as nock from 'nock'
 import expectOutput from '../../../helpers/utils/expectOutput'
 import heredoc from 'tsheredoc'
 import {expect} from 'chai'
-
-import {TelemetryDrain, TelemetryDrains} from '../../../../src/lib/types/telemetry'
+import {spaceTelemetryDrain1, appTelemetryDrain1, appTelemetryDrain2} from '../../../fixtures/telemetry/fixtures'
+import {TelemetryDrains} from '../../../../src/lib/types/telemetry'
 
 describe('telemetry:remove', function () {
-  const appId = '87654321-5717-4562-b3fc-2c963f66afa6'
-  const spaceId = '12345678-5717-4562-b3fc-2c963f66afa6'
-  let appTelemetryDrain: TelemetryDrain
-  let appTelemetryDrainTwo: TelemetryDrain
-  let spaceTelemetryDrain: TelemetryDrain
+  let appId: string
+  let spaceId: string
   let appTelemetryDrains: TelemetryDrains
   let spaceTelemetryDrains: TelemetryDrains
 
   beforeEach(function () {
-    spaceTelemetryDrain = {
-      id: '44444321-5717-4562-b3fc-2c963f66afa6',
-      owner: {id: spaceId, type: 'space', name: 'myspace'},
-      capabilities: ['traces', 'metrics', 'logs'],
-      exporter: {
-        type: 'otlphttp',
-        endpoint: 'https://api.honeycomb.io/',
-        headers: {
-          'x-honeycomb-team': 'your-api-key',
-          'x-honeycomb-dataset': 'your-dataset',
-        },
-      },
-    }
-    appTelemetryDrain = {
-      id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-      owner: {id: appId, type: 'app', name: 'myapp'},
-      capabilities: ['traces', 'metrics'],
-      exporter: {
-        type: 'otlphttp',
-        endpoint: 'https://api.honeycomb.io/',
-        headers: {
-          'x-honeycomb-team': 'your-api-key',
-          'x-honeycomb-dataset': 'your-dataset',
-        },
-      },
-    }
-    appTelemetryDrainTwo = {
-      id: '55555f64-5717-4562-b3fc-2c963f66afa6',
-      owner: {id: appId, type: 'app', name: 'myapp'},
-      capabilities: ['logs'],
-      exporter: {
-        type: 'otlphttp',
-        endpoint: 'https://api.papertrail.com/',
-        headers: {
-          'x-papertrail-team': 'your-api-key',
-          'x-papertrail-dataset': 'your-dataset',
-        },
-      },
-    }
-    appTelemetryDrains = [appTelemetryDrain, appTelemetryDrainTwo]
-    spaceTelemetryDrains = [spaceTelemetryDrain]
+    appId = appTelemetryDrain1.owner.id
+    spaceId = spaceTelemetryDrain1.owner.id
+    appTelemetryDrains = [appTelemetryDrain1, appTelemetryDrain2]
+    spaceTelemetryDrains = [spaceTelemetryDrain1]
   })
 
   afterEach(function () {
@@ -66,49 +26,49 @@ describe('telemetry:remove', function () {
   })
 
   it('deletes a space telemetry drain', async function () {
-    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
-      .get(`/telemetry-drains/${spaceTelemetryDrain.id}`)
-      .reply(200, spaceTelemetryDrain)
-    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
-      .delete(`/telemetry-drains/${spaceTelemetryDrain.id}`)
-      .reply(200, spaceTelemetryDrain)
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      .get(`/telemetry-drains/${spaceTelemetryDrain1.id}`)
+      .reply(200, spaceTelemetryDrain1)
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      .delete(`/telemetry-drains/${spaceTelemetryDrain1.id}`)
+      .reply(200, spaceTelemetryDrain1)
 
     await runCommand(Cmd, [
-      spaceTelemetryDrain.id,
+      spaceTelemetryDrain1.id,
     ])
     expectOutput(stderr.output, heredoc(`
-      Removing telemetry drain ${spaceTelemetryDrain.id}, which was configured for space ${spaceTelemetryDrain.owner.name}...
-      Removing telemetry drain ${spaceTelemetryDrain.id}, which was configured for space ${spaceTelemetryDrain.owner.name}... done
+      Removing telemetry drain ${spaceTelemetryDrain1.id}, which was configured for space ${spaceTelemetryDrain1.owner.name}...
+      Removing telemetry drain ${spaceTelemetryDrain1.id}, which was configured for space ${spaceTelemetryDrain1.owner.name}... done
     `))
   })
 
   it('deletes an app telemetry drains', async function () {
-    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
-      .get(`/telemetry-drains/${appTelemetryDrain.id}`)
-      .reply(200, appTelemetryDrain)
-    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
-      .delete(`/telemetry-drains/${appTelemetryDrain.id}`)
-      .reply(200, appTelemetryDrain)
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      .get(`/telemetry-drains/${appTelemetryDrain1.id}`)
+      .reply(200, appTelemetryDrain1)
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      .delete(`/telemetry-drains/${appTelemetryDrain1.id}`)
+      .reply(200, appTelemetryDrain1)
 
     await runCommand(Cmd, [
-      appTelemetryDrain.id,
+      appTelemetryDrain1.id,
     ])
     expectOutput(stderr.output, heredoc(`
-      Removing telemetry drain ${appTelemetryDrain.id}, which was configured for app ${appTelemetryDrain.owner.name}...
-      Removing telemetry drain ${appTelemetryDrain.id}, which was configured for app ${appTelemetryDrain.owner.name}... done
+      Removing telemetry drain ${appTelemetryDrain1.id}, which was configured for app ${appTelemetryDrain1.owner.name}...
+      Removing telemetry drain ${appTelemetryDrain1.id}, which was configured for app ${appTelemetryDrain1.owner.name}... done
     `))
   })
 
   it('deletes all drains from an app', async function () {
-    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
       .get(`/apps/${appId}/telemetry-drains`)
       .reply(200, appTelemetryDrains)
-    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
-      .delete(`/telemetry-drains/${appTelemetryDrain.id}`)
-      .reply(200, appTelemetryDrain)
-    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
-      .delete(`/telemetry-drains/${appTelemetryDrainTwo.id}`)
-      .reply(200, appTelemetryDrainTwo)
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      .delete(`/telemetry-drains/${appTelemetryDrain1.id}`)
+      .reply(200, appTelemetryDrain1)
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      .delete(`/telemetry-drains/${appTelemetryDrain2.id}`)
+      .reply(200, appTelemetryDrain2)
 
     await runCommand(Cmd, [
       '--app', appId,
@@ -120,12 +80,12 @@ describe('telemetry:remove', function () {
   })
 
   it('deletes all drains from a space', async function () {
-    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
       .get(`/spaces/${spaceId}/telemetry-drains`)
       .reply(200, spaceTelemetryDrains)
-    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
-      .delete(`/telemetry-drains/${spaceTelemetryDrain.id}`)
-      .reply(200, spaceTelemetryDrain)
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      .delete(`/telemetry-drains/${spaceTelemetryDrain1.id}`)
+      .reply(200, spaceTelemetryDrain1)
 
     await runCommand(Cmd, [
       '--space', spaceId,

--- a/packages/cli/test/unit/commands/telemetry/remove.unit.test.ts
+++ b/packages/cli/test/unit/commands/telemetry/remove.unit.test.ts
@@ -4,13 +4,18 @@ import runCommand from '../../../helpers/runCommand'
 import * as nock from 'nock'
 import expectOutput from '../../../helpers/utils/expectOutput'
 import heredoc from 'tsheredoc'
-import {TelemetryDrain} from '../../../../src/lib/types/telemetry'
+import {expect} from 'chai'
+
+import {TelemetryDrain, TelemetryDrains} from '../../../../src/lib/types/telemetry'
 
 describe('telemetry:remove', function () {
   const appId = '87654321-5717-4562-b3fc-2c963f66afa6'
   const spaceId = '12345678-5717-4562-b3fc-2c963f66afa6'
   let appTelemetryDrain: TelemetryDrain
+  let appTelemetryDrainTwo: TelemetryDrain
   let spaceTelemetryDrain: TelemetryDrain
+  let appTelemetryDrains: TelemetryDrains
+  let spaceTelemetryDrains: TelemetryDrains
 
   beforeEach(function () {
     spaceTelemetryDrain = {
@@ -39,6 +44,21 @@ describe('telemetry:remove', function () {
         },
       },
     }
+    appTelemetryDrainTwo = {
+      id: '55555f64-5717-4562-b3fc-2c963f66afa6',
+      owner: {id: appId, type: 'app', name: 'myapp'},
+      capabilities: ['logs'],
+      exporter: {
+        type: 'otlphttp',
+        endpoint: 'https://api.papertrail.com/',
+        headers: {
+          'x-papertrail-team': 'your-api-key',
+          'x-papertrail-dataset': 'your-dataset',
+        },
+      },
+    }
+    appTelemetryDrains = [appTelemetryDrain, appTelemetryDrainTwo]
+    spaceTelemetryDrains = [spaceTelemetryDrain]
   })
 
   afterEach(function () {
@@ -68,7 +88,7 @@ describe('telemetry:remove', function () {
       .reply(200, appTelemetryDrain)
     nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
       .delete(`/telemetry-drains/${appTelemetryDrain.id}`)
-      .reply(200, spaceTelemetryDrain)
+      .reply(200, appTelemetryDrain)
 
     await runCommand(Cmd, [
       appTelemetryDrain.id,
@@ -77,5 +97,49 @@ describe('telemetry:remove', function () {
       Removing telemetry drain ${appTelemetryDrain.id}, which was configured for app ${appTelemetryDrain.owner.name}...
       Removing telemetry drain ${appTelemetryDrain.id}, which was configured for app ${appTelemetryDrain.owner.name}... done
     `))
+  })
+
+  it('deletes all drains from an app', async function () {
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
+      .get(`/apps/${appId}/telemetry-drains`)
+      .reply(200, appTelemetryDrains)
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
+      .delete(`/telemetry-drains/${appTelemetryDrain.id}`)
+      .reply(200, appTelemetryDrain)
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
+      .delete(`/telemetry-drains/${appTelemetryDrainTwo.id}`)
+      .reply(200, appTelemetryDrainTwo)
+
+    await runCommand(Cmd, [
+      '--app', appId,
+    ])
+    expectOutput(stderr.output, heredoc(`
+      Removing all telemetry drains from app ${appId}...
+      Removing all telemetry drains from app ${appId}... done
+    `))
+  })
+
+  it('deletes all drains from a space', async function () {
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
+      .get(`/spaces/${spaceId}/telemetry-drains`)
+      .reply(200, spaceTelemetryDrains)
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
+      .delete(`/telemetry-drains/${spaceTelemetryDrain.id}`)
+      .reply(200, spaceTelemetryDrain)
+
+    await runCommand(Cmd, [
+      '--space', spaceId,
+    ])
+    expectOutput(stderr.output, heredoc(`
+      Removing all telemetry drains from space ${spaceId}...
+      Removing all telemetry drains from space ${spaceId}... done
+    `))
+  })
+
+  it('requires a telemetry id, an app id, or a space id', async function () {
+    const errorMessage = 'Requires either --app or --space or a TELEMETRY_DRAIN_ID to be provided.'
+    await runCommand(Cmd, []).catch(error => {
+      expect(error.message).to.contain(errorMessage)
+    })
   })
 })

--- a/packages/cli/test/unit/commands/telemetry/remove.unit.test.ts
+++ b/packages/cli/test/unit/commands/telemetry/remove.unit.test.ts
@@ -1,0 +1,81 @@
+import {stderr} from 'stdout-stderr'
+import Cmd from '../../../../src/commands/telemetry/remove'
+import runCommand from '../../../helpers/runCommand'
+import * as nock from 'nock'
+import expectOutput from '../../../helpers/utils/expectOutput'
+import heredoc from 'tsheredoc'
+import {TelemetryDrain} from '../../../../src/lib/types/telemetry'
+
+describe('telemetry:remove', function () {
+  const appId = '87654321-5717-4562-b3fc-2c963f66afa6'
+  const spaceId = '12345678-5717-4562-b3fc-2c963f66afa6'
+  let appTelemetryDrain: TelemetryDrain
+  let spaceTelemetryDrain: TelemetryDrain
+
+  beforeEach(function () {
+    spaceTelemetryDrain = {
+      id: '44444321-5717-4562-b3fc-2c963f66afa6',
+      owner: {id: spaceId, type: 'space', name: 'myspace'},
+      capabilities: ['traces', 'metrics', 'logs'],
+      exporter: {
+        type: 'otlphttp',
+        endpoint: 'https://api.honeycomb.io/',
+        headers: {
+          'x-honeycomb-team': 'your-api-key',
+          'x-honeycomb-dataset': 'your-dataset',
+        },
+      },
+    }
+    appTelemetryDrain = {
+      id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+      owner: {id: appId, type: 'app', name: 'myapp'},
+      capabilities: ['traces', 'metrics'],
+      exporter: {
+        type: 'otlphttp',
+        endpoint: 'https://api.honeycomb.io/',
+        headers: {
+          'x-honeycomb-team': 'your-api-key',
+          'x-honeycomb-dataset': 'your-dataset',
+        },
+      },
+    }
+  })
+
+  afterEach(function () {
+    return nock.cleanAll()
+  })
+
+  it('deletes a space telemetry drain', async function () {
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
+      .get(`/telemetry-drains/${spaceTelemetryDrain.id}`)
+      .reply(200, spaceTelemetryDrain)
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
+      .delete(`/telemetry-drains/${spaceTelemetryDrain.id}`)
+      .reply(200, spaceTelemetryDrain)
+
+    await runCommand(Cmd, [
+      spaceTelemetryDrain.id,
+    ])
+    expectOutput(stderr.output, heredoc(`
+      Removing telemetry drain ${spaceTelemetryDrain.id}, which was configured for space ${spaceTelemetryDrain.owner.name}...
+      Removing telemetry drain ${spaceTelemetryDrain.id}, which was configured for space ${spaceTelemetryDrain.owner.name}... done
+    `))
+  })
+
+  it('deletes an app telemetry drains', async function () {
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
+      .get(`/telemetry-drains/${appTelemetryDrain.id}`)
+      .reply(200, appTelemetryDrain)
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.fir'}})
+      .delete(`/telemetry-drains/${appTelemetryDrain.id}`)
+      .reply(200, spaceTelemetryDrain)
+
+    await runCommand(Cmd, [
+      appTelemetryDrain.id,
+    ])
+    expectOutput(stderr.output, heredoc(`
+      Removing telemetry drain ${appTelemetryDrain.id}, which was configured for app ${appTelemetryDrain.owner.name}...
+      Removing telemetry drain ${appTelemetryDrain.id}, which was configured for app ${appTelemetryDrain.owner.name}... done
+    `))
+  })
+})


### PR DESCRIPTION
[GUS WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE0000215aXkYAI/view)

### Description
Adds `telemetry:remove` command. Will accept an ID for a specific telemetry drain, or `--app` to remove all drains associated with an app or `--space` to remove all drains associated with a space.