### PR TITLE
feat(cli): Add Fir support to 'pipelines:diff'

### DIFF
--- a/packages/cli/src/lib/pipelines/ownership.ts
+++ b/packages/cli/src/lib/pipelines/ownership.ts
@@ -3,9 +3,9 @@ import {APIClient} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
 
-import {getTeam} from '../api'
+import {AppWithPipelineCoupling, getTeam} from '../api'
 
-export function warnMixedOwnership(pipelineApps: Array<Heroku.App>, pipeline: Heroku.Pipeline, owner: string) {
+export function warnMixedOwnership(pipelineApps: Array<AppWithPipelineCoupling>, pipeline: Heroku.Pipeline, owner: string) {
   const hasMixedOwnership = pipelineApps.some(app => {
     return (app.owner && app.owner.id) !== pipeline.owner.id
   })
@@ -20,7 +20,7 @@ export function warnMixedOwnership(pipelineApps: Array<Heroku.App>, pipeline: He
   }
 }
 
-export function getOwner(heroku: APIClient, apps: Array<Heroku.App>, pipeline: Heroku.Pipeline) {
+export function getOwner(heroku: APIClient, apps: Array<AppWithPipelineCoupling>, pipeline: Heroku.Pipeline) {
   let owner
   let ownerPromise
 

--- a/packages/cli/src/lib/pipelines/render-pipeline.ts
+++ b/packages/cli/src/lib/pipelines/render-pipeline.ts
@@ -5,11 +5,12 @@ import {ux} from '@oclif/core'
 import {sortBy} from 'lodash'
 
 import {getOwner, warnMixedOwnership} from './ownership'
+import {AppWithPipelineCoupling} from '../api'
 
 export default async function renderPipeline(
   heroku: APIClient,
   pipeline: Heroku.Pipeline,
-  pipelineApps: Array<Heroku.App>,
+  pipelineApps: Array<AppWithPipelineCoupling>,
   // eslint-disable-next-line unicorn/no-object-as-default-parameter
   {withOwners, showOwnerWarning} = {withOwners: false, showOwnerWarning: false}) {
   ux.styledHeader(pipeline.name!)
@@ -23,7 +24,7 @@ export default async function renderPipeline(
 
   ux.log('')
 
-  const columns: ux.Table.table.Columns<Heroku.App> = {
+  const columns: ux.Table.table.Columns<AppWithPipelineCoupling> = {
     name: {
       header: 'app name',
       get(row) {
@@ -33,7 +34,7 @@ export default async function renderPipeline(
     'coupling.stage': {
       header: 'stage',
       get(row) {
-        return row.coupling.stage
+        return row.pipelineCoupling.stage
       },
     },
   }
@@ -45,16 +46,16 @@ export default async function renderPipeline(
         const email = row.owner && row.owner.email
 
         if (email) {
-          return email.endsWith('@herokumanager.com') ? `${row.split('@')[0]} (team)` : email
+          return email.endsWith('@herokumanager.com') ? `${email.split('@')[0]} (team)` : email
         }
       },
     }
   }
 
-  const developmentApps = sortBy(pipelineApps.filter(app => app.coupling.stage === 'development'), ['name'])
-  const reviewApps = sortBy(pipelineApps.filter(app => app.coupling.stage === 'review'), ['name'])
-  const stagingApps = sortBy(pipelineApps.filter(app => app.coupling.stage === 'staging'), ['name'])
-  const productionApps = sortBy(pipelineApps.filter(app => app.coupling.stage === 'production'), ['name'])
+  const developmentApps = sortBy(pipelineApps.filter(app => app.pipelineCoupling.stage === 'development'), ['name'])
+  const reviewApps = sortBy(pipelineApps.filter(app => app.pipelineCoupling.stage === 'review'), ['name'])
+  const stagingApps = sortBy(pipelineApps.filter(app => app.pipelineCoupling.stage === 'staging'), ['name'])
+  const productionApps = sortBy(pipelineApps.filter(app => app.pipelineCoupling.stage === 'production'), ['name'])
   const apps = developmentApps.concat(reviewApps).concat(stagingApps).concat(productionApps)
 
   ux.table(apps, columns)

--- a/packages/cli/test/unit/commands/pipelines/diff.unit.test.ts
+++ b/packages/cli/test/unit/commands/pipelines/diff.unit.test.ts
@@ -1,6 +1,6 @@
 import {expect, test} from '@oclif/test'
 
-describe('pipelines:diff', function () {
+describe.only('pipelines:diff', function () {
   const apiUrl = 'https://api.heroku.com'
   const kolkrabbiApi = 'https://kolkrabbi.heroku.com'
   const githubApi = 'https://api.github.com'
@@ -10,10 +10,21 @@ describe('pipelines:diff', function () {
     name: 'example-pipeline',
   }
 
+  const firPipeline = {
+    id: '123-pipeline-fir',
+    name: 'example-pipeline',
+  }
+
   const targetApp = {
     id: '123-target-app-456',
     name: 'example-staging',
     pipeline,
+  }
+
+  const targetFirApp = {
+    id: '123-target-app-fir',
+    name: 'example-staging',
+    pipeline: firPipeline,
   }
 
   const targetCoupling = {
@@ -21,6 +32,15 @@ describe('pipelines:diff', function () {
     id: '123-target-app-456',
     pipeline,
     stage: 'staging',
+    generation: 'cedar',
+  }
+
+  const targetFirCoupling = {
+    app: targetFirApp,
+    id: '123-target-app-fir',
+    pipeline: firPipeline,
+    stage: 'staging',
+    generation: 'fir',
   }
 
   const targetGithubApp = {
@@ -33,11 +53,26 @@ describe('pipelines:diff', function () {
     pipeline,
   }
 
+  const downstreamFirApp1 = {
+    id: '123-downstream-app-1-fir',
+    name: 'example-production-eu',
+    pipeline: firPipeline,
+  }
+
   const downstreamCoupling1 = {
     app: downstreamApp1,
     id: '123-target-app-456',
     pipeline,
     stage: 'production',
+    generation: 'cedar',
+  }
+
+  const downstreamFirCoupling1 = {
+    app: downstreamFirApp1,
+    id: '123-target-app-fir',
+    pipeline: firPipeline,
+    stage: 'production',
+    generation: 'fir',
   }
 
   const downstreamApp1Github = {
@@ -50,11 +85,26 @@ describe('pipelines:diff', function () {
     pipeline,
   }
 
+  const downstreamFirApp2 = {
+    id: '123-downstream-app-2-fir',
+    name: 'example-production-us',
+    pipeline: firPipeline,
+  }
+
   const downstreamCoupling2 = {
     app: downstreamApp2,
     id: '123-target-app-456',
     pipeline,
     stage: 'production',
+    generation: 'cedar',
+  }
+
+  const downstreamFirCoupling2 = {
+    app: downstreamFirApp2,
+    id: '123-target-app-fir',
+    pipeline: firPipeline,
+    stage: 'production',
+    generation: 'fir',
   }
 
   const downstreamApp2Github = {
@@ -72,6 +122,17 @@ describe('pipelines:diff', function () {
       })
   }
 
+  function mockFirPipelineCoupling(testInstance: typeof test) {
+    return testInstance
+      .stderr()
+      .stdout()
+      .nock(apiUrl, api => {
+        api
+          .get(`/apps/${targetFirApp.name}/pipeline-couplings`)
+          .reply(200, targetFirCoupling)
+      })
+  }
+
   function mockApps(testInstance: typeof test) {
     return testInstance
       .stderr()
@@ -84,6 +145,21 @@ describe('pipelines:diff', function () {
         api
           .post('/filters/apps')
           .reply(200, [targetApp, downstreamApp1, downstreamApp2])
+      })
+  }
+
+  function mockFirApps(testInstance: typeof test) {
+    return testInstance
+      .stderr()
+      .stdout()
+      .nock(apiUrl, api => {
+        api
+          .get(`/pipelines/${firPipeline.id}/pipeline-couplings`)
+          .reply(200, [targetFirCoupling, downstreamFirCoupling1, downstreamFirCoupling2])
+
+        api
+          .post('/filters/apps')
+          .reply(200, [targetFirApp, downstreamFirApp1, downstreamFirApp2])
       })
   }
 
@@ -175,7 +251,7 @@ describe('pipelines:diff', function () {
       .it('should return an error if the target app has no release')
   })
 
-  describe('for valid apps with a pipeline', function () {
+  describe('for valid Cedar apps with a pipeline', function () {
     const targetSlugId = 'target-slug-id'
     const downstreamSlugId = 'downstream-slug-id'
 
@@ -240,6 +316,76 @@ describe('pipelines:diff', function () {
           .reply(404)
       })
       .command(['pipelines:diff', `--app=${targetApp.name}`])
+      .it('should handle non-200 responses from GitHub', ctx => {
+        expect(ctx.stdout).to.contain('unable to perform a diff')
+      })
+  })
+
+  describe('for valid Fir apps with a pipeline', function () {
+    const targetOciImageId = 'oci-image-id'
+    const downstreamOciImageId = 'downstream-oci-image-id'
+
+    const mockedTest = (testInstance: typeof test) => {
+      const t = mockFirPipelineCoupling(mockFirApps(testInstance))
+
+      return t
+        .stderr()
+        .stdout()
+        .nock(kolkrabbiApi, api => {
+          api
+            .get(`/apps/${targetFirApp.id}/github`)
+            .reply(200, targetGithubApp)
+            .get(`/apps/${downstreamFirApp1.id}/github`)
+            .reply(200, downstreamApp1Github)
+            .get(`/apps/${downstreamFirApp2.id}/github`)
+            .reply(200, downstreamApp2Github)
+            .get('/account/github/token')
+            .reply(200, {github: {token: 'github-token'}})
+        })
+        .nock(apiUrl, api => {
+          api
+            .get(`/apps/${targetFirApp.id}/releases`)
+            .reply(200, [{oci_image: {id: targetOciImageId}, status: 'succeeded'}])
+            .get(`/apps/${downstreamFirApp1.id}/releases`)
+            .reply(200, [
+              {status: 'failed'},
+              {oci_image: {id: downstreamOciImageId}, status: 'succeeded'},
+            ])
+        })
+    }
+
+    mockedTest(test)
+      .stdout()
+      .nock(apiUrl, api => {
+        api
+          .get(`/apps/${targetFirApp.id}/oci-images/${targetOciImageId}`)
+          .reply(200, [{commit: 'COMMIT-HASH'}])
+          .get(`/apps/${downstreamFirApp1.id}/oci-images/${downstreamOciImageId}`)
+          .reply(200, [{commit: 'COMMIT-HASH'}])
+      })
+      .command(['pipelines:diff', `--app=${targetFirApp.name}`])
+      .it('should not compare apps if update to date NOR if repo differs', ctx => {
+        expect(ctx.stdout).to.contain(`⬢ ${targetApp.name} is up to date with ⬢ ${downstreamApp1.name}`)
+        expect(ctx.stdout).to.contain(`⬢ ${targetApp.name} was not compared to ⬢ ${downstreamApp2.name}`)
+      })
+
+    const hashes = ['hash-1', 'hash-2']
+
+    mockedTest(test)
+      .stdout()
+      .nock(apiUrl, api => {
+        api
+          .get(`/apps/${targetFirApp.id}/oci-images/${targetOciImageId}`)
+          .reply(200, [{commit: hashes[0]}])
+          .get(`/apps/${downstreamFirApp1.id}/oci-images/${downstreamOciImageId}`)
+          .reply(200, [{commit: hashes[1]}])
+      })
+      .nock(githubApi, api => {
+        api
+          .get(`/repos/${targetGithubApp.repo}/compare/${hashes[1]}...${hashes[0]}`)
+          .reply(404)
+      })
+      .command(['pipelines:diff', `--app=${targetFirApp.name}`])
       .it('should handle non-200 responses from GitHub', ctx => {
         expect(ctx.stdout).to.contain('unable to perform a diff')
       })

--- a/packages/cli/test/unit/commands/pipelines/diff.unit.test.ts
+++ b/packages/cli/test/unit/commands/pipelines/diff.unit.test.ts
@@ -1,6 +1,6 @@
 import {expect, test} from '@oclif/test'
 
-describe.only('pipelines:diff', function () {
+describe('pipelines:diff', function () {
   const apiUrl = 'https://api.heroku.com'
   const kolkrabbiApi = 'https://kolkrabbi.heroku.com'
   const githubApi = 'https://api.github.com'


### PR DESCRIPTION
## Description

Here we add Fir pipelines support to command `pipelines:diff` requiring to read the Github commit SHA from the release OCI image, instead of the slug used for Cedar apps.

It was required to introduce some new interfaces based on the Fir types on a shared library and that made necessary to update other usages of the same functions in other `pipelines` topic commands, but changes are minimal.

## Testing

- Fetch this branch, run `yarn` and `yarn build`.
- Run `heroku pipelines:diff -a particleboard-staging`. There shouldn't be any errors and it should be up to date with `particleboard-production`.
- Repeat using `./bin/run pipelines:diff -a particleboard-staging`. The output should be exactly the same, no errors.
- Run `heroku pipelines:diff -a my-ruby-gsg-staging`. It errors out stating that no release was found, because of the lack of support for Fir apps.
- Repeat using `./bin/run pipelines:diff -a my-ruby-gsg-staging`. It shouldn't error out, showing that `my-ruby-gsg-staging` is 1 commit ahead of `my-ruby-gsg-production`.

## SOC2
GUS WI: [W-16679417](https://gus.lightning.force.com/a07EE000020liNkYAI)