### PR TITLE
fix: make HEROKU_DATA_HOST override redis host too.

### DIFF
--- a/packages/cli/src/lib/redis/api.ts
+++ b/packages/cli/src/lib/redis/api.ts
@@ -66,7 +66,7 @@ export type RedisFormationWaitResponse = {
 type HttpVerb = 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'PUT'
 
 export default (app: string, database: string | undefined, json: boolean, heroku: APIClient) => {
-  const HOST = process.env.HEROKU_REDIS_HOST || 'api.data.heroku.com'
+  const HOST = process.env.HEROKU_DATA_HOST || process.env.HEROKU_REDIS_HOST || 'api.data.heroku.com'
   const ADDON = process.env.HEROKU_REDIS_ADDON_NAME || 'heroku-redis'
 
   return {


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

`HEROKU_DATA_HOST` sets custom Data-API for Postgres, but not Redis. This makes it so that this env var sets Redis as well.