### PR TITLE
feat: add alias for heroku-sudo plugin

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -368,6 +368,7 @@
       "heroku-pipelines": null,
       "heroku-ps-wait": null,
       "heroku-redis": null,
+      "heroku-repo": "@heroku-cli/plugin-heroku-repo",
       "heroku-skynet-cli": "@heroku/skynet",
       "heroku-splunk": "@heroku/splunk",
       "heroku-sudo": "@heroku/sudo",


### PR DESCRIPTION
[Work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000028zx82YAA/view)

Adds an alias for `heroku-repo` since the plugin was renamed to `@heroku-cli/plugin-heroku-repo`.

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
