### PR TITLE
fix: add shortcode for --app flag in telemetry command

### DIFF
--- a/packages/cli/src/commands/telemetry/index.ts
+++ b/packages/cli/src/commands/telemetry/index.ts
@@ -7,7 +7,7 @@ export default class Index extends Command {
   static description = 'list telemetry drains'
   static flags = {
     space: Flags.string({char: 's', description: 'filter by space name', exactlyOne: ['app', 'space']}),
-    app: Flags.string({description: 'filter by app name'}),
+    app: Flags.string({char: 'a', description: 'filter by app name'}),
   };
 
   static example = '$ heroku telemetry'


### PR DESCRIPTION
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002AjtXwYAJ/view

Allows users to use `-a` instead of `--app` for the `heroku telemetry` command.

## Testing
- Pull down this branch and run `yarn && yarn build`
- With any app (doesn't matter if it has any telemetry drains), run `./bin/run telemetry -a APP_NAME`
- You should see the command successfully run, without the error that tells you `-a` is a nonexistent flag.

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
