### PR TITLE
refactor: update run:inside help text and add named args

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -260,6 +260,7 @@ psubscribe
 psut
 psql
 psqlrc
+pvpr
 pxxxxxxxx
 qqjs
 raulb

--- a/packages/cli/src/commands/run/inside.ts
+++ b/packages/cli/src/commands/run/inside.ts
@@ -3,17 +3,21 @@ import {ux} from '@oclif/core'
 import debugFactory from 'debug'
 import Dyno from '../../lib/run/dyno'
 import {buildCommand} from '../../lib/run/helpers'
+import heredoc from 'tsheredoc'
 
 const debug = debugFactory('heroku:run:inside')
 
 export default class RunInside extends Command {
-  static description = 'run a one-off process inside an existing heroku dyno'
+  static description = 'run a one-off process inside an existing heroku dyno (for Fir-generation apps only)'
 
-  static hidden = true;
-
-  static examples = [
-    '$ heroku run:inside web.1 bash',
-  ]
+  static example = heredoc`
+    Run bash
+      $ heroku run:inside web-848cd4f64d-pvpr2 bash
+    Run a command supplied by a script
+      $ heroku run:inside web-848cd4f64d-pvpr2 -- myscript.sh
+    Run a command declared for the worker process type in a Procfile
+      $ heroku run:inside worker
+    `
 
   static flags = {
     app: flags.app({required: true}),

--- a/packages/cli/src/commands/run/inside.ts
+++ b/packages/cli/src/commands/run/inside.ts
@@ -1,5 +1,5 @@
 import {Command, flags} from '@heroku-cli/command'
-import {ux} from '@oclif/core'
+import {Args, ux} from '@oclif/core'
 import debugFactory from 'debug'
 import Dyno from '../../lib/run/dyno'
 import {buildCommand} from '../../lib/run/helpers'
@@ -26,20 +26,21 @@ export default class RunInside extends Command {
     listen: flags.boolean({description: 'listen on a local port', hidden: true}),
   }
 
+  static args = {
+    DYNO_NAME: Args.string({required: true, description: 'name of the dyno to run command inside'}),
+    COMMAND: Args.string({required: true, description: 'command to run'}),
+  }
+
   static strict = false
 
   async run() {
-    const {flags, argv} = await this.parse(RunInside)
-
-    if (argv.length < 2) {
-      throw new Error('Usage: heroku run:inside DYNO COMMAND\n\nExample: heroku run:inside web.1 bash')
-    }
+    const {flags, args} = await this.parse(RunInside)
 
     const opts = {
       'exit-code': flags['exit-code'],
       app: flags.app,
-      command: buildCommand(argv.slice(1) as string[]),
-      dyno: argv[0] as string,
+      command: buildCommand([args.COMMAND]),
+      dyno: args.DYNO_NAME,
       heroku: this.heroku,
       listen: flags.listen,
     }


### PR DESCRIPTION
[Internal work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000025gXf8YAE/view)

Updates the the run:inside help text to match CX expectations (linked in the internal work item). Also adds named args so that they also appear in the documentation.

## Testing
- Clone this branch and run `yarn` and `yarn build`
- Run `./bin/run run:inside --help` and verify that the help text matches CX expectations
- Using the dyno id from a fir app, run `./bin/run run:inside DYNO_ID bash -a APP_NAME` to run bash in a dyno
    - You can find the dyno id by running `heroku ps -a APP_NAME`
- run `./bin/run run:inside bash -a APP_NAME` to validate that an error message tells the user that they are missing a required arg. It's going to say that you are missing the COMMAND arg because it's looking for the second arg. I'm not sure we can do much about this unless we add additional arg validation.


<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
