### PR TITLE
chore(cli): update help text and tests to reference heroku-24

### DIFF
--- a/packages/cli/src/commands/apps/create.ts
+++ b/packages/cli/src/commands/apps/create.ts
@@ -177,7 +177,7 @@ export default class Create extends Command {
 
   static examples = [
     `$ heroku apps:create
-Creating app... done, stack is heroku-22
+Creating app... done, stack is heroku-24
 https://floating-dragon-42.heroku.com/ | https://git.heroku.com/floating-dragon-42.git
 
 # or just

--- a/packages/cli/src/commands/apps/stacks/set.ts
+++ b/packages/cli/src/commands/apps/stacks/set.ts
@@ -11,8 +11,8 @@ function map(stack: string): string {
 export default class Set extends Command {
   static description = 'set the stack of an app'
 
-  static example = `$ heroku stack:set heroku-22 -a myapp
-Setting stack to heroku-22... done
+  static example = `$ heroku stack:set heroku-24 -a myapp
+Setting stack to heroku-24... done
 You will need to redeploy myapp for the change to take effect.
 Run git push heroku main to trigger a new build on myapp.`
 

--- a/packages/cli/test/unit/commands/apps/info.unit.test.ts
+++ b/packages/cli/test/unit/commands/apps/info.unit.test.ts
@@ -19,7 +19,7 @@ const app = {
 }
 
 const appStackChange = Object.assign({}, app, {
-  build_stack: {name: 'heroku-22'},
+  build_stack: {name: 'heroku-24'},
 })
 
 const appExtended = Object.assign({}, app, {

--- a/packages/cli/test/unit/commands/apps/info.unit.test.ts
+++ b/packages/cli/test/unit/commands/apps/info.unit.test.ts
@@ -349,7 +349,7 @@ Region:           eu
 Repo Size:        1000 B
 Slug Size:        1000 B
 Space:            myspace
-Stack:            cedar-14 (next build will use heroku-22)
+Stack:            cedar-14 (next build will use heroku-24)
 Web URL:          https://myapp.herokuapp.com
 `)
       expect(unwrap(stderr)).to.contains('')

--- a/packages/cli/test/unit/commands/apps/stacks/set.unit.test.ts
+++ b/packages/cli/test/unit/commands/apps/stacks/set.unit.test.ts
@@ -1,7 +1,7 @@
 import {expect, test} from '@oclif/test'
 
 const APP = 'myapp'
-const TO_STACK = 'heroku-22'
+const TO_STACK = 'heroku-24'
 const MAIN_REMOTE = 'main'
 const STAGE_REMOTE = 'staging'
 

--- a/packages/cli/test/unit/commands/container/push.unit.test.ts
+++ b/packages/cli/test/unit/commands/container/push.unit.test.ts
@@ -49,7 +49,7 @@ describe('container push', function () {
     beforeEach(function () {
       api
         .get('/apps/testapp')
-        .reply(200, {name: 'testapp', stack: {name: 'heroku-22'}, build_stack: {name: 'container'}})
+        .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}, build_stack: {name: 'container'}})
     })
 
     it('allows push to the docker registry', async function () {


### PR DESCRIPTION
One of the last steps in the [heroku-24 rollout plan](https://salesforce.quip.com/sMobAV0e0Awa) is to set `heroku-24` as the default stack for new apps. That change (https://github.com/heroku/api/pull/15582) will ship on October 23rd.

This PR updates a few areas of the CLI to match the new default. I don't think it's super important to ship this change exactly on October 23rd. A few days before or after is probably fine.