### PR TITLE
fix(cli): Fixing regression for 'container:release' command

### DIFF
--- a/packages/cli/src/commands/container/release.ts
+++ b/packages/cli/src/commands/container/release.ts
@@ -79,6 +79,11 @@ export default class ContainerRelease extends Command {
       })
     }
 
+    const {body: oldReleases} = await this.heroku.get<Heroku.Release[]>(`/apps/${app}/releases`, {
+      partial: true, headers: {Range: 'version ..; max=1, order=desc'},
+    })
+    const oldRelease = oldReleases[0]
+
     ux.action.start(`Releasing images ${argv.join(',')} to ${app}`)
     await this.heroku.patch(`/apps/${app}/formation`, {
       body: {updates: updateData}, headers: {
@@ -86,11 +91,6 @@ export default class ContainerRelease extends Command {
       },
     })
     ux.action.stop()
-
-    const {body: oldReleases} = await this.heroku.get<Heroku.Release[]>(`/apps/${app}/releases`, {
-      partial: true, headers: {Range: 'version ..; max=2, order=desc'},
-    })
-    const oldRelease = oldReleases[0]
 
     const {body: updatedReleases} = await this.heroku.get<Heroku.Release[]>(`/apps/${app}/releases`, {
       partial: true, headers: {Range: 'version ..; max=1, order=desc'},


### PR DESCRIPTION
## Description

Here we're fixing a regression introduced when the command was migrated to OClif Core (CLI version 9.x), because of the differences between the old way of specifying a UX action and the new one.

The code section that determines the _old_ release version needs to run before the create release action. It was being run after the creation because the command was written in a way where the actual action (create release request) was assigned to a function, the old version was fetched and then the UX action was called passing the function as the block to be executed. When migrating, the action call was splat in its `start` and `stop` calls around the request, but the release version fetching wasn't moved before the action call.

## SOC2 Compliance
[GUS Work Item](https://gus.lightning.force.com/a07EE0000236DX3YAM)