### PR TITLE
chore: fix moratorium check process for prereleases

### DIFF
--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -17,13 +17,7 @@ on:
         default: false
 
 jobs:
-  check-for-moratorium:
-    if: ${{ fromJSON(inputs.isStableCandidate) }}
-    uses: ./.github/workflows/tps-check-lock.yml
-    secrets: inherit
-
   get-version-channel:
-    needs: [check-for-moratorium]
     runs-on: ubuntu-latest
     outputs:
       channel: ${{ steps.getVersion.outputs.channel }}
@@ -38,7 +32,7 @@ jobs:
           path: './packages/cli/package.json'
 
   publish-npm:
-    needs: [get-version-channel, check-for-moratorium]
+    needs: [get-version-channel]
     # if NOT isStableCandidate confirm dist tag is in package.json version
     if: fromJSON(needs.get-version-channel.outputs.isStableRelease) || (!fromJSON(inputs.isStableCandidate) && !!needs.get-version-channel.outputs.channel)
     uses: ./.github/workflows/publish-npm.yml
@@ -48,12 +42,12 @@ jobs:
     secrets: inherit
 
   pack-upload:
-    needs: [publish-npm, check-for-moratorium]
+    needs: [publish-npm]
     uses: ./.github/workflows/pack-upload.yml
     secrets: inherit
 
   promote:
-    needs: [get-version-channel, pack-upload, check-for-moratorium]
+    needs: [get-version-channel, pack-upload]
     if: needs.pack-upload.result == 'success'
     uses: ./.github/workflows/promote-release.yml
     with:
@@ -63,7 +57,7 @@ jobs:
     secrets: inherit
 
   publish-docs:
-    needs: [get-version-channel, promote, check-for-moratorium]
+    needs: [get-version-channel, promote]
     uses: ./.github/workflows/devcenter-doc-update.yml
     with:
       isStableRelease: ${{ fromJSON(inputs.isStableCandidate) }}

--- a/.github/workflows/start-gh-release.yml
+++ b/.github/workflows/start-gh-release.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   get-source-branch-name:
-    needs: [check-for-moratorium]
     # GHA does not provide short name for branch being merged in. This shortens it so we can validate it with startsWith()
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest

--- a/.github/workflows/start-gh-release.yml
+++ b/.github/workflows/start-gh-release.yml
@@ -8,10 +8,6 @@ on:
       - closed
 
 jobs:
-  check-for-moratorium:
-    uses: ./.github/workflows/tps-check-lock.yml
-    secrets: inherit
-
   get-source-branch-name:
     needs: [check-for-moratorium]
     # GHA does not provide short name for branch being merged in. This shortens it so we can validate it with startsWith()
@@ -26,9 +22,14 @@ jobs:
         id: sourceName
         run: echo "sourceName=${GITHUB_HEAD_REF#refs/heads/}" >> $GITHUB_OUTPUT
 
-  start-release:
-    needs: [get-source-branch-name, check-for-moratorium]
+  validate-release:
+    needs: [get-source-branch-name]
     if: startsWith(needs.get-source-branch-name.outputs.sourceName, 'release-')
+    uses: ./.github/workflows/tps-check-lock.yml
+    secrets: inherit
+
+  start-release:
+    needs: [validate-release]
     uses: ./.github/workflows/tag-create-github-release.yml
     secrets: inherit
 


### PR DESCRIPTION
Updates our release process to fix a problem with our prereleases.

## Details
Since our prod release process is controlled through two Github workflows, I had previously added the moratorium check as a required job for each workflow. However, the create-cli-release workflow is also used by our prerelease process, for which we do not need to check the moratorium status. Unfortunately, requiring the moratorium check in this workflow resulted in prereleases not being published because the check was not being run.

This PR, then removes that requirement from the create-cli-release workflow, meaning that we will have to depend on the moratorium check in the start-gh-release workflow to catch a moratorium as part of the stable release process.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
