### PR TITLE
fix: Unable to list drains for a space in fir

### DIFF
--- a/packages/cli/src/commands/drains/index.ts
+++ b/packages/cli/src/commands/drains/index.ts
@@ -53,4 +53,3 @@ export default class Drains extends Command {
     }
   }
 }
-

--- a/packages/cli/src/commands/telemetry/index.ts
+++ b/packages/cli/src/commands/telemetry/index.ts
@@ -7,7 +7,7 @@ export default class Index extends Command {
   static description = 'list telemetry drains'
   static flags = {
     space: Flags.string({char: 's', description: 'filter by space name', exactlyOne: ['app', 'space']}),
-    app: Flags.app({description: 'filter by app name'}),
+    app: Flags.string({description: 'filter by app name'}),
   };
 
   static example = '$ heroku telemetry'


### PR DESCRIPTION
Fixes an issue with listing telemetry drains when a heroku remote exists and the `--team` flags is applied.
e.g. `heroku telemetry --space justins-dev-space` yields this error:

> ›  Error: The following error occurred:
> ›   --app cannot also be provided when using --space
> ›  See more help with --help

##To test 
1. build this branch and `./bin/run telemetry --space justins-dev-space`

[W-17568474](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000027kJEmYAM/view)