### PR TITLE
Fix access command API error handling

### DIFF
--- a/packages/cli/src/commands/access/index.ts
+++ b/packages/cli/src/commands/access/index.ts
@@ -1,6 +1,6 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
-import { HerokuAPIError } from '@heroku-cli/command/lib/api-client'
+import {HerokuAPIError} from '@heroku-cli/command/lib/api-client'
 import {ux} from '@oclif/core'
 import * as Heroku from '@heroku-cli/schema'
 import * as _ from 'lodash'

--- a/packages/cli/src/commands/access/index.ts
+++ b/packages/cli/src/commands/access/index.ts
@@ -95,7 +95,7 @@ export default class AccessIndex extends Command {
         })
         collaborators = buildCollaboratorsArray(collaborators, admins)
       } catch (error: any) {
-        if (error.statusCode !== 403)
+        if (error.http.statusCode !== 403)
           throw error
       }
     }

--- a/packages/cli/src/commands/access/index.ts
+++ b/packages/cli/src/commands/access/index.ts
@@ -1,5 +1,6 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
+import { HerokuAPIError } from '@heroku-cli/command/lib/api-client'
 import {ux} from '@oclif/core'
 import * as Heroku from '@heroku-cli/schema'
 import * as _ from 'lodash'
@@ -95,7 +96,7 @@ export default class AccessIndex extends Command {
         })
         collaborators = buildCollaboratorsArray(collaborators, admins)
       } catch (error: any) {
-        if (error.http.statusCode !== 403)
+        if (!(error instanceof HerokuAPIError && error.http.statusCode === 403))
           throw error
       }
     }


### PR DESCRIPTION
This PR improves error handling in the `heroku access` command by fixing an issue where permission-related errors weren't caught properly. The previous implementation incorrectly checked `error.statusCode`, which was undefined, causing the command to fail unnecessarily when users lacked permissions to access the `https://api.heroku.com/teams/<team>/members` endpoint.

The updated code now correctly identifies `HerokuAPIError` instances, and checks `error.http.statusCode`, ensuring the command can gracefully handle 403 permission errors and proceed without throwing an error.