### PR TITLE
Handle dyno name parsing for Fir apps

### DIFF
--- a/packages/cli/src/commands/ps/index.ts
+++ b/packages/cli/src/commands/ps/index.ts
@@ -1,14 +1,18 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
-import * as Heroku from '@heroku-cli/schema'
 import {ago} from '../../lib/time'
 import {APIClient} from '@heroku-cli/command'
 import {AccountQuota} from '../../lib/types/account_quota'
+import {AppProcessTier} from '../../lib/types/app_process_tier'
 import {DynoExtended} from '../../lib/types/dyno_extended'
 import heredoc from 'tsheredoc'
+import {Account} from '../../lib/types/fir'
 
 function getProcessNumber(s: string) : number {
+  if (s.includes('-') || !s.includes('.'))
+    return 0
+
   return Number.parseInt(s.split('.', 2)[1], 10)
 }
 
@@ -51,7 +55,7 @@ function truncate(s: string) {
 function printExtended(dynos: DynoExtended[]) {
   const sortedDynos = dynos.sort(byProcessTypeAndNumber)
 
-  ux.table(
+  ux.table<DynoExtended>(
     sortedDynos,
     {
       ID: {get: (dyno: DynoExtended) => dyno.id},
@@ -75,7 +79,7 @@ function printExtended(dynos: DynoExtended[]) {
   )
 }
 
-async function printAccountQuota(heroku: APIClient, app: Required<Heroku.App>, account: Required<Heroku.Account>) {
+async function printAccountQuota(heroku: APIClient, app: AppProcessTier, account: Account) {
   if (app.process_tier !== 'free' && app.process_tier !== 'eco') {
     return
   }
@@ -188,18 +192,24 @@ export default class Index extends Command {
     app: flags.app({required: true}),
     remote: flags.remote(),
     json: flags.boolean({description: 'display as json'}),
-    extended: flags.boolean({char: 'x', hidden: true}), // should be removed? Platform API doesn't serialize extended attributes even if the query param `extended=true` is sent.
+    extended: flags.boolean({char: 'x', hidden: true}), // only works with sudo privileges
   }
 
   public async run(): Promise<void> {
     const {flags, ...restParse} = await this.parse(Index)
     const {app, json, extended} = flags
     const types = restParse.argv as string[]
-    const suffix = extended ? '?extended=true' : '' // read previous comment, including this on the request doesn't make any difference.
+    const suffix = extended ? '?extended=true' : ''
     const promises = {
-      dynos: this.heroku.request<DynoExtended[]>(`/apps/${app}/dynos${suffix}`),
-      appInfo: this.heroku.request<Required<Heroku.App>>(`/apps/${app}`, {headers: {Accept: 'application/vnd.heroku+json; version=3.process-tier'}}),
-      accountInfo: this.heroku.request<Required<Heroku.Account>>('/account'),
+      dynos: this.heroku.request<DynoExtended[]>(`/apps/${app}/dynos${suffix}`, {
+        headers: {Accept: 'application/vnd.heroku+json; version=3.sdk'},
+      }),
+      appInfo: this.heroku.request<AppProcessTier>(`/apps/${app}`, {
+        headers: {Accept: 'application/vnd.heroku+json; version=3.sdk'},
+      }),
+      accountInfo: this.heroku.request<Account>('/account', {
+        headers: {Accept: 'application/vnd.heroku+json; version=3.sdk'},
+      }),
     }
     const [{body: dynos}, {body: appInfo}, {body: accountInfo}] = await Promise.all([promises.dynos, promises.appInfo, promises.accountInfo])
     const shielded = appInfo.space && appInfo.space.shield

--- a/packages/cli/src/commands/ps/index.ts
+++ b/packages/cli/src/commands/ps/index.ts
@@ -10,10 +10,12 @@ import heredoc from 'tsheredoc'
 import {Account} from '../../lib/types/fir'
 
 function getProcessNumber(s: string) : number {
-  if (s.includes('-') || !s.includes('.'))
+  const [processType, dynoNumber] = (s.match(/^([^.]+)\.(.*)$/) || []).slice(1, 3)
+
+  if (!processType || !dynoNumber?.match(/^\d+$/))
     return 0
 
-  return Number.parseInt(s.split('.', 2)[1], 10)
+  return Number.parseInt(dynoNumber, 10)
 }
 
 function uniqueValues(value: string, index: number, self: string[]) : boolean {

--- a/packages/cli/src/lib/types/app_process_tier.ts
+++ b/packages/cli/src/lib/types/app_process_tier.ts
@@ -1,0 +1,4 @@
+import {App} from './fir'
+export interface AppProcessTier extends App {
+  process_tier: string
+}

--- a/packages/cli/src/lib/types/dyno_extended.d.ts
+++ b/packages/cli/src/lib/types/dyno_extended.d.ts
@@ -1,6 +1,6 @@
-import {Dyno} from '@heroku-cli/schema'
+import {Dyno} from './fir'
 
-export interface DynoExtended extends Required<Dyno> {
+export interface DynoExtended extends Dyno {
   /**
    * Extended information.
    */
@@ -14,4 +14,5 @@ export interface DynoExtended extends Required<Dyno> {
     region: string | null,
     route: string | null,
   }
+  [name: string]: unknown
 }

--- a/packages/cli/test/unit/commands/ps/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/ps/index.unit.test.ts
@@ -74,7 +74,7 @@ describe('ps', function () {
       .reply(200, [
         {command: 'npm start', size: '1X-Classic', name: 'web.4ed720fa31-ur8z1', type: 'web', updated_at: hourAgo, state: 'up'},
         {command: 'npm start', size: '1X-Classic', name: 'web.4ed720fa31-5om2v', type: 'web', updated_at: hourAgo, state: 'up'},
-        {command: 'npm start ./worker.js', size: '2X-Compute', name: 'worker.4ed720fa31-w4llb', type: 'worker', updated_at: hourAgo, state: 'up'},
+        {command: 'npm start ./worker.js', size: '2X-Compute', name: 'node-worker.4ed720fa31-w4llb', type: 'node-worker', updated_at: hourAgo, state: 'up'},
       ])
     stubAppAndAccount()
 
@@ -86,14 +86,14 @@ describe('ps', function () {
     api.done()
 
     expect(stdout.output).to.equal(heredoc`
+      === node-worker (2X-Compute): npm start ./worker.js (1)
+
+      node-worker.4ed720fa31-w4llb: up ${hourAgoStr} (~ 1h ago)
+
       === web (1X-Classic): npm start (2)
 
       web.4ed720fa31-5om2v: up ${hourAgoStr} (~ 1h ago)
       web.4ed720fa31-ur8z1: up ${hourAgoStr} (~ 1h ago)
-
-      === worker (2X-Compute): npm start ./worker.js (1)
-
-      worker.4ed720fa31-w4llb: up ${hourAgoStr} (~ 1h ago)
 
     `)
     expect(stderr.output).to.equal('')

--- a/packages/cli/test/unit/commands/ps/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/ps/index.unit.test.ts
@@ -34,7 +34,7 @@ function stubAppAndAccount() {
     .reply(200, {id: '1234'})
 }
 
-describe.only('ps', function () {
+describe('ps', function () {
   afterEach(function () {
     nock.cleanAll()
   })

--- a/packages/cli/test/unit/commands/ps/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/ps/index.unit.test.ts
@@ -11,13 +11,13 @@ const hourAgo = new Date(Date.now() - (60 * 60 * 1000))
 const hourAgoStr = strftime('%Y/%m/%d %H:%M:%S %z', hourAgo)
 
 function stubAccountQuota(code: number, body: Record<string, unknown>) {
-  nock('https://api.heroku.com', {reqheaders: {accept: 'application/vnd.heroku+json; version=3.process-tier'}})
+  nock('https://api.heroku.com', {reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}})
     .get('/apps/myapp')
     .reply(200, {process_tier: 'eco', owner: {id: '1234'}, id: '6789'})
-  nock('https://api.heroku.com')
+  nock('https://api.heroku.com', {reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}})
     .get('/apps/myapp/dynos')
     .reply(200, [{command: 'bash', size: 'Eco', name: 'run.1', type: 'run', updated_at: hourAgo, state: 'up'}])
-  nock('https://api.heroku.com')
+  nock('https://api.heroku.com', {reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}})
     .get('/account')
     .reply(200, {id: '1234'})
   nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.account-quotas'}})
@@ -26,21 +26,21 @@ function stubAccountQuota(code: number, body: Record<string, unknown>) {
 }
 
 function stubAppAndAccount() {
-  nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.process-tier'}})
+  nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
     .get('/apps/myapp')
     .reply(200, {process_tier: 'basic', owner: {id: '1234'}, id: '6789'})
-  nock('https://api.heroku.com')
+  nock('https://api.heroku.com', {reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}})
     .get('/account')
     .reply(200, {id: '1234'})
 }
 
-describe('ps', function () {
+describe.only('ps', function () {
   afterEach(function () {
     nock.cleanAll()
   })
 
   it('shows dyno list', async function () {
-    const api = nock('https://api.heroku.com')
+    const api = nock('https://api.heroku.com', {reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}})
       .get('/apps/myapp/dynos')
       .reply(200, [
         {command: 'npm start', size: 'Eco', name: 'web.1', type: 'web', updated_at: hourAgo, state: 'up'},
@@ -69,7 +69,7 @@ describe('ps', function () {
   })
 
   it('shows dyno list for Fir apps', async function () {
-    const api = nock('https://api.heroku.com')
+    const api = nock('https://api.heroku.com', {reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}})
       .get('/apps/myapp/dynos')
       .reply(200, [
         {command: 'npm start', size: '1X-Classic', name: 'web.4ed720fa31-ur8z1', type: 'web', updated_at: hourAgo, state: 'up'},
@@ -100,7 +100,7 @@ describe('ps', function () {
   })
 
   it('shows shield dynos in dyno list for apps in a shielded private space', async function () {
-    const api = nock('https://api.heroku.com')
+    const api = nock('https://api.heroku.com', {reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}})
       .get('/apps/myapp')
       .reply(200, {space: {shield: true}})
       .get('/apps/myapp/dynos')
@@ -132,7 +132,7 @@ describe('ps', function () {
   })
 
   it('errors when no dynos found', async function () {
-    const api = nock('https://api.heroku.com')
+    const api = nock('https://api.heroku.com', {reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}})
       .get('/apps/myapp/dynos')
       .reply(200, [
         {command: 'npm start', size: 'Eco', name: 'web.1', type: 'web', updated_at: hourAgo, state: 'up'},
@@ -157,7 +157,7 @@ describe('ps', function () {
   })
 
   it('shows dyno list as json', async function () {
-    const api = nock('https://api.heroku.com')
+    const api = nock('https://api.heroku.com', {reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}})
       .get('/account')
       .reply(200, {id: '1234'})
       .get('/apps/myapp')
@@ -179,7 +179,7 @@ describe('ps', function () {
   })
 
   it('shows extended info', async function () {
-    const api = nock('https://api.heroku.com')
+    const api = nock('https://api.heroku.com', {reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}})
       .get('/account')
       .reply(200, {id: '1234'})
       .get('/apps/myapp')
@@ -225,7 +225,7 @@ describe('ps', function () {
   })
 
   it('shows extended info for Private Space app', async function () {
-    const api = nock('https://api.heroku.com')
+    const api = nock('https://api.heroku.com', {reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}})
       .get('/account')
       .reply(200, {id: '1234'})
       .get('/apps/myapp')
@@ -289,7 +289,7 @@ describe('ps', function () {
   })
 
   it('shows shield dynos in extended info if app is in a shielded private space', async function () {
-    const api = nock('https://api.heroku.com')
+    const api = nock('https://api.heroku.com', {reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}})
       .get('/account')
       .reply(200, {id: '1234'})
       .get('/apps/myapp')
@@ -463,10 +463,10 @@ describe('ps', function () {
   })
 
   it('does not print out for apps that are not owned', async function () {
-    nock('https://api.heroku.com')
+    nock('https://api.heroku.com', {reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}})
       .get('/account')
       .reply(200, {id: '1234'})
-    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.process-tier'}})
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
       .get('/apps/myapp')
       .reply(200, {
         process_tier: 'eco', owner: {id: '5678'},
@@ -474,7 +474,7 @@ describe('ps', function () {
     nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.account-quotas'}})
       .get('/accounts/1234/actions/get-quota')
       .reply(200, {account_quota: 1000, quota_used: 1, apps: []})
-    const dynos = nock('https://api.heroku.com')
+    const dynos = nock('https://api.heroku.com', {reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}})
       .get('/apps/myapp/dynos')
       .reply(200, [{command: 'bash', size: 'Eco', name: 'run.1', type: 'run', updated_at: hourAgo, state: 'up'}])
     const ecoExpression = heredoc`
@@ -496,13 +496,13 @@ describe('ps', function () {
   })
 
   it('does not print out for non-eco apps', async function () {
-    nock('https://api.heroku.com')
+    nock('https://api.heroku.com', {reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}})
       .get('/account')
       .reply(200, {id: '1234'})
-    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.process-tier'}})
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
       .get('/apps/myapp')
       .reply(200, {process_tier: 'eco', owner: {id: 1234}})
-    const dynos = nock('https://api.heroku.com')
+    const dynos = nock('https://api.heroku.com', {reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}})
       .get('/apps/myapp/dynos')
       .reply(200, [{command: 'bash', size: 'Eco', name: 'run.1', type: 'run', updated_at: hourAgo, state: 'up'}])
     const ecoExpression = heredoc`
@@ -542,7 +542,7 @@ describe('ps', function () {
   })
 
   it('logs to stdout and exits zero when no dynos', async function () {
-    const dynos = nock('https://api.heroku.com')
+    const dynos = nock('https://api.heroku.com', {reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}})
       .get('/apps/myapp/dynos')
       .reply(200, [])
     stubAppAndAccount()


### PR DESCRIPTION
## Description

Here we introduce changes to correctly parse dyno names for both Cedar & Fir generation apps, updating requests to use the `3.sdk` variant.

## SOC2
[GUS Work Item](https://gus.lightning.force.com/a07EE00001wVfD5YAK)
