### PR TITLE
fix: remove limited GA phrasing from spaces:create

### DIFF
--- a/packages/cli/src/commands/spaces/create.ts
+++ b/packages/cli/src/commands/spaces/create.ts
@@ -99,7 +99,7 @@ export default class Create extends Command {
     })
     ux.action.stop()
 
-    ux.warn(`${color.bold('Spend Alert.')} During the limited GA period, each Heroku ${spaceType} Private Space costs ~${dollarAmountHourly}/hour (max ${dollarAmountMonthly}/month), pro-rated to the second.`)
+    ux.warn(`${color.bold('Spend Alert.')} Each Heroku ${spaceType} Private Space costs ~${dollarAmountHourly}/hour (max ${dollarAmountMonthly}/month), pro-rated to the second.`)
     ux.warn(`Use ${color.cmd('heroku spaces:wait')} to track allocation.`)
 
     ux.styledHeader(space.name)

--- a/packages/cli/test/unit/commands/spaces/create.unit.test.ts
+++ b/packages/cli/test/unit/commands/spaces/create.unit.test.ts
@@ -5,6 +5,7 @@ import * as nock from 'nock'
 import {expect} from 'chai'
 import heredoc from 'tsheredoc'
 import {getGeneration} from '../../../../src/lib/apps/generation'
+import {unwrap} from '../../../helpers/utils/unwrap'
 
 describe('spaces:create', function () {
   const now = new Date()
@@ -90,9 +91,7 @@ describe('spaces:create', function () {
 
     api.done()
 
-    expect(stderr.output).to.include('Warning: Spend Alert. During the limited GA period, each Heroku Standard')
-    expect(stderr.output).to.include('Private Space costs ~$1.39/hour (max $1000/month), pro-rated to the')
-    expect(stderr.output).to.include('second.')
+    expect(unwrap(stderr.output)).to.include('Warning: Spend Alert. Each Heroku Standard Private Space costs ~$1.39/hour (max $1000/month), pro-rated to the second.')
   })
 
   it('creates a Shield space', async function () {
@@ -175,9 +174,7 @@ describe('spaces:create', function () {
 
     api.done()
 
-    expect(stderr.output).to.include('Warning: Spend Alert. During the limited GA period, each Heroku Shield')
-    expect(stderr.output).to.include('Private Space costs ~$4.17/hour (max $3000/month), pro-rated to the')
-    expect(stderr.output).to.include('second.')
+    expect(unwrap(stderr.output)).to.include('Warning: Spend Alert. Each Heroku Shield Private Space costs ~$4.17/hour (max $3000/month), pro-rated to the second.')
   })
 
   it('creates a space with custom cidr and data cidr', async function () {


### PR DESCRIPTION
Applies change originally from #3106. Removes limited GA language from price warning for `spaces:create` as it is no longer necessary.

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
