### PR TITLE
feat: add support for new columns in PG17

### DIFF
--- a/packages/cli/src/commands/pg/outliers.ts
+++ b/packages/cli/src/commands/pg/outliers.ts
@@ -72,36 +72,36 @@ export default class Outliers extends Command {
       CASE WHEN length(query) <= 40 THEN query ELSE substr(query, 0, 39) || '…' END
     ` : 'query'
 
+    let totalExecTimeField = ''
     if (version && Number.parseInt(version, 10) >= 13) {
-      return heredoc`
+      totalExecTimeField = 'total_exec_time'
+    } else {
+      totalExecTimeField = 'total_time'
+    }
+
+    let blkReadTimeField = ''
+    let blkWriteTimeField = ''
+    if (version && Number.parseInt(version, 10) >= 17) {
+      blkReadTimeField = 'shared_blk_read_time'
+      blkWriteTimeField = 'shared_blk_write_time'
+    } else {
+      blkReadTimeField = 'blk_read_time'
+      blkWriteTimeField = 'blk_write_time'
+    }
+
+    return heredoc`
         SELECT
-          interval '1 millisecond' * total_exec_time AS total_exec_time,
-          to_char((total_exec_time/sum(total_exec_time) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
+          interval '1 millisecond' * ${totalExecTimeField} AS total_exec_time,
+          to_char((${totalExecTimeField}/sum(${totalExecTimeField}) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
           to_char(calls, 'FM999G999G999G990') AS ncalls,
-          interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time,
+          interval '1 millisecond' * (${blkReadTimeField} + ${blkWriteTimeField}) AS sync_io_time,
           ${truncatedQueryString} AS query
         FROM pg_stat_statements
         WHERE userid = (
           SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1
         )
-        ORDER BY total_exec_time DESC
+        ORDER BY ${totalExecTimeField} DESC
         LIMIT ${limit};
       `
-    }
-
-    return heredoc`
-      SELECT
-        interval '1 millisecond' * total_time AS total_exec_time,
-        to_char((total_time/sum(total_time) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
-        to_char(calls, 'FM999G999G999G990') AS ncalls,
-        interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time,
-        ${truncatedQueryString} AS query
-      FROM pg_stat_statements
-      WHERE userid = (
-        SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1
-      )
-      ORDER BY total_time DESC
-      LIMIT ${limit};
-    `
   }
 }


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

Adds support for new column names in `pg_stat_statements` in Postgres v17.

Testing notes:
- `yarn`
- `yarn build`
- test on Postgres v16:
```
./bin/run pg:outliers HEROKU_POSTGRESQL_TCOLL_GRAY_URL -a tc-data-dev
 total_exec_time | prop_exec_time | ncalls |  sync_io_time   |                                                              query                                                               
-----------------+----------------+--------+-----------------+----------------------------------------------------------------------------------------------------------------------------------
 00:07:33.785423 | 97.9%          | 20,673 | 00:00:00        | SELECT queryid AS query_id, calls, total_time, blk_read_time, blk_write_time                                                    +
                 |                |        |                 |                 FROM (                                                                                                          +
                 |                |        |                 |                         SELECT queryid,                                                                                         +
                 |                |        |                 |                         SUM(calls) OVER (PARTITION BY queryid) AS calls,                                                        +
                 |                |        |                 |                         SUM(total_exec_time) OVER (PARTITION BY queryid) AS total_time,                                         +
                 |                |        |                 |                         SUM(blk_read_time) OVER (PARTITION BY queryid) AS blk_read_time,                                        +
                 |                |        |                 |                         SUM(blk_write_time) OVER (PARTITION BY queryid) AS blk_write_time,                                      +
                 |                |        |                 |                         (total_exec_time / SUM(total_exec_time) over ()) * $1 AS time_spent                                     +
                 |                |        |                 |                         FROM public.pg_stat_statements($2)                                                                      +
                 |                |        |                 |                         WHERE userid = (                                                                                        +
                 |                |        |                 |                                 SELECT usesysid                                                                                 +
                 |                |        |                 |                                 FROM pg_user                                                                                    +
                 |                |        |                 |                                 WHERE usename = current_user LIMIT $3                                                           +
                 |                |        |                 |                         )                                                                                                       +
                 |                |        |                 |                 ) ts                                                                                                            +
                 |                |        |                 |                 WHERE time_spent >= $4                                                                                          +
                 |                |        |                 |                 GROUP BY queryid, calls, total_time, blk_read_time, blk_write_time
 00:00:05.762465 | 1.2%           | 20,673 | 00:00:00.000027 | SELECT pid, state                                                                                                               +
                 |                |        |                 |                 FROM pg_stat_activity                                                                                           +
                 |                |        |                 |                 WHERE state = $1                                                                                                +
                 |                |        |                 |                 AND query like $2                                                                                               +
                 |                |        |                 |                 AND NOT query like $3
 00:00:01.244622 | 0.3%           | 20,673 | 00:00:00        | SELECT CASE                                                                                                                     +
                 |                |        |                 |                 WHEN $1 IN (SELECT extname FROM pg_extension) THEN $2                                                           +
                 |                |        |                 |                 WHEN pg_is_in_recovery() THEN $3                                                                                +
                 |                |        |                 |                 WHEN current_setting($4) LIKE $5 THEN $6                                                                        +
                 |                |        |                 |                 ELSE $7                                                                                                         +
                 |                |        |                 |                 END as status
 00:00:00.849656 | 0.2%           | 20,673 | 00:00:00        | SELECT quote_ident(nspname::text) FROM pg_extension x INNER JOIN pg_namespace ns ON ns.oid = x.extnamespace WHERE x.extname = $1
 00:00:00.674264 | 0.1%           | 20,673 | 00:00:00        | SELECT extversion::text AS version FROM pg_catalog.pg_extension WHERE extname = $1
 00:00:00.39777  | 0.1%           | 20,675 | 00:00:00        | SELECT current_setting($1)::numeric >= $2
 00:00:00.396962 | 0.1%           | 20,673 | 00:00:00        | SET statement_timeout = '10s'
 00:00:00.237397 | 0.1%           | 40,323 | 00:00:00        | SELECT $1
 00:00:00.026024 | 0.0%           | 1      | 00:00:00        | SELECT interval $1 * total_exec_time AS total_exec_time,                                                                        +
                 |                |        |                 | to_char((total_exec_time/sum(total_exec_time) OVER()) * $2, $3) || $4  AS prop_exec_time,                                       +
                 |                |        |                 | to_char(calls, $5) AS ncalls,                                                                                                   +
                 |                |        |                 | interval $6 * (blk_read_time + blk_write_time) AS sync_io_time,                                                                 +
                 |                |        |                 | query AS query                                                                                                                  +
                 |                |        |                 | FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT $7)                     +
                 |                |        |                 | ORDER BY calls DESC                                                                                                             +
                 |                |        |                 | LIMIT $8
 00:00:00.000932 | 0.0%           | 1      | 00:00:00        | SET application_name='Heroku Postgres - Automation - 52.4.86.217:18396'
(10 rows)

```
- test on PG17:
```
./bin/run pg:outliers HEROKU_POSTGRESQL_TCOLL_MAUVE_URL -a tc-data-dev
 total_exec_time | prop_exec_time | ncalls | sync_io_time |                                                              query                                                               
-----------------+----------------+--------+--------------+----------------------------------------------------------------------------------------------------------------------------------
 00:00:00.188967 | 57.8%          | 648    | 00:00:00     | SELECT pid, state                                                                                                               +
                 |                |        |              |                 FROM pg_stat_activity                                                                                           +
                 |                |        |              |                 WHERE state = $1                                                                                                +
                 |                |        |              |                 AND query like $2                                                                                               +
                 |                |        |              |                 AND NOT query like $3
 00:00:00.036011 | 11.0%          | 648    | 00:00:00     | SELECT CASE                                                                                                                     +
                 |                |        |              |                 WHEN $1 IN (SELECT extname FROM pg_extension) THEN $2                                                           +
                 |                |        |              |                 WHEN pg_is_in_recovery() THEN $3                                                                                +
                 |                |        |              |                 WHEN current_setting($4) LIKE $5 THEN $6                                                                        +
                 |                |        |              |                 ELSE $7                                                                                                         +
                 |                |        |              |                 END as status
 00:00:00.024527 | 7.5%           | 648    | 00:00:00     | SELECT quote_ident(nspname::text) FROM pg_extension x INNER JOIN pg_namespace ns ON ns.oid = x.extnamespace WHERE x.extname = $1
 00:00:00.020892 | 6.4%           | 648    | 00:00:00     | SET statement_timeout = '10s'
 00:00:00.018881 | 5.8%           | 648    | 00:00:00     | SELECT extversion::text AS version FROM pg_catalog.pg_extension WHERE extname = $1
 00:00:00.015858 | 4.9%           | 5      | 00:00:00     | SELECT interval $1 * total_exec_time AS total_exec_time,                                                                        +
                 |                |        |              | to_char((total_exec_time/sum(total_exec_time) OVER()) * $2, $3) || $4  AS prop_exec_time,                                       +
                 |                |        |              | to_char(calls, $5) AS ncalls,                                                                                                   +
                 |                |        |              | interval $6 * (shared_blk_read_time + shared_blk_write_time ) AS sync_io_time,                                                  +
                 |                |        |              | query AS query                                                                                                                  +
                 |                |        |              | FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT $7)                     +
                 |                |        |              | ORDER BY calls DESC                                                                                                             +
                 |                |        |              | LIMIT $8
 00:00:00.008568 | 2.6%           | 661    | 00:00:00     | SELECT current_setting($1)::numeric >= $2
 00:00:00.006597 | 2.0%           | 1,237  | 00:00:00     | SELECT $1
 00:00:00.000442 | 0.1%           | 12     | 00:00:00     | SELECT exists(                                                                                                                  +
                 |                |        |              |   SELECT $1                                                                                                                     +
                 |                |        |              |   FROM pg_extension e                                                                                                           +
                 |                |        |              |     LEFT JOIN pg_namespace n ON n.oid = e.extnamespace                                                                          +
                 |                |        |              |   WHERE e.extname = $2 AND n.nspname IN ($3, $4)                                                                                +
                 |                |        |              | ) AS available
 00:00:00.000261 | 0.1%           | 1      | 00:00:00     | SET application_name='Heroku Postgres - Automation - 52.4.86.217:27736'
(10 rows)
```