### PR TITLE
chore: update pack-deb job to use ubuntu-latest

### DIFF
--- a/.github/workflows/pack-upload.yml
+++ b/.github/workflows/pack-upload.yml
@@ -6,9 +6,7 @@ on:
 
 jobs:
   pack_deb:
-    # ubuntu started using a compression method after this version that debian currently does not support
-    # https://github.com/heroku/cli/pull/2245#issue-1590017122
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       HEROKU_AUTHOR: 'Heroku'
     steps:


### PR DESCRIPTION
[Work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002ArwkCYAR/view)

Updates our pack-deb job to use ubuntu-latest rather than ubuntu-20.04, which is being deprecated.

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
