### PR TITLE
Update install-standalone script

### DIFF
--- a/install-standalone.sh
+++ b/install-standalone.sh
@@ -17,11 +17,6 @@
 
   echoerr() { echo "\$@" 1>&2; }
 
-  if [[ ! ":$PATH:" == *":/usr/local/bin:"* ]]; then
-    echoerr "Your path is missing /usr/local/bin, you need to add this to use this installer."
-    exit 1
-  fi
-
   if [ "\$(uname)" == "Darwin" ]; then
     OS=darwin
   elif [ "\$(expr substr \$(uname -s) 1 5)" == "Linux" ]; then
@@ -40,6 +35,11 @@
     ARCH=arm64
   else
     echoerr "unsupported arch: \$ARCH"
+    exit 1
+  fi
+
+  if [[ ! ":$PATH:" == *":/usr/local/bin:"* ]]; then
+    echoerr "Your path is missing /usr/local/bin, you need to add this to use this installer."
     exit 1
   fi
 

--- a/install-standalone.sh
+++ b/install-standalone.sh
@@ -17,7 +17,7 @@
 
   echoerr() { echo "\$@" 1>&2; }
 
-  if [[ ! ":\$PATH:" == *":/usr/local/bin:"* ]]; then
+  if [[ ! ":$PATH:" == *":/usr/local/bin:"* ]]; then
     echoerr "Your path is missing /usr/local/bin, you need to add this to use this installer."
     exit 1
   fi


### PR DESCRIPTION
This applies two changes from the community:

* https://github.com/heroku/cli/pull/3175 which loosens regex check to support $PATH check and resolves https://github.com/heroku/cli/issues/3166
* https://github.com/heroku/cli/pull/2205 which moves the path check to after the OS checks, as that check only makes sense for specific OSes, and as the author points out, it's certainly more helpful to know when the OS is not supported before knowing if you satisfy the $PATH check
