### PR TITLE
fix: send correct value to api for grpc telemetry drains

### DIFF
--- a/packages/cli/src/commands/telemetry/add.ts
+++ b/packages/cli/src/commands/telemetry/add.ts
@@ -50,7 +50,7 @@ export default class Add extends Command {
       signals: validateAndFormatSignals(signals),
       exporter: {
         endpoint,
-        type: `otlp${transport}`,
+        type: (transport === 'grpc') ? 'otlp' : 'otlphttp',
         headers: JSON.parse(exporterHeaders),
       },
     }

--- a/packages/cli/test/fixtures/telemetry/fixtures.ts
+++ b/packages/cli/test/fixtures/telemetry/fixtures.ts
@@ -33,11 +33,25 @@ export const appTelemetryDrain2: TelemetryDrain = {
   owner: {id: '87654321-5717-4562-b3fc-2c963f66afa6', type: 'app', name: 'myapp'},
   signals: ['logs'],
   exporter: {
-    type: 'otlphttp',
+    type: 'otlp',
     endpoint: 'https://api.papertrail.com/',
     headers: {
       'x-papertrail-team': 'your-api-key',
       'x-papertrail-dataset': 'your-dataset',
+    },
+  },
+}
+
+export const grpcAppTelemetryDrain: TelemetryDrain = {
+  id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+  owner: {id: '745c1486-ad78-4de7-8da7-20d4f8b15b71', type: 'app', name: 'myapp'},
+  signals: ['traces', 'metrics', 'logs'],
+  exporter: {
+    type: 'otlp',
+    endpoint: 'https://api.honeycomb.io/',
+    headers: {
+      'x-honeycomb-team': 'your-api-key',
+      'x-honeycomb-dataset': 'your-dataset',
     },
   },
 }

--- a/packages/cli/test/unit/commands/telemetry/add.unit.test.ts
+++ b/packages/cli/test/unit/commands/telemetry/add.unit.test.ts
@@ -4,12 +4,13 @@ import runCommand from '../../../helpers/runCommand'
 import {expect} from 'chai'
 import * as nock from 'nock'
 import expectOutput from '../../../helpers/utils/expectOutput'
-import {spaceTelemetryDrain1, appTelemetryDrain1} from '../../../fixtures/telemetry/fixtures'
+import {spaceTelemetryDrain1, appTelemetryDrain1, grpcAppTelemetryDrain} from '../../../fixtures/telemetry/fixtures'
 import {firApp} from '../../../fixtures/apps/fixtures'
 import * as spaceFixtures from '../../../fixtures/spaces/fixtures'
 import {SpaceWithOutboundIps} from '../../../../src/lib/types/spaces'
 
 const appId = appTelemetryDrain1.owner.id
+const grpcDrainAppId = grpcAppTelemetryDrain.owner.id
 const spaceId = spaceTelemetryDrain1.owner.id
 const testEndpoint = appTelemetryDrain1.exporter.endpoint
 
@@ -132,5 +133,35 @@ describe('telemetry:add', function () {
       const {message} = error as { message: string }
       expect(message).to.contain('Invalid signal option: logs,all. Run heroku telemetry:add --help to see signal options.')
     }
+  })
+
+  it('successfully creates a telemetry drain for an app with grpc', async function () {
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      .get(`/apps/${grpcDrainAppId}`)
+      .reply(200, firApp)
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      .post('/telemetry-drains', {
+        owner: {
+          type: 'app',
+          id: grpcDrainAppId,
+        },
+        signals: ['traces', 'metrics', 'logs'],
+        exporter: {
+          endpoint: testEndpoint,
+          type: 'otlp',
+          headers: {},
+        },
+      })
+      .reply(200, spaceTelemetryDrain1)
+
+    await runCommand(Cmd, [
+      testEndpoint,
+      '--app',
+      grpcDrainAppId,
+      '--transport',
+      'grpc',
+    ])
+
+    expectOutput(stdout.output, `successfully added drain ${testEndpoint}`)
   })
 })


### PR DESCRIPTION
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE0000282ViQYAU/view

### Description

Currently we are sending `otlpgrpc` as a value to API when creating a grpc telemetry drain. The correct value should be `otlp`.

### Testing

1. Pull down this branch and yarn build
2. `./bin/run telemetry:add SOME_URL --app SOME_FIR_APP --transport grpc
3. See success