### PR TITLE
fix: only print slug size for apps:info for non-fir apps

### DIFF
--- a/packages/cli/src/commands/apps/info.ts
+++ b/packages/cli/src/commands/apps/info.ts
@@ -71,7 +71,7 @@ function print(info: Heroku.App, addons: Heroku.AddOn[], collaborators: Heroku.C
   data['Git URL'] = info.app.git_url
   data['Web URL'] = info.app.web_url
   data['Repo Size'] = filesize(info.app.repo_size, {standard: 'jedec', round: 0})
-  data['Slug Size'] = filesize(info.app.slug_size, {standard: 'jedec', round: 0})
+  if (info.app.generation.name !== 'fir') data['Slug Size'] = filesize(info.app.slug_size, {standard: 'jedec', round: 0})
   data.Owner = info.app.owner.email
   data.Region = info.app.region.name
   data.Dynos = countBy(info.dynos, 'type')
@@ -159,7 +159,7 @@ repo_size=5000000
       print('git_url', info.app.git_url)
       print('web_url', info.app.web_url)
       print('repo_size', filesize(info.app.repo_size, {standard: 'jedec', round: 0}))
-      print('slug_size', filesize(info.app.slug_size, {standard: 'jedec', round: 0}))
+      if (info.app.generation.name !== 'fir') print('slug_size', filesize(info.app.slug_size, {standard: 'jedec', round: 0}))
       print('owner', info.app.owner.email)
       print('region', info.app.region.name)
       print('dynos', util.inspect(countBy(info.dynos, 'type')))


### PR DESCRIPTION
[Work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000026Gh3pYAC/view)

Fixes `apps:info` so that "slug size" only appears in the output for non-fir apps. It will still appear in the JSON output (as null).

## Testing
- pull down this branch and run `yarn` and `yarn build`
- Run `./bin/run apps:info -a FIR_APP` and confirm that "slug size" does not appear in the output
- Run `./bin/run apps:info -a CEDAR_APP` and confirm that "slug size" does appear in the output


<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
