### PR TITLE
Update artifact download/uplaod to v4, remove extra docs md upload

### DIFF
--- a/.github/workflows/devcenter-doc-update.yml
+++ b/.github/workflows/devcenter-doc-update.yml
@@ -46,8 +46,3 @@ jobs:
           ./scripts/postrelease/dev_center_docs
         env:
           HEROKU_DEVCENTER_API_KEY: ${{ secrets.HEROKU_DEVCENTER_API_KEY }}
-      - name: Upload md file as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: heroku-cli-commands
-          path: /tmp/heroku-cli-commands.md

--- a/.github/workflows/pack-upload.yml
+++ b/.github/workflows/pack-upload.yml
@@ -22,7 +22,7 @@ jobs:
         run: yarn --immutable --network-timeout 1000000
       - name: Building deb
         run: yarn oclif pack:deb --root="./packages/cli"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: packed-deb
           path: /home/runner/work/cli/cli/packages/cli/dist
@@ -40,7 +40,7 @@ jobs:
         run: yarn --immutable --network-timeout 1000000
       - name: Building tarballs
         run: yarn oclif pack tarballs --root="./packages/cli"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: packed-tarballs
           path: /home/runner/work/cli/cli/packages/cli/dist
@@ -57,14 +57,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: sudo mkdir -p /build
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: packed-deb
           path: /home/runner/work/cli/cli/packages/cli/dist
       - run: |
           cd /home/runner/work/cli/cli/packages/cli/dist/deb
           /home/runner/work/cli/cli/packages/cli/scripts/sign/deb
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: signed-deb
           path: /home/runner/work/cli/cli/packages/cli/dist
@@ -81,12 +81,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: sudo mkdir -p /build
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: signed-deb
           path: /home/runner/work/cli/cli/packages/cli/dist
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: packed-tarballs
           path: /home/runner/work/cli/cli/packages/cli/dist


### PR DESCRIPTION
[GUS WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000020GZIaYAO/view)

### Description

This updates the `actions/upload-artifact` and `actions/download-artifact` actions we rely on to v4. The new versions have been successfully tested with the 9.5.1-beta.0 prelease, https://github.com/heroku/cli/tree/prerelease/9.5.1-beta. This PR also removes the redundant `Upload md file as artifact` action now that we have confidence in our normal oclif dev docs upload.