### PR TITLE
Update release commands to work with eligibility attribute.

### DIFF
--- a/packages/cli/src/commands/releases/index.ts
+++ b/packages/cli/src/commands/releases/index.ts
@@ -87,8 +87,10 @@ export default class Index extends Command {
     const url = `/apps/${app}/releases${extended ? '?extended=true' : ''}`
 
     const {body: releases} = await this.heroku.request<Heroku.Release[]>(url, {
-      partial: true, headers: {
+      partial: true,
+      headers: {
         Range: `version ..; max=${num || 15}, order=desc`,
+        Accept: 'application/vnd.heroku+json; version=3.sdk',
       },
     })
 
@@ -136,7 +138,7 @@ export default class Index extends Command {
       let header = `${app} Releases`
       const currentRelease = releases.find(r => r.current === true)
       if (currentRelease) {
-        header += ' - ' + color.blue(`Current: v${currentRelease.version}`)
+        header += ' - ' + color.cyan(`Current: v${currentRelease.version}`)
       }
 
       ux.styledHeader(header)

--- a/packages/cli/src/commands/releases/info.ts
+++ b/packages/cli/src/commands/releases/info.ts
@@ -42,7 +42,11 @@ export default class Info extends Command {
 
         ux.styledHeader(`Release ${color.cyan('v' + release.version)}`)
         ux.styledObject({
-          'Add-ons': release.addon_plan_names, Change: releaseChange, By: userEmail, When: release.created_at,
+          'Add-ons': release.addon_plan_names,
+          Change: releaseChange,
+          By: userEmail,
+          'Eligible for Rollback?': release.eligible_for_rollback ? 'Yes' : 'No',
+          When: release.created_at,
         })
         ux.log()
         ux.styledHeader(`${color.cyan('v' + release.version)} Config vars`)

--- a/packages/cli/src/lib/releases/status_helper.ts
+++ b/packages/cli/src/lib/releases/status_helper.ts
@@ -4,6 +4,8 @@ export const description = function (release: {status?: string, [k: string]: any
     return 'release command executing'
   case 'failed':
     return 'release command failed'
+  case 'expired':
+    return 'release command expired'
   default:
     return ''
   }
@@ -15,7 +17,9 @@ export const color = function (s?: string) {
     return 'yellow'
   case 'failed':
     return 'red'
+  case 'expired':
+    return 'gray'
   default:
-    return 'white'
+    return 'cyan'
   }
 }

--- a/packages/cli/src/lib/releases/status_helper.ts
+++ b/packages/cli/src/lib/releases/status_helper.ts
@@ -5,7 +5,7 @@ export const description = function (release: {status?: string, [k: string]: any
   case 'failed':
     return 'release command failed'
   case 'expired':
-    return 'release command expired'
+    return 'release expired'
   default:
     return ''
   }

--- a/packages/cli/test/unit/commands/releases/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/releases/index.unit.test.ts
@@ -107,11 +107,6 @@ describe('releases', function () {
       },
     },
   ]
-  const slug = {
-    process_types: {
-      release: 'bundle exec rake db:migrate',
-    },
-  }
 
   it('shows releases', async function () {
     process.stdout.isTTY = true
@@ -134,7 +129,7 @@ describe('releases', function () {
  v37 first commit                  rdagg@heroku.com 2015/11/18 01:36:38 +0000 
 `)
     assertLineWidths(stdout.output, 80)
-    // expect(stderr.output).to.equal('')
+    expect(stderr.output).to.equal('')
     api.done()
   })
 

--- a/packages/cli/test/unit/commands/releases/info.unit.test.ts
+++ b/packages/cli/test/unit/commands/releases/info.unit.test.ts
@@ -3,6 +3,8 @@ import Cmd  from '../../../../src/commands/releases/info'
 import runCommand from '../../../helpers/runCommand'
 import * as nock from 'nock'
 import {expect} from 'chai'
+import expectOutput from '../../../helpers/utils/expectOutput'
+import heredoc from 'tsheredoc'
 
 const d = new Date(2000, 1, 1)
 describe('releases:info', function () {
@@ -14,98 +16,200 @@ describe('releases:info', function () {
     description: 'something changed',
     user: {
       email: 'foo@foo.com',
-    }, created_at: d, version: 10, addon_plan_names: ['addon1', 'addon2'],
+    }, created_at: d,
+    version: 10,
+    eligible_for_rollback: true,
+    addon_plan_names: ['addon1', 'addon2'],
   }
 
   const configVars = {FOO: 'foo', BAR: 'bar'}
 
-  it('shows most recent release info', function () {
-    const api = nock('https://api.heroku.com:443')
+  it('shows most recent release info', async function () {
+    nock('https://api.heroku.com')
       .get('/apps/myapp/releases')
       .reply(200, [release])
       .get('/apps/myapp/releases/10/config-vars')
       .reply(200, configVars)
-    return runCommand(Cmd, [
+    await runCommand(Cmd, [
       '--app',
       'myapp',
     ])
-      .then(() => expect(stdout.output).to.equal(`=== Release v10\n\nAdd-ons: addon1\n         addon2\nBy:      foo@foo.com\nChange:  something changed\nWhen:    ${d.toISOString()}\n\n=== v10 Config vars\n\nBAR: bar\nFOO: foo\n`))
-      .then(() => api.done())
+    expectOutput(stdout.output, heredoc(`
+      === Release v10
+      Add-ons:                addon1
+                              addon2
+      By:                     foo@foo.com
+      Change:                 something changed
+      Eligible for Rollback?: Yes
+      When:                   ${d.toISOString()}
+
+      === v10 Config vars
+
+      BAR: bar
+      FOO: foo
+    `))
   })
 
-  it('shows most recent release info config vars as shell', function () {
-    const api = nock('https://api.heroku.com:443')
+  it('shows most recent release info config vars as shell', async function () {
+    nock('https://api.heroku.com')
       .get('/apps/myapp/releases')
       .reply(200, [release])
       .get('/apps/myapp/releases/10/config-vars')
       .reply(200, configVars)
-    return runCommand(Cmd, [
+    await runCommand(Cmd, [
       '--app',
       'myapp',
       '--shell',
     ])
-      .then(() => expect(stdout.output).to.equal(`=== Release v10\n\nAdd-ons: addon1\n         addon2\nBy:      foo@foo.com\nChange:  something changed\nWhen:    ${d.toISOString()}\n\n=== v10 Config vars\n\nFOO=foo\nBAR=bar\n`))
-      .then(() => api.done())
+    expectOutput(stdout.output, heredoc(`
+      === Release v10
+      Add-ons:                addon1
+                              addon2
+      By:                     foo@foo.com
+      Change:                 something changed
+      Eligible for Rollback?: Yes
+      When:                   ${d.toISOString()}
+
+      === v10 Config vars
+
+      BAR=bar
+      FOO=foo
+    `))
   })
 
-  it('shows release info by id', function () {
-    const api = nock('https://api.heroku.com:443')
+  it('shows release info by id', async function () {
+    nock('https://api.heroku.com')
       .get('/apps/myapp/releases/10')
       .reply(200, release)
       .get('/apps/myapp/releases/10/config-vars')
       .reply(200, configVars)
-    return runCommand(Cmd, [
+    await runCommand(Cmd, [
       '--app',
       'myapp',
       'v10',
     ])
-      .then(() => expect(stdout.output).to.equal(`=== Release v10\n\nAdd-ons: addon1\n         addon2\nBy:      foo@foo.com\nChange:  something changed\nWhen:    ${d.toISOString()}\n\n=== v10 Config vars\n\nBAR: bar\nFOO: foo\n`))
-      .then(() => api.done())
+    expectOutput(stdout.output, heredoc(`
+      === Release v10
+      Add-ons:                addon1
+                              addon2
+      By:                     foo@foo.com
+      Change:                 something changed
+      Eligible for Rollback?: Yes
+      When:                   ${d.toISOString()}
+
+      === v10 Config vars
+
+      BAR: bar
+      FOO: foo
+    `))
   })
 
-  it('shows recent release as json', function () {
-    const api = nock('https://api.heroku.com:443')
+  it('shows recent release as json', async function () {
+    nock('https://api.heroku.com')
       .get('/apps/myapp/releases/10')
       .reply(200, release)
-    return runCommand(Cmd, [
+    await runCommand(Cmd, [
       '--app',
       'myapp',
       '--json',
       'v10',
     ])
-      .then(() => expect(stdout.output).to.contain('"version": 10'))
-      .then(() => api.done())
+    expect(stdout.output).to.contain('"version": 10')
   })
 
-  it('shows a failed release info', function () {
-    const api = nock('https://api.heroku.com:443')
+  it('shows a failed release info', async function () {
+    nock('https://api.heroku.com')
       .get('/apps/myapp/releases')
       .reply(200, [{
-        description: 'something changed', status: 'failed', user: {email: 'foo@foo.com'}, created_at: d, version: 10,
+        description: 'something changed',
+        status: 'failed',
+        eligible_for_rollback: false,
+        user: {email: 'foo@foo.com'},
+        created_at: d,
+        version: 10,
       }])
       .get('/apps/myapp/releases/10/config-vars')
       .reply(200, configVars)
-    return runCommand(Cmd, [
+    await runCommand(Cmd, [
       '--app',
       'myapp',
     ])
-      .then(() => expect(stdout.output).to.equal(`=== Release v10\n\nBy:      foo@foo.com\nChange:  something changed (release command failed)\nWhen:    ${d.toISOString()}\n\n=== v10 Config vars\n\nBAR: bar\nFOO: foo\n`))
-      .then(() => api.done())
+    expectOutput(stdout.output, heredoc(`
+      === Release v10
+      By:                     foo@foo.com
+      Change:                 something changed (release command failed)
+      Eligible for Rollback?: No
+      When:                   ${d.toISOString()}
+
+      === v10 Config vars
+
+      BAR: bar
+      FOO: foo
+    `))
   })
 
-  it('shows a pending release info', function () {
-    const api = nock('https://api.heroku.com:443')
+  it('shows a pending release info', async function () {
+    nock('https://api.heroku.com')
       .get('/apps/myapp/releases')
       .reply(200, [{
-        addon_plan_names: ['addon1', 'addon2'], description: 'something changed', status: 'pending', user: {email: 'foo@foo.com'}, version: 10, created_at: d,
+        addon_plan_names: ['addon1', 'addon2'],
+        description: 'something changed',
+        status: 'pending',
+        user: {email: 'foo@foo.com'},
+        version: 10,
+        eligible_for_rollback: false,
+        created_at: d,
       }])
       .get('/apps/myapp/releases/10/config-vars')
       .reply(200, configVars)
-    return runCommand(Cmd, [
+    await runCommand(Cmd, [
       '--app',
       'myapp',
     ])
-      .then(() => expect(stdout.output).to.equal(`=== Release v10\n\nAdd-ons: addon1\n         addon2\nBy:      foo@foo.com\nChange:  something changed (release command executing)\nWhen:    ${d.toISOString()}\n\n=== v10 Config vars\n\nBAR: bar\nFOO: foo\n`))
-      .then(() => api.done())
+    expectOutput(stdout.output, heredoc(`
+      === Release v10
+      Add-ons:                addon1
+                              addon2
+      By:                     foo@foo.com
+      Change:                 something changed (release command executing)
+      Eligible for Rollback?: No
+      When:                   ${d.toISOString()}
+
+      === v10 Config vars
+
+      BAR: bar
+      FOO: foo
+    `))
+  })
+
+  it("shows an expired release's info", async function () {
+    nock('https://api.heroku.com')
+      .get('/apps/myapp/releases')
+      .reply(200, [{
+        description: 'something changed',
+        status: 'expired',
+        eligible_for_rollback: false,
+        user: {email: 'foo@foo.com'},
+        created_at: d,
+        version: 10,
+      }])
+      .get('/apps/myapp/releases/10/config-vars')
+      .reply(200, configVars)
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+    ])
+    expectOutput(stdout.output, heredoc(`
+      === Release v10
+      By:                     foo@foo.com
+      Change:                 something changed (release expired)
+      Eligible for Rollback?: No
+      When:                   ${d.toISOString()}
+
+      === v10 Config vars
+
+      BAR: bar
+      FOO: foo
+    `))
   })
 })

--- a/packages/cli/test/unit/commands/releases/info.unit.test.ts
+++ b/packages/cli/test/unit/commands/releases/info.unit.test.ts
@@ -72,8 +72,8 @@ describe('releases:info', function () {
 
       === v10 Config vars
 
-      BAR=bar
       FOO=foo
+      BAR=bar
     `))
   })
 

--- a/packages/cli/test/unit/commands/releases/info.unit.test.ts
+++ b/packages/cli/test/unit/commands/releases/info.unit.test.ts
@@ -1,4 +1,4 @@
-import {stdout, stderr} from 'stdout-stderr'
+import {stdout} from 'stdout-stderr'
 import Cmd  from '../../../../src/commands/releases/info'
 import runCommand from '../../../helpers/runCommand'
 import * as nock from 'nock'

--- a/packages/cli/test/unit/commands/releases/rollback.unit.test.ts
+++ b/packages/cli/test/unit/commands/releases/rollback.unit.test.ts
@@ -29,7 +29,7 @@ describe('releases:rollback', function () {
   it('rolls back to the latest release', async function () {
     const api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
-      .reply(200, [{id: 'current_release', version: 41, status: 'succeeded'}, {id: 'previous_release', version: 40, status: 'succeeded'}])
+      .reply(200, [{id: 'current_release', version: 41, status: 'succeeded', eligible_for_rollback: true}, {id: 'previous_release', version: 40, status: 'succeeded', eligible_for_rollback: true}])
       .post('/apps/myapp/releases', {release: 'previous_release'})
       .reply(200, {})
 
@@ -44,7 +44,7 @@ describe('releases:rollback', function () {
   it('does not roll back to a failed release', async function () {
     const api = nock('https://api.heroku.com:443')
       .get('/apps/myapp/releases')
-      .reply(200, [{id: 'current_release', version: 41, status: 'succeeded'}, {id: 'failed_release', version: 40, status: 'failed'}, {id: 'succeeded_release', version: 39, status: 'succeeded'}])
+      .reply(200, [{id: 'current_release', version: 41, status: 'succeeded', eligible_for_rollback: true}, {id: 'failed_release', version: 40, status: 'failed', eligible_for_rollback: false}, {id: 'succeeded_release', version: 39, status: 'succeeded', eligible_for_rollback: true}])
       .post('/apps/myapp/releases', {release: 'succeeded_release'})
       .reply(200, {})
 
@@ -76,7 +76,7 @@ describe('releases:rollback', function () {
     api.done()
 
     const stderr_output = unwrap(stderr.output)
-    expect(stderr_output).to.contain('Rolling back myapp to v40... done, v40')
+    expect(stderr_output).to.contain('Rolling back ⬢ myapp to v40... done, v40')
     expect(stderr_output).to.contain("Rollback affects code and config vars; it doesn't add or remove addons.")
     expect(stderr_output).to.contain('To undo, run: heroku rollback v39')
     expect(stdout.output).to.equal('Running release command...\nRelease Output Content')


### PR DESCRIPTION
[GUS WI 1](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000024xGDsYAM/view)
[GUS WI 2](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000024wRJaYAM/view)

### Description

With fir APIs, a new attribute, `eligible_for_rollback`, has been introduced to determine if that release can be rolled back to. This PR:
1. Updates `releases:info` to display the value explicitly
2. Updates `releases` to display `expired` status when a release is expired
3. Updates `releases:rollback` to filter based on rollback eligibility
4. Updates color of `v` label in `releases` to account for `expired` status

### Testing

There aren't any releases created that are expired (yet?), but running `releases`, `releases:info`, and `releases:rollback` on an app to ensure no regressions introduced is good.