### PR TITLE
Fix GUS-aware CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,9 @@
-# All files require review from the Dev Tools team
+# All files require review from the Heroku Front-End Dev Tools team.
 
+# Comment line immediately above ownership line is reserved for related GUS information.
+# Please exercise caution while editing.
+
+#GUSINFO: Heroku FE Dev Tools,Heroku CLI & Plugins
 * @heroku/frontend-dev-tooling
 
 #ECCN:Open Source
-#GUSINFO:Heroku Front End Dept (FE Infra & Arch),Heroku CLI


### PR DESCRIPTION
Our CODEOWNERS file is using a shelved schema for setting up the required GUS information and the wrong team and product tags.

This PR just fixes that.

## SOC2 compliance
GUS WI: [W-17568080](https://gus.lightning.force.com/a07EE000027kEFKYA2) 