### PR TITLE
chore: switch from 3.add-ons-sso to 3.sdk

### DIFF
--- a/packages/cli/src/commands/addons/open.ts
+++ b/packages/cli/src/commands/addons/open.ts
@@ -127,7 +127,7 @@ export default class Open extends Command {
     const sso: HTTP<AddonSso> = await this.heroku.request(`/apps/${app}/addons/${args.addon}/sso`, {
       method: 'GET',
       headers: {
-        Accept: 'application/vnd.heroku+json; version=3.add-ons-sso',
+        Accept: 'application/vnd.heroku+json; version=3.sdk',
       },
     })
     const {method, action} = sso.body


### PR DESCRIPTION
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE0000285wZdYAI/view

### Description

Web services is deprecating 3.add-ons-sso variant and has moved its functionality to 3.sdk. This updates our use of that variant.

### Testing

Because of the interaction with `sudo`, it's a bit annoying to test this. Here's how I tested:

1. Pull down this branch
2. In `commands/addons/open.ts`, comment out lines 97 and 99. Also comment out lines 101-122.
3. `yarn build`
4. `./bin/run addons:open DATABASE_NAME --app APP_NAME