### PR TITLE
fix: don't send an empty body in GET requests

### DIFF
--- a/packages/cli/src/lib/redis/api.ts
+++ b/packages/cli/src/lib/redis/api.ts
@@ -71,9 +71,18 @@ export default (app: string, database: string | undefined, json: boolean, heroku
 
   return {
     request<T>(path: string, method: HttpVerb = 'GET', body = {}) {
-      const headers = {Accept: 'application/json'}
+      const headers = {Accept: 'application/vnd.heroku+json; version=3'}
       if (process.env.HEROKU_HEADERS) {
         Object.assign(headers, JSON.parse(process.env.HEROKU_HEADERS))
+      }
+
+      // don't send an empty body, Cloudfront will reject the request
+      if (Object.keys(body).length === 0) {
+        return heroku.request<T>(path, {
+          hostname: HOST,
+          method,
+          headers,
+        })
       }
 
       return heroku.request<T>(path, {

--- a/packages/cli/src/lib/redis/api.ts
+++ b/packages/cli/src/lib/redis/api.ts
@@ -77,7 +77,7 @@ export default (app: string, database: string | undefined, json: boolean, heroku
       }
 
       // don't send an empty body, Cloudfront will reject the request
-      if (Object.keys(body).length === 0) {
+      if (Object.keys(body).length === 0 && method === 'GET') {
         return heroku.request<T>(path, {
           hostname: HOST,
           method,


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

Modifies the API client for `redis:*` commands to avoid sending an empty request body for `GET` requests. This change is for compliance with Heroku's security posture.

Ref: https://gus.lightning.force.com/lightning/r/Case/500EE00001TPNrZYAX/view
