### PR TITLE
Updated analytics to be passive yet guaranteed to complete before exit

### DIFF
--- a/packages/cli/src/analytics.ts
+++ b/packages/cli/src/analytics.ts
@@ -36,15 +36,18 @@ export default class AnalyticsCommand {
 
   http: typeof deps.HTTP
 
+  initialize: Promise<void>;
+
   constructor(config: Interfaces.Config) {
     this.config = config
     this.http = deps.HTTP.create({
       headers: {'user-agent': config.userAgent},
     })
+    this.initialize = this.init()
   }
 
   async record(opts: RecordOpts) {
-    await this.init()
+    await this.initialize
     const plugin = opts.Command.plugin
     if (!plugin) {
       debug('no plugin found for analytics')

--- a/packages/cli/src/hooks/postrun/performance_analytics.ts
+++ b/packages/cli/src/hooks/postrun/performance_analytics.ts
@@ -12,6 +12,7 @@ const performance_analytics: Hook<'postrun'> = async function () {
   const cmdStartTime = global.cliTelemetry.commandRunDuration
   global.cliTelemetry.commandRunDuration = telemetry.computeDuration(cmdStartTime)
   global.cliTelemetry.lifecycleHookCompletion.postrun = true
+  await Reflect.get(globalThis, 'recordPromise')
 }
 
 export default performance_analytics

--- a/packages/cli/src/hooks/prerun/analytics.ts
+++ b/packages/cli/src/hooks/prerun/analytics.ts
@@ -12,7 +12,7 @@ const analytics: Hook<'prerun'> = async function (options) {
 
   global.cliTelemetry = telemetry.setupTelemetry(this.config, options)
   const analytics = new Analytics(this.config)
-  await analytics.record(options)
+  Reflect.set(globalThis, 'recordPromise', analytics.record(options))
 }
 
 export default analytics


### PR DESCRIPTION
This PR boosts execution performance by 2x. 

Before: Analytics was run sequential to command execution.
After: Analytics runs parallel to command execution but is awaited if the command finishes first.

This give approx 100% increase in performance.