### PR TITLE
chore: make moratorium check required for all jobs in create-cli-release

### DIFF
--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -22,6 +22,7 @@ jobs:
     uses: ./.github/workflows/ctc.yml
 
   get-version-channel:
+    needs: [check-for-moratorium]
     runs-on: ubuntu-latest
     outputs:
       channel: ${{ steps.getVersion.outputs.channel }}
@@ -36,7 +37,7 @@ jobs:
           path: './packages/cli/package.json'
 
   publish-npm:
-    needs: [get-version-channel]
+    needs: [check-for-moratorium, get-version-channel]
     # if NOT isStableCandidate confirm dist tag is in package.json version
     if: fromJSON(needs.get-version-channel.outputs.isStableRelease) || (!fromJSON(inputs.isStableCandidate) && !!needs.get-version-channel.outputs.channel)
     uses: ./.github/workflows/publish-npm.yml
@@ -46,12 +47,12 @@ jobs:
     secrets: inherit
 
   pack-upload:
-    needs: [ publish-npm ]
+    needs: [check-for-moratorium, publish-npm]
     uses: ./.github/workflows/pack-upload.yml
     secrets: inherit
 
   promote:
-    needs: [get-version-channel, pack-upload]
+    needs: [check-for-moratorium, get-version-channel, pack-upload]
     if: needs.pack-upload.result == 'success'
     uses: ./.github/workflows/promote-release.yml
     with:
@@ -61,7 +62,7 @@ jobs:
     secrets: inherit
 
   publish-docs:
-    needs: [ get-version-channel, promote ]
+    needs: [check-for-moratorium, get-version-channel, promote]
     uses: ./.github/workflows/devcenter-doc-update.yml
     with:
       isStableRelease: ${{ needs.get-version-channel.outputs.isStableRelease }}

--- a/.github/workflows/start-gh-release.yml
+++ b/.github/workflows/start-gh-release.yml
@@ -8,7 +8,11 @@ on:
       - closed
 
 jobs:
+  check-for-moratorium:
+    uses: ./.github/workflows/ctc.yml
+
   get-source-branch-name:
+    needs: [check-for-moratorium]
     # GHA does not provide short name for branch being merged in. This shortens it so we can validate it with startsWith()
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
@@ -22,7 +26,7 @@ jobs:
         run: echo "sourceName=${GITHUB_HEAD_REF#refs/heads/}" >> $GITHUB_OUTPUT
 
   start-release:
-    needs: [ get-source-branch-name ]
+    needs: [ get-source-branch-name, check-for-moratorium ]
     if: startsWith(needs.get-source-branch-name.outputs.sourceName, 'release-')
     uses: ./.github/workflows/tag-create-github-release.yml
     secrets: inherit


### PR DESCRIPTION
Requires that the check-for-moratorium job pass for any of the other jobs in create-cli-release.yml to run. This is probably overkill, we probably only need to require it for get-version-channel, but I want to make absolutely sure that none of these jobs run unless the moratorium check passes.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
