### PR TITLE
chore: move fig workflow to create-cli-release.yml

### DIFF
--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -56,6 +56,12 @@ jobs:
       channel: ${{ needs.get-version-channel.outputs.channel }}
     secrets: inherit
 
+  create-fig-autocomplete-pr:
+    needs: [promote]
+    if: fromJSON(inputs.isStableRelease)
+    ## Calls publish-to-fig-autocomplete workflow during post release jobs
+    uses: ./.github/workflows/publish-to-fig-autocomplete.yml
+
   publish-docs:
     needs: [get-version-channel, promote]
     uses: ./.github/workflows/devcenter-doc-update.yml

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -62,8 +62,3 @@ jobs:
     secrets: inherit
     with:
       isStableCandidate: ${{ fromJSON(inputs.isStableRelease) }}
-
-  create-fig-autocomplete-pr:
-    if: fromJSON(inputs.isStableRelease)
-    ## Calls publish-to-fig-autocomplete workflow during post release jobs
-    uses: ./.github/workflows/publish-to-fig-autocomplete.yml


### PR DESCRIPTION
Moves the `create-fig-autocomplete-pr` job out of the `promote-release` workflow so that if it fails it does not block the `publish-docs` job from running.

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
