### PR TITLE
chore(W-17237970): Improve buildpacks:index for fir apps

### DIFF
--- a/packages/cli/src/commands/buildpacks/index.ts
+++ b/packages/cli/src/commands/buildpacks/index.ts
@@ -30,7 +30,7 @@ export default class Index extends Command {
       const pluralizedBuildpacks = buildpacks.length > 1 ? 'Buildpacks' : 'Buildpack'
       let header = `${color.app(flags.app)}`
       if (isFirApp) {
-        header += ` Cloud Native ${pluralizedBuildpacks} (from latest release OCI image)`
+        header += ` Cloud Native ${pluralizedBuildpacks} (from the latest release OCI image)`
       } else {
         header += ` Classic ${pluralizedBuildpacks} (from buildpack registry)`
       }

--- a/packages/cli/src/commands/buildpacks/index.ts
+++ b/packages/cli/src/commands/buildpacks/index.ts
@@ -30,7 +30,7 @@ export default class Index extends Command {
       const pluralizedBuildpacks = buildpacks.length > 1 ? 'Buildpacks' : 'Buildpack'
       let header = `${color.app(flags.app)}`
       if (isFirApp) {
-        header += ` Cloud Native ${pluralizedBuildpacks} (from the latest release OCI image)`
+        header += ` Cloud Native ${pluralizedBuildpacks} (from the latest release's OCI image)`
       } else {
         header += ` Classic ${pluralizedBuildpacks} (from the Heroku Buildpack Registry)`
       }

--- a/packages/cli/src/commands/buildpacks/index.ts
+++ b/packages/cli/src/commands/buildpacks/index.ts
@@ -7,7 +7,7 @@ import {BuildpackCommand} from '../../lib/buildpacks/buildpacks'
 import {getGeneration} from '../../lib/apps/generation'
 
 export default class Index extends Command {
-  static description = 'display the buildpacks for an app'
+  static description = 'List the buildpacks on an app. For Fir apps, buildpacks are retrieved from the latest release\'s OCI image data. For Cedar apps, buildpacks are retrieved from the classic buildpack registry.'
 
   static flags = {
     app: Flags.app({required: true}),
@@ -22,11 +22,20 @@ export default class Index extends Command {
         Accept: 'application/vnd.heroku+json; version=3.sdk',
       },
     })
-    const buildpacks = await buildpacksCommand.fetch(flags.app, getGeneration(app) === 'fir')
+    const isFirApp = getGeneration(app) === 'fir'
+    const buildpacks = await buildpacksCommand.fetch(flags.app, isFirApp)
     if (buildpacks.length === 0) {
       this.log(`${color.app(flags.app)} has no Buildpacks.`)
     } else {
-      ux.styledHeader(`${color.app(flags.app)} Buildpack${buildpacks.length > 1 ? 's' : ''}`)
+      const pluralizedBuildpacks = buildpacks.length > 1 ? 'Buildpacks' : 'Buildpack'
+      let header = `${color.app(flags.app)}`
+      if (isFirApp) {
+        header += ` Cloud Native ${pluralizedBuildpacks} (from latest release OCI image)`
+      } else {
+        header += ` Classic ${pluralizedBuildpacks} (from buildpack registry)`
+      }
+
+      ux.styledHeader(header)
       buildpacksCommand.display(buildpacks, '')
     }
   }

--- a/packages/cli/src/commands/buildpacks/index.ts
+++ b/packages/cli/src/commands/buildpacks/index.ts
@@ -7,7 +7,7 @@ import {BuildpackCommand} from '../../lib/buildpacks/buildpacks'
 import {getGeneration} from '../../lib/apps/generation'
 
 export default class Index extends Command {
-  static description = 'List the buildpacks on an app. For Fir apps, buildpacks are retrieved from the latest release\'s OCI image data. For Cedar apps, buildpacks are retrieved from the classic buildpack registry.'
+  static description = 'list the buildpacks on an app'
 
   static flags = {
     app: Flags.app({required: true}),

--- a/packages/cli/src/commands/buildpacks/index.ts
+++ b/packages/cli/src/commands/buildpacks/index.ts
@@ -32,7 +32,7 @@ export default class Index extends Command {
       if (isFirApp) {
         header += ` Cloud Native ${pluralizedBuildpacks} (from the latest release OCI image)`
       } else {
-        header += ` Classic ${pluralizedBuildpacks} (from buildpack registry)`
+        header += ` Classic ${pluralizedBuildpacks} (from the Heroku Buildpack Registry)`
       }
 
       ux.styledHeader(header)

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -58,7 +58,7 @@ export default class Logs extends Command {
     tail: flags.boolean({
       char: 't',
       default: false,
-      description: 'continually stream logs (defaults to true for Fir generation apps)',
+      description: 'continually stream logs (always enabled for Fir-generation apps)',
     }),
     'process-type': flags.string({
       char: 'p',

--- a/packages/cli/test/acceptance/commands-output.ts
+++ b/packages/cli/test/acceptance/commands-output.ts
@@ -51,7 +51,7 @@ authorizations:revoke                          revoke OAuth authorization
 authorizations:rotate                          updates an OAuth authorization token
 authorizations:update                          updates an OAuth authorization
 autocomplete                                   display autocomplete installation instructions
-buildpacks                                     List the buildpacks on an app. For Fir apps, buildpacks are retrieved from the latest release's OCI image data. For Cedar apps, buildpacks are retrieved from the classic buildpack registry.
+buildpacks                                     list the buildpacks on an app
 buildpacks:add                                 add new app buildpack, inserting into list of buildpacks if necessary
 buildpacks:clear                               clear all buildpacks set on the app
 buildpacks:info                                fetch info about a buildpack

--- a/packages/cli/test/acceptance/commands-output.ts
+++ b/packages/cli/test/acceptance/commands-output.ts
@@ -51,7 +51,7 @@ authorizations:revoke                          revoke OAuth authorization
 authorizations:rotate                          updates an OAuth authorization token
 authorizations:update                          updates an OAuth authorization
 autocomplete                                   display autocomplete installation instructions
-buildpacks                                     display the buildpacks for an app
+buildpacks                                     List the buildpacks on an app. For Fir apps, buildpacks are retrieved from the latest release's OCI image data. For Cedar apps, buildpacks are retrieved from the classic buildpack registry.
 buildpacks:add                                 add new app buildpack, inserting into list of buildpacks if necessary
 buildpacks:clear                               clear all buildpacks set on the app
 buildpacks:info                                fetch info about a buildpack

--- a/packages/cli/test/unit/commands/buildpacks/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/buildpacks/index.unit.test.ts
@@ -131,7 +131,7 @@ describe('buildpacks', function () {
     .it('# displays the buildpack URL', ctx => {
       expect(ctx.stderr).to.equal('')
       expect(ctx.stdout).to.equal(heredoc(`
-        === ⬢ ${cedarApp.name} Classic Buildpack (from buildpack registry)
+        === ⬢ ${cedarApp.name} Classic Buildpack (from the Heroku Buildpack Registry)
 
         https://github.com/heroku/heroku-buildpack-ruby
       `))
@@ -148,7 +148,7 @@ describe('buildpacks', function () {
     .it('# maps buildpack urns to names', ctx => {
       expect(ctx.stderr).to.equal('')
       expect(ctx.stdout).to.equal(heredoc(`
-        === ⬢ ${cedarApp.name} Classic Buildpack (from buildpack registry)
+        === ⬢ ${cedarApp.name} Classic Buildpack (from the Heroku Buildpack Registry)
 
         heroku/ruby
       `))
@@ -165,7 +165,7 @@ describe('buildpacks', function () {
     .it('# does not map buildpack s3 to names', ctx => {
       expect(ctx.stderr).to.equal('')
       expect(ctx.stdout).to.equal(heredoc(`
-        === ⬢ ${cedarApp.name} Classic Buildpack (from buildpack registry)
+        === ⬢ ${cedarApp.name} Classic Buildpack (from the Heroku Buildpack Registry)
 
         https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz
       `))
@@ -200,7 +200,7 @@ describe('buildpacks', function () {
     .it('# with two buildpack URLs set displays the buildpack URL', ctx => {
       expect(ctx.stderr).to.equal('')
       expect(ctx.stdout).to.equal(heredoc(`
-        === ⬢ ${cedarApp.name} Classic Buildpacks (from buildpack registry)
+        === ⬢ ${cedarApp.name} Classic Buildpacks (from the Heroku Buildpack Registry)
 
         1. https://github.com/heroku/heroku-buildpack-java
         2. https://github.com/heroku/heroku-buildpack-ruby
@@ -221,7 +221,7 @@ describe('buildpacks', function () {
     .it('# returns the buildpack registry name back', ctx => {
       expect(ctx.stderr).to.equal('')
       expect(ctx.stdout).to.equal(heredoc(`
-        === ⬢ ${cedarApp.name} Classic Buildpacks (from buildpack registry)
+        === ⬢ ${cedarApp.name} Classic Buildpacks (from the Heroku Buildpack Registry)
 
         1. heroku/java
         2. rust-lang/rust
@@ -239,7 +239,7 @@ describe('buildpacks', function () {
     .it('# displays the buildpack URL with classic buildpack source', ctx => {
       expect(ctx.stderr).to.equal('')
       expect(ctx.stdout).to.equal(heredoc(`
-      === ⬢ ${cedarApp.name} Classic Buildpack (from buildpack registry)
+      === ⬢ ${cedarApp.name} Classic Buildpack (from the Heroku Buildpack Registry)
 
       https://github.com/heroku/heroku-buildpack-ruby
     `))
@@ -259,7 +259,7 @@ describe('buildpacks', function () {
     .it('# returns cnb buildpack ids for fir apps with OCI source', ctx => {
       expect(ctx.stderr).to.equal('')
       expect(ctx.stdout).to.equal(heredoc(`
-      === ⬢ ${firApp.name} Cloud Native Buildpack (from latest release OCI image)
+      === ⬢ ${firApp.name} Cloud Native Buildpack (from the latest release's OCI image)
 
       heroku/ruby
     `))
@@ -279,7 +279,7 @@ describe('buildpacks', function () {
     .it('# with multiple buildpack URLs shows plural form and source', ctx => {
       expect(ctx.stderr).to.equal('')
       expect(ctx.stdout).to.equal(heredoc(`
-      === ⬢ ${cedarApp.name} Classic Buildpacks (from buildpack registry)
+      === ⬢ ${cedarApp.name} Classic Buildpacks (from the Heroku Buildpack Registry)
 
       1. https://github.com/heroku/heroku-buildpack-java
       2. https://github.com/heroku/heroku-buildpack-ruby


### PR DESCRIPTION
This PR updates the `buildpacks` command to distinguish between classic and fir buildpacks

## Testing
1. run `buildpacks --help` Note the updated help text
2. run `buildpacks -a <APP_NAME>` where APP_NAME is a Fir app and again for a cedar app.
3. Observe the new styled headers
