### PR TITLE
fix: add standard -a shortcut  for app flag

### DIFF
--- a/packages/cli/src/commands/telemetry/index.ts
+++ b/packages/cli/src/commands/telemetry/index.ts
@@ -7,7 +7,7 @@ export default class Index extends Command {
   static description = 'list telemetry drains'
   static flags = {
     space: Flags.string({char: 's', description: 'filter by space name', exactlyOne: ['app', 'space']}),
-    app: Flags.string({description: 'filter by app name'}),
+    app: Flags.string({char: 'a', description: 'filter by app name'}),
   };
 
   static example = '$ heroku telemetry'


### PR DESCRIPTION
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002AjtXwYAJ/view

### Description

this adds the `-a` back to telemetry:index


### Testing

1. Pull down branch and `yarn build`
2. ./bin/run telemetry -a APP_NAME
