### PR TITLE
chore: read isStableRelease from JSON in publish-docs job

### DIFF
--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -64,5 +64,5 @@ jobs:
     needs: [ get-version-channel, promote ]
     uses: ./.github/workflows/devcenter-doc-update.yml
     with:
-      isStableRelease: ${{ needs.get-version-channel.outputs.isStableRelease }}
+      isStableRelease: ${{ fromJSON(needs.get-version-channel.outputs.isStableRelease) }}
     secrets: inherit


### PR DESCRIPTION
🤞 this fixes the issue with our publish-docs job. This fix is in response to this error we are seeing when running this job:
<img width="1073" alt="image" src="https://github.com/user-attachments/assets/2b4b7b33-0fef-44e5-b457-fe2ff44a3645">


<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
