### PR TITLE
Move trusted-ip commands to use v3.

### DIFF
--- a/packages/cli/src/commands/spaces/create.ts
+++ b/packages/cli/src/commands/spaces/create.ts
@@ -24,7 +24,7 @@ export default class Create extends Command {
     CIDR:       10.0.0.0/16
     Data CIDR:  172.23.0.0/20
     State:      allocating
-    Generation: fir
+    Generation: cedar
     Created at: 2016-01-06T03:23:13Z
   `]
 

--- a/packages/cli/src/commands/spaces/trusted-ips/add.ts
+++ b/packages/cli/src/commands/spaces/trusted-ips/add.ts
@@ -28,16 +28,13 @@ export default class Add extends Command {
     const {flags, args} = await this.parse(Add)
     const {space} = flags
     const url = `/spaces/${space}/inbound-ruleset`
-    const options = {
-      headers: {Accept: 'application/vnd.heroku+json; version=3.dogwood'},
-    }
-    const {body: ruleset} = await this.heroku.get<Heroku.InboundRuleset>(url, options)
+    const {body: ruleset} = await this.heroku.get<Heroku.InboundRuleset>(url)
     if (!this.isUniqueRule(ruleset, args.source)) {
       throw new Error(`A rule already exists for ${args.source}.`)
     }
 
     ruleset.rules.push({action: 'allow', source: args.source})
-    await this.heroku.put(url, {...options, body: ruleset})
+    await this.heroku.put(url, {body: ruleset})
     ux.log(`Added ${color.cyan.bold(args.source)} to trusted IP ranges on ${color.cyan.bold(space)}`)
     ux.warn('It may take a few moments for the changes to take effect.')
   }

--- a/packages/cli/src/commands/spaces/trusted-ips/index.ts
+++ b/packages/cli/src/commands/spaces/trusted-ips/index.ts
@@ -31,10 +31,7 @@ export default class Index extends Command {
       throw new Error('Space name required.\nUSAGE: heroku trusted-ips my-space')
     }
 
-    const {body: rules} = await this.heroku.get<Required<Heroku.InboundRuleset>>(`/spaces/${space}/inbound-ruleset`,
-      {
-        headers: {Accept: 'application/vnd.heroku+json; version=3.dogwood'},
-      })
+    const {body: rules} = await this.heroku.get<Required<Heroku.InboundRuleset>>(`/spaces/${space}/inbound-ruleset`)
 
     if (flags.json) {
       ux.log(JSON.stringify(rules, null, 2))

--- a/packages/cli/src/commands/spaces/trusted-ips/remove.ts
+++ b/packages/cli/src/commands/spaces/trusted-ips/remove.ts
@@ -29,8 +29,7 @@ export default class Remove extends Command {
     const {flags, args} = await this.parse(Remove)
     const space = flags.space
     const url = `/spaces/${space}/inbound-ruleset`
-    const opts = {headers: {Accept: 'application/vnd.heroku+json; version=3.dogwood'}}
-    const {body: rules} = await this.heroku.get<Heroku.InboundRuleset>(url, opts)
+    const {body: rules} = await this.heroku.get<Heroku.InboundRuleset>(url)
     if (rules.rules?.length === 0) {
       throw new Error('No IP ranges are configured. Nothing to do.')
     }
@@ -41,7 +40,7 @@ export default class Remove extends Command {
       throw new Error(`No IP range matching ${args.source} was found.`)
     }
 
-    await this.heroku.put(url, {...opts, body: rules})
+    await this.heroku.put(url, {body: rules})
     ux.log(`Removed ${color.cyan.bold(args.source)} from trusted IP ranges on ${color.cyan.bold(space)}`)
     ux.warn('It may take a few moments for the changes to take effect.')
   }


### PR DESCRIPTION
[GUS WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000021CssvYAC/view)

`inbound-ruleset` is part of v3. This switches API calls away from the `3.dogwood` variant to v3.