### PR TITLE
feat(utils): add a getGeneration helper function

### DIFF
--- a/packages/cli/src/commands/apps/info.ts
+++ b/packages/cli/src/commands/apps/info.ts
@@ -4,6 +4,7 @@ import * as Heroku from '@heroku-cli/schema'
 import * as util from 'util'
 import * as _ from 'lodash'
 import {filesize} from 'filesize'
+import {getGeneration} from '../../lib/apps/generation'
 const {countBy, snakeCase} = _
 
 function formatDate(date: Date) {
@@ -71,7 +72,7 @@ function print(info: Heroku.App, addons: Heroku.AddOn[], collaborators: Heroku.C
   data['Git URL'] = info.app.git_url
   data['Web URL'] = info.app.web_url
   data['Repo Size'] = filesize(info.app.repo_size, {standard: 'jedec', round: 0})
-  if (info.app.generation.name !== 'fir') data['Slug Size'] = filesize(info.app.slug_size, {standard: 'jedec', round: 0})
+  if (getGeneration(info.app) !== 'fir') data['Slug Size'] = filesize(info.app.slug_size, {standard: 'jedec', round: 0})
   data.Owner = info.app.owner.email
   data.Region = info.app.region.name
   data.Dynos = countBy(info.dynos, 'type')
@@ -159,7 +160,7 @@ repo_size=5000000
       print('git_url', info.app.git_url)
       print('web_url', info.app.web_url)
       print('repo_size', filesize(info.app.repo_size, {standard: 'jedec', round: 0}))
-      if (info.app.generation.name !== 'fir') print('slug_size', filesize(info.app.slug_size, {standard: 'jedec', round: 0}))
+      if (getGeneration(info.app) !== 'fir') print('slug_size', filesize(info.app.slug_size, {standard: 'jedec', round: 0}))
       print('owner', info.app.owner.email)
       print('region', info.app.region.name)
       print('dynos', util.inspect(countBy(info.dynos, 'type')))

--- a/packages/cli/src/commands/buildpacks/index.ts
+++ b/packages/cli/src/commands/buildpacks/index.ts
@@ -4,6 +4,7 @@ import {App} from '../../lib/types/fir'
 import color from '@heroku-cli/color'
 
 import {BuildpackCommand} from '../../lib/buildpacks/buildpacks'
+import {getGeneration} from '../../lib/apps/generation'
 
 export default class Index extends Command {
   static description = 'display the buildpacks for an app'
@@ -21,7 +22,7 @@ export default class Index extends Command {
         Accept: 'application/vnd.heroku+json; version=3.sdk',
       },
     })
-    const buildpacks = await buildpacksCommand.fetch(flags.app, app.generation === 'fir')
+    const buildpacks = await buildpacksCommand.fetch(flags.app, getGeneration(app) === 'fir')
     if (buildpacks.length === 0) {
       this.log(`${color.app(flags.app)} has no Buildpacks.`)
     } else {

--- a/packages/cli/src/commands/pipelines/diff.ts
+++ b/packages/cli/src/commands/pipelines/diff.ts
@@ -7,6 +7,7 @@ import {getCoupling, getPipeline, getReleases, listPipelineApps, SDK_HEADER} fro
 import KolkrabbiAPI from '../../lib/pipelines/kolkrabbi-api'
 import type {OciImage, Slug, PipelineCoupling} from '../../lib/types/fir'
 import type {Commit, GitHubDiff} from '../../lib/types/github'
+import {GenerationKind, getGeneration} from '../../lib/apps/generation'
 
 interface AppInfo {
   name: string;
@@ -87,7 +88,7 @@ export default class PipelinesDiff extends Command {
 
   kolkrabbi: KolkrabbiAPI = new KolkrabbiAPI(this.config.userAgent, () => this.heroku.auth)
 
-  getAppInfo = async (appName: string, appId: string, generation: string): Promise<AppInfo> => {
+  getAppInfo = async (appName: string, appId: string, generation: GenerationKind): Promise<AppInfo> => {
     // Find GitHub connection for the app
     const githubApp = await this.kolkrabbi.getAppLink(appId)
       .catch(() => {
@@ -139,7 +140,7 @@ export default class PipelinesDiff extends Command {
     const {body: pipeline} = await getPipeline(this.heroku, coupling.pipeline!.id!)
 
     const targetAppId = coupling!.app!.id!
-    const generation = pipeline!.generation!.name!
+    const generation = getGeneration(pipeline)!
 
     ux.action.start('Fetching apps from pipeline')
     const allApps = await listPipelineApps(this.heroku, coupling!.pipeline!.id!)

--- a/packages/cli/src/commands/ps/autoscale/enable.ts
+++ b/packages/cli/src/commands/ps/autoscale/enable.ts
@@ -2,6 +2,7 @@ import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
 import {App, Formation} from '../../../lib/types/fir'
+import {getGeneration} from '../../../lib/apps/generation'
 
 const METRICS_HOST = 'api.metrics.heroku.com'
 
@@ -42,7 +43,7 @@ export default class Enable extends Command {
     const formations = formationResponse.body
     const webFormation = formations.find((f: any) => f.type === 'web')
 
-    if (app.generation === 'fir') {
+    if (getGeneration(app) === 'fir') {
       throw new Error('Autoscaling is unavailable for apps in this space. See https://devcenter.heroku.com/articles/generations.')
     }
 

--- a/packages/cli/src/commands/spaces/create.ts
+++ b/packages/cli/src/commands/spaces/create.ts
@@ -6,6 +6,7 @@ import heredoc from 'tsheredoc'
 import {displayShieldState} from '../../lib/spaces/spaces'
 import {RegionCompletion} from '../../lib/autocomplete/completions'
 import {splitCsv} from '../../lib/spaces/parsers'
+import {getGeneration} from '../../lib/apps/generation'
 
 export default class Create extends Command {
   static topic = 'spaces'
@@ -103,7 +104,7 @@ export default class Create extends Command {
 
     ux.styledHeader(space.name)
     ux.styledObject({
-      ID: space.id, Team: space.team.name, Region: space.region.name, CIDR: space.cidr, 'Data CIDR': space.data_cidr, State: space.state, Shield: displayShieldState(space), Generation: space.generation, 'Created at': space.created_at,
+      ID: space.id, Team: space.team.name, Region: space.region.name, CIDR: space.cidr, 'Data CIDR': space.data_cidr, State: space.state, Shield: displayShieldState(space), Generation: getGeneration(space), 'Created at': space.created_at,
     }, ['ID', 'Team', 'Region', 'CIDR', 'Data CIDR', 'State', 'Shield', 'Generation', 'Created at'])
   }
 }

--- a/packages/cli/src/commands/spaces/destroy.ts
+++ b/packages/cli/src/commands/spaces/destroy.ts
@@ -6,6 +6,7 @@ import confirmCommand from '../../lib/confirmCommand'
 import {displayNat} from '../../lib/spaces/spaces'
 import color from '@heroku-cli/color'
 import {Space} from '../../lib/types/fir'
+import {getGeneration} from '../../lib/apps/generation'
 
 type RequiredSpaceWithNat = Required<Space> & {outbound_ips?: Required<Heroku.SpaceNetworkAddressTranslation>}
 
@@ -45,7 +46,7 @@ export default class Destroy extends Command {
     if (space.state === 'allocated') {
       ({body: space.outbound_ips} = await this.heroku.get<Required<Heroku.SpaceNetworkAddressTranslation>>(`/spaces/${spaceName}/nat`))
       if (space.outbound_ips && space.outbound_ips.state === 'enabled') {
-        const ipv6 = space.generation?.name === 'fir' ? ' and IPv6' : ''
+        const ipv6 = getGeneration(space) === 'fir' ? ' and IPv6' : ''
         natWarning = heredoc`
         ${color.dim('===')} ${color.bold('WARNING: Outbound IPs Will Be Reused')}
         ${color.yellow(`⚠️ Deleting this space frees up the following outbound IPv4${ipv6} IPs for reuse:`)}

--- a/packages/cli/src/commands/spaces/index.ts
+++ b/packages/cli/src/commands/spaces/index.ts
@@ -2,6 +2,7 @@ import color from '@heroku-cli/color'
 import {Command, flags as Flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
 import {Space} from '../../lib/types/fir'
+import {getGeneration} from '../../lib/apps/generation'
 
 type SpaceArray = Array<Required<Space>>
 
@@ -58,7 +59,7 @@ export default class Index extends Command {
         Team: {get: space => space.team.name},
         Region: {get: space => space.region.name},
         State: {get: space => space.state},
-        Generation: {get: space => space.generation},
+        Generation: {get: space => getGeneration(space)},
         createdAt: {
           header: 'Created At',
           get: space => space.created_at,

--- a/packages/cli/src/lib/apps/generation.ts
+++ b/packages/cli/src/lib/apps/generation.ts
@@ -1,27 +1,63 @@
 import {APIClient} from '@heroku-cli/command'
-import {App} from '../types/fir'
+import {App, Space, DynoSize, TeamApp, Pipeline, Generation, AppGeneration, DynoSizeGeneration, PipelineGeneration} from '../types/fir'
+import Dyno from '../run/dyno'
 
-async function getApp(appOrName: App | string, herokuApi?: APIClient): Promise<App> {
-  if (typeof appOrName === 'string') {
-    if (herokuApi === undefined)
-      throw new Error('herokuApi parameter is required when passing an app name')
+export type GenerationKind = 'fir' | 'cedar';
+// web.1 web-1234abcde-123ab
+export type GenerationLike = Generation | AppGeneration | DynoSizeGeneration | PipelineGeneration | Dyno
+export type GenerationCapable = App | Space | DynoSize | TeamApp | Pipeline
 
-    const {body: app} = await herokuApi.get<App>(
-      `/apps/${appOrName}`, {
-        headers: {Accept: 'application/vnd.heroku+json; version=3.sdk'},
-      })
-    return app
+function getGenerationFromGenerationLike(generation: string | GenerationLike | undefined): GenerationKind | undefined {
+  let maybeGeneration = ''
+
+  if (typeof generation === 'string') {
+    maybeGeneration = generation
+  } else if (generation && 'name' in generation) {
+    maybeGeneration = generation.name ?? ''
   }
 
-  return appOrName
+  if (/(fir|cedar)/.test(maybeGeneration)) {
+    return maybeGeneration as GenerationKind
+  }
+
+  // web-1234abcde44-123ab etc. fir
+  if (/^web-[0-9a-z]+-[0-9a-z]{5}$/.test(maybeGeneration)) {
+    return 'fir'
+  }
+
+  // web.n cedar
+  if (/^web\.[0-9]+$/.test(maybeGeneration)) {
+    return 'cedar'
+  }
+
+  return undefined
 }
 
-export async function isFirApp(appOrName: App | string, herokuApi?: APIClient) {
-  const app = await getApp(appOrName, herokuApi)
-  return app.generation.name === 'fir'
+/**
+ * Get the generation of an object
+ *
+ * @param source The object to get the generation from
+ * @returns The generation of the object
+ */
+export function getGeneration(source: GenerationLike | GenerationCapable | string): GenerationKind | undefined {
+  if (typeof source === 'object' && 'generation' in source) {
+    return getGenerationFromGenerationLike(source.generation)
+  }
+
+  return getGenerationFromGenerationLike(source)
 }
 
-export async function isCedarApp(appOrName: App | string, herokuApi?: APIClient) {
-  const app = await getApp(appOrName, herokuApi)
-  return app.generation.name === 'cedar'
+/**
+ * Get the generation of an app by id or name
+ *
+ * @param appIdOrName The id or name of the app to get the generation for
+ * @param herokuApi The Heroku API client to use
+ * @returns The generation of the app
+ */
+export async function getGenerationByAppId(appIdOrName: string, herokuApi: APIClient) {
+  const {body: app} = await herokuApi.get<App>(
+    `/apps/${appIdOrName}`, {
+      headers: {Accept: 'application/vnd.heroku+json; version=3.sdk'},
+    })
+  return getGeneration(app)
 }

--- a/packages/cli/src/lib/run/log-displayer.ts
+++ b/packages/cli/src/lib/run/log-displayer.ts
@@ -2,8 +2,8 @@ import {APIClient} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
 import color from '@heroku-cli/color'
 import colorize from './colorize'
-import {isFirApp} from '../apps/generation'
 import {LogSession} from '../types/fir'
+import {getGenerationByAppId} from '../apps/generation'
 
 const EventSource = require('@heroku/eventsource')
 
@@ -68,7 +68,7 @@ async function logDisplayer(heroku: APIClient, options: LogDisplayerOptions) {
     }
   })
 
-  const firApp = await isFirApp(options.app, heroku)
+  const firApp = (await getGenerationByAppId(options.app, heroku)) === 'fir'
   const isTail = firApp || options.tail
 
   const requestBodyParameters = {

--- a/packages/cli/src/lib/spaces/spaces.ts
+++ b/packages/cli/src/lib/spaces/spaces.ts
@@ -2,6 +2,7 @@ import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
 import {SpaceNat} from '../types/fir'
 import {SpaceWithOutboundIps} from '../types/spaces'
+import {getGeneration} from '../apps/generation'
 
 export function displayShieldState(space: Heroku.Space) {
   return space.shield ? 'on' : 'off'
@@ -28,7 +29,7 @@ export function renderInfo(space: SpaceWithOutboundIps, json: boolean) {
         State: space.state,
         Shield: displayShieldState(space),
         'Outbound IPs': displayNat(space.outbound_ips),
-        Generation: space.generation.name,
+        Generation: getGeneration(space),
         'Created at': space.created_at,
       },
       ['ID', 'Team', 'Region', 'CIDR', 'Data CIDR', 'State', 'Shield', 'Outbound IPs', 'Generation', 'Created at'],

--- a/packages/cli/src/lib/types/fir.d.ts
+++ b/packages/cli/src/lib/types/fir.d.ts
@@ -544,63 +544,6 @@ export interface AddOn {
 }
 /**
  *
- * [Heroku Platform API - add-on-service](https://devcenter.heroku.com/articles/platform-api-reference#add-on-service)
- * Add-on services represent add-ons that may be provisioned for apps. Endpoints under add-on services can be accessed without authentication.
- */
-export interface AddOnService {
- /**
-  * npm package name of the add-on service's Heroku CLI plugin
-  *
-  * @example "heroku-papertrail"
-  */
-  readonly cli_plugin_name: string | null;
- /**
-  * when add-on-service was created
-  *
-  * @example "2012-01-01T12:00:00Z"
-  */
-  readonly created_at: string;
- /**
-  * human-readable name of the add-on service provider
-  *
-  * @example "Heroku Postgres"
-  */
-  readonly human_name: string;
- /**
-  * unique identifier of this add-on-service
-  *
-  * @example "01234567-89ab-cdef-0123-456789abcdef"
-  */
-  readonly id: string;
- /**
-  * unique name of this add-on-service
-  *
-  * @example "heroku-postgresql"
-  */
-  readonly name: string;
- /**
-  * release status for add-on service
-  *
-  * @example "ga"
-  */
-  readonly state: 'alpha' | 'beta' | 'ga' | 'shutdown';
- /**
-  * whether or not apps can have access to more than one instance of this add-on at the same time
-  */
-  readonly supports_multiple_installations: boolean;
- /**
-  * whether or not apps can have access to add-ons billed to a different app
-  */
-  readonly supports_sharing: boolean;
- /**
-  * when add-on-service was updated
-  *
-  * @example "2012-01-01T12:00:00Z"
-  */
-  readonly updated_at: string;
-}
-/**
- *
  * billing entity associated with this add-on
  */
 export interface BillingEntity {
@@ -629,127 +572,129 @@ export interface BillingEntity {
  * An app represents the program that you would like to deploy and run on Heroku.
  */
 export interface App {
- /**
-  * ACM status of this app
-  */
+  /**
+   * ACM status of this app
+   */
   readonly acm: boolean;
- /**
-  * when app was archived
-  *
-  * @example "2012-01-01T12:00:00Z"
-  */
+  /**
+   * when app was archived
+   *
+   * @example "2012-01-01T12:00:00Z"
+   */
   readonly archived_at: null | string;
- /**
-  * name of the image used for the base layers of the OCI image
-  *
-  * @example "heroku/heroku:22-cnb"
-  */
+  /**
+   * name of the image used for the base layers of the OCI image
+   *
+   * @example "heroku/heroku:22-cnb"
+   */
   readonly base_image_name: null | string;
- /**
-  * identity of the stack that will be used for new builds
-  */
+  /**
+   * identity of the stack that will be used for new builds
+   */
   build_stack: BuildStack;
- /**
-  * description from buildpack of app
-  *
-  * @example "Ruby/Rack"
-  */
+  /**
+   * description from buildpack of app
+   *
+   * @example "Ruby/Rack"
+   */
   readonly buildpack_provided_description: null | string;
- /**
-  * buildpacks of the OCI image
-  */
+  /**
+   * buildpacks of the OCI image
+   */
   buildpacks: null | Buildpack[];
- /**
-  * when app was created
-  *
-  * @example "2012-01-01T12:00:00Z"
-  */
+  /**
+   * when app was created
+   *
+   * @example "2012-01-01T12:00:00Z"
+   */
   readonly created_at: string;
- /**
-  * current build architecture for the app
-  *
-  * @example "[arm64]"
-  */
-  current_build_architecture: unknown[];
- /**
-  * Generation of the Heroku platform for this app
-  */
-  readonly generation: AppGeneration;
- /**
-  * git repo URL of app
-  *
-  * @example "https://git.heroku.com/example.git"
-  */
+  /**
+   * current build architecture for the app
+   *
+   * @example "[arm64]"
+   */
+  current_build_architecture: [];
+  /**
+   * the generation of the app
+   *
+   * @example "fir"
+   */
+  readonly generation: string;
+  /**
+   * git repo URL of app
+   *
+   * @example "https://git.heroku.com/example.git"
+   */
   readonly git_url: string;
- /**
-  * unique identifier of app
-  *
-  * @example "01234567-89ab-cdef-0123-456789abcdef"
-  */
+  /**
+   * unique identifier of app
+   *
+   * @example "01234567-89ab-cdef-0123-456789abcdef"
+   */
   readonly id: string;
- /**
-  * describes whether a Private Spaces app is externally routable or not
-  */
+  /**
+   * describes whether a Private Spaces app is externally routable or not
+   */
   internal_routing: boolean | null;
- /**
-  * maintenance status of app
-  */
+  /**
+   * maintenance status of app
+   */
   maintenance: boolean;
- /**
-  * unique name of app
-  *
-  * @example "example"
-  */
+  /**
+   * unique name of app
+   *
+   * @example "example"
+   */
   name: string;
- /**
-  * identity of app owner
-  */
+  /**
+   * identity of app owner
+   */
   owner: AppOwner;
- /**
-  * identity of team
-  */
+  /**
+   * identity of team
+   */
   organization: null | AppOrganization;
- /**
-  * identity of team
-  */
+  /**
+   * identity of team
+   */
   team: null | AppTeam;
- /**
-  * identity of app region
-  */
+  /**
+   * identity of app region
+   */
   region: AppRegion;
- /**
-  * when app was released
-  *
-  * @example "2012-01-01T12:00:00Z"
-  */
+  /**
+   * when app was released
+   *
+   * @example "2012-01-01T12:00:00Z"
+   */
   readonly released_at: null | string;
- /**
-  * git repo size in bytes of app
-  */
+  /**
+   * git repo size in bytes of app
+   */
   readonly repo_size: number | null;
- /**
-  * slug size in bytes of app
-  */
+  /**
+   * slug size in bytes of app
+   */
   readonly slug_size: number | null;
- /**
-  * identity of space
-  */
+  /**
+   * identity of space
+   */
   space: null | Space;
- /**
-  * identity of app stack
-  */
+  /**
+   * identity of app stack
+   */
   stack: Stack;
- /**
-  * when app was updated
-  *
-  * @example "2012-01-01T12:00:00Z"
-  */
+  /**
+   * when app was updated
+   *
+   * @example "2012-01-01T12:00:00Z"
+   */
   readonly updated_at: string;
- /**
-  * web URL of app
-  *
-  * @example "https://example.herokuapp.com/"
-  */
+  /**
+   * web URL of app
+   *
+   * @example "https://example.herokuapp.com/"
+   */
   readonly web_url: null | string;
 }
 /**
@@ -876,6 +821,80 @@ export interface AddonService {
   * @example "heroku-postgresql"
   */
   readonly name: string;
+}
+/**
+ *
+ * [Heroku Platform API - add-on-service](https://devcenter.heroku.com/articles/platform-api-reference#add-on-service)
+ * Add-on services represent add-ons that may be provisioned for apps. Endpoints under add-on services can be accessed without authentication.
+ */
+export interface AddOnService {
+  /**
+   * npm package name of the add-on service's Heroku CLI plugin
+   *
+   * @example "heroku-papertrail"
+   */
+  readonly cli_plugin_name: string | null;
+  /**
+   * when add-on-service was created
+   *
+   * @example "2012-01-01T12:00:00Z"
+   */
+  readonly created_at: string;
+  /**
+   * human-readable name of the add-on service provider
+   *
+   * @example "Heroku Postgres"
+   */
+  readonly human_name: string;
+  /**
+   * unique identifier of this add-on-service
+   *
+   * @example "01234567-89ab-cdef-0123-456789abcdef"
+   */
+  readonly id: string;
+  /**
+   * unique name of this add-on-service
+   *
+   * @example "heroku-postgresql"
+   */
+  readonly name: string;
+  /**
+   * release status for add-on service
+   *
+   * @example "ga"
+   */
+  readonly state: 'alpha' | 'beta' | 'ga' | 'shutdown';
+  /**
+   * whether or not apps can have access to more than one instance of this add-on at the same time
+   */
+  readonly supports_multiple_installations: boolean;
+  /**
+   * whether or not apps can have access to add-ons billed to a different app
+   */
+  readonly supports_sharing: boolean;
+  /**
+   * when add-on-service was updated
+   *
+   * @example "2012-01-01T12:00:00Z"
+   */
+  readonly updated_at: string;
+  /**
+   * generations supported by this add-on
+   */
+  supported_generations: Array<{
+    /**
+     * unique name of generation
+     *
+     * @example "fir"
+     */
+    readonly name?: string;
+    /**
+     * unique identifier of generation
+     *
+     * @example "01234567-89ab-cdef-0123-456789abcdef"
+     */
+    readonly id?: string;
+  }>;
 }
 /**
  *
@@ -2354,75 +2373,72 @@ export interface AppRegion {
  * A space is an isolated, highly available, secure app execution environment.
  */
 export interface Space {
- /**
-  * when space was created
-  *
-  * @example "2012-01-01T12:00:00Z"
-  */
+  /**
+   * when space was created
+   *
+   * @example "2012-01-01T12:00:00Z"
+   */
   readonly created_at: string;
- /**
-  * unique identifier of space
-  *
-  * @example "01234567-89ab-cdef-0123-456789abcdef"
-  */
+  /**
+   * unique identifier of space
+   *
+   * @example "01234567-89ab-cdef-0123-456789abcdef"
+   */
   readonly id: string;
- /**
-  * unique name of space
-  *
-  * @example "nasa"
-  */
+  /**
+   * unique name of space
+   *
+   * @example "nasa"
+   */
   name: string;
- /**
-  * organization that owns this space
-  */
+  /**
+   * organization that owns this space
+   */
   organization: Organization;
- /**
-  * team that owns this space
-  */
+  /**
+   * team that owns this space
+   */
   team: SpaceTeam;
- /**
-  * identity of space region
-  */
+  /**
+   * identity of space region
+   */
   region: SpaceRegion;
- /**
-  * true if this space has shield enabled
-  *
-  * @example true
-  */
+  /**
+   * true if this space has shield enabled
+   *
+   * @example true
+   */
   readonly shield: boolean;
- /**
-  * availability of this space
-  *
-  * @example "allocated"
-  */
+  /**
+   * availability of this space
+   *
+   * @example "allocated"
+   */
   readonly state: 'allocating' | 'allocated' | 'deleting';
- /**
-  * when space was updated
-  *
-  * @example "2012-01-01T12:00:00Z"
-  */
+  /**
+   * when space was updated
+   *
+   * @example "2012-01-01T12:00:00Z"
+   */
   readonly updated_at: string;
- /**
-  * The RFC-1918 CIDR the Private Space will use. It must be a /16 in 10.0.0.0/8, 172.16.0.0/12 or 192.168.0.0/16
-  *
-  * @example "172.20.20.30/16"
-  */
+  /**
+   * The RFC-1918 CIDR the Private Space will use. It must be a /16 in 10.0.0.0/8, 172.16.0.0/12 or 192.168.0.0/16
+   *
+   * @example "172.20.20.30/16"
+   */
   cidr: string;
- /**
-  * The RFC-1918 CIDR that the Private Space will use for the Heroku-managed peering connection that's automatically created when using Heroku Data add-ons. It must be between a /16 and a /20
-  *
-  * @example "10.2.0.0/16"
-  */
+  /**
+   * The RFC-1918 CIDR that the Private Space will use for the Heroku-managed peering connection that's automatically created when using Heroku Data add-ons. It must be between a /16 and a /20
+   *
+   * @example "10.2.0.0/16"
+   */
   data_cidr: string;
- /**
-  * generation for space
-  *
-  * @example "fir"
-  */
-  generation: {
-    id: string,
-    name: string,
- }
+  /**
+   * generation for space
+   *
+   * @example "fir"
+   */
+  generation: string;
 }
 /**
  *
@@ -3262,60 +3278,96 @@ export interface DomainUpdatePayload {
  * Dyno sizes are the values and details of sizes that can be assigned to dynos. This information can also be found at : [https://devcenter.heroku.com/articles/dyno-types](https://devcenter.heroku.com/articles/dyno-types).
  */
 export interface DynoSize {
- /**
-  * CPU architecture of this dyno
-  *
-  * @example "arm64"
-  */
+  /**
+   * CPU architecture of this dyno
+   *
+   * @example "arm64"
+   */
   readonly architecture: string;
- /**
-  * minimum vCPUs, non-dedicated may get more depending on load
-  *
-  * @example 1
-  */
+  /**
+   * minimum vCPUs, non-dedicated may get more depending on load
+   *
+   * @example 1
+   */
   readonly compute: number;
- /**
-  * price information for this dyno size
-  */
+  /**
+   * whether this dyno size's product tier can use auto-scaling
+   *
+   * @example true
+   */
+  readonly can_autoscale: boolean;
+  /**
+   * price information for this dyno size
+   */
   readonly cost: null | Record<string, unknown>;
- /**
-  * whether this dyno will be dedicated to one user
-  */
+  /**
+   * whether this dyno will be dedicated to one user
+   */
   readonly dedicated: boolean;
- /**
-  * unit of consumption for Heroku Enterprise customers to 2 decimal places
-  *
-  * @example 0.28
-  */
+  /**
+   * unit of consumption for Heroku Enterprise customers to 2 decimal places
+   *
+   * @example 0.28
+   */
   readonly precise_dyno_units: number;
- /**
-  * unique identifier of this dyno size
-  *
-  * @example "01234567-89ab-cdef-0123-456789abcdef"
-  */
+  /**
+   * unique identifier of the dyno size
+   *
+   * @example "01234567-89ab-cdef-0123-456789abcdef"
+   */
   readonly id: string;
- /**
-  * amount of RAM in GB
-  *
-  * @example 0.5
-  */
+  /**
+   * amount of RAM in GB
+   *
+   * @example 0.5
+   */
   readonly memory: number;
- /**
-  * the name of this dyno-size
-  *
-  * @example "eco"
-  */
+  /**
+   * name of the dyno size
+   *
+   * @example "eco"
+   */
   readonly name: string;
- /**
-  * whether this dyno can only be provisioned in a private space
-  */
+  /**
+   * whether this dyno can only be provisioned in a private space
+   */
   readonly private_space_only: boolean;
- /**
-  * generation for space
-  *
-  * @example "fir"
-  */
-  generation: string;
+  /**
+   * Generation of the Heroku platform for this dyno size
+   */
+  readonly generation: DynoSizeGeneration;
+  /**
+   * infrastructure tier for this dyno
+   *
+   * @example "production"
+   */
+  readonly infrastructure_tier: string;
+  /**
+   * product tier for this dyno
+   *
+   * @example "standard"
+   */
+  readonly product_dyno_tier: string;
+}
+
+/**
+ *
+ * [Heroku Platform API - generation](https://devcenter.heroku.com/articles/platform-api-reference#generation)
+ * Generation of the Heroku platform for this dyno size
+ */
+export interface DynoSizeGeneration {
+  /**
+   * unique identifier of the generation of the Heroku platform for this dyno size
+   *
+   * @example "01234567-89ab-cdef-0123-456789abcdef"
+   */
+  readonly id?: string;
+  /**
+   * unique name of the generation of the Heroku platform for this dyno size
+   *
+   * @example "cedar"
+   */
+  readonly name?: string;
 }
 /**
  *
@@ -4000,129 +4052,129 @@ export interface In {
  * A team app encapsulates the team specific functionality of Heroku apps.
  */
 export interface TeamApp {
- /**
-  * when app was archived
-  *
-  * @example "2012-01-01T12:00:00Z"
-  */
+  /**
+   * when app was archived
+   *
+   * @example "2012-01-01T12:00:00Z"
+   */
   readonly archived_at?: null | string;
- /**
-  * name of the image used for the base layers of the OCI image
-  *
-  * @example "heroku/heroku:22-cnb"
-  */
+  /**
+   * name of the image used for the base layers of the OCI image
+   *
+   * @example "heroku/heroku:22-cnb"
+   */
   readonly base_image_name?: null | string;
- /**
-  * identity of the stack that will be used for new builds
-  */
+  /**
+   * identity of the stack that will be used for new builds
+   */
   build_stack?: BuildStack;
- /**
-  * description from buildpack of app
-  *
-  * @example "Ruby/Rack"
-  */
+  /**
+   * description from buildpack of app
+   *
+   * @example "Ruby/Rack"
+   */
   readonly buildpack_provided_description?: null | string;
- /**
-  * buildpacks of the OCI image
-  */
+  /**
+   * buildpacks of the OCI image
+   */
   buildpacks?: null | Buildpack[];
- /**
-  * current build architecture for the app
-  *
-  * @example "[arm64]"
-  */
-  current_build_architecture?: unknown[];
- /**
-  * when app was created
-  *
-  * @example "2012-01-01T12:00:00Z"
-  */
+  /**
+   * current build architecture for the app
+   *
+   * @example "[arm64]"
+   */
+  current_build_architecture?: [];
+  /**
+   * when app was created
+   *
+   * @example "2012-01-01T12:00:00Z"
+   */
   readonly created_at?: string;
- /**
-  * the generation of the app
-  *
-  * @example "fir"
-  */
+  /**
+   * the generation of the app
+   *
+   * @example "fir"
+   */
   readonly generation?: string;
- /**
-  * git repo URL of app
-  *
-  * @example "https://git.heroku.com/example.git"
-  */
+  /**
+   * git repo URL of app
+   *
+   * @example "https://git.heroku.com/example.git"
+   */
   readonly git_url?: string;
- /**
-  * unique identifier of app
-  *
-  * @example "01234567-89ab-cdef-0123-456789abcdef"
-  */
+  /**
+   * unique identifier of app
+   *
+   * @example "01234567-89ab-cdef-0123-456789abcdef"
+   */
   readonly id?: string;
- /**
-  * describes whether a Private Spaces app is externally routable or not
-  */
+  /**
+   * describes whether a Private Spaces app is externally routable or not
+   */
   internal_routing?: boolean | null;
- /**
-  * is the current member a collaborator on this app.
-  */
+  /**
+   * is the current member a collaborator on this app.
+   */
   joined?: boolean;
- /**
-  * are other team members forbidden from joining this app.
-  */
+  /**
+   * are other team members forbidden from joining this app.
+   */
   locked?: boolean;
- /**
-  * maintenance status of app
-  */
+  /**
+   * maintenance status of app
+   */
   maintenance?: boolean;
- /**
-  * unique name of app
-  *
-  * @example "example"
-  */
+  /**
+   * unique name of app
+   *
+   * @example "example"
+   */
   name?: string;
- /**
-  * team that owns this app
-  */
+  /**
+   * team that owns this app
+   */
   team?: null | Team;
- /**
-  * identity of app owner
-  */
+  /**
+   * identity of app owner
+   */
   owner?: null | TeamAppOwner;
- /**
-  * identity of app region
-  */
+  /**
+   * identity of app region
+   */
   region?: TeamAppRegion;
- /**
-  * when app was released
-  *
-  * @example "2012-01-01T12:00:00Z"
-  */
+  /**
+   * when app was released
+   *
+   * @example "2012-01-01T12:00:00Z"
+   */
   readonly released_at?: null | string;
- /**
-  * git repo size in bytes of app
-  */
+  /**
+   * git repo size in bytes of app
+   */
   readonly repo_size?: number | null;
- /**
-  * slug size in bytes of app
-  */
+  /**
+   * slug size in bytes of app
+   */
   readonly slug_size?: number | null;
- /**
-  * identity of space
-  */
+  /**
+   * identity of space
+   */
   space?: null | TeamAppSpace;
- /**
-  * identity of app stack
-  */
+  /**
+   * identity of app stack
+   */
   stack?: Stack;
- /**
-  * when app was updated
-  *
-  * @example "2012-01-01T12:00:00Z"
-  */
+  /**
+   * when app was updated
+   *
+   * @example "2012-01-01T12:00:00Z"
+   */
   readonly updated_at?: string;
- /**
-  * web URL of app
-  *
-  * @example "https://example.herokuapp.com/"
-  */
+  /**
+   * web URL of app
+   *
+   * @example "https://example.herokuapp.com/"
+   */
   readonly web_url?: null | string;
 }
 /**
@@ -5465,38 +5517,38 @@ export interface PipelineCouplingApp {
  * A pipeline allows grouping of apps into different stages.
  */
 export interface Pipeline {
- /**
-  * when pipeline was created
-  *
-  * @example "2012-01-01T12:00:00Z"
-  */
+  /**
+   * when pipeline was created
+   *
+   * @example "2012-01-01T12:00:00Z"
+   */
   readonly created_at?: string;
- /**
-  * unique identifier of pipeline
-  *
-  * @example "01234567-89ab-cdef-0123-456789abcdef"
-  */
+  /**
+   * unique identifier of pipeline
+   *
+   * @example "01234567-89ab-cdef-0123-456789abcdef"
+   */
   readonly id?: string;
- /**
-  * name of pipeline
-  *
-  * @example "example"
-  */
+  /**
+   * name of pipeline
+   *
+   * @example "example"
+   */
   name?: string;
- /**
-  * Owner of a pipeline.
-  */
+  /**
+   * Owner of a pipeline.
+   */
   owner?: PipelineOwner | null;
- /**
-  * when pipeline was updated
-  *
-  * @example "2012-01-01T12:00:00Z"
-  */
+  /**
+   * when pipeline was updated
+   *
+   * @example "2012-01-01T12:00:00Z"
+   */
   readonly updated_at?: string;
   /**
    * the generation of the Heroku platform for this pipeline
    */
-  generation?: PipelineGeneration | null;
+  generation?: PipelineGeneration;
 }
 export interface PipelineCouplingCreatePayload {
  /**
@@ -8242,37 +8294,37 @@ export interface VpnConnectionUpdatePayload {
 /**
  *
  * [Heroku Platform API - generation](https://devcenter.heroku.com/articles/platform-api-reference#generation)
- * Generations are the different application execution environments available in the Heroku platform.
+ * A generation represents a version of the Heroku platform that includes the app execution environment, routing, telemetry, and build systems.
  */
 export interface Generation {
- /**
-  * when generation was introduced
-  *
-  * @example "2012-01-01T12:00:00Z"
-  */
+  /**
+   * when generation was created
+   *
+   * @example "2024-12-01T12:00:00Z"
+   */
   readonly created_at: string;
- /**
-  * unique identifier of generation
-  *
-  * @example "01234567-89ab-cdef-0123-456789abcdef"
-  */
+  /**
+   * unique identifier of generation
+   *
+   * @example "01234567-89ab-cdef-0123-456789abcdef"
+   */
   readonly id: string;
- /**
-  * unique name of generation
-  *
-  * @example "fir"
-  */
+  /**
+   * unique name of generation
+   *
+   * @example "fir"
+   */
   readonly name: string;
- /**
-  * when generation was last modified
-  *
-  * @example "2012-01-01T12:00:00Z"
-  */
+  /**
+   * when generation was updated
+   *
+   * @example "2024-12-01T12:00:00Z"
+   */
   readonly updated_at: string;
- /**
-  * features unsupported by this generation
-  */
-  unsupported_features: string[] | null;
+  /**
+   * features unsupported by this generation
+   */
+  unsupported_features: string[];
 }
 /**
  *

--- a/packages/cli/test/fixtures/apps/fixtures.ts
+++ b/packages/cli/test/fixtures/apps/fixtures.ts
@@ -26,7 +26,7 @@ export const cedarApp: Partial<App> = {
   internal_routing: null,
   updated_at: '2024-10-17T16:20:42Z',
   web_url: 'https://my-cedar-app-a6b0f2f1519f.herokuapp.com/',
-  generation: {name: 'cedar'},
+  generation: 'cedar',
 }
 
 export const firApp: Partial<App> = {
@@ -55,5 +55,5 @@ export const firApp: Partial<App> = {
   internal_routing: null,
   updated_at: '2024-10-17T16:20:42Z',
   web_url: 'https://my-fir-app-c07499750516.herokuapp.com/',
-  generation: {name: 'fir'},
+  generation: 'fir',
 }

--- a/packages/cli/test/fixtures/spaces/fixtures.ts
+++ b/packages/cli/test/fixtures/spaces/fixtures.ts
@@ -21,7 +21,7 @@ export const spaces: Record<string, SpaceWithOutboundIps> = {
     organization: {
       name: 'my-org',
     },
-    generation: {id: '123', name: 'cedar'},
+    generation: 'cedar',
     created_at: '2016-01-06T03:23:13Z',
     updated_at: '2016-01-06T03:23:13Z',
   },
@@ -43,7 +43,7 @@ export const spaces: Record<string, SpaceWithOutboundIps> = {
     organization: {
       name: 'my-org',
     },
-    generation: {id: '123', name: 'cedar'},
+    generation: 'cedar',
     created_at: '2016-01-06T03:23:13Z',
     updated_at: '2016-01-06T03:23:13Z',
   },
@@ -66,7 +66,7 @@ export const spaces: Record<string, SpaceWithOutboundIps> = {
     organization: {
       name: 'my-org',
     },
-    generation: {id: '123', name: 'cedar'},
+    generation: 'cedar',
     created_at: '2016-01-06T03:23:13Z',
     updated_at: '2016-01-06T03:23:13Z',
   },

--- a/packages/cli/test/unit/commands/apps/info.unit.test.ts
+++ b/packages/cli/test/unit/commands/apps/info.unit.test.ts
@@ -1,4 +1,5 @@
 import {expect, test} from '@oclif/test'
+import type {App} from '../../../../src/lib/types/fir'
 import {unwrap} from '../../../helpers/utils/unwrap'
 
 const app = {
@@ -15,7 +16,7 @@ const app = {
   stack: {name: 'cedar-14'},
   owner: {email: 'foo@foo.com'},
   space: {name: 'myspace'},
-  generation: {id: '123', name: 'cedar'},
+  generation: 'cedar',
   internal_routing: true,
 }
 
@@ -28,12 +29,12 @@ const firApp = {
   slug_size: null,
   git_url: 'https://git.heroku.com/myapp',
   web_url: 'https://myapp.herokuapp.com',
-  region: {name: 'eu'},
+  region: {name: 'eu', id: ''},
   build_stack: {name: 'cedar-14'},
   stack: {name: 'cedar-14'},
-  owner: {email: 'foo@foo.com'},
+  owner: {email: 'foo@foo.com', id: ''},
   space: {name: 'myspace'},
-  generation: {id: '123', name: 'fir'},
+  generation: 'fir',
   internal_routing: true,
 }
 

--- a/packages/cli/test/unit/commands/spaces/create.unit.test.ts
+++ b/packages/cli/test/unit/commands/spaces/create.unit.test.ts
@@ -4,6 +4,7 @@ import runCommand from '../../../helpers/runCommand'
 import * as nock from 'nock'
 import {expect} from 'chai'
 import heredoc from 'tsheredoc'
+import {getGeneration} from '../../../../src/lib/apps/generation'
 
 describe('spaces:create', function () {
   const now = new Date()
@@ -242,7 +243,7 @@ describe('spaces:create', function () {
     nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
       .post('/spaces', {
         features: firSpace.features,
-        generation: firSpace.generation,
+        generation: getGeneration(firSpace),
         name: firSpace.name,
         region: firSpace.region.name,
         team: firSpace.team.name,
@@ -259,7 +260,7 @@ describe('spaces:create', function () {
       '--features',
       firSpace.features.join(','),
       '--generation',
-      firSpace.generation,
+      getGeneration(firSpace)!,
     ])
     expect(stderr.output).to.include('Fir is currently a pilot service')
     expect(stdout.output).to.eq(heredoc`
@@ -271,7 +272,7 @@ describe('spaces:create', function () {
       Data CIDR:  ${firSpace.data_cidr}
       State:      ${firSpace.state}
       Shield:     off
-      Generation: ${firSpace.generation}
+      Generation: ${getGeneration(firSpace)!}
       Created at: ${now.toISOString()}
     `)
   })

--- a/packages/cli/test/unit/commands/spaces/destroy.unit.test.ts
+++ b/packages/cli/test/unit/commands/spaces/destroy.unit.test.ts
@@ -28,7 +28,7 @@ describe('spaces:destroy', function () {
         region: {name: 'my-region'},
         state: 'allocated',
         created_at: now,
-        generation: {name: 'fir'},
+        generation: 'fir',
       })
       .get('/spaces/my-space/nat')
       .reply(200, {state: 'enabled', sources: ['1.1.1.1', '2.2.2.2']})
@@ -70,7 +70,7 @@ describe('spaces:destroy', function () {
         region: {name: 'my-region'},
         state: 'allocated',
         created_at: now,
-        generation: {name: 'cedar'},
+        generation: 'cedar',
       })
       .get('/spaces/my-space/nat')
       .reply(200, {state: 'enabled', sources: ['1.1.1.1', '2.2.2.2']})

--- a/packages/cli/test/unit/commands/spaces/info.unit.test.ts
+++ b/packages/cli/test/unit/commands/spaces/info.unit.test.ts
@@ -6,6 +6,7 @@ import heredoc from 'tsheredoc'
 import expectOutput from '../../../helpers/utils/expectOutput'
 import * as fixtures from '../../../fixtures/spaces/fixtures'
 import {SpaceWithOutboundIps} from '../../../../src/lib/types/spaces'
+import {getGeneration} from '../../../../src/lib/apps/generation'
 
 describe('spaces:info', function () {
   let space: SpaceWithOutboundIps
@@ -34,7 +35,7 @@ describe('spaces:info', function () {
       Data CIDR:    ${space.data_cidr}
       State:        ${space.state}
       Shield:       off
-      Generation:   ${space.generation.name}
+      Generation:   ${getGeneration(space)}
       Created at:   ${space.created_at}
     `))
   })
@@ -74,7 +75,7 @@ describe('spaces:info', function () {
       State:        ${space.state}
       Shield:       off
       Outbound IPs: 123.456.789.123
-      Generation:   ${space.generation.name}
+      Generation:   ${getGeneration(space)}
       Created at:   ${space.created_at}
     `))
   })
@@ -101,7 +102,7 @@ describe('spaces:info', function () {
       State:        ${space.state}
       Shield:       off
       Outbound IPs: disabled
-      Generation:   ${space.generation.name}
+      Generation:   ${getGeneration(space)}
       Created at:   ${space.created_at}
     `))
   })
@@ -124,7 +125,7 @@ describe('spaces:info', function () {
       Data CIDR:    ${space.data_cidr}
       State:        ${space.state}
       Shield:       off
-      Generation:   ${space.generation.name}
+      Generation:   ${getGeneration(space)}
       Created at:   ${space.created_at}
     `))
   })
@@ -147,7 +148,7 @@ describe('spaces:info', function () {
       Data CIDR:    ${shieldSpace.data_cidr}
       State:        ${shieldSpace.state}
       Shield:       on
-      Generation:   ${space.generation.name}
+      Generation:   ${getGeneration(space)}
       Created at:   ${shieldSpace.created_at}
     `))
   })
@@ -169,7 +170,7 @@ describe('spaces:info', function () {
       Data CIDR:    ${space.data_cidr}
       State:        ${space.state}
       Shield:       off
-      Generation:   ${space.generation.name}
+      Generation:   ${getGeneration(space)}
       Created at:   ${space.created_at}
     `))
   })

--- a/packages/cli/test/unit/commands/spaces/wait.unit.test.ts
+++ b/packages/cli/test/unit/commands/spaces/wait.unit.test.ts
@@ -8,6 +8,7 @@ import expectOutput from '../../../helpers/utils/expectOutput'
 import * as fixtures from '../../../fixtures/spaces/fixtures'
 import * as sinon from 'sinon'
 import {SpaceWithOutboundIps} from '../../../../src/lib/types/spaces'
+import {getGeneration} from '../../../../src/lib/apps/generation'
 
 describe('spaces:wait', function () {
   let allocatingSpace: SpaceWithOutboundIps
@@ -56,7 +57,7 @@ describe('spaces:wait', function () {
       State:        ${allocatedSpace.state}
       Shield:       off
       Outbound IPs: 123.456.789.123
-      Generation:   ${allocatedSpace.generation.name}
+      Generation:   ${getGeneration(allocatedSpace)}
       Created at:   ${allocatedSpace.created_at}
     `))
     expect(notifySpy.called).to.be.true
@@ -115,7 +116,7 @@ describe('spaces:wait', function () {
       Data CIDR:    ${allocatedSpace.data_cidr}
       State:        ${allocatedSpace.state}
       Shield:       off
-      Generation:   ${allocatedSpace.generation.name}
+      Generation:   ${getGeneration(allocatedSpace)}
       Created at:   ${allocatedSpace.created_at}
     `))
     expect(notifySpy.called).to.be.true


### PR DESCRIPTION
This PR provides the following:
1. partially updates interfaces to match the [3.sdk](https://github.com/heroku/api/blob/main/schema/variants/3.sdk/schema.json) schemas 
2. adds a utility function to get the generation kind from the various types.

## Testing
Testing involves execution of commands where generation kinds are retrieved and ensuring they are correct. Please see commit for files affected.