### PR TITLE
fix(W-17568149): pg:settings:log-min-duration-statement command is su…

### DIFF
--- a/packages/cli/src/commands/pg/settings/log-min-duration-statement.ts
+++ b/packages/cli/src/commands/pg/settings/log-min-duration-statement.ts
@@ -19,7 +19,7 @@ export default class LogMinDurationStatement extends PGSettingsCommand {
   protected settingKey:SettingKey = 'log_min_duration_statement'
 
   protected convertValue(val: unknown): number {
-    return val as number
+    return Number.parseInt(val as string, 10)
   }
 
   protected explain(setting: Setting<unknown>) {

--- a/packages/cli/src/lib/types/fir.d.ts
+++ b/packages/cli/src/lib/types/fir.d.ts
@@ -1418,7 +1418,7 @@ export interface AddOnWebhookCreatePayload {
  /**
   * a custom `Authorization` header that Heroku will include with all webhook notifications
   *
-  * @example "Bearer 9266671b2767f804c9d5809c2d384ed57d8f8ce1abd1043e1fb3fbbcb8c3"
+  * @example "Bearer <the_token>"
   */
   authorization?: null | string;
  /**
@@ -1434,7 +1434,7 @@ export interface AddOnWebhookCreatePayload {
  /**
   * a value that Heroku will use to sign all webhook notification requests (the signature is included in the request’s `Heroku-Webhook-Hmac-SHA256` header)
   *
-  * @example "dcbff0c4430a2960a2552389d587bc58d30a37a8cf3f75f8fb77abe667ad"
+  * @example "<the_token>"
   */
   secret?: null | string;
  /**
@@ -1500,7 +1500,7 @@ export interface AddOnWebhookUpdatePayload {
  /**
   * a custom `Authorization` header that Heroku will include with all webhook notifications
   *
-  * @example "Bearer 9266671b2767f804c9d5809c2d384ed57d8f8ce1abd1043e1fb3fbbcb8c3"
+  * @example "Bearer <the_token>"
   */
   authorization?: null | string;
  /**
@@ -1516,7 +1516,7 @@ export interface AddOnWebhookUpdatePayload {
  /**
   * a value that Heroku will use to sign all webhook notification requests (the signature is included in the request’s `Heroku-Webhook-Hmac-SHA256` header)
   *
-  * @example "dcbff0c4430a2960a2552389d587bc58d30a37a8cf3f75f8fb77abe667ad"
+  * @example "<the_token>"
   */
   secret?: null | string;
  /**
@@ -2131,7 +2131,7 @@ export interface AppWebhookCreatePayload {
  /**
   * a custom `Authorization` header that Heroku will include with all webhook notifications
   *
-  * @example "Bearer 9266671b2767f804c9d5809c2d384ed57d8f8ce1abd1043e1fb3fbbcb8c3"
+  * @example "Bearer <the_token>"
   */
   authorization?: null | string;
  /**
@@ -2147,7 +2147,7 @@ export interface AppWebhookCreatePayload {
  /**
   * a value that Heroku will use to sign all webhook notification requests (the signature is included in the request’s `Heroku-Webhook-Hmac-SHA256` header)
   *
-  * @example "dcbff0c4430a2960a2552389d587bc58d30a37a8cf3f75f8fb77abe667ad"
+  * @example "<the_token>"
   */
   secret?: null | string;
  /**
@@ -2195,7 +2195,7 @@ export interface AppWebhookUpdatePayload {
  /**
   * a custom `Authorization` header that Heroku will include with all webhook notifications
   *
-  * @example "Bearer 9266671b2767f804c9d5809c2d384ed57d8f8ce1abd1043e1fb3fbbcb8c3"
+  * @example "Bearer <the_token>"
   */
   authorization?: null | string;
  /**
@@ -2211,7 +2211,7 @@ export interface AppWebhookUpdatePayload {
  /**
   * a value that Heroku will use to sign all webhook notification requests (the signature is included in the request’s `Heroku-Webhook-Hmac-SHA256` header)
   *
-  * @example "dcbff0c4430a2960a2552389d587bc58d30a37a8cf3f75f8fb77abe667ad"
+  * @example "<the_token>"
   */
   secret?: null | string;
  /**


### PR DESCRIPTION
This PR addresses 2 issues:

1. fix([W-17568149](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000027k6XtYAI/view)): pg:settings:log-min-duration-statement command is submitting a string instead of number
>›  Error: The value for log_min_duration_statement needs to be a number
> ›  Error ID: bad_request
2. fix([W-17414774](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000026dTr2YAE/view)): Triage credential scan results for https://github.com/heroku/cli

The latter was a never a security issue but the text was changed anyway so as not to trigger further false alarms.

## Test
1. `heroku pg:settings:log-min-duration-statement -a <your app> <your db> 3000`
2. Observe the error is no longer present