### PR TITLE
fix(redis): Remove empty object body from GET requests to Redis API

### DIFF
--- a/packages/cli/src/commands/redis/credentials.ts
+++ b/packages/cli/src/commands/redis/credentials.ts
@@ -24,7 +24,7 @@ export default class Credentials extends Command {
 
     if (reset) {
       ux.log(`Resetting credentials for ${addon.name}`)
-      await redisApi(app, database, false, this.heroku).request(`/redis/v0/databases/${addon.name}/credentials_rotation`, 'POST')
+      await redisApi(app, database, false, this.heroku).request(`/redis/v0/databases/${addon.name}/credentials_rotation`, 'POST', {})
     } else {
       const {body: redis} = await redisApi(app, database, false, this.heroku).request<RedisFormationResponse>(`/redis/v0/databases/${addon.name}`)
       ux.log(redis.resource_url)

--- a/packages/cli/src/commands/redis/stats-reset.ts
+++ b/packages/cli/src/commands/redis/stats-reset.ts
@@ -31,7 +31,7 @@ export default class StatsReset extends Command {
 
     ux.action.start(`Resetting stats on ${color.addon(addon.name || '')}`)
     const {body: response} = await redisApi(app, database, false, this.heroku)
-      .request<RedisApiResponse>(`/redis/v0/databases/${addon.id}/stats/reset`, 'POST')
+      .request<RedisApiResponse>(`/redis/v0/databases/${addon.id}/stats/reset`, 'POST', {})
     ux.action.stop(response.message)
   }
 }

--- a/packages/cli/src/commands/redis/wait.ts
+++ b/packages/cli/src/commands/redis/wait.ts
@@ -36,7 +36,7 @@ export default class Wait extends Command {
       let waiting = false
       while (true) {
         try {
-          status = await api.request<RedisFormationWaitResponse>(`/redis/v0/databases/${addon.name}/wait`, 'GET').then(response => response.body)
+          status = await api.request<RedisFormationWaitResponse>(`/redis/v0/databases/${addon.name}/wait`).then(response => response.body)
         } catch (error) {
           const httpError = error as HTTPError
           if (httpError.statusCode !== 404)

--- a/packages/cli/src/lib/redis/api.ts
+++ b/packages/cli/src/lib/redis/api.ts
@@ -70,8 +70,8 @@ export default (app: string, database: string | undefined, json: boolean, heroku
   const ADDON = process.env.HEROKU_REDIS_ADDON_NAME || 'heroku-redis'
 
   return {
-    request<T>(path: string, method: HttpVerb = 'GET', body = {}) {
-      const headers = {Accept: 'application/json'}
+    request<T>(path: string, method: HttpVerb = 'GET', body: unknown = null) {
+      const headers = {}
       if (process.env.HEROKU_HEADERS) {
         Object.assign(headers, JSON.parse(process.env.HEROKU_HEADERS))
       }


### PR DESCRIPTION
## Description

There's a bug in the `request` function from the shared Redis API lib file used for most of `redis:...` commands, where the default value for the request body is an empty object (`{}`). That makes all `GET` requests using that function to send that empty body when, according to standards, `GET` requests shouldn't send a body.

Here we change the default to a `null` value, so no body gets sent with `GET` requests and add an empty object body to all non-GET requests that would've inherited the previous default to avoid behavior changes.

## Testing

Checkout this branch, ensure you're running Node 20.x and run `yarn && yarn build`. For the tests you will need access to a test app with a Redis database installed. If you don't have one at hand let me know and I can add you to one of my test apps.

There will be no behavior change on execution of the commands, only the headers sent with the request will change.

- Run the following command through your usual Heroku CLI:
```
DEBUG=http,http:headers heroku redis:info <redis-addon-name> -a <test-app-name>
```
You should see on the Redis API request debug output (`GET https://api.heroku.com/redis/v0/databases/...`) that the following headers are set:
```
accept: 'application/json'
content-length: '2'
content-type: 'application/json'
```

- Compare against the same command, but run through this branch's version:
```
DEBUG=http,http:headers ./bin/run redis:info <redis-addon-name> -a <test-app-name>
```
You should see on the Redis API request debug output (`GET https://api.heroku.com/redis/v0/databases/...`) that no `content-type` and `content-length` headers are included and the accept header is now:
```
accept: 'application/vnd.heroku+json; version=3'
```

- Repeat for other commands that make `GET` requests like `redis:wait` and `redis:credentials`. The same behavior should be observed.

## SOC2 Compliance
GUS Work Item: [W-18015751](https://gus.lightning.force.com/a07EE00002Aw2c9YAB)