### PR TITLE
feat: add accounts commands

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -78,7 +78,8 @@
     "urijs": "^1.19.11",
     "validator": "^13.7.0",
     "word-wrap": "^1.2.5",
-    "ws": "^6.2.2"
+    "ws": "^6.2.2",
+    "yaml": "^2.0.1"
   },
   "devDependencies": {
     "@heroku-cli/schema": "^1.0.25",

--- a/packages/cli/src/commands/accounts/add.ts
+++ b/packages/cli/src/commands/accounts/add.ts
@@ -11,7 +11,7 @@ export default class Add extends Command {
   async run() {
     const {args} = await this.parse(Add)
     const {name} = args
-    const logInMessage = 'You need to be logged in to run this command.'
+    const logInMessage = 'You need to be logged in to run this command'
     let account: Heroku.Account
     let email = ''
 

--- a/packages/cli/src/commands/accounts/add.ts
+++ b/packages/cli/src/commands/accounts/add.ts
@@ -16,20 +16,13 @@ export default class Add extends Command {
     const {args} = await this.parse(Add)
     const {name} = args
     const logInMessage = 'You must be logged in to run this command.'
-    let account: Heroku.Account
-    let email = ''
 
     if (list().some(a => a.name === name)) {
       ux.error(`${name} already exists`)
     }
 
-    try {
-      account = await this.heroku.get<Heroku.Account>('/account', {retryAuth: false})
-      email = account.body.email || ''
-    } catch (error: any) {
-      if (error.statusCode === 401) ux.error(logInMessage)
-      throw error
-    }
+    const {body: account} = await this.heroku.get<Heroku.Account>('/account')
+    const email = account.email || ''
 
     const token = this.heroku.auth || ''
 

--- a/packages/cli/src/commands/accounts/add.ts
+++ b/packages/cli/src/commands/accounts/add.ts
@@ -1,0 +1,37 @@
+import {Command} from '@heroku-cli/command'
+import {Args, ux} from '@oclif/core'
+import * as Heroku from '@heroku-cli/schema'
+import {add, list} from '../../lib/accounts/accounts'
+
+export default class Add extends Command {
+  static args = {
+    name: Args.string({description: 'name of account to add', required: true}),
+  }
+
+  async run() {
+    const {args} = await this.parse(Add)
+    const {name} = args
+    let account: Heroku.Account
+    let email = ''
+
+    if (list().find(a => a.name === name)) {
+      ux.error(`${name} already exists`)
+    }
+
+    const token = this.heroku.auth || ''
+
+    try {
+      account = await this.heroku.get<Heroku.Account>('/account', {retryAuth: false})
+      email = account.email || ''
+    } catch (error) {
+      const {message} = error as {message: string}
+      ux.error(message)
+    }
+
+    if (token === '' || email === '') {
+      ux.error('You need to be logged in to run this command.')
+    }
+
+    add(name, email, token)
+  }
+}

--- a/packages/cli/src/commands/accounts/add.ts
+++ b/packages/cli/src/commands/accounts/add.ts
@@ -4,9 +4,13 @@ import * as Heroku from '@heroku-cli/schema'
 import {add, list} from '../../lib/accounts/accounts'
 
 export default class Add extends Command {
+  static description = 'add a new Heroku account to your cache'
+
   static args = {
     name: Args.string({description: 'name of account to add', required: true}),
   }
+
+  static example = 'heroku accounts:add my-account'
 
   async run() {
     const {args} = await this.parse(Add)
@@ -15,7 +19,7 @@ export default class Add extends Command {
     let account: Heroku.Account
     let email = ''
 
-    if (list().find(a => a.name === name)) {
+    if (list().some(a => a.name === name)) {
       ux.error(`${name} already exists`)
     }
 

--- a/packages/cli/src/commands/accounts/add.ts
+++ b/packages/cli/src/commands/accounts/add.ts
@@ -4,10 +4,10 @@ import * as Heroku from '@heroku-cli/schema'
 import {add, list} from '../../lib/accounts/accounts'
 
 export default class Add extends Command {
-  static description = 'add a new Heroku account to your cache'
+  static description = 'add a Heroku account to your cache'
 
   static args = {
-    name: Args.string({description: 'name of account to add', required: true}),
+    name: Args.string({description: 'name of Heroku account to add', required: true}),
   }
 
   static example = 'heroku accounts:add my-account'
@@ -15,7 +15,7 @@ export default class Add extends Command {
   async run() {
     const {args} = await this.parse(Add)
     const {name} = args
-    const logInMessage = 'You need to be logged in to run this command'
+    const logInMessage = 'You must be logged in to run this command.'
     let account: Heroku.Account
     let email = ''
 

--- a/packages/cli/src/commands/accounts/current.ts
+++ b/packages/cli/src/commands/accounts/current.ts
@@ -1,6 +1,7 @@
 import {Command} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
 import {current} from '../../lib/accounts/accounts'
+import color from '@heroku-cli/color'
 
 export default class Current extends Command {
   static description = 'display the current Heroku account'
@@ -12,7 +13,7 @@ export default class Current extends Command {
     if (account) {
       ux.styledHeader(`Current account is ${account}`)
     } else {
-      ux.error('No account is currently set.')
+      ux.error(`You haven't set an account. Run ${color.cmd('heroku login')} to confirm you're logged in to Heroku.`)
     }
   }
 }

--- a/packages/cli/src/commands/accounts/current.ts
+++ b/packages/cli/src/commands/accounts/current.ts
@@ -1,0 +1,14 @@
+import {Command} from '@heroku-cli/command'
+import {ux} from '@oclif/core'
+import {current} from '../../lib/accounts/accounts'
+
+export default class Current extends Command {
+  async run() {
+    const account = current()
+    if (account) {
+      ux.styledHeader(`Current account is ${account}`)
+    } else {
+      ux.error('No account currently set')
+    }
+  }
+}

--- a/packages/cli/src/commands/accounts/current.ts
+++ b/packages/cli/src/commands/accounts/current.ts
@@ -12,7 +12,7 @@ export default class Current extends Command {
     if (account) {
       ux.styledHeader(`Current account is ${account}`)
     } else {
-      ux.error('No account currently set')
+      ux.error('No account is currently set.')
     }
   }
 }

--- a/packages/cli/src/commands/accounts/current.ts
+++ b/packages/cli/src/commands/accounts/current.ts
@@ -13,7 +13,7 @@ export default class Current extends Command {
     if (account) {
       ux.styledHeader(`Current account is ${account}`)
     } else {
-      ux.error(`You haven't set an account. Run ${color.cmd('heroku login')} to confirm you're logged in to Heroku.`)
+      ux.error(`You haven't set an account. Run ${color.cmd('heroku accounts:add <account-name>')} to add an account to your cache or ${color.cmd('heroku accounts:set <account-name>')} to set the current account.`)
     }
   }
 }

--- a/packages/cli/src/commands/accounts/current.ts
+++ b/packages/cli/src/commands/accounts/current.ts
@@ -3,6 +3,10 @@ import {ux} from '@oclif/core'
 import {current} from '../../lib/accounts/accounts'
 
 export default class Current extends Command {
+  static description = 'display the current Heroku account'
+
+  static example = 'heroku accounts:current'
+
   async run() {
     const account = current()
     if (account) {

--- a/packages/cli/src/commands/accounts/index.ts
+++ b/packages/cli/src/commands/accounts/index.ts
@@ -1,0 +1,20 @@
+import {Command} from '@heroku-cli/command'
+import {ux} from '@oclif/core'
+import {current, list} from '../../lib/accounts/accounts'
+
+export default class AccountsIndex extends Command {
+  async run() {
+    const accounts = list()
+    if (accounts.length === 0) {
+      ux.error('No accounts')
+    }
+
+    for (const account of accounts) {
+      if (account.name === current()) {
+        ux.log(`* ${account.name}`)
+      } else {
+        ux.log(`  ${account.name}`)
+      }
+    }
+  }
+}

--- a/packages/cli/src/commands/accounts/index.ts
+++ b/packages/cli/src/commands/accounts/index.ts
@@ -10,7 +10,7 @@ export default class AccountsIndex extends Command {
   async run() {
     const accounts = list()
     if (accounts.length === 0) {
-      ux.error('No accounts')
+      ux.error('No accounts found in cache.')
     }
 
     for (const account of accounts) {

--- a/packages/cli/src/commands/accounts/index.ts
+++ b/packages/cli/src/commands/accounts/index.ts
@@ -3,6 +3,10 @@ import {ux} from '@oclif/core'
 import {current, list} from '../../lib/accounts/accounts'
 
 export default class AccountsIndex extends Command {
+  static description = 'list the Heroku accounts in your cache'
+
+  static example = 'heroku accounts'
+
   async run() {
     const accounts = list()
     if (accounts.length === 0) {

--- a/packages/cli/src/commands/accounts/index.ts
+++ b/packages/cli/src/commands/accounts/index.ts
@@ -10,7 +10,7 @@ export default class AccountsIndex extends Command {
   async run() {
     const accounts = list()
     if (accounts.length === 0) {
-      ux.error('No accounts found in cache.')
+      ux.error('You don\'t have any accounts in your cache.')
     }
 
     for (const account of accounts) {

--- a/packages/cli/src/commands/accounts/remove.ts
+++ b/packages/cli/src/commands/accounts/remove.ts
@@ -16,7 +16,7 @@ export default class Remove extends Command {
     const {name} = args
 
     if (!list().some(a => a.name === name)) {
-      ux.error(`${name} does not exist.`)
+      ux.error(`${name} doesn't exist in your accounts cache.`)
     }
 
     if (current() === name) {

--- a/packages/cli/src/commands/accounts/remove.ts
+++ b/packages/cli/src/commands/accounts/remove.ts
@@ -1,0 +1,24 @@
+import {Command} from '@heroku-cli/command'
+import {Args, ux} from '@oclif/core'
+import {current, list, remove} from '../../lib/accounts/accounts'
+
+export default class Remove extends Command {
+  static args = {
+    name: Args.string({description: 'name of account to add', required: true}),
+  }
+
+  async run() {
+    const {args} = await this.parse(Remove)
+    const {name} = args
+
+    if (!list().some(a => a.name === name)) {
+      ux.error(`${name} does not exist`)
+    }
+
+    if (current() === name) {
+      ux.error(`${name} is the current account`)
+    }
+
+    remove(name)
+  }
+}

--- a/packages/cli/src/commands/accounts/remove.ts
+++ b/packages/cli/src/commands/accounts/remove.ts
@@ -6,7 +6,7 @@ export default class Remove extends Command {
   static description = 'remove a Heroku account from your cache'
 
   static args = {
-    name: Args.string({description: 'name of account to remove', required: true}),
+    name: Args.string({description: 'name of Heroku account to remove', required: true}),
   }
 
   static example = 'heroku accounts:remove my-account'

--- a/packages/cli/src/commands/accounts/remove.ts
+++ b/packages/cli/src/commands/accounts/remove.ts
@@ -16,11 +16,11 @@ export default class Remove extends Command {
     const {name} = args
 
     if (!list().some(a => a.name === name)) {
-      ux.error(`${name} does not exist`)
+      ux.error(`${name} does not exist.`)
     }
 
     if (current() === name) {
-      ux.error(`${name} is the current account`)
+      ux.error(`${name} is the current account.`)
     }
 
     remove(name)

--- a/packages/cli/src/commands/accounts/remove.ts
+++ b/packages/cli/src/commands/accounts/remove.ts
@@ -3,9 +3,13 @@ import {Args, ux} from '@oclif/core'
 import {current, list, remove} from '../../lib/accounts/accounts'
 
 export default class Remove extends Command {
+  static description = 'remove a Heroku account from your cache'
+
   static args = {
-    name: Args.string({description: 'name of account to add', required: true}),
+    name: Args.string({description: 'name of account to remove', required: true}),
   }
+
+  static example = 'heroku accounts:remove my-account'
 
   async run() {
     const {args} = await this.parse(Remove)

--- a/packages/cli/src/commands/accounts/set.ts
+++ b/packages/cli/src/commands/accounts/set.ts
@@ -16,7 +16,7 @@ export default class Set extends Command {
     const {name} = args
 
     if (!list().some(a => a.name === name)) {
-      ux.error(`${name} does not exist as a Heroku account.`)
+      ux.error(`${name} does not exist in your accounts cache.`)
     }
 
     set(name)

--- a/packages/cli/src/commands/accounts/set.ts
+++ b/packages/cli/src/commands/accounts/set.ts
@@ -16,7 +16,7 @@ export default class Set extends Command {
     const {name} = args
 
     if (!list().some(a => a.name === name)) {
-      ux.error(`${name} does not exist`)
+      ux.error(`${name} does not exist as a Heroku account.`)
     }
 
     set(name)

--- a/packages/cli/src/commands/accounts/set.ts
+++ b/packages/cli/src/commands/accounts/set.ts
@@ -3,9 +3,13 @@ import {Args, ux} from '@oclif/core'
 import {list, set} from '../../lib/accounts/accounts'
 
 export default class Set extends Command {
+  static description = 'set the current Heroku account from your cache'
+
   static args = {
-    name: Args.string({description: 'name of account to add', required: true}),
+    name: Args.string({description: 'name of account to set', required: true}),
   }
+
+  static example = 'heroku accounts:set my-account'
 
   async run() {
     const {args} = await this.parse(Set)

--- a/packages/cli/src/commands/accounts/set.ts
+++ b/packages/cli/src/commands/accounts/set.ts
@@ -1,0 +1,20 @@
+import {Command} from '@heroku-cli/command'
+import {Args, ux} from '@oclif/core'
+import {list, set} from '../../lib/accounts/accounts'
+
+export default class Set extends Command {
+  static args = {
+    name: Args.string({description: 'name of account to add', required: true}),
+  }
+
+  async run() {
+    const {args} = await this.parse(Set)
+    const {name} = args
+
+    if (!list().some(a => a.name === name)) {
+      ux.error(`${name} does not exist`)
+    }
+
+    set(name)
+  }
+}

--- a/packages/cli/src/lib/accounts/accounts.ts
+++ b/packages/cli/src/lib/accounts/accounts.ts
@@ -1,6 +1,6 @@
 import {parse, stringify} from 'yaml'
 import * as fs from 'fs'
-import * as os from 'os'
+import * as os from 'node:os'
 import * as path from 'node:path'
 import netrc, {Netrc} from 'netrc-parser'
 
@@ -13,11 +13,8 @@ function configDir() {
   return path.join(os.homedir(), '.config', 'heroku')
 }
 
-const basedir = path.join(configDir(), 'accounts')
-
-const netrcFile: Netrc = netrc.loadSync() as unknown as Netrc
-
 function account(name: string) {
+  const basedir = path.join(configDir(), 'accounts')
   const file = fs.readFileSync(path.join(basedir, name), 'utf8')
   const account = parse(file)
   if (account[':username']) {
@@ -32,6 +29,7 @@ function account(name: string) {
 }
 
 export function list() {
+  const basedir = path.join(configDir(), 'accounts')
   try {
     return fs.readdirSync(basedir)
       .map(name => Object.assign(account(name), {name}))
@@ -41,6 +39,7 @@ export function list() {
 }
 
 export function current() {
+  const netrcFile: Netrc = netrc.loadSync() as unknown as Netrc
   if (netrcFile.machines['api.heroku.com']) {
     const current = list().find(a => a.username === netrcFile.machines['api.heroku.com'].login)
     return current ? current.name : null
@@ -50,6 +49,7 @@ export function current() {
 }
 
 export function add(name: string, username: string, password: string) {
+  const basedir = path.join(configDir(), 'accounts')
   fs.mkdirSync(basedir, {recursive: true})
 
   fs.writeFileSync(
@@ -61,10 +61,12 @@ export function add(name: string, username: string, password: string) {
 }
 
 export function remove(name: string) {
+  const basedir = path.join(configDir(), 'accounts')
   fs.unlinkSync(path.join(basedir, name))
 }
 
 export function set(name: string) {
+  const netrcFile: Netrc = netrc.loadSync() as unknown as Netrc
   const current = account(name)
   netrcFile.machines['git.heroku.com'] = {}
   netrcFile.machines['api.heroku.com'] = {}

--- a/packages/cli/src/lib/accounts/accounts.ts
+++ b/packages/cli/src/lib/accounts/accounts.ts
@@ -1,0 +1,77 @@
+import {parse, stringify} from 'yaml'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'node:path'
+import netrc, {Netrc} from 'netrc-parser'
+
+function configDir() {
+  const legacyDir = path.join(os.homedir(), '.heroku')
+  if (fs.existsSync(legacyDir)) {
+    return legacyDir
+  }
+
+  return path.join(os.homedir(), '.config', 'heroku')
+}
+
+const basedir = path.join(configDir(), 'accounts')
+
+const netrcFile: Netrc = netrc.loadSync() as unknown as Netrc
+
+function account(name: string) {
+  const file = fs.readFileSync(path.join(basedir, name), 'utf8')
+  const account = parse(file)
+  if (account[':username']) {
+    // convert from ruby symbols
+    account.username = account[':username']
+    account.password = account[':password']
+    delete account[':username']
+    delete account[':password']
+  }
+
+  return account
+}
+
+export function list() {
+  try {
+    return fs.readdirSync(basedir)
+      .map(name => Object.assign(account(name), {name}))
+  } catch {
+    return []
+  }
+}
+
+export function current() {
+  if (netrcFile.machines['api.heroku.com']) {
+    const current = list().find(a => a.username === netrcFile.machines['api.heroku.com'].login)
+    return current ? current.name : null
+  }
+
+  return null
+}
+
+export function add(name: string, username: string, password: string) {
+  fs.mkdirSync(basedir, {recursive: true})
+
+  fs.writeFileSync(
+    path.join(basedir, name),
+    stringify({username, password}),
+    'utf8',
+  )
+  fs.chmodSync(path.join(basedir, name), 0o600)
+}
+
+export function remove(name: string) {
+  fs.unlinkSync(path.join(basedir, name))
+}
+
+export function set(name: string) {
+  const current = account(name)
+  netrcFile.machines['git.heroku.com'] = {}
+  netrcFile.machines['api.heroku.com'] = {}
+  netrcFile.machines['git.heroku.com'].login = current.username
+  netrcFile.machines['api.heroku.com'].login = current.username
+  netrcFile.machines['git.heroku.com'].password = current.password
+  netrcFile.machines['api.heroku.com'].password = current.password
+
+  netrcFile.saveSync()
+}

--- a/packages/cli/src/lib/accounts/accounts.ts
+++ b/packages/cli/src/lib/accounts/accounts.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import * as Heroku from '@heroku-cli/schema'
-import netrc, {Netrc} from 'netrc-parser'
+import Netrc from 'netrc-parser'
 
 function configDir() {
   const legacyDir = path.join(os.homedir(), '.heroku')
@@ -40,9 +40,8 @@ export function list(): Heroku.Account[] | [] {
 }
 
 export function current(): string | null {
-  const netrcFile: Netrc = netrc.loadSync() as unknown as Netrc
-  if (netrcFile.machines['api.heroku.com']) {
-    const current = list().find(a => a.username === netrcFile.machines['api.heroku.com'].login)
+  if (Netrc.machines['api.heroku.com']) {
+    const current = list().find(a => a.username === Netrc.machines['api.heroku.com'].login)
     return current && current.name ? current.name : null
   }
 
@@ -67,14 +66,13 @@ export function remove(name: string) {
 }
 
 export function set(name: string) {
-  const netrcFile: Netrc = netrc.loadSync() as unknown as Netrc
   const current = account(name)
-  netrcFile.machines['git.heroku.com'] = {}
-  netrcFile.machines['api.heroku.com'] = {}
-  netrcFile.machines['git.heroku.com'].login = current.username
-  netrcFile.machines['api.heroku.com'].login = current.username
-  netrcFile.machines['git.heroku.com'].password = current.password
-  netrcFile.machines['api.heroku.com'].password = current.password
+  Netrc.machines['git.heroku.com'] = {}
+  Netrc.machines['api.heroku.com'] = {}
+  Netrc.machines['git.heroku.com'].login = current.username
+  Netrc.machines['api.heroku.com'].login = current.username
+  Netrc.machines['git.heroku.com'].password = current.password
+  Netrc.machines['api.heroku.com'].password = current.password
 
-  netrcFile.saveSync()
+  Netrc.saveSync()
 }

--- a/packages/cli/src/lib/accounts/accounts.ts
+++ b/packages/cli/src/lib/accounts/accounts.ts
@@ -2,6 +2,7 @@ import {parse, stringify} from 'yaml'
 import * as fs from 'fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
+import * as Heroku from '@heroku-cli/schema'
 import netrc, {Netrc} from 'netrc-parser'
 
 function configDir() {
@@ -13,7 +14,7 @@ function configDir() {
   return path.join(os.homedir(), '.config', 'heroku')
 }
 
-function account(name: string) {
+function account(name: string): Heroku.Account {
   const basedir = path.join(configDir(), 'accounts')
   const file = fs.readFileSync(path.join(basedir, name), 'utf8')
   const account = parse(file)
@@ -28,7 +29,7 @@ function account(name: string) {
   return account
 }
 
-export function list() {
+export function list(): Heroku.Account[] | [] {
   const basedir = path.join(configDir(), 'accounts')
   try {
     return fs.readdirSync(basedir)
@@ -42,7 +43,7 @@ export function current(): string | null {
   const netrcFile: Netrc = netrc.loadSync() as unknown as Netrc
   if (netrcFile.machines['api.heroku.com']) {
     const current = list().find(a => a.username === netrcFile.machines['api.heroku.com'].login)
-    return current ? current.name : null
+    return current && current.name ? current.name : null
   }
 
   return null

--- a/packages/cli/src/lib/accounts/accounts.ts
+++ b/packages/cli/src/lib/accounts/accounts.ts
@@ -38,7 +38,7 @@ export function list() {
   }
 }
 
-export function current() {
+export function current(): string | null {
   const netrcFile: Netrc = netrc.loadSync() as unknown as Netrc
   if (netrcFile.machines['api.heroku.com']) {
     const current = list().find(a => a.username === netrcFile.machines['api.heroku.com'].login)

--- a/packages/cli/test/integration/access.integration.test.ts
+++ b/packages/cli/test/integration/access.integration.test.ts
@@ -2,7 +2,7 @@ import {expect, test} from '@oclif/test'
 
 describe('access', function () {
   test
-    .skip()
+    .skip() // skipped due to account access issues with heroku-cli-ci-smoke-test-app
     .stdout()
     .command(['access', '--app=heroku-cli-ci-smoke-test-app'])
     .it('shows a table with access status', ctx => {

--- a/packages/cli/test/unit/commands/accounts/add.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/add.unit.test.ts
@@ -42,7 +42,7 @@ describe('accounts:add', function () {
 
       await runCommand(Cmd, ['testAccountName'])
         .catch(error =>  {
-          expect(error.message).to.equal('You need to be logged in to run this command.')
+          expect(error.message).to.equal('You need to be logged in to run this command')
         })
     })
 
@@ -53,7 +53,7 @@ describe('accounts:add', function () {
 
       await runCommand(Cmd, ['testAccountName'])
         .catch(error =>  {
-          expect(error.message).to.equal('You need to be logged in to run this command.')
+          expect(error.message).to.equal('You need to be logged in to run this command')
         })
     })
   })
@@ -66,7 +66,7 @@ describe('accounts:add', function () {
 
       await runCommand(Cmd, ['testAccountName'])
         .catch((error: Error) =>  {
-          expect(error.message).to.equal('You need to be logged in to run this command.')
+          expect(error.message).to.equal('You need to be logged in to run this command')
         })
     })
   })

--- a/packages/cli/test/unit/commands/accounts/add.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/add.unit.test.ts
@@ -65,7 +65,7 @@ describe('accounts:add', function () {
         .reply(401)
 
       await runCommand(Cmd, ['testAccountName'])
-        .catch(error =>  {
+        .catch((error: Error) =>  {
           expect(error.message).to.equal('You need to be logged in to run this command.')
         })
     })

--- a/packages/cli/test/unit/commands/accounts/add.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/add.unit.test.ts
@@ -1,0 +1,73 @@
+import {expect} from 'chai'
+import runCommand from '../../../helpers/runCommand'
+import * as nock from 'nock'
+import * as sinon from 'sinon'
+import Cmd from '../../../../src/commands/accounts/add'
+import * as accounts from '../../../../src/lib/accounts/accounts'
+
+describe('accounts:add', function () {
+  let api: nock.Scope
+  let addStub: sinon.SinonStub
+
+  beforeEach(function () {
+    sinon.stub(accounts, 'list').returns([])
+    addStub = sinon.stub(accounts, 'add')
+    api = nock('https://api.heroku.com')
+  })
+
+  afterEach(function () {
+    delete process.env.HEROKU_API_KEY
+    sinon.restore()
+    api.done()
+    nock.cleanAll()
+  })
+
+  describe('when the user is logged in', function () {
+    it('should call the accounts.add function with the account name, user email, and auth token', async function () {
+      process.env.HEROKU_API_KEY = 'testHerokuAPIKey'
+      api.get('/account')
+        .reply(200, {email: 'testEmail'})
+
+      await runCommand(Cmd, ['testAccountName'])
+      expect(addStub.calledOnce).to.equal(true)
+      expect(addStub.args[0][0]).to.equal('testAccountName')
+      expect(addStub.args[0][1]).to.equal('testEmail')
+      expect(addStub.args[0][2]).to.equal('testHerokuAPIKey')
+    })
+
+    it('should prompt the user to log in if the user does not have an auth token', async function () {
+      process.env.HEROKU_API_KEY = ''
+      api.get('/account')
+        .reply(200, {email: 'testEmail'})
+
+      await runCommand(Cmd, ['testAccountName'])
+        .catch(error =>  {
+          expect(error.message).to.equal('You need to be logged in to run this command.')
+        })
+    })
+
+    it('should prompt the user to log in if the user does not have an email', async function () {
+      process.env.HEROKU_API_KEY = 'testHerokuAPIKey'
+      api.get('/account')
+        .reply(200, {})
+
+      await runCommand(Cmd, ['testAccountName'])
+        .catch(error =>  {
+          expect(error.message).to.equal('You need to be logged in to run this command.')
+        })
+    })
+  })
+
+  describe('when the user is not logged in', function () {
+    it('should prompt the user to log in', async function () {
+      process.env.HEROKU_API_KEY = ''
+      api.get('/account')
+        .reply(401)
+
+      await runCommand(Cmd, ['testAccountName'])
+        .catch(error =>  {
+          expect(error.message).to.equal('You need to be logged in to run this command.')
+        })
+    })
+  })
+})

--- a/packages/cli/test/unit/commands/accounts/add.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/add.unit.test.ts
@@ -42,7 +42,7 @@ describe('accounts:add', function () {
 
       await runCommand(Cmd, ['testAccountName'])
         .catch(error =>  {
-          expect(error.message).to.equal('You need to be logged in to run this command')
+          expect(error.message).to.equal('You must be logged in to run this command.')
         })
     })
 
@@ -53,7 +53,7 @@ describe('accounts:add', function () {
 
       await runCommand(Cmd, ['testAccountName'])
         .catch(error =>  {
-          expect(error.message).to.equal('You need to be logged in to run this command')
+          expect(error.message).to.equal('You must be logged in to run this command.')
         })
     })
   })
@@ -66,7 +66,7 @@ describe('accounts:add', function () {
 
       await runCommand(Cmd, ['testAccountName'])
         .catch((error: Error) =>  {
-          expect(error.message).to.equal('You need to be logged in to run this command')
+          expect(error.message).to.equal('You must be logged in to run this command.')
         })
     })
   })

--- a/packages/cli/test/unit/commands/accounts/add.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/add.unit.test.ts
@@ -57,17 +57,4 @@ describe('accounts:add', function () {
         })
     })
   })
-
-  describe('when the user is not logged in', function () {
-    it('should prompt the user to log in', async function () {
-      process.env.HEROKU_API_KEY = ''
-      api.get('/account')
-        .reply(401)
-
-      await runCommand(Cmd, ['testAccountName'])
-        .catch((error: Error) =>  {
-          expect(error.message).to.equal('You must be logged in to run this command.')
-        })
-    })
-  })
 })

--- a/packages/cli/test/unit/commands/accounts/current.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/current.unit.test.ts
@@ -4,6 +4,8 @@ import * as sinon from 'sinon'
 import Cmd from '../../../../src/commands/accounts/current'
 import * as accounts from '../../../../src/lib/accounts/accounts'
 import {stdout} from 'stdout-stderr'
+import heredoc from 'tsheredoc'
+import stripAnsi = require('strip-ansi')
 
 describe('accounts:current', function () {
   let currentStub: sinon.SinonStub
@@ -26,7 +28,7 @@ describe('accounts:current', function () {
     currentStub.returns(null)
     await runCommand(Cmd, [])
       .catch((error: Error) => {
-        expect(error.message).to.contain('No account is currently set.')
+        expect(stripAnsi(error.message)).to.equal('You haven\'t set an account. Run heroku login to confirm you\'re logged in to Heroku.')
       })
   })
 })

--- a/packages/cli/test/unit/commands/accounts/current.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/current.unit.test.ts
@@ -6,7 +6,7 @@ import * as accounts from '../../../../src/lib/accounts/accounts'
 import {stdout} from 'stdout-stderr'
 import stripAnsi = require('strip-ansi')
 
-describe.only('accounts:current', function () {
+describe('accounts:current', function () {
   let currentStub: sinon.SinonStub
 
   beforeEach(function () {

--- a/packages/cli/test/unit/commands/accounts/current.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/current.unit.test.ts
@@ -26,7 +26,7 @@ describe('accounts:current', function () {
     currentStub.returns(null)
     await runCommand(Cmd, [])
       .catch((error: Error) => {
-        expect(error.message).to.contain('No account currently set')
+        expect(error.message).to.contain('No account is currently set.')
       })
   })
 })

--- a/packages/cli/test/unit/commands/accounts/current.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/current.unit.test.ts
@@ -1,0 +1,32 @@
+import {expect} from 'chai'
+import runCommand from '../../../helpers/runCommand'
+import * as sinon from 'sinon'
+import Cmd from '../../../../src/commands/accounts/current'
+import * as accounts from '../../../../src/lib/accounts/accounts'
+import {stdout} from 'stdout-stderr'
+
+describe('accounts:current', function () {
+  let currentStub: sinon.SinonStub
+
+  beforeEach(function () {
+    currentStub = sinon.stub(accounts, 'current')
+  })
+
+  afterEach(function () {
+    sinon.restore()
+  })
+
+  it('should print the name of the current account if an account is found', async function () {
+    currentStub.returns('test-account')
+    await runCommand(Cmd, [])
+    expect(stdout.output).to.contain('test-account')
+  })
+
+  it('should print an error message if no account is found', async function () {
+    currentStub.returns(null)
+    await runCommand(Cmd, [])
+      .catch((error: Error) => {
+        expect(error.message).to.contain('No account currently set')
+      })
+  })
+})

--- a/packages/cli/test/unit/commands/accounts/current.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/current.unit.test.ts
@@ -4,10 +4,9 @@ import * as sinon from 'sinon'
 import Cmd from '../../../../src/commands/accounts/current'
 import * as accounts from '../../../../src/lib/accounts/accounts'
 import {stdout} from 'stdout-stderr'
-import heredoc from 'tsheredoc'
 import stripAnsi = require('strip-ansi')
 
-describe('accounts:current', function () {
+describe.only('accounts:current', function () {
   let currentStub: sinon.SinonStub
 
   beforeEach(function () {
@@ -28,7 +27,7 @@ describe('accounts:current', function () {
     currentStub.returns(null)
     await runCommand(Cmd, [])
       .catch((error: Error) => {
-        expect(stripAnsi(error.message)).to.equal('You haven\'t set an account. Run heroku login to confirm you\'re logged in to Heroku.')
+        expect(stripAnsi(error.message)).to.equal('You haven\'t set an account. Run heroku accounts:add <account-name> to add an account to your cache or heroku accounts:set <account-name> to set the current account.')
       })
   })
 })

--- a/packages/cli/test/unit/commands/accounts/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/index.unit.test.ts
@@ -29,7 +29,7 @@ describe('accounts', function () {
     listStub.returns([])
     await runCommand(Cmd, [])
       .catch((error: Error) => {
-        expect(error.message).to.contain('No accounts')
+        expect(error.message).to.contain('No accounts found in cache.')
       })
   })
 })

--- a/packages/cli/test/unit/commands/accounts/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/index.unit.test.ts
@@ -29,7 +29,7 @@ describe('accounts', function () {
     listStub.returns([])
     await runCommand(Cmd, [])
       .catch((error: Error) => {
-        expect(error.message).to.contain('No accounts found in cache.')
+        expect(error.message).to.contain('You don\'t have any accounts in your cache.')
       })
   })
 })

--- a/packages/cli/test/unit/commands/accounts/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/index.unit.test.ts
@@ -1,0 +1,35 @@
+import {expect} from 'chai'
+import runCommand from '../../../helpers/runCommand'
+import * as sinon from 'sinon'
+import Cmd from '../../../../src/commands/accounts/index'
+import * as accounts from '../../../../src/lib/accounts/accounts'
+import {stdout} from 'stdout-stderr'
+
+describe('accounts', function () {
+  let currentStub: sinon.SinonStub
+  let listStub: sinon.SinonStub
+
+  beforeEach(function () {
+    currentStub = sinon.stub(accounts, 'current')
+    listStub = sinon.stub(accounts, 'list')
+  })
+
+  afterEach(function () {
+    sinon.restore()
+  })
+
+  it('should print a list of added accounts with the current account highlighted if accounts are found', async function () {
+    currentStub.returns('test-account')
+    listStub.returns([{name: 'test-account'}, {name: 'test-account-2'}])
+    await runCommand(Cmd, [])
+    expect(stdout.output).to.equal('* test-account\n  test-account-2\n')
+  })
+
+  it('should print an error message if no accounts are found', async function () {
+    listStub.returns([])
+    await runCommand(Cmd, [])
+      .catch((error: Error) => {
+        expect(error.message).to.contain('No accounts')
+      })
+  })
+})

--- a/packages/cli/test/unit/commands/accounts/remove.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/remove.unit.test.ts
@@ -31,7 +31,7 @@ describe('accounts:remove', function () {
     listStub.returns([{name: 'test-account'}, {name: 'test-account-2'}])
     await runCommand(Cmd, ['test-account-3'])
       .catch((error: Error) => {
-        expect(error.message).to.contain('test-account-3 does not exist.')
+        expect(error.message).to.contain('test-account-3 doesn\'t exist in your accounts cache.')
       })
   })
 

--- a/packages/cli/test/unit/commands/accounts/remove.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/remove.unit.test.ts
@@ -1,0 +1,47 @@
+import {expect} from 'chai'
+import runCommand from '../../../helpers/runCommand'
+import * as sinon from 'sinon'
+import Cmd from '../../../../src/commands/accounts/remove'
+import * as accounts from '../../../../src/lib/accounts/accounts'
+import {stdout} from 'stdout-stderr'
+
+describe('accounts:remove', function () {
+  let currentStub: sinon.SinonStub
+  let listStub: sinon.SinonStub
+  let removeStub: sinon.SinonStub
+
+  beforeEach(function () {
+    currentStub = sinon.stub(accounts, 'current')
+    listStub = sinon.stub(accounts, 'list')
+    removeStub = sinon.stub(accounts, 'remove')
+  })
+
+  afterEach(function () {
+    sinon.restore()
+  })
+
+  it('calls the remove function with the account name when the account exists and it is not the current account', async function () {
+    currentStub.returns('test-account')
+    listStub.returns([{name: 'test-account'}, {name: 'test-account-2'}])
+    await runCommand(Cmd, ['test-account-2'])
+    expect(removeStub.calledWith('test-account-2'))
+  })
+
+  it('should return an error if the selected account name is not included in the account list', async function () {
+    currentStub.returns('test-account')
+    listStub.returns([{name: 'test-account'}, {name: 'test-account-2'}])
+    await runCommand(Cmd, ['test-account-3'])
+      .catch((error: Error) => {
+        expect(error.message).to.contain('test-account-3 does not exist')
+      })
+  })
+
+  it('should return an error if the selected account name is the current account', async function () {
+    currentStub.returns('test-account')
+    listStub.returns([{name: 'test-account'}, {name: 'test-account-2'}])
+    await runCommand(Cmd, ['test-account'])
+      .catch((error: Error) => {
+        expect(error.message).to.contain('test-account is the current account')
+      })
+  })
+})

--- a/packages/cli/test/unit/commands/accounts/remove.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/remove.unit.test.ts
@@ -3,7 +3,6 @@ import runCommand from '../../../helpers/runCommand'
 import * as sinon from 'sinon'
 import Cmd from '../../../../src/commands/accounts/remove'
 import * as accounts from '../../../../src/lib/accounts/accounts'
-import {stdout} from 'stdout-stderr'
 
 describe('accounts:remove', function () {
   let currentStub: sinon.SinonStub

--- a/packages/cli/test/unit/commands/accounts/remove.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/remove.unit.test.ts
@@ -31,7 +31,7 @@ describe('accounts:remove', function () {
     listStub.returns([{name: 'test-account'}, {name: 'test-account-2'}])
     await runCommand(Cmd, ['test-account-3'])
       .catch((error: Error) => {
-        expect(error.message).to.contain('test-account-3 does not exist')
+        expect(error.message).to.contain('test-account-3 does not exist.')
       })
   })
 
@@ -40,7 +40,7 @@ describe('accounts:remove', function () {
     listStub.returns([{name: 'test-account'}, {name: 'test-account-2'}])
     await runCommand(Cmd, ['test-account'])
       .catch((error: Error) => {
-        expect(error.message).to.contain('test-account is the current account')
+        expect(error.message).to.contain('test-account is the current account.')
       })
   })
 })

--- a/packages/cli/test/unit/commands/accounts/set.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/set.unit.test.ts
@@ -27,7 +27,7 @@ describe('accounts:set', function () {
     listStub.returns([{name: 'test-account'}, {name: 'test-account-2'}])
     await runCommand(Cmd, ['test-account-3'])
       .catch((error: Error) => {
-        expect(error.message).to.contain('test-account-3 does not exist.')
+        expect(error.message).to.contain('test-account-3 does not exist in your accounts cache.')
       })
   })
 })

--- a/packages/cli/test/unit/commands/accounts/set.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/set.unit.test.ts
@@ -27,7 +27,7 @@ describe('accounts:set', function () {
     listStub.returns([{name: 'test-account'}, {name: 'test-account-2'}])
     await runCommand(Cmd, ['test-account-3'])
       .catch((error: Error) => {
-        expect(error.message).to.contain('test-account-3 does not exist')
+        expect(error.message).to.contain('test-account-3 does not exist.')
       })
   })
 })

--- a/packages/cli/test/unit/commands/accounts/set.unit.test.ts
+++ b/packages/cli/test/unit/commands/accounts/set.unit.test.ts
@@ -1,0 +1,33 @@
+import {expect} from 'chai'
+import runCommand from '../../../helpers/runCommand'
+import * as sinon from 'sinon'
+import Cmd from '../../../../src/commands/accounts/set'
+import * as accounts from '../../../../src/lib/accounts/accounts'
+
+describe('accounts:set', function () {
+  let listStub: sinon.SinonStub
+  let setStub: sinon.SinonStub
+
+  beforeEach(function () {
+    listStub = sinon.stub(accounts, 'list')
+    setStub = sinon.stub(accounts, 'set')
+  })
+
+  afterEach(function () {
+    sinon.restore()
+  })
+
+  it('calls the set function with the account name when the account exists', async function () {
+    listStub.returns([{name: 'test-account'}, {name: 'test-account-2'}])
+    await runCommand(Cmd, ['test-account-2'])
+    expect(setStub.calledWith('test-account-2'))
+  })
+
+  it('should return an error if the selected account name is not included in the account list', async function () {
+    listStub.returns([{name: 'test-account'}, {name: 'test-account-2'}])
+    await runCommand(Cmd, ['test-account-3'])
+      .catch((error: Error) => {
+        expect(error.message).to.contain('test-account-3 does not exist')
+      })
+  })
+})

--- a/packages/cli/test/unit/lib/accounts/accounts.unit.test.ts
+++ b/packages/cli/test/unit/lib/accounts/accounts.unit.test.ts
@@ -1,0 +1,223 @@
+import {expect} from 'chai'
+import * as fs from 'fs'
+import * as sinon from 'sinon'
+import netrc from 'netrc-parser'
+import * as accounts from '../../../../src/lib/accounts/accounts'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import * as yaml from 'yaml'
+
+const netrcFile = {
+  machines: {
+    'api.heroku.com': {
+      login: 'user1',
+      password: 'XXXXX',
+    },
+    'git.heroku.com': {
+      login: 'user2',
+      password: 'XXXXX',
+    },
+  },
+  saveSync: sinon.stub(),
+}
+
+describe('accounts', function () {
+  let fsReaddirStub: sinon.SinonStub
+  let fsReadFileStub: sinon.SinonStub
+  let netrcLoadSyncStub: sinon.SinonStub
+
+  beforeEach(function () {
+    // Setup stubs before each test
+    fsReaddirStub = sinon.stub(fs, 'readdirSync')
+    fsReadFileStub = sinon.stub(fs, 'readFileSync')
+    netrcLoadSyncStub = sinon.stub(netrc, 'loadSync')
+  })
+
+  afterEach(function () {
+    // Restore stubs after each test
+    sinon.restore()
+  })
+
+  describe('list()', function () {
+    it('should return an empty array when directory is not accessible', function () {
+      fsReaddirStub.throws(new Error('Directory not found'))
+      const result = accounts.list()
+      expect(result).to.be.an('array').that.is.empty
+    })
+
+    it('should return array of account objects when files exist', function () {
+      fsReaddirStub.returns(['account1', 'account2'])
+      fsReadFileStub.withArgs(sinon.match(/account1$/), 'utf8')
+        .returns('{"username": "user1", "password": "pass1"}')
+      fsReadFileStub.withArgs(sinon.match(/account2$/), 'utf8')
+        .returns('{"username": "user2", "password": "pass2"}')
+
+      const result = accounts.list()
+
+      expect(result).to.be.an('array')
+      expect(result).to.have.lengthOf(2)
+      expect(result[0]).to.deep.include({
+        name: 'account1',
+        username: 'user1',
+        password: 'pass1',
+      })
+      expect(result[1]).to.deep.include({
+        name: 'account2',
+        username: 'user2',
+        password: 'pass2',
+      })
+    })
+
+    it('should handle ruby-style symbol keys', function () {
+      fsReaddirStub.returns(['account1'])
+      fsReadFileStub.withArgs(sinon.match(/account1$/), 'utf8')
+        .returns('{":username": "user1", ":password": "pass1"}')
+
+      const result = accounts.list()
+
+      expect(result).to.be.an('array')
+      expect(result).to.have.lengthOf(1)
+      expect(result[0]).to.deep.include({
+        name: 'account1',
+        username: 'user1',
+        password: 'pass1',
+      })
+      expect(result[0]).to.not.have.property(':username')
+      expect(result[0]).to.not.have.property(':password')
+    })
+  })
+
+  describe('accounts.current()', function () {
+    it('should return null when no api.heroku.com machine exists', function () {
+      netrcLoadSyncStub.returns({machines: {}})
+
+      const result = accounts.current()
+      expect(result).to.be.null
+    })
+
+    it('should return null when username does not match any account', function () {
+      netrcLoadSyncStub.returns(netrcFile)
+
+      sinon.stub(accounts, 'list').returns([])
+
+      const result = accounts.current()
+      expect(result).to.be.null
+    })
+
+    it('should return account name when username matches', function () {
+      netrcLoadSyncStub.returns(netrcFile)
+      fsReaddirStub.returns(['account1', 'account2'])
+      fsReadFileStub.withArgs(sinon.match(/account1$/), 'utf8')
+        .returns('{"username": "user1", "password": "pass1"}')
+      fsReadFileStub.withArgs(sinon.match(/account2$/), 'utf8')
+        .returns('{"username": "user2", "password": "pass2"}')
+
+      const result = accounts.current()
+      expect(result).to.equal('account1')
+    })
+  })
+
+  describe('add', function () {
+    let mkdirSyncStub: sinon.SinonStub
+    let writeFileSyncStub: sinon.SinonStub
+    let chmodSyncStub: sinon.SinonStub
+
+    beforeEach(function () {
+      // Setup stubs before each test
+      mkdirSyncStub = sinon.stub(fs, 'mkdirSync')
+      writeFileSyncStub = sinon.stub(fs, 'writeFileSync')
+      chmodSyncStub = sinon.stub(fs, 'chmodSync')
+    })
+
+    it('should create directory with recursive option', function () {
+      accounts.add('test-user', 'username123', 'password123')
+
+      expect(mkdirSyncStub.calledOnce).to.be.true
+      expect(mkdirSyncStub.firstCall.args[1]).to.deep.equal({recursive: true})
+    })
+
+    it('should write credentials to file with correct format', function () {
+      const testName = 'test-user'
+      const testUsername = 'username123'
+      const testPassword = 'password123'
+
+      accounts.add(testName, testUsername, testPassword)
+
+      expect(writeFileSyncStub.calledOnce).to.be.true
+      expect(writeFileSyncStub.firstCall.args[1]).to.equal('username: username123\npassword: password123\n')
+      expect(writeFileSyncStub.firstCall.args[2]).to.equal('utf8')
+    })
+
+    it('should set correct file permissions', function () {
+      const testName = 'test-user'
+
+      accounts.add(testName, 'username123', 'password123')
+
+      expect(chmodSyncStub.calledOnce).to.be.true
+      expect(chmodSyncStub.firstCall.args[1]).to.equal(0o600)
+    })
+
+    it('should throw error if directory creation fails', function () {
+      mkdirSyncStub.throws(new Error('Directory creation failed'))
+
+      expect(() => accounts.add('test-user', 'username123', 'password123')).to.throw()
+    })
+  })
+
+  describe('remove', function () {
+    let unlinkStub: sinon.SinonStub
+    let osHomeStub: sinon.SinonStub
+    let existsSyncStub: sinon.SinonStub
+
+    beforeEach(function () {
+      // Create a stub for fs.unlinkSync before each test
+      unlinkStub = sinon.stub(fs, 'unlinkSync')
+      osHomeStub = sinon.stub(os, 'homedir')
+      existsSyncStub = sinon.stub(fs, 'existsSync')
+    })
+
+    it('should remove the account file with the given name', function () {
+      const accountName = 'test-account'
+      const basedir = '/user/home'
+
+      osHomeStub.returns(basedir)
+      existsSyncStub.returns(false)
+
+      accounts.remove(accountName)
+
+      expect(unlinkStub.calledOnce).to.be.true
+      expect(unlinkStub.firstCall.args[0]).to.equal(
+        path.join(`${basedir}/.config/heroku/accounts`, accountName),
+      )
+    })
+
+    it('should throw an error if the file cannot be removed', function () {
+      const accountName = 'non-existent-account'
+      const error = new Error('File not found')
+      unlinkStub.throws(error)
+
+      expect(() => accounts.remove(accountName)).to.throw(Error)
+    })
+  })
+
+  describe('set', function () {
+    beforeEach(function () {
+      // Setup stubs before each test
+      netrcLoadSyncStub.returns(netrcFile)
+      fsReaddirStub.returns(['account1', 'account2'])
+      fsReadFileStub.withArgs(sinon.match(/account1$/), 'utf8')
+        .returns('{"username": "user1", "password": "pass1"}')
+      fsReadFileStub.withArgs(sinon.match(/account2$/), 'utf8')
+        .returns('{"username": "user2", "password": "pass2"}')
+      sinon.stub(yaml, 'parse').returns('account1')
+    })
+
+    it('should call saveSync to persist changes', function () {
+      const accountName = 'test-account'
+
+      accounts.set(accountName)
+
+      expect(netrcFile.saveSync.called).to.be.true
+    })
+  })
+})

--- a/packages/cli/test/unit/lib/accounts/accounts.unit.test.ts
+++ b/packages/cli/test/unit/lib/accounts/accounts.unit.test.ts
@@ -87,7 +87,7 @@ describe('accounts', function () {
     })
   })
 
-  describe('accounts.current()', function () {
+  describe('current()', function () {
     it('should return null when no api.heroku.com machine exists', function () {
       netrcLoadSyncStub.returns({machines: {}})
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10472,6 +10472,7 @@ __metadata:
     validator: ^13.7.0
     word-wrap: ^1.2.5
     ws: ^6.2.2
+    yaml: ^2.0.1
   bin:
     heroku: ./bin/run
   languageName: unknown
@@ -17277,6 +17278,15 @@ __metadata:
   version: 1.10.2
   resolution: "yaml@npm:1.10.2"
   checksum: ce4ada136e8a78a0b08dc10b4b900936912d15de59905b2bf415b4d33c63df1d555d23acb2a41b23cf9fb5da41c256441afca3d6509de7247daa062fd2c5ea5f
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.0.1":
+  version: 2.7.0
+  resolution: "yaml@npm:2.7.0"
+  bin:
+    yaml: bin.mjs
+  checksum: 6e8b2f9b9d1b18b10274d58eb3a47ec223d9a93245a890dcb34d62865f7e744747190a9b9177d5f0ef4ea2e44ad2c0214993deb42e0800766203ac46f00a12dd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
[Work item
](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE0000290DPbYAM/view)

This PR moves the commands from [heroku/heroku-accounts](https://github.com/heroku/heroku-accounts) to the CLI core, migrates them to TypeScript and oclif/core v2, updates and adds descriptions and error text, and adds tests.

These commands made use of functionality from heroku-cli-utils that is implemented differently in heroku-cli/command and oclif. Because of this, the migrated commands may be implemented a little differently than the originals. The overall functionality should be roughly the same and should accomplish the same tasks.

## Testing
1. Check out this branch and run `yarn && yarn build`
2. Sign into a Heroku account
3. Run `./bin/run accounts:add ACCOUNT_NAME` (the account name can be whatever makes sense to you)
4. Run `./bin/run accounts` and verify that your new account is listed
5. Sign into a different Heroku account (I used a testing account, just be sure to sign out when you are done)
6. Run `./bin/run accounts:add ACCOUNT_NAME` using a different account name
7. Run `./bin/run accounts` and verify that both accounts are now listed
8. Run `./bin/run accounts:current` and verify that the account you are currently logged into is listed
9. Run `./bin/run accounts:set ACCOUNT_NAME` using the name of the account you are not currently logged into
10. Run `./bin/run accounts:current` and verify that it lists the account you set
11. Run `./bin/run accounts:remove ACCOUNT_NAME` using the name of the account you are not currently logged into
12. Run `./bin/run accounts` and verify that only one account is now listed

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
