### PR TITLE
Get buildpacks from latest release for fir apps

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -76,7 +76,6 @@
     "tslib": "1.14.1",
     "tunnel-ssh": "4.1.6",
     "urijs": "^1.19.11",
-    "valid-url": "^1.0.9",
     "validator": "^13.7.0",
     "word-wrap": "^1.2.5",
     "ws": "^6.2.2"

--- a/packages/cli/src/commands/buildpacks/index.ts
+++ b/packages/cli/src/commands/buildpacks/index.ts
@@ -23,7 +23,7 @@ export default class Index extends Command {
     })
     const buildpacks = await buildpacksCommand.fetch(flags.app, app.generation === 'fir')
     if (buildpacks.length === 0) {
-      this.log(`${flags.app} has no Buildpack URL set.`)
+      this.log(`${color.app(flags.app)} has no Buildpacks.`)
     } else {
       ux.styledHeader(`${color.app(flags.app)} Buildpack${buildpacks.length > 1 ? 's' : ''}`)
       buildpacksCommand.display(buildpacks, '')

--- a/packages/cli/src/commands/buildpacks/index.ts
+++ b/packages/cli/src/commands/buildpacks/index.ts
@@ -1,5 +1,7 @@
 import {Command, flags as Flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {App} from '../../lib/types/fir'
+import color from '@heroku-cli/color'
 
 import {BuildpackCommand} from '../../lib/buildpacks/buildpacks'
 
@@ -14,12 +16,16 @@ export default class Index extends Command {
   async run() {
     const {flags} = await this.parse(Index)
     const buildpacksCommand = new BuildpackCommand(this.heroku)
-
-    const buildpacks = await buildpacksCommand.fetch(flags.app)
+    const {body: app} = await this.heroku.get<App>(`/apps/${flags.app}`, {
+      headers: {
+        Accept: 'application/vnd.heroku+json; version=3.sdk',
+      },
+    })
+    const buildpacks = await buildpacksCommand.fetch(flags.app, app.generation === 'fir')
     if (buildpacks.length === 0) {
       this.log(`${flags.app} has no Buildpack URL set.`)
     } else {
-      ux.styledHeader(`${flags.app} Buildpack URL${buildpacks.length > 1 ? 's' : ''}`)
+      ux.styledHeader(`${color.app(flags.app)} Buildpack${buildpacks.length > 1 ? 's' : ''}`)
       buildpacksCommand.display(buildpacks, '')
     }
   }

--- a/packages/cli/test/unit/commands/buildpacks/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/buildpacks/index.unit.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable mocha/no-setup-in-describe */
 import {expect, test} from '@oclif/test'
 import * as nock from 'nock'
+import heredoc from 'tsheredoc'
 
 import {BuildpackInstallationsStub as Stubber} from '../../../helpers/buildpacks/buildpack-installations-stub'
 nock.disableNetConnect()
@@ -129,11 +130,11 @@ describe('buildpacks', function () {
     .command(['buildpacks', '-a', cedarApp.name])
     .it('# displays the buildpack URL', ctx => {
       expect(ctx.stderr).to.equal('')
-      expect(ctx.stdout).to.equal(
-        `=== ⬢ ${cedarApp.name} Buildpack
+      expect(ctx.stdout).to.equal(heredoc(`
+        === ⬢ ${cedarApp.name} Buildpack
 
-https://github.com/heroku/heroku-buildpack-ruby
-`)
+        https://github.com/heroku/heroku-buildpack-ruby
+      `))
     })
 
   test
@@ -146,11 +147,11 @@ https://github.com/heroku/heroku-buildpack-ruby
     .command(['buildpacks', '-a', cedarApp.name])
     .it('# maps buildpack urns to names', ctx => {
       expect(ctx.stderr).to.equal('')
-      expect(ctx.stdout).to.equal(
-        `=== ⬢ ${cedarApp.name} Buildpack
+      expect(ctx.stdout).to.equal(heredoc(`
+        === ⬢ ${cedarApp.name} Buildpack
 
-heroku/ruby
-`)
+        heroku/ruby
+      `))
     })
 
   test
@@ -163,11 +164,11 @@ heroku/ruby
     .command(['buildpacks', '-a', cedarApp.name])
     .it('# does not map buildpack s3 to names', ctx => {
       expect(ctx.stderr).to.equal('')
-      expect(ctx.stdout).to.equal(
-        `=== ⬢ ${cedarApp.name} Buildpack
+      expect(ctx.stdout).to.equal(heredoc(`
+        === ⬢ ${cedarApp.name} Buildpack
 
-https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz
-`)
+        https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz
+      `))
     })
 
   test
@@ -180,9 +181,9 @@ https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz
     .command(['buildpacks', '-a', cedarApp.name])
     .it('# with no buildpack URL set does not display a buildpack URL', ctx => {
       expect(ctx.stderr).to.equal('')
-      expect(ctx.stdout).to.equal(
-        `${cedarApp.name} has no Buildpack URL set.
-`)
+      expect(ctx.stdout).to.equal(heredoc(`
+        ⬢ ${cedarApp.name} has no Buildpacks.
+      `))
     })
 
   test
@@ -198,12 +199,12 @@ https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz
     .command(['buildpacks', '-a', cedarApp.name])
     .it('# with two buildpack URLs set displays the buildpack URL', ctx => {
       expect(ctx.stderr).to.equal('')
-      expect(ctx.stdout).to.equal(
-        `=== ⬢ ${cedarApp.name} Buildpacks
+      expect(ctx.stdout).to.equal(heredoc(`
+        === ⬢ ${cedarApp.name} Buildpacks
 
-1. https://github.com/heroku/heroku-buildpack-java
-2. https://github.com/heroku/heroku-buildpack-ruby
-`)
+        1. https://github.com/heroku/heroku-buildpack-java
+        2. https://github.com/heroku/heroku-buildpack-ruby
+      `))
     })
 
   test
@@ -219,12 +220,12 @@ https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz
     .command(['buildpacks', '-a', cedarApp.name])
     .it('# returns the buildpack registry name back', ctx => {
       expect(ctx.stderr).to.equal('')
-      expect(ctx.stdout).to.equal(
-        `=== ⬢ ${cedarApp.name} Buildpacks
+      expect(ctx.stdout).to.equal(heredoc(`
+        === ⬢ ${cedarApp.name} Buildpacks
 
-1. heroku/java
-2. rust-lang/rust
-`)
+        1. heroku/java
+        2. rust-lang/rust
+      `))
     })
 
   test
@@ -240,10 +241,27 @@ https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz
     .command(['buildpacks', '-a', cedarApp.name])
     .it('# returns cnb buildpack ids for fir apps', ctx => {
       expect(ctx.stderr).to.equal('')
-      expect(ctx.stdout).to.equal(
-        `=== ⬢ ${firApp.name} Buildpack
+      expect(ctx.stdout).to.equal(heredoc(`
+        === ⬢ ${firApp.name} Buildpack
 
-heroku/ruby
-`)
+        heroku/ruby
+      `))
+    })
+
+  test
+    .nock('https://api.heroku.com', {
+      reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'},
+    }, (api: nock.Scope) => {
+      api.get(`/apps/${firApp.name}`).reply(200, firApp)
+      api.get(`/apps/${firApp.name}/releases`).reply(200, [])
+    })
+    .stdout()
+    .stderr()
+    .command(['buildpacks', '-a', cedarApp.name])
+    .it('# returns nothing when no releases', ctx => {
+      expect(ctx.stderr).to.equal('')
+      expect(ctx.stdout).to.equal(heredoc(`
+        ⬢ ${cedarApp.name} has no Buildpacks.
+      `))
     })
 })

--- a/packages/cli/test/unit/commands/buildpacks/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/buildpacks/index.unit.test.ts
@@ -1,21 +1,136 @@
+/* eslint-disable mocha/no-setup-in-describe */
 import {expect, test} from '@oclif/test'
 import * as nock from 'nock'
 
 import {BuildpackInstallationsStub as Stubber} from '../../../helpers/buildpacks/buildpack-installations-stub'
 nock.disableNetConnect()
 
+const cedarApp = {
+  acm: false,
+  archived_at: null,
+  build_stack: {name: 'heroku-24'},
+  created_at: '2024-09-06T17:45:29Z',
+  git_url: 'https://git.heroku.com',
+  id: '12345678-aaaa-bbbb-cccc-b2443790f501',
+  generation: 'cedar',
+  maintenance: false,
+  name: 'example',
+  owner: {email: 'example-owner@heroku.com'},
+  internal_routing: null,
+  region: {name: 'virginia'},
+  released_at: '2024-11-13T20:07:47Z',
+  repo_size: null,
+  slug_size: null,
+  stack: {name: 'heroku-24'},
+  updated_at: '2024-11-13T20:07:47Z',
+  web_url: 'https://cedar-example-app.herokuapp.com',
+}
+
+const firApp = {
+  acm: false,
+  archived_at: null,
+  build_stack: {name: 'heroku-24'},
+  created_at: '2024-09-06T17:45:29Z',
+  generation: 'fir',
+  git_url: 'https://git.heroku.com',
+  id: '12345678-aaaa-bbbb-cccc-b2443790f501',
+  maintenance: false,
+  name: 'example',
+  owner: {email: 'example-owner@heroku.com'},
+  internal_routing: null,
+  region: {name: 'virginia'},
+  released_at: '2024-11-13T20:07:47Z',
+  repo_size: null,
+  slug_size: null,
+  stack: {name: 'heroku-24'},
+  updated_at: '2024-11-13T20:07:47Z',
+  web_url: 'https://fir-example-app.herokuapp.com',
+}
+
+const releases = [
+  {
+    addon_plan_names: [
+      'heroku-postgresql:dev',
+    ],
+    artifacts: [
+      {
+        type: 'oci-image',
+        id: '01234567-89ab-cdef-0123-456789abcdef',
+      },
+    ],
+    app: {
+      name: 'example',
+      id: '01234567-89ab-cdef-0123-456789abcdef',
+    },
+    created_at: '2012-01-01T12:00:00Z',
+    description: 'Added new feature',
+    id: '01234567-89ab-cdef-0123-456789abcdef',
+    updated_at: '2012-01-01T12:00:00Z',
+    oci_image: {
+      id: '01234567-89ab-cdef-0123-456789abcdef',
+    },
+    slug: {
+      id: '01234567-89ab-cdef-0123-456789abcdef',
+    },
+    status: 'succeeded',
+    user: {
+      id: '01234567-89ab-cdef-0123-456789abcdef',
+      email: 'username@example.com',
+    },
+    version: 11,
+    current: true,
+    output_stream_url: 'https://release-output.heroku.com/streams/01234567-89ab-cdef-0123-456789abcdef',
+    eligible_for_rollback: true,
+  },
+]
+
+const ociImages = [
+  {
+    id: '01234567-89ab-cdef-0123-456789abcdef',
+    base_image_name: 'heroku/heroku:22-cnb',
+    base_top_layer: 'sha256:ea36ae5fbc1e7230e0a782bf216fb46500e210382703baa6bab8acf2c6a23f78',
+    commit: '60883d9e8947a57e04dc9124f25df004866a2051',
+    commit_description: 'fixed a bug with API documentation',
+    image_repo: 'd7ba1ace-b396-4691-968c-37ae53153426/builds',
+    digest: 'sha256:dc14ae5fbc1e7230e0a782bf216fb46500e210631703bcc6bab8acf2c6a23f42',
+    stack: {
+      id: 'ba46bf09-7bd1-42fd-90df-a1a9a93eb4a2',
+      name: 'cnb',
+    },
+    process_types: {
+      web: {
+        name: 'web',
+        display_cmd: 'bundle exec puma -p $PORT',
+        command: '/cnb/process/web',
+        working_dir: '/workspace/webapp',
+        default: true,
+      },
+    },
+    buildpacks: [
+      {
+        id: 'heroku/ruby',
+        version: '2.0.0',
+        homepage: 'https://github.com/heroku/buildpacks-ruby',
+      },
+    ],
+    created_at: '2012-01-01T12:00:00Z',
+    updated_at: '2012-01-01T12:00:00Z',
+    architecture: 'arm64',
+  },
+]
 describe('buildpacks', function () {
   test
     .nock('https://api.heroku.com', (api: nock.Scope) => {
+      api.get(`/apps/${cedarApp.name}`).reply(200, cedarApp)
       Stubber.get(api, ['https://github.com/heroku/heroku-buildpack-ruby'])
     })
     .stdout()
     .stderr()
-    .command(['buildpacks', '-a', 'example'])
+    .command(['buildpacks', '-a', cedarApp.name])
     .it('# displays the buildpack URL', ctx => {
       expect(ctx.stderr).to.equal('')
       expect(ctx.stdout).to.equal(
-        `=== example Buildpack URL
+        `=== ⬢ ${cedarApp.name} Buildpack
 
 https://github.com/heroku/heroku-buildpack-ruby
 `)
@@ -23,15 +138,16 @@ https://github.com/heroku/heroku-buildpack-ruby
 
   test
     .nock('https://api.heroku.com', (api: nock.Scope) => {
+      api.get(`/apps/${cedarApp.name}`).reply(200, cedarApp)
       Stubber.get(api, [{url: 'urn:buildpack:heroku/ruby', name: 'heroku/ruby'}])
     })
     .stdout()
     .stderr()
-    .command(['buildpacks', '-a', 'example'])
+    .command(['buildpacks', '-a', cedarApp.name])
     .it('# maps buildpack urns to names', ctx => {
       expect(ctx.stderr).to.equal('')
       expect(ctx.stdout).to.equal(
-        `=== example Buildpack URL
+        `=== ⬢ ${cedarApp.name} Buildpack
 
 heroku/ruby
 `)
@@ -39,15 +155,16 @@ heroku/ruby
 
   test
     .nock('https://api.heroku.com', (api: nock.Scope) => {
+      api.get(`/apps/${cedarApp.name}`).reply(200, cedarApp)
       Stubber.get(api, ['https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz'])
     })
     .stdout()
     .stderr()
-    .command(['buildpacks', '-a', 'example'])
+    .command(['buildpacks', '-a', cedarApp.name])
     .it('# does not map buildpack s3 to names', ctx => {
       expect(ctx.stderr).to.equal('')
       expect(ctx.stdout).to.equal(
-        `=== example Buildpack URL
+        `=== ⬢ ${cedarApp.name} Buildpack
 
 https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz
 `)
@@ -55,20 +172,22 @@ https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz
 
   test
     .nock('https://api.heroku.com', (api: nock.Scope) => {
+      api.get(`/apps/${cedarApp.name}`).reply(200, cedarApp)
       Stubber.get(api)
     })
     .stdout()
     .stderr()
-    .command(['buildpacks', '-a', 'example'])
+    .command(['buildpacks', '-a', cedarApp.name])
     .it('# with no buildpack URL set does not display a buildpack URL', ctx => {
       expect(ctx.stderr).to.equal('')
       expect(ctx.stdout).to.equal(
-        `example has no Buildpack URL set.
+        `${cedarApp.name} has no Buildpack URL set.
 `)
     })
 
   test
     .nock('https://api.heroku.com', (api: nock.Scope) => {
+      api.get(`/apps/${cedarApp.name}`).reply(200, cedarApp)
       Stubber.get(api, [
         'https://github.com/heroku/heroku-buildpack-java',
         'https://github.com/heroku/heroku-buildpack-ruby',
@@ -76,11 +195,11 @@ https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz
     })
     .stdout()
     .stderr()
-    .command(['buildpacks', '-a', 'example'])
+    .command(['buildpacks', '-a', cedarApp.name])
     .it('# with two buildpack URLs set displays the buildpack URL', ctx => {
       expect(ctx.stderr).to.equal('')
       expect(ctx.stdout).to.equal(
-        `=== example Buildpack URLs
+        `=== ⬢ ${cedarApp.name} Buildpacks
 
 1. https://github.com/heroku/heroku-buildpack-java
 2. https://github.com/heroku/heroku-buildpack-ruby
@@ -89,6 +208,7 @@ https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz
 
   test
     .nock('https://api.heroku.com', (api: nock.Scope) => {
+      api.get(`/apps/${cedarApp.name}`).reply(200, cedarApp)
       Stubber.get(api, [
         'https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/java.tgz',
         'https://buildpack-registry.s3.amazonaws.com/buildpacks/rust-lang/rust.tgz',
@@ -96,14 +216,34 @@ https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz
     })
     .stdout()
     .stderr()
-    .command(['buildpacks', '-a', 'example'])
+    .command(['buildpacks', '-a', cedarApp.name])
     .it('# returns the buildpack registry name back', ctx => {
       expect(ctx.stderr).to.equal('')
       expect(ctx.stdout).to.equal(
-        `=== example Buildpack URLs
+        `=== ⬢ ${cedarApp.name} Buildpacks
 
 1. heroku/java
 2. rust-lang/rust
+`)
+    })
+
+  test
+    .nock('https://api.heroku.com', {
+      reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}
+    }, (api: nock.Scope) => {
+      api.get(`/apps/${firApp.name}`).reply(200, firApp)
+      api.get(`/apps/${firApp.name}/releases`).reply(200, releases)
+      api.get(`/apps/${firApp.name}/oci-images/${releases[0].id}`).reply(200, ociImages)
+    })
+    .stdout()
+    .stderr()
+    .command(['buildpacks', '-a', cedarApp.name])
+    .it('# returns cnb buildpack ids for fir apps', ctx => {
+      expect(ctx.stderr).to.equal('')
+      expect(ctx.stdout).to.equal(
+        `=== ⬢ ${firApp.name} Buildpack
+
+heroku/ruby
 `)
     })
 })

--- a/packages/cli/test/unit/commands/buildpacks/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/buildpacks/index.unit.test.ts
@@ -229,7 +229,7 @@ https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz
 
   test
     .nock('https://api.heroku.com', {
-      reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}
+      reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'},
     }, (api: nock.Scope) => {
       api.get(`/apps/${firApp.name}`).reply(200, firApp)
       api.get(`/apps/${firApp.name}/releases`).reply(200, releases)

--- a/yarn.lock
+++ b/yarn.lock
@@ -10625,7 +10625,6 @@ __metadata:
     tunnel-ssh: 4.1.6
     typescript: 4.8.4
     urijs: ^1.19.11
-    valid-url: ^1.0.9
     validator: ^13.7.0
     word-wrap: ^1.2.5
     ws: ^6.2.2
@@ -17299,13 +17298,6 @@ __metadata:
   version: 2.3.0
   resolution: "v8-compile-cache@npm:2.3.0"
   checksum: adb0a271eaa2297f2f4c536acbfee872d0dd26ec2d76f66921aa7fc437319132773483344207bdbeee169225f4739016d8d2dbf0553913a52bb34da6d0334f8e
-  languageName: node
-  linkType: hard
-
-"valid-url@npm:^1.0.9":
-  version: 1.0.9
-  resolution: "valid-url@npm:1.0.9"
-  checksum: 3ecb030559404441c2cf104cbabab8770efb0f36d117db03d1081052ef133015a68806148ce954bb4dd0b5c42c14b709a88783c93d66b0916cb67ba771c98702
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
[GUS WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000021TcXhYAK/view)

### Description

With fir, buildpack data is now configured via project.toml and the active state of what buildpacks are installed for an app is not stored explicitly in Platform API. For the `buildpacks` command, we'll now display that state as derived from the oci image from the latest release of an app.

### Testing

1. pull down this branch and `yarn build`
2. `./bin/run buildpacks --app APP` where APP is a cedar app
3. see no difference from what is in production
4. `./bin/run buildpacks --app APP` where APP is a fir app
5. See that it does not fail, and displays the relevant cnb buildpack(s)