### PR TITLE
Add new usage addons command

### DIFF
--- a/packages/cli/src/commands/usage/addons.ts
+++ b/packages/cli/src/commands/usage/addons.ts
@@ -25,8 +25,8 @@ export default class UsageAddons extends Command {
     const {flags} = await this.parse(UsageAddons)
     const {app} = flags
     ux.action.start('Gathering usage data')
-    const [usageResponse, {body: appAddons}] = await Promise.all([
-      this.heroku.get<unknown>(`/apps/${app}/usage`, {
+    const [{body: usageData}, {body: appAddons}] = await Promise.all([
+      this.heroku.get<AppUsage>(`/apps/${app}/usage`, {
         headers: {
           Accept: 'application/vnd.heroku+json; version=3.sdk',
         },
@@ -35,8 +35,6 @@ export default class UsageAddons extends Command {
     ])
     ux.action.stop()
     ux.log()
-    const usageApp = usageResponse.body
-    const usageData: AppUsage = typeof usageApp === 'string' ? JSON.parse(usageApp) : usageApp
     const usageAddons = usageData.addons
 
     if (usageAddons.length === 0) {

--- a/packages/cli/src/commands/usage/addons.ts
+++ b/packages/cli/src/commands/usage/addons.ts
@@ -1,0 +1,38 @@
+import {Command, flags} from '@heroku-cli/command'
+import {ux} from '@oclif/core'
+import heredoc from 'tsheredoc'
+import color from '@heroku-cli/color'
+import * as Heroku from '@heroku-cli/schema'
+
+type AppUsage = {
+  addons: {
+    id: string;
+    meters: {
+      storage: {
+        quantity: number
+      }
+    }
+  }[]
+}
+
+export default class UsageAddons extends Command {
+  static topic = 'usage'
+  static description = 'list usage values for metered addons associated with a given app'
+  static flags = {
+    app: flags.app({required: true}),
+  }
+
+  public async run(): Promise<void> {
+    const {flags} = await this.parse(UsageAddons)
+    const {app} = flags
+    const [{body: usageResponse}, {body: appAddons}] = await Promise.all([
+      this.heroku.get<AppUsage>(`/apps/${app}/usage`, {
+        headers: {
+          Accept: 'application/vnd.heroku+json; version=3.sdk',
+        },
+      }),
+      this.heroku.get<Heroku.AddOn[]>(`/apps/${app}/addons`),
+    ])
+    const usageAddons = usageResponse.addons
+  }
+}

--- a/packages/cli/src/lib/addons/util.ts
+++ b/packages/cli/src/lib/addons/util.ts
@@ -41,7 +41,7 @@ export const formatPriceText = function (price: Heroku.AddOn['price']) {
   const priceHourly = formatPrice({price, hourly: true})
   const priceMonthly = formatPrice({price, hourly: false})
   if (!priceHourly) return ''
-  if (priceHourly === 'free' || priceHourly === 'contract') return `${color.green(priceHourly)}`
+  if (priceHourly === 'free' || priceHourly === 'contract' || priceHourly === 'metered') return `${color.green(priceHourly)}`
 
   return `${color.green(priceHourly)} (max ${priceMonthly})`
 }

--- a/packages/cli/test/unit/commands/usage/addons.unit.test.ts
+++ b/packages/cli/test/unit/commands/usage/addons.unit.test.ts
@@ -1,0 +1,77 @@
+import {stdout} from 'stdout-stderr'
+import Cmd from '../../../../src/commands/usage/addons'
+import * as nock from 'nock'
+import expectOutput from '../../../helpers/utils/expectOutput'
+import heredoc from 'tsheredoc'
+import runCommand from '../../../helpers/runCommand'
+import * as fixtures from '../../../fixtures/addons/fixtures'
+import * as Heroku from '@heroku-cli/schema'
+
+describe('usage:addons', function () {
+  let redisAddon: Heroku.AddOn
+
+  beforeEach(function () {
+    redisAddon = fixtures.addons['www-redis']
+    nock.cleanAll()
+  })
+
+  it('shows usage for metered addons', async function () {
+    const app = 'myapp'
+    const usage = {
+      addons: [{
+        id: 'redis-123',
+        meters: {
+          'Data Storage': {
+            quantity: 2.5,
+          },
+          Connections: {
+            quantity: 100,
+          },
+        },
+      }],
+    }
+
+    nock('https://api.heroku.com')
+      .get(`/apps/${app}/usage`)
+      .reply(200, usage)
+
+    nock('https://api.heroku.com')
+      .get(`/apps/${app}/addons`)
+      .reply(200, [redisAddon])
+
+    await runCommand(Cmd, [
+      '--app',
+      app,
+    ])
+
+    expectOutput(stdout.output, heredoc(`
+      === Usage for ⬢ ${app}
+       Addon     Meter        Quantity
+       ───────── ──────────── ────────
+       redis-123 Data Storage 2.5
+       redis-123 Connections  100
+    `))
+  })
+
+  it('handles apps with no usage', async function () {
+    const app = 'myapp'
+    const usage = {
+      addons: [],
+    }
+
+    nock('https://api.heroku.com')
+      .get(`/apps/${app}/usage`)
+      .reply(200, usage)
+
+    nock('https://api.heroku.com')
+      .get(`/apps/${app}/addons`)
+      .reply(200, [])
+
+    await runCommand(Cmd, [
+      '--app',
+      app,
+    ])
+
+    expectOutput(stdout.output, `No usage found for ${app}`)
+  })
+})


### PR DESCRIPTION
[W-18033570](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002B2Q82YAF/view)

### Description

This adds a new command to display metered usage for addons associated with an app. It displays each token and its value for each metered addon of a given app. If no metered usage data is returned by the API, it displays a generic message indicating that.

Example output:

<img width="474" alt="Screenshot 2025-04-03 at 9 57 46 AM" src="https://github.com/user-attachments/assets/abf073a3-a43c-4e69-a3e9-c6132efe225d" />


### Testing

1. Pull down this branch and `yarn build`
2. `./bin/run usage:addons --app APP` where APP has no attached metered addons
3. `/bin/run usage:addons --app APP` where APP is a personal app that has attached metered addons
4. `/bin/run usage:addons --app APP` where APP is a team app that has attached metered addons