### PR TITLE
fix(W-17544106): pg:wait command addon not found warning

### DIFF
--- a/packages/cli/src/commands/pg/wait.ts
+++ b/packages/cli/src/commands/pg/wait.ts
@@ -39,7 +39,7 @@ export default class Wait extends Command {
       let status
       let waiting = false
       let retries = 20
-      const notFoundMessage = 'Waiting for provisioning to start...'
+      const notFoundMessage = 'Waiting to provision...'
 
       while (true) {
         try {

--- a/packages/cli/src/commands/pg/wait.ts
+++ b/packages/cli/src/commands/pg/wait.ts
@@ -39,6 +39,7 @@ export default class Wait extends Command {
       let status
       let waiting = false
       let retries = 20
+      const notFoundMessage = 'Waiting for provisioning to start...'
 
       while (true) {
         try {
@@ -51,7 +52,7 @@ export default class Wait extends Command {
           pgDebug(httpError)
           if (!retries || httpError.statusCode !== 404) throw httpError
           retries--
-          status = {'waiting?': true}
+          status = {'waiting?': true, message: notFoundMessage}
         }
 
         if (status['error?']) {


### PR DESCRIPTION
This PR updates the message in pg:wait from "Addon not found" to "Waiting for provisioning to start..."

The start of the provisioning process can take 5-10 seconds in some cases. The "Addon not found" message is inaccurate and can confuse the user. 

## to test
Provision an add-on and use `pg:wait`

[GUS](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000027cHB5YAM/view)