### PR TITLE
Update commands to work with published APIs

### DIFF
--- a/packages/cli/src/commands/telemetry/add.ts
+++ b/packages/cli/src/commands/telemetry/add.ts
@@ -23,7 +23,7 @@ export default class Add extends Command {
 
   static example = heredoc(`
     Add a telemetry drain to an app to collect logs and traces:
-    $ heroku telemetry:add --app myapp --signals logs,traces --endpoint https://my-endpoint.com --transport http '{"x-drain-example-team": "API_KEY", "x-drain-example-dataset": "METRICS_DATASET"'
+    $ heroku telemetry:add --app myapp --signals logs,traces --endpoint https://my-endpoint.com --transport http '{"x-drain-example-team": "API_KEY", "x-drain-example-dataset": "METRICS_DATASET"}'
   `)
 
   public async run(): Promise<void> {

--- a/packages/cli/src/commands/telemetry/add.ts
+++ b/packages/cli/src/commands/telemetry/add.ts
@@ -3,6 +3,8 @@ import {Args, ux} from '@oclif/core'
 import {TelemetryDrain} from '../../lib/types/telemetry'
 import heredoc from 'tsheredoc'
 import {validateAndFormatSignals} from '../../lib/telemetry/util'
+import {App, Space} from '@heroku-cli/schema'
+
 export default class Add extends Command {
   static description = 'Add and configure a new telemetry drain. Defaults to collecting all telemetry unless otherwise specified.'
 
@@ -21,26 +23,29 @@ export default class Add extends Command {
 
   static example = heredoc(`
     Add a telemetry drain to an app to collect logs and traces:
-    $ heroku telemetry:add --signals logs,traces --endpoint https://my-endpoint.com --transport http 'x-drain-example-team: API_KEY x-drain-example-dataset: METRICS_DATASET'
+    $ heroku telemetry:add --app myapp --signals logs,traces --endpoint https://my-endpoint.com --transport http '{"x-drain-example-team": "API_KEY", "x-drain-example-dataset": "METRICS_DATASET"'
   `)
-
-  private getTypeAndName = function (app: string | undefined, space: string | undefined) {
-    if (app) {
-      return {type: 'app', name: app}
-    }
-
-    return {type: 'space', name: space}
-  }
 
   public async run(): Promise<void> {
     const {flags, args} = await this.parse(Add)
     const {app, space, signals, endpoint, transport} = flags
     const {headers} = args
-    const typeAndName = this.getTypeAndName(app, space)
+    let id
+    if (app) {
+      const {body: herokuApp} = await this.heroku.get<App>(
+        `/apps/${app}`, {
+          headers: {Accept: 'application/vnd.heroku+json; version=3.sdk'},
+        })
+      id = herokuApp.id
+    } else {
+      const {body: herokuSpace} = await this.heroku.get<Space>(`/spaces/${space}`)
+      id = herokuSpace.id
+    }
+
     const drainConfig = {
       owner: {
-        type: typeAndName.type,
-        id: typeAndName.name,
+        type: app ? 'app' : 'space',
+        id,
       },
       signals: validateAndFormatSignals(signals),
       exporter: {
@@ -50,24 +55,13 @@ export default class Add extends Command {
       },
     }
 
-    if (app) {
-      const {body: drain} = await this.heroku.post<TelemetryDrain>(`/apps/${app}/telemetry-drains`, {
-        body: drainConfig,
-        headers: {
-          Accept: 'application/vnd.heroku+json; version=3.sdk',
-        },
-      })
+    const {body: drain} = await this.heroku.post<TelemetryDrain>('/telemetry-drains', {
+      body: drainConfig,
+      headers: {
+        Accept: 'application/vnd.heroku+json; version=3.sdk',
+      },
+    })
 
-      ux.log(`successfully added drain ${drain.exporter.endpoint}`)
-    } else if (space) {
-      const {body: drain} = await this.heroku.post<TelemetryDrain>(`/spaces/${space}/telemetry-drains`, {
-        body: drainConfig,
-        headers: {
-          Accept: 'application/vnd.heroku+json; version=3.sdk',
-        },
-      })
-
-      ux.log(`successfully added drain ${drain.exporter.endpoint}`)
-    }
+    ux.log(`successfully added drain ${drain.exporter.endpoint}`)
   }
 }

--- a/packages/cli/src/commands/telemetry/remove.ts
+++ b/packages/cli/src/commands/telemetry/remove.ts
@@ -27,8 +27,8 @@ export default class Remove extends Command {
     }
 
     if (telemetry_drain_id) {
-      const telemetryDrain = await this.removeDrain(telemetry_drain_id)
-      ux.action.start(`Removing telemetry drain ${telemetry_drain_id}, which was configured for ${telemetryDrain.owner.type} ${telemetryDrain.owner.name}`)
+      ux.action.start(`Removing telemetry drain ${telemetry_drain_id}`)
+      await this.removeDrain(telemetry_drain_id)
     } else if (app) {
       ux.action.start(`Removing all telemetry drains from app ${app}`)
       const {body: telemetryDrains} = await this.heroku.get<TelemetryDrain[]>(`/apps/${app}/telemetry-drains`, {

--- a/packages/cli/test/unit/commands/telemetry/add.unit.test.ts
+++ b/packages/cli/test/unit/commands/telemetry/add.unit.test.ts
@@ -5,12 +5,21 @@ import {expect} from 'chai'
 import * as nock from 'nock'
 import expectOutput from '../../../helpers/utils/expectOutput'
 import {spaceTelemetryDrain1, appTelemetryDrain1} from '../../../fixtures/telemetry/fixtures'
+import {firApp} from '../../../fixtures/apps/fixtures'
+import * as spaceFixtures from '../../../fixtures/spaces/fixtures'
+import {SpaceWithOutboundIps} from '../../../../src/lib/types/spaces'
 
 const appId = appTelemetryDrain1.owner.id
 const spaceId = spaceTelemetryDrain1.owner.id
 const testEndpoint = appTelemetryDrain1.exporter.endpoint
 
 describe('telemetry:add', function () {
+  let space: SpaceWithOutboundIps
+
+  beforeEach(function () {
+    space = spaceFixtures.spaces['non-shield-space']
+  })
+
   afterEach(function () {
     return nock.cleanAll()
   })
@@ -31,7 +40,7 @@ describe('telemetry:add', function () {
       await runCommand(Cmd, [
         '{"x-honeycomb-team": "your-api-key", "x-honeycomb-dataset": "your-dataset"}',
         '--app',
-        'myapp',
+        firApp.name || '',
         '--space',
         'myspace',
       ])
@@ -43,7 +52,10 @@ describe('telemetry:add', function () {
 
   it('successfully creates a telemetry drain for an app', async function () {
     nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
-      .post(`/apps/${appId}/telemetry-drains`)
+      .get(`/apps/${appId}`)
+      .reply(200, firApp)
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      .post('/telemetry-drains')
       .reply(200, spaceTelemetryDrain1)
 
     await runCommand(Cmd, [
@@ -62,8 +74,11 @@ describe('telemetry:add', function () {
   })
 
   it('successfully creates a telemetry drain for a space', async function () {
+    nock('https://api.heroku.com')
+      .get(`/spaces/${spaceId}`)
+      .reply(200, space)
     nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
-      .post(`/spaces/${spaceId}/telemetry-drains`)
+      .post('/telemetry-drains')
       .reply(200, spaceTelemetryDrain1)
 
     await runCommand(Cmd, [
@@ -82,6 +97,9 @@ describe('telemetry:add', function () {
   })
 
   it('does not accept options other than logs, metrics, traces, or all for the --signal flag', async function () {
+    nock('https://api.heroku.com')
+      .get(`/spaces/${spaceId}`)
+      .reply(200, space)
     try {
       await runCommand(Cmd, [
         '{"x-honeycomb-team": "your-api-key", "x-honeycomb-dataset": "your-dataset"}',
@@ -101,6 +119,9 @@ describe('telemetry:add', function () {
   })
 
   it('returns an error when the --signal flag is set to "all" in combination with other options', async function () {
+    nock('https://api.heroku.com')
+      .get(`/spaces/${spaceId}`)
+      .reply(200, space)
     try {
       await runCommand(Cmd, [
         '{"x-honeycomb-team": "your-api-key", "x-honeycomb-dataset": "your-dataset"}',

--- a/packages/cli/test/unit/commands/telemetry/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/telemetry/index.unit.test.ts
@@ -34,10 +34,10 @@ describe('telemetry:index', function () {
       spaceId,
     ])
     expectOutput(stdout.output, heredoc(`
-      === Space Telemetry Drains
-       Id                                   Signals                         Endpoint                  Space
-       ──────────────────────────────────── ─────────────────────────────── ───────────────────────── ───────
-       44444321-5717-4562-b3fc-2c963f66afa6 [ 'traces', 'metrics', 'logs' ] https://api.honeycomb.io/ myspace
+      === ${spaceId} Telemetry Drains
+       Id                                   Signals                         Endpoint                 
+       ──────────────────────────────────── ─────────────────────────────── ─────────────────────────
+       44444321-5717-4562-b3fc-2c963f66afa6 [ 'traces', 'metrics', 'logs' ] https://api.honeycomb.io/
     `))
   })
 
@@ -51,11 +51,25 @@ describe('telemetry:index', function () {
       appId,
     ])
     expectOutput(stdout.output, heredoc(`
-      === App Telemetry Drains
-       Id                                   Signals                 Endpoint                    App
-       ──────────────────────────────────── ─────────────────────── ─────────────────────────── ─────
-       3fa85f64-5717-4562-b3fc-2c963f66afa6 [ 'traces', 'metrics' ] https://api.honeycomb.io/   myapp
-       55555f64-5717-4562-b3fc-2c963f66afa6 [ 'logs' ]              https://api.papertrail.com/ myapp
+      === ${appId} Telemetry Drains
+       Id                                   Signals                 Endpoint                   
+       ──────────────────────────────────── ─────────────────────── ───────────────────────────
+       3fa85f64-5717-4562-b3fc-2c963f66afa6 [ 'traces', 'metrics' ] https://api.honeycomb.io/
+       55555f64-5717-4562-b3fc-2c963f66afa6 [ 'logs' ]              https://api.papertrail.com/
+    `))
+  })
+
+  it('shows a message when there are no telemetry drains', async function () {
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      .get(`/apps/${appId}/telemetry-drains`)
+      .reply(200, [])
+
+    await runCommand(Cmd, [
+      '--app',
+      appId,
+    ])
+    expectOutput(stdout.output, heredoc(`
+      There are no telemetry drains in ${appId}
     `))
   })
 })

--- a/packages/cli/test/unit/commands/telemetry/remove.unit.test.ts
+++ b/packages/cli/test/unit/commands/telemetry/remove.unit.test.ts
@@ -37,8 +37,8 @@ describe('telemetry:remove', function () {
       spaceTelemetryDrain1.id,
     ])
     expectOutput(stderr.output, heredoc(`
-      Removing telemetry drain ${spaceTelemetryDrain1.id}, which was configured for space ${spaceTelemetryDrain1.owner.name}...
-      Removing telemetry drain ${spaceTelemetryDrain1.id}, which was configured for space ${spaceTelemetryDrain1.owner.name}... done
+      Removing telemetry drain ${spaceTelemetryDrain1.id}...
+      Removing telemetry drain ${spaceTelemetryDrain1.id}... done
     `))
   })
 
@@ -54,8 +54,8 @@ describe('telemetry:remove', function () {
       appTelemetryDrain1.id,
     ])
     expectOutput(stderr.output, heredoc(`
-      Removing telemetry drain ${appTelemetryDrain1.id}, which was configured for app ${appTelemetryDrain1.owner.name}...
-      Removing telemetry drain ${appTelemetryDrain1.id}, which was configured for app ${appTelemetryDrain1.owner.name}... done
+      Removing telemetry drain ${appTelemetryDrain1.id}...
+      Removing telemetry drain ${appTelemetryDrain1.id}... done
     `))
   })
 


### PR DESCRIPTION
[GUS WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000024eNQWYA2/view)

### Description

This updates our OTel command implementations to work with the just published APIs. Notably, the APIs at the moment seem to require IDs instead of names, which is not ideal. Our CLI interface almost always expects the name of a resource, not the ID (if a name exists for the resource, of course). So, for now, we have to make an extra API request to get that name. I also added a "You have no telemetry drains" message for the `telemetry` index list command.

### Testing

1. Pull down branch and `yarn build`
2. `./bin/run telemetry ...` with an app or space
3. see the "you have no drains" message
4. `./bin/run telemetry:add ...` with an app or space
5. `./bin/run telemetry ...` with the app or space using the same app or space
6. see that the new telemetry drain is listed
7. `./bin/run telemetry:update ...`
8. `./bin/run telemetry` ...` and see the changes you made with `update`
9. `./bin/run telemetry:remove ...`
10. `./bin/run telemetry` ...` and see the drain has been removed