### PR TITLE
chore: remove installation of awscli in workflows

### DIFF
--- a/.github/workflows/cache-invalidation.yml
+++ b/.github/workflows/cache-invalidation.yml
@@ -13,8 +13,5 @@ jobs:
       AWS_EC2_METADATA_DISABLED: true
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -y awscli
-          aws configure set preview.cloudfront true
+      - run: aws configure set preview.cloudfront true
       - run: ./scripts/postrelease/invalidate_cdn_cache

--- a/.github/workflows/pack-upload.yml
+++ b/.github/workflows/pack-upload.yml
@@ -93,9 +93,6 @@ jobs:
       - name: List all the downloaded files (for debugging)
         run: ls -R
         working-directory: /home/runner/work/cli/cli/packages/cli/dist
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -y awscli
       - name: yarn install
         run: yarn --immutable --network-timeout 1000000
       - name: Upload production artifacts

--- a/.github/workflows/promote-windows.yml
+++ b/.github/workflows/promote-windows.yml
@@ -40,7 +40,7 @@ jobs:
       - name: install apt-get dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y awscli jq
+          sudo apt-get install -y jq
       - name: promote
         env:
           prerelease-channel: ${{ inputs.channel || 'beta'}}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -53,7 +53,7 @@ jobs:
       - name: install apt-get dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y awscli jq
+          sudo apt-get install -y jq
       - name: promote
         env:
           prerelease-channel: ${{ inputs.channel || 'beta'}}


### PR DESCRIPTION
awscli comes pre-installed on the [ubuntu-latest](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#cli-tools) runner. Installing this way was causing our builds to fail once ubuntu-latest updated to Ubuntu 22. This has been tested with the 10.0.1-beta release.

**EDIT**
I found a few more places where we are installing awscli in our workflows and removed them. However, I only removed them in workflows where we are running on the ubuntu-latest image. In a couple of other workflows we are using a Heroku private runner image and it appears that awscli is [not installed there](https://devcenter.heroku.com/articles/stack-packages).

<!--
Note: Windows jobs on CircleCI will sometimes fail to exit (a bug in their containers), if this happens simply re-run the job or workflow.

When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`) and the package name.

Examples:

`feat(spaces): add growl notification to spaces:wait`

`fix(apps-v5): handle special characters in app names`

`chore(ci): refactor tests`

`chore(autocomplete): update typings`

`chore(cli): edit README`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
