### PR TITLE
Move endpoint to ARG, headers to flag

### DIFF
--- a/packages/cli/src/commands/telemetry/add.ts
+++ b/packages/cli/src/commands/telemetry/add.ts
@@ -10,14 +10,14 @@ export default class Add extends Command {
 
   static flags = {
     app: Flags.string({char: 'a', exactlyOne: ['app', 'space'], description: 'app to add a drain to'}),
+    headers: Flags.string({description: 'custom headers to configure the drain in json format'}),
     space: Flags.string({char: 's', description: 'space to add a drain to'}),
     signals: Flags.string({default: 'all', description: 'comma-delimited list of signals to collect (traces, metrics, logs). Use "all" to collect all signals.'}),
-    endpoint: Flags.string({required: true, description: 'drain url'}),
-    transport: Flags.string({required: true, options: ['http', 'grpc'], description: 'transport protocol for the drain'}),
+    transport: Flags.string({default: 'http', options: ['http', 'grpc'], description: 'transport protocol for the drain'}),
   }
 
   static args = {
-    headers: Args.string({required: true, description: 'custom headers to configure the drain in json format'}),
+    endpoint: Args.string({required: true, description: 'drain url'}),
   }
 
   static example = heredoc(`
@@ -27,8 +27,8 @@ export default class Add extends Command {
 
   public async run(): Promise<void> {
     const {flags, args} = await this.parse(Add)
-    const {app, space, signals, endpoint, transport} = flags
-    const {headers} = args
+    const {app, headers, space, signals, transport} = flags
+    const {endpoint} = args
     let id
     if (app) {
       const {body: herokuApp} = await this.heroku.get<App>(
@@ -41,6 +41,7 @@ export default class Add extends Command {
       id = herokuSpace.id
     }
 
+    const exporterHeaders = headers || '{}'
     const drainConfig = {
       owner: {
         type: app ? 'app' : 'space',
@@ -50,7 +51,7 @@ export default class Add extends Command {
       exporter: {
         endpoint,
         type: `otlp${transport}`,
-        headers: JSON.parse(headers),
+        headers: JSON.parse(exporterHeaders),
       },
     }
 

--- a/packages/cli/src/commands/telemetry/add.ts
+++ b/packages/cli/src/commands/telemetry/add.ts
@@ -22,7 +22,7 @@ export default class Add extends Command {
 
   static example = heredoc(`
     Add a telemetry drain to an app to collect logs and traces:
-    $ heroku telemetry:add --app myapp --signals logs,traces --endpoint https://my-endpoint.com --transport http '{"x-drain-example-team": "API_KEY", "x-drain-example-dataset": "METRICS_DATASET"}'
+    $ heroku telemetry:add https://my-endpoint.com --app myapp --signals logs,traces --headers '{"x-drain-example-team": "API_KEY", "x-drain-example-dataset": "METRICS_DATASET"}'
   `)
 
   public async run(): Promise<void> {

--- a/packages/cli/src/commands/telemetry/update.ts
+++ b/packages/cli/src/commands/telemetry/update.ts
@@ -9,12 +9,12 @@ export default class Update extends Command {
   static description = 'updates a telemetry drain with provided attributes (attributes not provided remain unchanged)'
   static args = {
     telemetry_drain_id: Args.string({required: true, description: 'ID of the drain to update'}),
-    headers: Args.string({description: 'custom headers to configure the drain in json format'}),
   }
 
   static flags = {
-    signals: Flags.string({description: 'comma-delimited list of signals to collect (traces, metrics, logs). Use "all" to collect all signals.'}),
     endpoint: Flags.string({description: 'drain url'}),
+    headers: Flags.string({description: 'custom headers to configure the drain in json format'}),
+    signals: Flags.string({description: 'comma-delimited list of signals to collect (traces, metrics, logs). Use "all" to collect all signals.'}),
     transport: Flags.string({options: ['http', 'grpc'], description: 'transport protocol for the drain'}),
   }
 
@@ -24,9 +24,9 @@ export default class Update extends Command {
 
   public async run(): Promise<void> {
     const {args, flags} = await this.parse(Update)
-    const {telemetry_drain_id, headers} = args
-    const {signals, endpoint, transport} = flags
-    if (!(headers || signals || endpoint || transport)) {
+    const {telemetry_drain_id} = args
+    const {endpoint, headers, signals, transport} = flags
+    if (!(endpoint || headers || signals || transport)) {
       ux.error(heredoc(`
         Requires either --signals, --endpoint, --transport or HEADERS to be provided.
         See more help with --help

--- a/packages/cli/test/unit/commands/telemetry/add.unit.test.ts
+++ b/packages/cli/test/unit/commands/telemetry/add.unit.test.ts
@@ -27,6 +27,8 @@ describe('telemetry:add', function () {
   it('returns an error if an app, remote, or space is not set', async function () {
     try {
       await runCommand(Cmd, [
+        testEndpoint,
+        '--headers',
         '{"x-honeycomb-team": "your-api-key", "x-honeycomb-dataset": "your-dataset"}',
       ])
     } catch (error) {
@@ -38,7 +40,7 @@ describe('telemetry:add', function () {
   it('returns an error if values are provided for both the app and the space flags', async function () {
     try {
       await runCommand(Cmd, [
-        '{"x-honeycomb-team": "your-api-key", "x-honeycomb-dataset": "your-dataset"}',
+        testEndpoint,
         '--app',
         firApp.name || '',
         '--space',
@@ -59,15 +61,13 @@ describe('telemetry:add', function () {
       .reply(200, spaceTelemetryDrain1)
 
     await runCommand(Cmd, [
+      testEndpoint,
+      '--headers',
       '{"x-honeycomb-team": "your-api-key", "x-honeycomb-dataset": "your-dataset"}',
       '--app',
       appId,
       '--signals',
       'logs',
-      '--endpoint',
-      testEndpoint,
-      '--transport',
-      'http',
     ])
 
     expectOutput(stdout.output, `successfully added drain ${testEndpoint}`)
@@ -82,15 +82,13 @@ describe('telemetry:add', function () {
       .reply(200, spaceTelemetryDrain1)
 
     await runCommand(Cmd, [
+      testEndpoint,
+      '--headers',
       '{"x-honeycomb-team": "your-api-key", "x-honeycomb-dataset": "your-dataset"}',
       '--space',
       spaceId,
       '--signals',
       'logs',
-      '--endpoint',
-      testEndpoint,
-      '--transport',
-      'http',
     ])
 
     expectOutput(stdout.output, `successfully added drain ${testEndpoint}`)
@@ -102,15 +100,13 @@ describe('telemetry:add', function () {
       .reply(200, space)
     try {
       await runCommand(Cmd, [
+        testEndpoint,
+        '--headers',
         '{"x-honeycomb-team": "your-api-key", "x-honeycomb-dataset": "your-dataset"}',
         '--space',
         spaceId,
         '--signals',
         'logs,foo',
-        '--endpoint',
-        testEndpoint,
-        '--transport',
-        'http',
       ])
     } catch (error) {
       const {message} = error as { message: string }
@@ -124,15 +120,13 @@ describe('telemetry:add', function () {
       .reply(200, space)
     try {
       await runCommand(Cmd, [
+        testEndpoint,
+        '--headers',
         '{"x-honeycomb-team": "your-api-key", "x-honeycomb-dataset": "your-dataset"}',
         '--space',
         spaceId,
         '--signals',
         'logs,all',
-        '--endpoint',
-        testEndpoint,
-        '--transport',
-        'http',
       ])
     } catch (error) {
       const {message} = error as { message: string }


### PR DESCRIPTION
[GUS WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000026GoMVYA0/view)

### Description

This changes the interface to `telemetry` command in the following ways to improve usability:

1. In `telemetry:add`, moves `HEADERS` from an argument to a flag, and makes it not required
2. In `telemetry:add`, moves `endpoint` from a flag to an argument
3. In `telemetry:add`, makes `transport` not required and defaults to `http`
4. In `telemetry:update`, moves `HEADERS` from an argument to a flag