### PR TITLE
fix: bug with telemetry:add

### DIFF
--- a/packages/cli/src/commands/telemetry/add.ts
+++ b/packages/cli/src/commands/telemetry/add.ts
@@ -9,8 +9,7 @@ export default class Add extends Command {
   static description = 'Add and configure a new telemetry drain. Defaults to collecting all telemetry unless otherwise specified.'
 
   static flags = {
-    app: Flags.string({char: 'a', exactlyOne: ['app', 'remote', 'space'], description: 'app to add a drain to'}),
-    remote: Flags.remote({description: 'git remote of app to add a drain to'}),
+    app: Flags.string({char: 'a', exactlyOne: ['app', 'space'], description: 'app to add a drain to'}),
     space: Flags.string({char: 's', description: 'space to add a drain to'}),
     signals: Flags.string({default: 'all', description: 'comma-delimited list of signals to collect (traces, metrics, logs). Use "all" to collect all signals.'}),
     endpoint: Flags.string({required: true, description: 'drain url'}),

--- a/packages/cli/src/commands/telemetry/add.ts
+++ b/packages/cli/src/commands/telemetry/add.ts
@@ -9,7 +9,7 @@ export default class Add extends Command {
   static description = 'Add and configure a new telemetry drain. Defaults to collecting all telemetry unless otherwise specified.'
 
   static flags = {
-    app: Flags.app({exactlyOne: ['app', 'remote', 'space'], description: 'app to add a drain to'}),
+    app: Flags.string({char: 'a', exactlyOne: ['app', 'remote', 'space'], description: 'app to add a drain to'}),
     remote: Flags.remote({description: 'git remote of app to add a drain to'}),
     space: Flags.string({char: 's', description: 'space to add a drain to'}),
     signals: Flags.string({default: 'all', description: 'comma-delimited list of signals to collect (traces, metrics, logs). Use "all" to collect all signals.'}),

--- a/packages/cli/test/unit/commands/telemetry/add.unit.test.ts
+++ b/packages/cli/test/unit/commands/telemetry/add.unit.test.ts
@@ -31,7 +31,7 @@ describe('telemetry:add', function () {
       ])
     } catch (error) {
       const {message} = error as { message: string }
-      expect(message).to.contain('Exactly one of the following must be provided: --app, --remote, --space')
+      expect(message).to.contain('Exactly one of the following must be provided: --app, --space')
     }
   })
 


### PR DESCRIPTION
[GUS WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000025UeKGYA0/view)

### Description

Currently, if the working directory is a heroku remote defined, a user cannot add a space telemetry drain. This is because `--space` and `--app` are defined as exclusive, and `Flags.app` will automatically pick up the local heroku remote if it can. This PR changes the `app` flag to a `string`. This means this command will _not_ pick up the local remote even if `--space` is not provided.

### Testing

1. pull down this branch and `yarn build`
2. `./bin/run telemetry:add --space some-space fakerandomtext --endpoint url.com --transport http`
3. you should not see a `--space cannot also be provided when using --app` error