### PR TITLE
feat: add fir-specific error message for autoscale:enable

### DIFF
--- a/packages/cli/test/unit/commands/ps/enable.unit.test.ts
+++ b/packages/cli/test/unit/commands/ps/enable.unit.test.ts
@@ -12,7 +12,7 @@ function commonSetup() {
     .stderr()
     .nock(API_HOST, api => api
       .get(`/apps/${APP_NAME}`)
-      .reply(200, {id: APP_ID, name: APP_NAME}),
+      .reply(200, {id: APP_ID, name: APP_NAME, generation: 'cedar'}),
     )
 }
 
@@ -130,4 +130,18 @@ describe('with a Hobby dyno', function () {
     .command(['ps:autoscale:enable', '--min', '1', '--max', '2', '--app', APP_NAME])
     .catch(error => expect(error.message).to.contain('Autoscaling is only available with Performance or Private dynos'))
     .it('rejected non-performance dynos')
+})
+
+describe('with a fir app', function () {
+  test
+    .stderr()
+    .nock(API_HOST, api => api
+      .get(`/apps/${APP_NAME}`)
+      .reply(200, {id: APP_ID, name: APP_NAME, generation: 'fir'})
+      .get(`/apps/${APP_NAME}/formation`)
+      .reply(200, [{id: FORMATION_ID, type: 'web', size: 'Performance-L'}]),
+    )
+    .command(['ps:autoscale:enable', '--min', '1', '--max', '2', '--app', APP_NAME])
+    .catch(error => expect(error.message).to.contain('Autoscaling is unavailable for apps in this space. See https://devcenter.heroku.com/articles/generations.'))
+    .it('rejected fir app')
 })


### PR DESCRIPTION
[Work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE0000201VQxYAM/view)

## Testing
- pull down this branch and run `yarn && yarn build`
- Using a fir app with a dyno, run `./bin/run ps:autoscale:enable -a APP_NAME --min 1 --max 3`
- You should get an error message that reads "Autoscaling is unavailable for apps in this space. See https://devcenter.heroku.com/articles/generations."

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
