### PR TITLE
Update CODEOWNERS to assign security issues to appropriate team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,3 +4,4 @@
 # These owners will be the default owners for everything in the repo.
 * @heroku/front-end
 #ECCN:Open Source
+#GUSINFO:Heroku Front End Dept (FE Infra & Arch),Heroku CLI

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -98,6 +98,7 @@ Gdvb
 getreqs
 Ghpcy
 githuborg
+GUSINFO
 hamurai
 herokai
 herokuapp


### PR DESCRIPTION
Issues like this one should get routed to the Heroku CLI tag: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000026XxJ0YAK/view

This change should enable that routing.
