### PR TITLE
feat(addons): add inference disclaimer

### DIFF
--- a/packages/cli/src/commands/addons/create.ts
+++ b/packages/cli/src/commands/addons/create.ts
@@ -75,10 +75,30 @@ export default class Create extends Command {
     const argv = (restParse.argv as string[])
     // oclif duplicates specified args in argv
       .filter(arg => arg !== servicePlan)
+    const inferenceRegex = /heroku-inference.*/
+    const isInferenceAddon = inferenceRegex.test(servicePlan)
 
     if (restParse.nonExistentFlags && restParse.nonExistentFlags.length > 0) {
       process.stderr.write(` ${color.yellow('›')}   For example: ${color.cyan(`heroku addons:create -a ${app} ${restParse.raw[0].input} -- ${restParse.nonExistentFlags.join(' ')}`)}`)
       process.stderr.write(` ${color.yellow('›')}   See https://devcenter.heroku.com/changelog-items/2925 for more info.\n`)
+    }
+
+    if (isInferenceAddon) {
+      ux.warn(
+        '\n\nThis pilot feature is a Beta Service. You may opt to try such Beta Service in your sole discretion. ' +
+    'Any use of the Beta Service is subject to the applicable Beta Services Terms provided at ' +
+    'https://www.salesforce.com/company/legal/customer-agreements/. While use of the pilot feature itself is free, ' +
+    'to the extent such use consumes a generally available Service, you may be charged for that consumption as set ' +
+    'forth in the Documentation. Your continued use of this pilot feature constitutes your acceptance of the foregoing.\n\n' +
+    'For clarity and without limitation, the various third-party machine learning and generative artificial intelligence ' +
+    '(AI) models and applications (each a “Platform”) integrated with the Beta Service are Non-SFDC Applications, ' +
+    'as that term is defined in the Beta Services Terms. Note that these third-party Platforms include features that use ' +
+    'generative AI technology. Due to the nature of generative AI, the output that a Platform generates may be ' +
+    'unpredictable, and may include inaccurate or harmful responses. Before using any generative AI output, Customer is ' +
+    'solely responsible for reviewing the output for accuracy, safety, and compliance with applicable laws and third-party ' +
+    'acceptable use policies. In addition, Customer’s use of each Platform may be subject to the Platform’s own terms and ' +
+    'conditions, compliance with which Customer is solely responsible.\n',
+      )
     }
 
     const config = parseConfig(argv)

--- a/packages/cli/src/commands/addons/create.ts
+++ b/packages/cli/src/commands/addons/create.ts
@@ -75,7 +75,7 @@ export default class Create extends Command {
     const argv = (restParse.argv as string[])
     // oclif duplicates specified args in argv
       .filter(arg => arg !== servicePlan)
-    const inferenceRegex = /heroku-inference.*/
+    const inferenceRegex = /^heroku-inference/
     const isInferenceAddon = inferenceRegex.test(servicePlan)
 
     if (restParse.nonExistentFlags && restParse.nonExistentFlags.length > 0) {

--- a/packages/cli/test/unit/commands/addons/create.unit.test.ts
+++ b/packages/cli/test/unit/commands/addons/create.unit.test.ts
@@ -14,6 +14,9 @@ describe('addons:create', function () {
   const addon = {
     id: 201, name: 'db3-swiftly-123', addon_service: {name: 'heroku-db3'}, app: {name: 'myapp', id: 101}, config_vars: ['DATABASE_URL'], plan: {price: {cents: 10000, unit: 'month'}}, state: 'provisioned', provision_message: 'provision message',
   }
+  const inferenceAddon = {
+    id: 201, name: 'claude-3-5-sonnet-acute-43973', addon_service: {name: 'heroku-inference-claude'}, app: {name: 'myapp', id: 101}, config_vars: ['INFERENCE_KEY', 'INFERENCE_MODEL_ID', 'INFERENCE_URL'], plan: {price: {cents: 0, unit: 'month'}}, state: 'provisioned', provision_message: 'provision message',
+  }
 
   beforeEach(async function () {
     api = nock('https://api.heroku.com:443')
@@ -371,6 +374,25 @@ describe('addons:create', function () {
       ])
       expect(stderr.output).to.contain('Creating heroku-postgresql:standard-0 on ⬢ myapp... ~$0.139/hour (max $100/month)\n')
       expect(stdout.output).to.equal('provision message\nCreated db3-swiftly-123\nUse heroku addons:docs heroku-db3 to view documentation\n')
+    })
+  })
+
+  context('creating an inference addon', function () {
+    beforeEach(function () {
+      api.post('/apps/myapp/addons', {
+        plan: {name: 'heroku-inference:claude-3-5-sonnet'}, name: 'foobar', attachment: {}, config: {},
+      })
+        .reply(200, inferenceAddon)
+    })
+    it('displays disclaimer when creating inference addon', async function () {
+      await runCommand(Cmd, [
+        'heroku-inference:claude-3-5-sonnet',
+        '--app',
+        'myapp',
+        '--name',
+        'foobar',
+      ])
+      expect(stderr.output).to.contain('This pilot feature is a Beta Service.')
     })
   })
 })


### PR DESCRIPTION
## Description
[Work Item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000024oOrVYAU/view)

This PR adds a disclaimer when creating inference models using `heroku addons:create`

## Testing
1. Pull down branch & `yarn` it up
2. Confirm disclaimer is present when creating an inference model instance via `./bin/run addons:create heroku-inference-staging:claude-3-5-sonnet -a heroku-cli-test-staging`
3. Destroy addon for clean up via `./bin/run addons:destroy <INFERENCE_MODEL_ID> -a heroku-cli-test-staging`