### PR TITLE
Prepend 'launcher' to commands executed with 'heroku run:inside'

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -260,6 +260,7 @@ psubscribe
 psut
 psql
 psqlrc
+pvpr
 pxxxxxxxx
 qqjs
 raulb

--- a/packages/cli/src/commands/run/inside.ts
+++ b/packages/cli/src/commands/run/inside.ts
@@ -1,43 +1,77 @@
 import {Command, flags} from '@heroku-cli/command'
-import {ux} from '@oclif/core'
+import {Args, ux} from '@oclif/core'
 import debugFactory from 'debug'
+import heredoc from 'tsheredoc'
 import Dyno from '../../lib/run/dyno'
 import {buildCommand} from '../../lib/run/helpers'
+import {App} from '../../lib/types/fir'
 
 const debug = debugFactory('heroku:run:inside')
 
 export default class RunInside extends Command {
-  static description = 'run a one-off process inside an existing heroku dyno'
+  static description = 'run a command inside an existing dyno (for Fir-generation apps only)'
 
-  static hidden = true;
-
-  static examples = [
-    '$ heroku run:inside web.1 bash',
-  ]
+  static strict = false
+  static args = {
+    dyno_name: Args.string({
+      description: 'name of the dyno to run command inside',
+      required: true,
+    }),
+    command: Args.string({
+      description: 'command to run (Heroku automatically prepends ‘launcher’ to the command)',
+      required: true,
+    }),
+  }
 
   static flags = {
     app: flags.app({required: true}),
-    remote: flags.remote(),
-    'exit-code': flags.boolean({char: 'x', description: 'passthrough the exit code of the remote command'}),
+    'exit-code': flags.boolean({
+      char: 'x',
+      description: 'passthrough the exit code of the remote command',
+    }),
     listen: flags.boolean({description: 'listen on a local port', hidden: true}),
+    'no-launcher': flags.boolean({
+      description: 'don’t prepend ‘launcher’ before a command',
+      default: false,
+    }),
+    remote: flags.remote(),
   }
 
-  static strict = false
+  static examples = [
+    heredoc`
+      Run bash
+      heroku run:inside web-848cd4f64d-pvpr2 bash -a my-app
+    `,
+    heredoc`
+      Run a command supplied by a script taking option flags
+      heroku run:inside web-848cd4f64d-pvpr2 -a my-app -- myscript.sh -x --log-level=warn
+    `,
+    heredoc`
+      Run a command declared for the worker process type in a Procfile
+      heroku run:inside web-848cd4f64d-pvpr2 worker -a my-app
+    `,
+  ]
 
   async run() {
-    const {flags, argv} = await this.parse(RunInside)
+    const {args, argv, flags} = await this.parse(RunInside)
 
-    if (argv.length < 2) {
-      throw new Error('Usage: heroku run:inside DYNO COMMAND\n\nExample: heroku run:inside web.1 bash')
-    }
+    const {dyno_name: dynoName} = args
+    const {app: appName, 'exit-code': exitCode, listen, 'no-launcher': noLauncher} = flags
+    const prependLauncher = !noLauncher
+
+    const {body: app} = await this.heroku.get<App>(
+      `/apps/${appName}`, {
+        headers: {Accept: 'application/vnd.heroku+json; version=3.sdk'},
+      })
+    const appStackIsCnb = app.stack.name === 'cnb'
 
     const opts = {
-      'exit-code': flags['exit-code'],
-      app: flags.app,
-      command: buildCommand(argv.slice(1) as string[]),
-      dyno: argv[0] as string,
+      app: appName,
+      command: buildCommand(argv.slice(1) as string[], appStackIsCnb && prependLauncher),
+      dyno: dynoName,
+      'exit-code': exitCode,
       heroku: this.heroku,
-      listen: flags.listen,
+      listen,
     }
 
     const dyno = new Dyno(opts)

--- a/packages/cli/src/lib/run/helpers.ts
+++ b/packages/cli/src/lib/run/helpers.ts
@@ -28,11 +28,11 @@ export function revertSortedArgs(processArgs: Array<string>, argv: Array<string>
   return originalInputOrder
 }
 
-export function buildCommand(args: Array<string>) {
+export function buildCommand(args: Array<string>, prependLauncher: boolean = false) {
   if (args.length === 1) {
     // do not add quotes around arguments if there is only one argument
     // `heroku run "rake test"` should work like `heroku run rake test`
-    return args[0]
+    return `${prependLauncher ? 'launcher ' : ''}${args[0]}`
   }
 
   let cmd = ''
@@ -44,7 +44,7 @@ export function buildCommand(args: Array<string>) {
     cmd = cmd + ' ' + arg
   }
 
-  return cmd.trim()
+  return `${prependLauncher ? 'launcher ' : ''}${cmd.trim()}`
 }
 
 export function buildEnvFromFlag(flag: string) {

--- a/packages/cli/src/lib/run/helpers.ts
+++ b/packages/cli/src/lib/run/helpers.ts
@@ -29,10 +29,12 @@ export function revertSortedArgs(processArgs: Array<string>, argv: Array<string>
 }
 
 export function buildCommand(args: Array<string>, prependLauncher: boolean = false) {
+  const prependText = prependLauncher ? 'launcher ' : ''
+
   if (args.length === 1) {
     // do not add quotes around arguments if there is only one argument
     // `heroku run "rake test"` should work like `heroku run rake test`
-    return `${prependLauncher ? 'launcher ' : ''}${args[0]}`
+    return `${prependText}${args[0]}`
   }
 
   let cmd = ''
@@ -44,7 +46,7 @@ export function buildCommand(args: Array<string>, prependLauncher: boolean = fal
     cmd = cmd + ' ' + arg
   }
 
-  return `${prependLauncher ? 'launcher ' : ''}${cmd.trim()}`
+  return `${prependText}${cmd.trim()}`
 }
 
 export function buildEnvFromFlag(flag: string) {

--- a/packages/cli/test/unit/lib/run/helpers.unit.test.ts
+++ b/packages/cli/test/unit/lib/run/helpers.unit.test.ts
@@ -4,15 +4,20 @@ import {buildCommand, buildEnvFromFlag} from '../../../../src/lib/run/helpers'
 
 describe('helpers.buildCommand()', function () {
   [
-    {args: ['echo foo'], expected: 'echo foo'},
-    {args: ['echo', 'foo bar'], expected: 'echo "foo bar"'},
-    {args: ['echo', 'foo', 'bar'], expected: 'echo foo bar'},
-    {args: ['echo', '{"foo": "bar"}'], expected: 'echo "{\\"foo\\": \\"bar\\"}"'},
-    {args: ['echo', '{"foo":"bar"}'], expected: 'echo "{\\"foo\\":\\"bar\\"}"'},
+    {args: ['echo foo'], prependLauncher: false, expected: 'echo foo'},
+    {args: ['echo foo'], prependLauncher: true, expected: 'launcher echo foo'},
+    {args: ['echo', 'foo bar'], prependLauncher: false, expected: 'echo "foo bar"'},
+    {args: ['echo', 'foo bar'], prependLauncher: true, expected: 'launcher echo "foo bar"'},
+    {args: ['echo', 'foo', 'bar'], prependLauncher: false, expected: 'echo foo bar'},
+    {args: ['echo', 'foo', 'bar'], prependLauncher: true, expected: 'launcher echo foo bar'},
+    {args: ['echo', '{"foo": "bar"}'], prependLauncher: false, expected: 'echo "{\\"foo\\": \\"bar\\"}"'},
+    {args: ['echo', '{"foo": "bar"}'], prependLauncher: true, expected: 'launcher echo "{\\"foo\\": \\"bar\\"}"'},
+    {args: ['echo', '{"foo":"bar"}'], prependLauncher: false, expected: 'echo "{\\"foo\\":\\"bar\\"}"'},
+    {args: ['echo', '{"foo":"bar"}'], prependLauncher: true, expected: 'launcher echo "{\\"foo\\":\\"bar\\"}"'},
   ].forEach(example => {
     test
-      .it(`parses \`${example.args.join(' ')}\` as ${example.expected}`, () => {
-        expect(buildCommand(example.args)).to.equal(example.expected)
+      .it(`parses \`${example.args.join(' ')}\` ${example.prependLauncher ? 'with' : 'without'} \`prependLauncher\` as \`${example.expected}\``, () => {
+        expect(buildCommand(example.args, example.prependLauncher)).to.equal(example.expected)
       })
   })
 })


### PR DESCRIPTION
## Description

Changes implemented here are better described on [this Slack thread](https://salesforce-internal.slack.com/archives/C06NM9FFY57/p1731952194176329) (Heroku internal).

TL;DR we're providing `heroku run:inside` for customers on Fir Pilot to replace `heroku run` which isn't supported on Fir apps yet, to run arbitrary commands on a dyno. For CNB stack apps (all Fir apps, currently), commands provided by a buildpack or depending on configs set by a buildpack need to be run through an entrypoint script called `launcher`). Here we first check the app stack and if it's a CNB app, we prepend the string `launcher` to the command being invoked by default.

We also change some copy texts to the approved CX strings, remove the `hidden` property for this command to be exposed and add a `--no-launcher` flag that allows to opt-out from the automatically added prefix for some edge use cases.

## Testing

### Pre-work

For running these tests you will need the latest beta version for Heroku CLI (`heroku update beta`) and both a deployed app to a Cedar (Dogwood) Private Space and another one deployed to a Fir space, with active dynos. I did the following for preparation (thanks @justinwilaby for letting me use your test spaces):
- Create a Cedar PS app: ```heroku apps:create test-run-inside-cedar --space justins-dev-space```.
- Create a Fir PS app: ```heroku apps:create test-run-inside-fir --space justins-dev-fir-space```.
- Clone the Node.js Getting started app: ```git clone git@github.com:heroku/node-js-getting-started.git```.
- Added remotes for both apps to the same codebase: ```cd node-js-getting-started && heroku git:remote -a test-run-inside-cedar -r cedar && heroku git:remote -a test-run-inside-fir -r fir```.
- Deploy the code to the cedar app: ```git push cedar main```, wait for build and release to finish.
- Repeat with the fir app: ```git push fir main```.

### Actual testing
- Get the dyno name for the cedar app: ```heroku ps -a test-run-inside-cedar```, it should always be `web.1`.
- Get the dyno name for the fir app: ```heroku ps -a test-run-inside-fir```, for me it was `web-55695d5c49-n9sc2`, but it'll change for you, just grab whatever the dyno name is.
- Attempt to run a command inside the cedar app dyno: ```heroku run:inside web.1 -a test-run-inside-cedar -- echo test```. It should error out saying the command is unavailable for that app (it requires a special flag for cedar apps).
- Flag the app to allow `run:inside`: ```heroku labs:enable dyno-run-inside -a test-run-inside-cedar```.
- Retry the same command: ```heroku run:inside web.1 -a test-run-inside-cedar -- echo test```. Now it should work and you should see the message `test`.
- Now try the same command in the fir app: ```heroku run:inside web-55695d5c49-n9sc2 -a test-run-inside-fir -- echo test```. It should run prepending `launcher` to the actual command and it should work.
- Now try the same command in the fir app with option --no-launcher: ```heroku run:inside web-55695d5c49-n9sc2 -a test-run-inside-fir --no-launcher -- echo test```. It should run without prepending `launcher` to the command and it should work.

A caveat, though, there seems to be an issue with the `launcher` script when using double quotes around the command arguments, this doesn't work on the dyno:

```
$ ./bin/run run:inside web-55695d5c49-n9sc2 -a test-run-inside-fir -- echo "this is a test"
Running launcher echo "this is a test" on ⬢ test-run-inside-fir... up, web-55695d5c49-n9sc2
echo: eval: line 1: unexpected EOF while looking for matching `"'
echo: eval: line 1: unexpected EOF while looking for matching `"'
 is a 
```

Using `--no-launcher` makes work, but the response isn't the expected one either:

```
$ ./bin/run run:inside web-55695d5c49-n9sc2 -a test-run-inside-fir --no-launcher -- echo "this is a test"
Running echo "this is a test" on ⬢ test-run-inside-fir... up, web-55695d5c49-n9sc2
"this is a test"
```
(notice the quotes were included in the output, when they shouldn't)

This is a failure coming from the dyno, probably due to a bad parsing of arguments on the `launcher` script. We will notify this on the Slack thread.

## SOC2 Compliance
GUS Work Item: [W-17309565](https://gus.lightning.force.com/a07EE000025zoPLYAY)