### PR TITLE
feature:  Update  command warning message for Fir spaces

### DIFF
--- a/packages/cli/src/commands/spaces/destroy.ts
+++ b/packages/cli/src/commands/spaces/destroy.ts
@@ -54,7 +54,7 @@ export default class Destroy extends Command {
           ${color.dim('=')} Security group configurations
           ${color.dim('=')} Network ACLs
 
-          ${color.yellow('Ensure all IPv4 and IPv6 addresses are removed from your security configurations.')}
+          ${color.yellow('Ensure that you remove the listed IPv4 and IPv6 addresses from your security configurations.')}
         `
       }
     }

--- a/packages/cli/src/commands/spaces/destroy.ts
+++ b/packages/cli/src/commands/spaces/destroy.ts
@@ -45,7 +45,7 @@ export default class Destroy extends Command {
       if (space.outbound_ips && space.outbound_ips.state === 'enabled') {
         natWarning = heredoc`
           ${color.dim('===')} ${color.bold('WARNING: Outbound IPs Will Be Reused')}
-          ${color.yellow('⚠️ The following outbound IPs (IPv4 and IPv6) will become available for reuse:')}
+          ${color.yellow('⚠️ Deleting this space frees up the following outbound IPv4 and IPv6 IPs for reuse:')}
           ${color.bold(displayNat(space.outbound_ips) ?? '')}
 
           ${color.dim('Please update the following configurations:')}

--- a/packages/cli/src/commands/spaces/destroy.ts
+++ b/packages/cli/src/commands/spaces/destroy.ts
@@ -48,7 +48,7 @@ export default class Destroy extends Command {
           ${color.yellow('⚠️ Deleting this space frees up the following outbound IPv4 and IPv6 IPs for reuse:')}
           ${color.bold(displayNat(space.outbound_ips) ?? '')}
 
-          ${color.dim('Please update the following configurations:')}
+          ${color.dim('Update the following configurations:')}
           ${color.dim('=')} IP allowlists
           ${color.dim('=')} Firewall rules
           ${color.dim('=')} Security group configurations

--- a/packages/cli/src/commands/spaces/destroy.ts
+++ b/packages/cli/src/commands/spaces/destroy.ts
@@ -1,11 +1,10 @@
 import {Args, ux} from '@oclif/core'
-import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import heredoc from 'tsheredoc'
 import confirmCommand from '../../lib/confirmCommand'
 import {displayNat} from '../../lib/spaces/spaces'
-import chalk from 'chalk'
+import color from '@heroku-cli/color'
 
 type RequiredSpaceWithNat = Required<Heroku.Space> & {outbound_ips?: Required<Heroku.SpaceNetworkAddressTranslation>}
 
@@ -45,17 +44,17 @@ export default class Destroy extends Command {
       ({body: space.outbound_ips} = await this.heroku.get<Required<Heroku.SpaceNetworkAddressTranslation>>(`/spaces/${spaceName}/nat`))
       if (space.outbound_ips && space.outbound_ips.state === 'enabled') {
         natWarning = heredoc`
-          ${chalk.dim('===')} ${chalk.bold('WARNING: Outbound IPs Will Be Reused')}
-          ${chalk.yellow('⚠️ The following outbound IPs (IPv4 and IPv6) will become available for reuse:')}
-          ${chalk.bold(displayNat(space.outbound_ips) ?? '')}
+          ${color.dim('===')} ${color.bold('WARNING: Outbound IPs Will Be Reused')}
+          ${color.yellow('⚠️ The following outbound IPs (IPv4 and IPv6) will become available for reuse:')}
+          ${color.bold(displayNat(space.outbound_ips) ?? '')}
 
-          ${chalk.dim('Please update the following configurations:')}
-          ${chalk.dim('=')} IP allowlists
-          ${chalk.dim('=')} Firewall rules
-          ${chalk.dim('=')} Security group configurations
-          ${chalk.dim('=')} Network ACLs
+          ${color.dim('Please update the following configurations:')}
+          ${color.dim('=')} IP allowlists
+          ${color.dim('=')} Firewall rules
+          ${color.dim('=')} Security group configurations
+          ${color.dim('=')} Network ACLs
 
-          ${chalk.yellow('Ensure all IPv4 and IPv6 addresses are removed from your security configurations.')}
+          ${color.yellow('Ensure all IPv4 and IPv6 addresses are removed from your security configurations.')}
         `
       }
     }

--- a/packages/cli/src/commands/spaces/destroy.ts
+++ b/packages/cli/src/commands/spaces/destroy.ts
@@ -5,8 +5,9 @@ import heredoc from 'tsheredoc'
 import confirmCommand from '../../lib/confirmCommand'
 import {displayNat} from '../../lib/spaces/spaces'
 import color from '@heroku-cli/color'
+import {Space} from '../../lib/types/fir'
 
-type RequiredSpaceWithNat = Required<Heroku.Space> & {outbound_ips?: Required<Heroku.SpaceNetworkAddressTranslation>}
+type RequiredSpaceWithNat = Required<Space> & {outbound_ips?: Required<Heroku.SpaceNetworkAddressTranslation>}
 
 export default class Destroy extends Command {
   static topic = 'spaces'
@@ -40,22 +41,31 @@ export default class Destroy extends Command {
 
     let natWarning = ''
     const {body: space} = await this.heroku.get<RequiredSpaceWithNat>(`/spaces/${spaceName}`)
+
     if (space.state === 'allocated') {
       ({body: space.outbound_ips} = await this.heroku.get<Required<Heroku.SpaceNetworkAddressTranslation>>(`/spaces/${spaceName}/nat`))
       if (space.outbound_ips && space.outbound_ips.state === 'enabled') {
-        natWarning = heredoc`
+        if (space.generation?.name === 'fir') {
+          natWarning = heredoc`
           ${color.dim('===')} ${color.bold('WARNING: Outbound IPs Will Be Reused')}
-          ${color.yellow('⚠️ Deleting this space frees up the following outbound IPv4 and IPv6 IPs for reuse:')}
+          ${color.yellow('⚠️ The following outbound IPs (IPv4 and IPv6) will become available for reuse:')}
           ${color.bold(displayNat(space.outbound_ips) ?? '')}
 
-          ${color.dim('Update the following configurations:')}
+          ${color.dim('Please update the following configurations:')}
           ${color.dim('=')} IP allowlists
           ${color.dim('=')} Firewall rules
           ${color.dim('=')} Security group configurations
           ${color.dim('=')} Network ACLs
 
-          ${color.yellow('Ensure that you remove the listed IPv4 and IPv6 addresses from your security configurations.')}
+          ${color.yellow('Ensure all IPv4 and IPv6 addresses are removed from your security configurations.')}
         `
+        } else {
+          natWarning = heredoc`
+          ${color.dim('===')} ${color.bold('WARNING: Outbound IPs Will Be Reused')}
+          ${color.yellow('⚠️ The following outbound IPs will become available for reuse:')}
+          ${color.bold(displayNat(space.outbound_ips) ?? '')}
+        `
+        }
       }
     }
 

--- a/packages/cli/src/commands/spaces/destroy.ts
+++ b/packages/cli/src/commands/spaces/destroy.ts
@@ -45,27 +45,20 @@ export default class Destroy extends Command {
     if (space.state === 'allocated') {
       ({body: space.outbound_ips} = await this.heroku.get<Required<Heroku.SpaceNetworkAddressTranslation>>(`/spaces/${spaceName}/nat`))
       if (space.outbound_ips && space.outbound_ips.state === 'enabled') {
-        if (space.generation?.name === 'fir') {
-          natWarning = heredoc`
-          ${color.dim('===')} ${color.bold('WARNING: Outbound IPs Will Be Reused')}
-          ${color.yellow('⚠️ The following outbound IPs (IPv4 and IPv6) will become available for reuse:')}
-          ${color.bold(displayNat(space.outbound_ips) ?? '')}
+        const ipv6 = space.generation?.name === 'fir' ? ' and IPv6' : ''
+        natWarning = heredoc`
+        ${color.dim('===')} ${color.bold('WARNING: Outbound IPs Will Be Reused')}
+        ${color.yellow(`⚠️ Deleting this space frees up the following outbound IPv4${ipv6} IPs for reuse:`)}
+        ${color.bold(displayNat(space.outbound_ips) ?? '')}
 
-          ${color.dim('Please update the following configurations:')}
-          ${color.dim('=')} IP allowlists
-          ${color.dim('=')} Firewall rules
-          ${color.dim('=')} Security group configurations
-          ${color.dim('=')} Network ACLs
+        ${color.dim('Update the following configurations:')}
+        ${color.dim('=')} IP allowlists
+        ${color.dim('=')} Firewall rules
+        ${color.dim('=')} Security group configurations
+        ${color.dim('=')} Network ACLs
 
-          ${color.yellow('Ensure all IPv4 and IPv6 addresses are removed from your security configurations.')}
-        `
-        } else {
-          natWarning = heredoc`
-          ${color.dim('===')} ${color.bold('WARNING: Outbound IPs Will Be Reused')}
-          ${color.yellow('⚠️ The following outbound IPs will become available for reuse:')}
-          ${color.bold(displayNat(space.outbound_ips) ?? '')}
-        `
-        }
+        ${color.yellow(`Ensure that you remove the listed IPv4${ipv6} addresses from your security configurations.`)}
+      `
       }
     }
 

--- a/packages/cli/test/unit/commands/spaces/destroy.unit.test.ts
+++ b/packages/cli/test/unit/commands/spaces/destroy.unit.test.ts
@@ -37,8 +37,8 @@ describe('spaces:destroy', function () {
 
     await runCommand(Cmd, ['--space', 'my-space'])
     api.done()
-
-    expect(stderr.output).to.eq(heredoc`     ›   Warning: Destructive Action
+    const replacer = /([»›])/g
+    expect(stderr.output.replace(replacer, '')).to.eq(heredoc(`     ›   Warning: Destructive Action
      ›   This command will destroy the space my-space
      ›   === WARNING: Outbound IPs Will Be Reused
      ›   ⚠️ Deleting this space frees up the following outbound IPv4 and IPv6 IPs 
@@ -58,7 +58,7 @@ describe('spaces:destroy', function () {
 
     Destroying space my-space...
     Destroying space my-space... done
-    `)
+    `.replace(replacer, '')))
   })
 
   it('shows simple NAT warning for non-fir generation space', async function () {
@@ -79,8 +79,8 @@ describe('spaces:destroy', function () {
 
     await runCommand(Cmd, ['--space', 'my-space'])
     api.done()
-
-    expect(stderr.output).to.eq(heredoc`     ›   Warning: Destructive Action
+    const replacer = /([»›])/g
+    expect(stderr.output.replace(replacer, '')).to.eq(heredoc(`     ›   Warning: Destructive Action
      ›   This command will destroy the space my-space
      ›   === WARNING: Outbound IPs Will Be Reused
      ›   ⚠️ Deleting this space frees up the following outbound IPv4 IPs for reuse:
@@ -99,6 +99,6 @@ describe('spaces:destroy', function () {
 
     Destroying space my-space...
     Destroying space my-space... done
-    `)
+    `.replace(replacer, '')))
   })
 })

--- a/packages/cli/test/unit/commands/spaces/destroy.unit.test.ts
+++ b/packages/cli/test/unit/commands/spaces/destroy.unit.test.ts
@@ -41,21 +41,21 @@ describe('spaces:destroy', function () {
     expect(stderr.output).to.eq(heredoc`     ›   Warning: Destructive Action
      ›   This command will destroy the space my-space
      ›   === WARNING: Outbound IPs Will Be Reused
-     ›   ⚠️ The following outbound IPs (IPv4 and IPv6) will become available for 
-     ›   reuse:
+     ›   ⚠️ Deleting this space frees up the following outbound IPv4 and IPv6 IPs 
+     ›   for reuse:
      ›   1.1.1.1, 2.2.2.2
      ›
-     ›   Please update the following configurations:
+     ›   Update the following configurations:
      ›   = IP allowlists
      ›   = Firewall rules
      ›   = Security group configurations
      ›   = Network ACLs
      ›
-     ›   Ensure all IPv4 and IPv6 addresses are removed from your security 
-     ›   configurations.
+     ›   Ensure that you remove the listed IPv4 and IPv6 addresses from your 
+     ›   security configurations.
      ›
      ›
-    
+
     Destroying space my-space...
     Destroying space my-space... done
     `)
@@ -83,11 +83,20 @@ describe('spaces:destroy', function () {
     expect(stderr.output).to.eq(heredoc`     ›   Warning: Destructive Action
      ›   This command will destroy the space my-space
      ›   === WARNING: Outbound IPs Will Be Reused
-     ›   ⚠️ The following outbound IPs will become available for reuse:
+     ›   ⚠️ Deleting this space frees up the following outbound IPv4 IPs for reuse:
      ›   1.1.1.1, 2.2.2.2
      ›
+     ›   Update the following configurations:
+     ›   = IP allowlists
+     ›   = Firewall rules
+     ›   = Security group configurations
+     ›   = Network ACLs
      ›
-    
+     ›   Ensure that you remove the listed IPv4 addresses from your security 
+     ›   configurations.
+     ›
+     ›
+
     Destroying space my-space...
     Destroying space my-space... done
     `)

--- a/packages/cli/test/unit/commands/spaces/destroy.unit.test.ts
+++ b/packages/cli/test/unit/commands/spaces/destroy.unit.test.ts
@@ -6,6 +6,7 @@ import {expect} from 'chai'
 import heredoc from 'tsheredoc'
 import {ux} from '@oclif/core'
 import * as sinon from 'sinon'
+
 describe('spaces:destroy', function () {
   const now = new Date()
 
@@ -18,10 +19,17 @@ describe('spaces:destroy', function () {
     sinon.restore()
   })
 
-  it('destroys a space', async function () {
+  it('shows extended NAT warning for fir generation space', async function () {
     const api = nock('https://api.heroku.com')
       .get('/spaces/my-space')
-      .reply(200, {name: 'my-space', team: {name: 'my-team'}, region: {name: 'my-region'}, state: 'allocated', created_at: now})
+      .reply(200, {
+        name: 'my-space',
+        team: {name: 'my-team'},
+        region: {name: 'my-region'},
+        state: 'allocated',
+        created_at: now,
+        generation: {name: 'fir'},
+      })
       .get('/spaces/my-space/nat')
       .reply(200, {state: 'enabled', sources: ['1.1.1.1', '2.2.2.2']})
       .delete('/spaces/my-space')
@@ -45,6 +53,38 @@ describe('spaces:destroy', function () {
      ›
      ›   Ensure all IPv4 and IPv6 addresses are removed from your security 
      ›   configurations.
+     ›
+     ›
+    
+    Destroying space my-space...
+    Destroying space my-space... done
+    `)
+  })
+
+  it('shows simple NAT warning for non-fir generation space', async function () {
+    const api = nock('https://api.heroku.com')
+      .get('/spaces/my-space')
+      .reply(200, {
+        name: 'my-space',
+        team: {name: 'my-team'},
+        region: {name: 'my-region'},
+        state: 'allocated',
+        created_at: now,
+        generation: {name: 'cedar'},
+      })
+      .get('/spaces/my-space/nat')
+      .reply(200, {state: 'enabled', sources: ['1.1.1.1', '2.2.2.2']})
+      .delete('/spaces/my-space')
+      .reply(200)
+
+    await runCommand(Cmd, ['--space', 'my-space'])
+    api.done()
+
+    expect(stderr.output).to.eq(heredoc`     ›   Warning: Destructive Action
+     ›   This command will destroy the space my-space
+     ›   === WARNING: Outbound IPs Will Be Reused
+     ›   ⚠️ The following outbound IPs will become available for reuse:
+     ›   1.1.1.1, 2.2.2.2
      ›
      ›
     


### PR DESCRIPTION
This PR provides an updated warning message to users that the ipv4 and ipv6 addresses previously associated with their soon to be destroyed space will be re-used and to take appropriate security precautions.

to test:
1. delete a space
2. observe warning message

[CX Review Request Link](https://salesforce-internal.slack.com/archives/C028EAW6SDB/p1736529165702709)