### PR TITLE
fix: show only generation name in spaces:info output

### DIFF
--- a/packages/cli/src/lib/spaces/spaces.ts
+++ b/packages/cli/src/lib/spaces/spaces.ts
@@ -28,7 +28,7 @@ export function renderInfo(space: SpaceWithOutboundIps, json: boolean) {
         State: space.state,
         Shield: displayShieldState(space),
         'Outbound IPs': displayNat(space.outbound_ips),
-        Generation: space.generation,
+        Generation: space.generation.name,
         'Created at': space.created_at,
       },
       ['ID', 'Team', 'Region', 'CIDR', 'Data CIDR', 'State', 'Shield', 'Outbound IPs', 'Generation', 'Created at'],

--- a/packages/cli/src/lib/types/fir.d.ts
+++ b/packages/cli/src/lib/types/fir.d.ts
@@ -2407,7 +2407,10 @@ export interface Space {
   *
   * @example "fir"
   */
-  generation: string;
+  generation: {
+    id: string,
+    name: string,
+ }
 }
 /**
  *

--- a/packages/cli/test/fixtures/spaces/fixtures.ts
+++ b/packages/cli/test/fixtures/spaces/fixtures.ts
@@ -21,7 +21,7 @@ export const spaces: Record<string, SpaceWithOutboundIps> = {
     organization: {
       name: 'my-org',
     },
-    generation: 'cedar',
+    generation: {id: '123', name: 'cedar'},
     created_at: '2016-01-06T03:23:13Z',
     updated_at: '2016-01-06T03:23:13Z',
   },
@@ -43,7 +43,7 @@ export const spaces: Record<string, SpaceWithOutboundIps> = {
     organization: {
       name: 'my-org',
     },
-    generation: 'cedar',
+    generation: {id: '123', name: 'cedar'},
     created_at: '2016-01-06T03:23:13Z',
     updated_at: '2016-01-06T03:23:13Z',
   },
@@ -66,7 +66,7 @@ export const spaces: Record<string, SpaceWithOutboundIps> = {
     organization: {
       name: 'my-org',
     },
-    generation: 'cedar',
+    generation: {id: '123', name: 'cedar'},
     created_at: '2016-01-06T03:23:13Z',
     updated_at: '2016-01-06T03:23:13Z',
   },

--- a/packages/cli/test/unit/commands/spaces/info.unit.test.ts
+++ b/packages/cli/test/unit/commands/spaces/info.unit.test.ts
@@ -34,7 +34,7 @@ describe('spaces:info', function () {
       Data CIDR:    ${space.data_cidr}
       State:        ${space.state}
       Shield:       off
-      Generation:   ${space.generation}
+      Generation:   ${space.generation.name}
       Created at:   ${space.created_at}
     `))
   })
@@ -74,7 +74,7 @@ describe('spaces:info', function () {
       State:        ${space.state}
       Shield:       off
       Outbound IPs: 123.456.789.123
-      Generation:   ${space.generation}
+      Generation:   ${space.generation.name}
       Created at:   ${space.created_at}
     `))
   })
@@ -101,7 +101,7 @@ describe('spaces:info', function () {
       State:        ${space.state}
       Shield:       off
       Outbound IPs: disabled
-      Generation:   ${space.generation}
+      Generation:   ${space.generation.name}
       Created at:   ${space.created_at}
     `))
   })
@@ -124,7 +124,7 @@ describe('spaces:info', function () {
       Data CIDR:    ${space.data_cidr}
       State:        ${space.state}
       Shield:       off
-      Generation:   ${space.generation}
+      Generation:   ${space.generation.name}
       Created at:   ${space.created_at}
     `))
   })
@@ -147,7 +147,7 @@ describe('spaces:info', function () {
       Data CIDR:    ${shieldSpace.data_cidr}
       State:        ${shieldSpace.state}
       Shield:       on
-      Generation:   ${space.generation}
+      Generation:   ${space.generation.name}
       Created at:   ${shieldSpace.created_at}
     `))
   })
@@ -169,7 +169,7 @@ describe('spaces:info', function () {
       Data CIDR:    ${space.data_cidr}
       State:        ${space.state}
       Shield:       off
-      Generation:   ${space.generation}
+      Generation:   ${space.generation.name}
       Created at:   ${space.created_at}
     `))
   })

--- a/packages/cli/test/unit/commands/spaces/wait.unit.test.ts
+++ b/packages/cli/test/unit/commands/spaces/wait.unit.test.ts
@@ -56,7 +56,7 @@ describe('spaces:wait', function () {
       State:        ${allocatedSpace.state}
       Shield:       off
       Outbound IPs: 123.456.789.123
-      Generation:   ${allocatedSpace.generation}
+      Generation:   ${allocatedSpace.generation.name}
       Created at:   ${allocatedSpace.created_at}
     `))
     expect(notifySpy.called).to.be.true
@@ -115,7 +115,7 @@ describe('spaces:wait', function () {
       Data CIDR:    ${allocatedSpace.data_cidr}
       State:        ${allocatedSpace.state}
       Shield:       off
-      Generation:   ${allocatedSpace.generation}
+      Generation:   ${allocatedSpace.generation.name}
       Created at:   ${allocatedSpace.created_at}
     `))
     expect(notifySpy.called).to.be.true


### PR DESCRIPTION
[Work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE0000262f6QYAQ/view)

In the output of the `spaces:info` and `spaces:wait` commands, the "generation" field was showing the UUID and the name of the generation, instead of just the name. This was due to a change in the API. This PR updates the output to only show the name.

## Testing
- Pull down this branch and run `yarn` and `yarn build`
- Run `./bin/run spaces:info -s FIR-SPACE-NAME`. Verify that the output shows only the name of the generation and not an object with the UUID.
- Run `./bin/run spaces:info -s CEDAR-SPACE-NAME`. Verify that the output shows only the name of the generation and not an object with the UUID
- Run `./bin/run spaces:wait -s FIR-SPACE-NAME`. Verify that the output shows only the name of the generation and not an object with the UUID.

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
