### PR TITLE
chore: update moratorium check and change management workflows

### DIFF
--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -18,8 +18,9 @@ on:
 
 jobs:
   check-for-moratorium:
-    if: fromJSON(inputs.isStableCandidate)
+    if: ${{ fromJSON(inputs.isStableCandidate) }}
     uses: ./.github/workflows/tps-check-lock.yml
+    secrets: inherit
 
   get-version-channel:
     needs: [check-for-moratorium]

--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -65,5 +65,5 @@ jobs:
     needs: [get-version-channel, promote, check-for-moratorium]
     uses: ./.github/workflows/devcenter-doc-update.yml
     with:
-      isStableRelease: ${{ fromJSON(needs.get-version-channel.outputs.isStableRelease) }}
+      isStableRelease: ${{ fromJSON(inputs.isStableCandidate) }}
     secrets: inherit

--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -19,12 +19,10 @@ on:
 jobs:
   check-for-moratorium:
     if: fromJSON(inputs.isStableCandidate)
-    run: ./scripts/release/tps_check_lock cli ${{ github.sha }}
-    environment: ChangeManagement
-    env:
-      TPS_API_TOKEN: ${{ secrets.TPS_API_TOKEN_PARAM }}
+    uses: ./.github/workflows/tps-check-lock.yml
 
   get-version-channel:
+    needs: [check-for-moratorium]
     runs-on: ubuntu-latest
     outputs:
       channel: ${{ steps.getVersion.outputs.channel }}
@@ -39,7 +37,7 @@ jobs:
           path: './packages/cli/package.json'
 
   publish-npm:
-    needs: [get-version-channel]
+    needs: [get-version-channel, check-for-moratorium]
     # if NOT isStableCandidate confirm dist tag is in package.json version
     if: fromJSON(needs.get-version-channel.outputs.isStableRelease) || (!fromJSON(inputs.isStableCandidate) && !!needs.get-version-channel.outputs.channel)
     uses: ./.github/workflows/publish-npm.yml
@@ -49,12 +47,12 @@ jobs:
     secrets: inherit
 
   pack-upload:
-    needs: [ publish-npm ]
+    needs: [publish-npm, check-for-moratorium]
     uses: ./.github/workflows/pack-upload.yml
     secrets: inherit
 
   promote:
-    needs: [get-version-channel, pack-upload]
+    needs: [get-version-channel, pack-upload, check-for-moratorium]
     if: needs.pack-upload.result == 'success'
     uses: ./.github/workflows/promote-release.yml
     with:
@@ -64,7 +62,7 @@ jobs:
     secrets: inherit
 
   publish-docs:
-    needs: [ get-version-channel, promote ]
+    needs: [get-version-channel, promote, check-for-moratorium]
     uses: ./.github/workflows/devcenter-doc-update.yml
     with:
       isStableRelease: ${{ fromJSON(needs.get-version-channel.outputs.isStableRelease) }}

--- a/.github/workflows/devcenter-doc-update.yml
+++ b/.github/workflows/devcenter-doc-update.yml
@@ -20,7 +20,7 @@ jobs:
   update-devcenter-command-docs:
     name: Update Devcenter command docs
     runs-on: ubuntu-latest
-    if: fromJSON(inputs.isStableRelease)
+    if: ${{ fromJSON(inputs.isStableRelease) }}
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 16.x

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -58,16 +58,9 @@ jobs:
   change-management:
     needs: [ promote ]
     if: fromJSON(inputs.isStableRelease)
-    # Failure to record the release should not fail the workflow
-    continue-on-error: true
-    steps:
-      # Checkout required to get github.sha
-      - uses: actions/checkout@v3
-      - run: ./scripts/postrelease/tps_record_release cli ${{ github.sha }}
-    environment: ChangeManagement
-    env:
-      ACTOR_EMAIL: ${{ secrets.TPS_API_RELEASE_ACTOR_EMAIL }}
-      TPS_API_TOKEN: ${{ secrets.TPS_API_TOKEN_PARAM }}
+    uses: ./.github/workflows/tps-record-release.yml
+    with:
+      isStableRelease: ${{ fromJSON(inputs.isStableRelease) }}
 
   create-fig-autocomplete-pr:
     if: fromJSON(inputs.isStableRelease)

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -59,6 +59,7 @@ jobs:
     needs: [ promote ]
     if: fromJSON(inputs.isStableRelease)
     uses: ./.github/workflows/tps-record-release.yml
+    secrets: inherit
     with:
       isStableRelease: ${{ fromJSON(inputs.isStableRelease) }}
 

--- a/.github/workflows/start-gh-release.yml
+++ b/.github/workflows/start-gh-release.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   check-for-moratorium:
     uses: ./.github/workflows/tps-check-lock.yml
+    secrets: inherit
 
   get-source-branch-name:
     needs: [check-for-moratorium]

--- a/.github/workflows/start-gh-release.yml
+++ b/.github/workflows/start-gh-release.yml
@@ -8,7 +8,11 @@ on:
       - closed
 
 jobs:
+  check-for-moratorium:
+    uses: ./.github/workflows/tps-check-lock.yml
+
   get-source-branch-name:
+    needs: [check-for-moratorium]
     # GHA does not provide short name for branch being merged in. This shortens it so we can validate it with startsWith()
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
@@ -22,7 +26,7 @@ jobs:
         run: echo "sourceName=${GITHUB_HEAD_REF#refs/heads/}" >> $GITHUB_OUTPUT
 
   start-release:
-    needs: [ get-source-branch-name ]
+    needs: [get-source-branch-name, check-for-moratorium]
     if: startsWith(needs.get-source-branch-name.outputs.sourceName, 'release-')
     uses: ./.github/workflows/tag-create-github-release.yml
     secrets: inherit

--- a/.github/workflows/tps-check-lock.yml
+++ b/.github/workflows/tps-check-lock.yml
@@ -1,25 +1,10 @@
 name: Check for moratorium
 
-on:
-  workflow_dispatch:
-    inputs:
-      isStableCandidate:
-        type: boolean
-        description: Is this a stable/prod candidate?
-        required: true
-        default: false
-  workflow_call:
-    inputs:
-      isStableCandidate:
-        type: boolean
-        description: Is this a stable/prod candidate?
-        required: true
-        default: false
+on: [workflow_dispatch, workflow_call]
 
 jobs:
   moratoriumCheck:
     runs-on: ubuntu-latest
-    if: ${{ fromJSON(inputs.isStableCandidate) }}
     environment: ChangeManagement
     steps:
       - env:

--- a/.github/workflows/tps-check-lock.yml
+++ b/.github/workflows/tps-check-lock.yml
@@ -1,0 +1,27 @@
+name: Check for moratorium
+
+on:
+  workflow_dispatch:
+    inputs:
+      isStableCandidate:
+        type: boolean
+        description: Is this a stable/prod candidate?
+        required: true
+        default: false
+  workflow_call:
+    inputs:
+      isStableCandidate:
+        type: boolean
+        description: Is this a stable/prod candidate?
+        required: true
+        default: false
+
+jobs:
+  moratoriumCheck:
+    runs-on: ubuntu-latest
+    if: ${{ fromJSON(inputs.isStableCandidate) }}
+    environment: ChangeManagement
+    steps:
+      - env:
+          TPS_API_TOKEN: ${{ secrets.TPS_API_TOKEN_PARAM }}
+        run: ./scripts/release/tps_check_lock cli ${{ github.sha }}

--- a/.github/workflows/tps-check-lock.yml
+++ b/.github/workflows/tps-check-lock.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: ChangeManagement
     steps:
+      # checkout required to get github.sha
+      - uses: actions/checkout@v3
       - env:
           TPS_API_TOKEN: ${{ secrets.TPS_API_TOKEN_PARAM }}
         run: ./scripts/release/tps_check_lock cli ${{ github.sha }}

--- a/.github/workflows/tps-record-release.yml
+++ b/.github/workflows/tps-record-release.yml
@@ -1,0 +1,30 @@
+name: Publish release to Change Management
+
+on:
+  workflow_dispatch:
+    inputs:
+      isStableCandidate:
+        type: boolean
+        description: Is this a stable/prod candidate?
+        required: true
+        default: false
+  workflow_call:
+    inputs:
+      isStableCandidate:
+        type: boolean
+        description: Is this a stable/prod candidate?
+        required: true
+        default: false
+
+jobs:
+  publishToChangeManagement:
+    runs-on: ubuntu-latest
+    if: ${{ fromJSON(inputs.isStableCandidate) }}
+    environment: ChangeManagement
+    steps:
+      # checkout required to get github.sha
+      - uses: actions/checkout@v3
+      - env:
+          ACTOR_EMAIL: ${{ secrets.TPS_API_RELEASE_ACTOR_EMAIL
+          TPS_API_TOKEN: ${{ secrets.TPS_API_TOKEN_PARAM }}
+        run: ./scripts/postrelease/tps_record_release cli ${{ github.sha }}


### PR DESCRIPTION
This PR updates our new change management workflows in a couple of ways:
- It moves the check-for-moratorium and change-management workflows to their own github workflow files
    - This will make testing them easier and will enable to us to run them independently in case of a failure
- It updates the create-cli-release and start-gh-release workflows so that they require the moratorium check for all stable releases.

This PR also includes a small change that will hopefully fix the devcenter-doc-update workflow

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
