### PR TITLE
chore: remove ruby install from devcenter-doc-update.yml

### DIFF
--- a/.github/workflows/devcenter-doc-update.yml
+++ b/.github/workflows/devcenter-doc-update.yml
@@ -32,7 +32,7 @@ jobs:
         run: yarn --immutable --network-timeout 1000000
       - name: Install Devcenter CLI
         run: |
-          gem install devcenter
+          gem install devcenter --user-install
           devcenter help
 #      - name: Build CLI
 #        run: yarn build

--- a/.github/workflows/devcenter-doc-update.yml
+++ b/.github/workflows/devcenter-doc-update.yml
@@ -32,15 +32,14 @@ jobs:
         run: yarn --immutable --network-timeout 1000000
       - name: Install Devcenter CLI
         run: |
-
           gem install devcenter --user-install
           export PATH="$PATH:$HOME/.local/share/gem/ruby/3.2.0/bin"
           devcenter help
-#      - name: Build CLI
-#        run: yarn build
-#      - name: Compile documentation and push to devcenter
-#        run: |
-#          cd packages/cli
-#          ./scripts/postrelease/dev_center_docs
-#        env:
-#          HEROKU_DEVCENTER_API_KEY: ${{ secrets.HEROKU_DEVCENTER_API_KEY }}
+      - name: Build CLI
+        run: yarn build
+      - name: Compile documentation and push to devcenter
+        run: |
+          cd packages/cli
+          ./scripts/postrelease/dev_center_docs
+        env:
+          HEROKU_DEVCENTER_API_KEY: ${{ secrets.HEROKU_DEVCENTER_API_KEY }}

--- a/.github/workflows/devcenter-doc-update.yml
+++ b/.github/workflows/devcenter-doc-update.yml
@@ -28,10 +28,6 @@ jobs:
         with:
           node-version: 16.x
           cache: yarn
-      - name: Install Ruby
-        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
-        with:
-          ruby-version: '3.1'
       - name: Install package deps
         run: yarn --immutable --network-timeout 1000000
       - name: Install Devcenter CLI

--- a/.github/workflows/devcenter-doc-update.yml
+++ b/.github/workflows/devcenter-doc-update.yml
@@ -34,11 +34,11 @@ jobs:
         run: |
           gem install devcenter
           devcenter help
-      - name: Build CLI
-        run: yarn build
-      - name: Compile documentation and push to devcenter
-        run: |
-          cd packages/cli
-          ./scripts/postrelease/dev_center_docs
-        env:
-          HEROKU_DEVCENTER_API_KEY: ${{ secrets.HEROKU_DEVCENTER_API_KEY }}
+#      - name: Build CLI
+#        run: yarn build
+#      - name: Compile documentation and push to devcenter
+#        run: |
+#          cd packages/cli
+#          ./scripts/postrelease/dev_center_docs
+#        env:
+#          HEROKU_DEVCENTER_API_KEY: ${{ secrets.HEROKU_DEVCENTER_API_KEY }}

--- a/.github/workflows/devcenter-doc-update.yml
+++ b/.github/workflows/devcenter-doc-update.yml
@@ -32,7 +32,9 @@ jobs:
         run: yarn --immutable --network-timeout 1000000
       - name: Install Devcenter CLI
         run: |
+
           gem install devcenter --user-install
+          export PATH="$PATH:$HOME/.local/share/gem/ruby/3.2.0/bin"
           devcenter help
 #      - name: Build CLI
 #        run: yarn build


### PR DESCRIPTION
The last time we tried to run this workflow it [failed](https://github.com/heroku/cli/actions/runs/13423136770/job/37501302121) on the Ruby installation. However, since Ruby seems to be [preinstalled](https://github.com/actions/runner-images/blob/ubuntu24/20250209.1/images/ubuntu/Ubuntu2404-Readme.md) on the Ubuntu 24.04 image, we should be able to remove the installation entirely.

You can see this [workflow passing here](https://github.com/heroku/cli/actions/runs/13503469950/job/37727456975) (without pushing to devcenter).

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
