### PR TITLE
Update help text and dyno type/process type flag names

### DIFF
--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -13,14 +13,15 @@ export default class Logs extends Command {
   static examples = [
     'heroku logs --app=my-app',
     'heroku logs --num=50 --app=my-app',
-    'heroku logs --dyno=web-123-456 --app=my-app',
-    'heroku logs --type=web --app=my-app',
+    'heroku logs --dyno-name=web-123-456 --app=my-app',
+    'heroku logs --process-type=web --app=my-app',
     'heroku logs --app=my-app --tail',
   ]
 
   static flags = {
     app: flags.app({required: true}),
-    dyno: flags.string({
+    'dyno-name': flags.string({
+      aliases: ['dyno'],
       char: 'd',
       description: 'only show output from this dyno (such as "web-123-456" or "worker.2")',
     }),
@@ -59,7 +60,8 @@ export default class Logs extends Command {
       default: false,
       description: 'continually stream logs (defaults to true for Fir generation apps)',
     }),
-    type: flags.string({
+    'process-type': flags.string({
+      char: 'p',
       description: 'only show output from this process type (such as "web" or "worker")',
       relationships: [
         {type: 'none', flags: ['dyno', 'ps']},
@@ -70,7 +72,7 @@ export default class Logs extends Command {
 
   async run() {
     const {flags} = await this.parse(Logs)
-    const {app, dyno, 'force-colors': forceColors, num, ps, source, tail, type} = flags
+    const {app, 'dyno-name': dyno, 'force-colors': forceColors, num, ps, source, tail, 'process-type': type} = flags
 
     if (forceColors)
       color.enabled = true

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -46,7 +46,7 @@ export default class Logs extends Command {
       hidden: true,
       description: 'hidden alias for type',
       relationships: [
-        {type: 'none', flags: ['dyno']},
+        {type: 'none', flags: ['dyno-name']},
       ],
       completion: ProcessTypeCompletion,
     }),
@@ -64,7 +64,7 @@ export default class Logs extends Command {
       char: 'p',
       description: 'only show output from this process type (such as "web" or "worker")',
       relationships: [
-        {type: 'none', flags: ['dyno', 'ps']},
+        {type: 'none', flags: ['dyno-name', 'ps']},
       ],
       completion: ProcessTypeCompletion,
     }),

--- a/packages/cli/src/commands/ps/stop.ts
+++ b/packages/cli/src/commands/ps/stop.ts
@@ -6,31 +6,32 @@ import {ProcessTypeCompletion} from '@heroku-cli/command/lib/completions'
 import heredoc from 'tsheredoc'
 
 export default class Stop extends Command {
-  static description = 'stop app dyno or dyno type'
+  static description = 'stop an app dyno or process type'
   static topic = 'ps'
   static aliases = ['dyno:stop', 'ps:kill', 'dyno:kill']
   static hiddenAliases = ['stop', 'kill']
 
   static examples = [
-    '$ heroku ps:stop --app myapp --dyno run.1828',
-    '$ heroku ps:stop --app myapp --type run',
+    '$ heroku ps:stop --app myapp --dyno-name run.1828',
+    '$ heroku ps:stop --app myapp --process-type run',
   ]
 
   static args = {
-    dyno: Args.string({required: false, deprecated: true}),
+    dyno: Args.string({description: 'name of the dyno to stop', required: false, deprecated: true}),
   }
 
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
-    dyno: flags.string({
+    'dyno-name': flags.string({
       char: 'd',
-      description: 'stop a specific dyno (such as "web-123-456" or "worker.2")',
+      description: 'name of the dyno to stop',
     }),
-    type: flags.string({
-      description: 'stop all dynos of a process type (such as "web" or "worker")',
+    'process-type': flags.string({
+      char: 'p',
+      description: 'name of the process type to stop',
       completion: ProcessTypeCompletion,
-      exclusive: ['dyno'],
+      exclusive: ['dyno-name'],
     }),
   }
 
@@ -38,8 +39,8 @@ export default class Stop extends Command {
     const {args, flags} = await this.parse(Stop)
 
     const app = flags.app
-    const dyno = flags.dyno || args.dyno
-    const type = flags.type
+    const dyno = flags['dyno-name'] || args.dyno
+    const type = flags['process-type']
     let msg = 'Stopping'
     let stopUrl = ''
 
@@ -48,14 +49,14 @@ export default class Stop extends Command {
       stopUrl = `/apps/${app}/formations/${encodeURIComponent(type)}/actions/stop`
     } else if (dyno) {
       if (args.dyno) {
-        ux.warn(`Passing DYNO as an arg is deprecated. Please use ${color.cmd('heroku ps:stop --dyno')} or ${color.cmd('heroku ps:stop --type')} instead.`)
+        ux.warn(`DYNO is a deprecated argument. Use ${color.cmd('--dyno-name')} or ${color.cmd('--process-type')} instead.`)
       }
 
       msg += ` dyno ${color.cyan(dyno)}`
       stopUrl = `/apps/${app}/dynos/${encodeURIComponent(dyno)}/actions/stop`
     } else {
       ux.error(heredoc(`
-        Please specify a process type or dyno to stop.
+        Please specify a process type or dyno name to stop.
         See more help with --help
       `))
     }

--- a/packages/cli/src/commands/ps/type.ts
+++ b/packages/cli/src/commands/ps/type.ts
@@ -80,7 +80,7 @@ const displayFormation = async (heroku: APIClient, app: string) => {
     throw emptyFormationErr(app)
   }
 
-  ux.styledHeader('Dyno Types')
+  ux.styledHeader('Process Types')
   ux.table(formationTableData, {
     type: {},
     size: {},
@@ -88,7 +88,7 @@ const displayFormation = async (heroku: APIClient, app: string) => {
     'cost/hour': {},
     'max cost/month': {},
   })
-
+  ux.log()
   ux.styledHeader('Dyno Totals')
   ux.table(dynoTotalsTableData, {
     type: {},

--- a/packages/cli/test/acceptance/commands-output.ts
+++ b/packages/cli/test/acceptance/commands-output.ts
@@ -114,7 +114,7 @@ drains:add                                     adds a log drain to an app
 drains:remove                                  removes a log drain from an app
 dyno:kill                                      stop app dyno or dyno type
 dyno:resize                                    manage dyno sizes
-dyno:restart                                   restart app dynos
+dyno:restart                                   restart an app dyno or process type
 dyno:scale                                     scale dyno quantity up or down
 dyno:stop                                      stop app dyno or dyno type
 features                                       list available app features
@@ -238,12 +238,12 @@ ps:autoscale:enable                            enable web dyno autoscaling
 ps:copy                                        Copy a file from a dyno to the local filesystem
 ps:exec                                        Create an SSH session to a dyno
 ps:forward                                     Forward traffic on a local port to a dyno
-ps:kill                                        stop app dyno or dyno type
+ps:kill                                        stop an app dyno or process type
 ps:resize                                      manage dyno sizes
-ps:restart                                     restart app dynos
+ps:restart                                     restart an app dyno or process type
 ps:scale                                       scale dyno quantity up or down
 ps:socks                                       Launch a SOCKS proxy into a dyno
-ps:stop                                        stop app dyno or dyno type
+ps:stop                                        stop an app dyno or process type
 ps:type                                        manage dyno sizes
 ps:wait                                        wait for all dynos to be running latest version after a release
 psql                                           open a psql shell to the database

--- a/packages/cli/test/acceptance/commands-output.ts
+++ b/packages/cli/test/acceptance/commands-output.ts
@@ -112,11 +112,11 @@ domains:wait                                   wait for domain to be active for 
 drains                                         display the log drains of an app
 drains:add                                     adds a log drain to an app
 drains:remove                                  removes a log drain from an app
-dyno:kill                                      stop app dyno or dyno type
+dyno:kill                                      stop an app dyno or process type
 dyno:resize                                    manage dyno sizes
 dyno:restart                                   restart an app dyno or process type
 dyno:scale                                     scale dyno quantity up or down
-dyno:stop                                      stop app dyno or dyno type
+dyno:stop                                      stop an app dyno or process type
 features                                       list available app features
 features:disable                               disables an app feature
 features:enable                                enables an app feature

--- a/packages/cli/test/unit/commands/logs.unit.test.ts
+++ b/packages/cli/test/unit/commands/logs.unit.test.ts
@@ -59,7 +59,7 @@ describe('logs', function () {
     })
   })
 
-  context('with --dyno option', function () {
+  context('with --dyno-name option', function () {
     it('calls logDisplayer function with dyno filter set', async function () {
       await runCommand(Cmd, [
         '--app=my-app',
@@ -113,7 +113,7 @@ describe('logs', function () {
     })
   })
 
-  context('with both --dyno and --ps options', function () {
+  context('with both --dyno-name and --ps options', function () {
     it('shows an error and doesn’t call logDisplayer function', async function () {
       try {
         await runCommand(Cmd, [
@@ -123,14 +123,14 @@ describe('logs', function () {
         ])
       } catch (error: unknown) {
         const {message} = error as CLIError
-        expect(message).to.include('--dyno=web.1 cannot also be provided when using --ps')
+        expect(message).to.include('--dyno-name=web.1 cannot also be provided when using --ps')
       }
 
       expect(logDisplayerStub.notCalled).to.be.true
     })
   })
 
-  context('with both --dyno and --type options', function () {
+  context('with both --dyno-name and --type options', function () {
     it('shows an error and doesn’t call logDisplayer function', async function () {
       try {
         await runCommand(Cmd, [
@@ -140,7 +140,7 @@ describe('logs', function () {
         ])
       } catch (error: unknown) {
         const {message} = error as CLIError
-        expect(message).to.include('--dyno=web.1 cannot also be provided when using --type')
+        expect(message).to.include('--dyno-name=web.1 cannot also be provided when using --process-type')
       }
 
       expect(logDisplayerStub.notCalled).to.be.true
@@ -153,11 +153,11 @@ describe('logs', function () {
         await runCommand(Cmd, [
           '--app=my-app',
           '--ps=web',
-          '--type=worker',
+          '--process-type=worker',
         ])
       } catch (error: unknown) {
         const {message} = error as CLIError
-        expect(message).to.include('--ps=web cannot also be provided when using --type')
+        expect(message).to.include('--ps=web cannot also be provided when using --process-type')
       }
 
       expect(logDisplayerStub.notCalled).to.be.true

--- a/packages/cli/test/unit/commands/logs.unit.test.ts
+++ b/packages/cli/test/unit/commands/logs.unit.test.ts
@@ -63,7 +63,7 @@ describe('logs', function () {
     it('calls logDisplayer function with dyno filter set', async function () {
       await runCommand(Cmd, [
         '--app=my-app',
-        '--dyno=web.2',
+        '--dyno-name=web.2',
       ])
 
       expect(logDisplayerStub.calledWith(sinon.match.any, {
@@ -81,7 +81,7 @@ describe('logs', function () {
     it('calls logDisplayer function with type filter set', async function () {
       await runCommand(Cmd, [
         '--app=my-app',
-        '--type=web',
+        '--process-type=web',
       ])
 
       expect(logDisplayerStub.calledWith(sinon.match.any, {
@@ -118,7 +118,7 @@ describe('logs', function () {
       try {
         await runCommand(Cmd, [
           '--app=my-app',
-          '--dyno=web.1',
+          '--dyno-name=web.1',
           '--ps=worker',
         ])
       } catch (error: unknown) {
@@ -135,8 +135,8 @@ describe('logs', function () {
       try {
         await runCommand(Cmd, [
           '--app=my-app',
-          '--dyno=web.1',
-          '--type=worker',
+          '--dyno-name=web.1',
+          '--process-type=worker',
         ])
       } catch (error: unknown) {
         const {message} = error as CLIError

--- a/packages/cli/test/unit/commands/ps/restart.unit.test.ts
+++ b/packages/cli/test/unit/commands/ps/restart.unit.test.ts
@@ -31,7 +31,7 @@ describe('ps:restart', function () {
     await runCommand(Cmd, [
       '--app',
       'myapp',
-      '--type',
+      '--process-type',
       'web',
     ])
     expectOutput(stderr.output, heredoc(`
@@ -48,7 +48,7 @@ describe('ps:restart', function () {
     await runCommand(Cmd, [
       '--app',
       'myapp',
-      '--dyno',
+      '--dyno-name',
       'web.1',
     ])
     expectOutput(stderr.output, heredoc(`
@@ -67,7 +67,7 @@ describe('ps:restart', function () {
       'myapp',
       'web.1',
     ])
-    expect(stripAnsi(stderr.output)).to.include('Warning: Passing DYNO as an arg is deprecated.')
+    expect(stripAnsi(stderr.output)).to.include('DYNO is a deprecated argument.')
     expect(stderr.output).to.include('Restarting dyno web.1 on ⬢ myapp... done')
   })
 })

--- a/packages/cli/test/unit/commands/ps/stop.unit.test.ts
+++ b/packages/cli/test/unit/commands/ps/stop.unit.test.ts
@@ -13,7 +13,7 @@ describe('ps:stop', function () {
       '--app',
       'myapp',
     ]).catch(error => {
-      expect(error.message).to.include('Please specify a process type or dyno to stop.')
+      expect(error.message).to.include('Please specify a process type or dyno name to stop.')
     })
   })
 

--- a/packages/cli/test/unit/commands/ps/stop.unit.test.ts
+++ b/packages/cli/test/unit/commands/ps/stop.unit.test.ts
@@ -25,7 +25,7 @@ describe('ps:stop', function () {
     await runCommand(Cmd, [
       '--app',
       'myapp',
-      '--type',
+      '--process-type',
       'web',
     ])
     expectOutput(stderr.output, heredoc(`
@@ -42,7 +42,7 @@ describe('ps:stop', function () {
     await runCommand(Cmd, [
       '--app',
       'myapp',
-      '--dyno',
+      '--dyno-name',
       'web.1',
     ])
     expectOutput(stderr.output, heredoc(`
@@ -61,7 +61,7 @@ describe('ps:stop', function () {
       'myapp',
       'web.1',
     ])
-    expect(stripAnsi(stderr.output)).to.include('Warning: Passing DYNO as an arg is deprecated.')
+    expect(stripAnsi(stderr.output)).to.include('Warning: DYNO is a deprecated argument.')
     expect(stderr.output).to.include('Stopping dyno web.1 on ⬢ myapp... done')
   })
 })

--- a/packages/cli/test/unit/commands/ps/type.unit.test.ts
+++ b/packages/cli/test/unit/commands/ps/type.unit.test.ts
@@ -52,6 +52,7 @@ describe('ps:type', function () {
        web  Performance-L-RAM 1   ~$0.694   $500           
        web  Performance-XL    1   ~$1.042   $750           
        web  Performance-2XL   1   ~$2.083   $1500          
+
       === Dyno Totals
        Type              Total 
        ───────────────── ───── 
@@ -94,6 +95,7 @@ describe('ps:type', function () {
        Type Size              Qty Cost/hour Max cost/month 
        ──── ───────────────── ─── ───────── ────────────── 
        web  Performance-L-RAM 1   ~$0.694   $500           
+
       === Dyno Totals
 
        Type              Total 
@@ -128,6 +130,7 @@ describe('ps:type', function () {
  ────── ───── ─── ───────── ──────────────
  web    Basic 1   ~$0.010   $7
  worker Basic 2   ~$0.019   $14
+
 === Dyno Totals
  Type  Total
  ───── ─────
@@ -160,6 +163,7 @@ describe('ps:type', function () {
  ────── ─────────── ─── ───────── ──────────────
  web    Standard-1X 1   ~$0.035   $25
  worker Standard-2X 2   ~$0.139   $100
+
 === Dyno Totals
  Type        Total
  ─────────── ─────
@@ -187,6 +191,7 @@ describe('ps:type', function () {
  ──── ──────── ─── ───────── ──────────────
  web  Shield-M 0
  web  Shield-L 0
+
 === Dyno Totals
  Type     Total
  ──────── ─────

--- a/packages/cli/test/unit/commands/ps/type.unit.test.ts
+++ b/packages/cli/test/unit/commands/ps/type.unit.test.ts
@@ -39,7 +39,7 @@ describe('ps:type', function () {
     ])
 
     expectOutput(stdout.output, heredoc`
-      === Dyno Types
+      === Process Types
 
        Type Size              Qty Cost/hour Max cost/month 
        ──── ───────────────── ─── ───────── ────────────── 
@@ -89,7 +89,7 @@ describe('ps:type', function () {
     api.done()
 
     expect(stdout.output).to.eq(heredoc`
-      === Dyno Types
+      === Process Types
 
        Type Size              Qty Cost/hour Max cost/month 
        ──── ───────────────── ─── ───────── ────────────── 
@@ -123,7 +123,7 @@ describe('ps:type', function () {
       'basic',
     ])
 
-    expectOutput(stdout.output, `=== Dyno Types
+    expectOutput(stdout.output, `=== Process Types
  Type   Size  Qty Cost/hour Max cost/month
  ────── ───── ─── ───────── ──────────────
  web    Basic 1   ~$0.010   $7
@@ -155,7 +155,7 @@ describe('ps:type', function () {
       'worker=standard-2x',
     ])
 
-    expectOutput(stdout.output, `=== Dyno Types
+    expectOutput(stdout.output, `=== Process Types
  Type   Size        Qty Cost/hour Max cost/month
  ────── ─────────── ─── ───────── ──────────────
  web    Standard-1X 1   ~$0.035   $25
@@ -182,7 +182,7 @@ describe('ps:type', function () {
       'myapp',
     ])
 
-    expectOutput(stdout.output, `=== Dyno Types
+    expectOutput(stdout.output, `=== Process Types
  Type Size     Qty Cost/hour Max cost/month
  ──── ──────── ─── ───────── ──────────────
  web  Shield-M 0


### PR DESCRIPTION
[GUS WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000024ZVf9YAG/view)

### Description

This updates text based on cx feedback. It includes standardizing `ps:stop`, `ps:restart`, and `logs` on `--process-type` and `--dyno-name`.

### Testing

1. Pull down branch and `yarn build`
2. Run `heroku logs`, `heroku ps:stop` and `heroku ps:restart` with new flag names.
