### PR TITLE
feat: create pg:upgrade:cancel command

### DIFF
--- a/packages/cli/src/commands/pg/upgrade/cancel.ts
+++ b/packages/cli/src/commands/pg/upgrade/cancel.ts
@@ -38,7 +38,7 @@ export default class Upgrade extends Command {
 
     const {body: replica} = await this.heroku.get<PgDatabase>(`/client/v11/databases/${db.id}`, {hostname: pgHost()})
     if (replica.following)
-      ux.error(`You can't use ${color.cmd('pg:upgrade:prepare')} on follower databases.  You can only use this command on Standard-tier and higher leader databases.`)
+      ux.error(`You can't use ${color.cmd('pg:upgrade:cancel')} on follower databases.  You can only use this command on Standard-tier and higher leader databases.`)
 
     await confirmCommand(app, confirm, heredoc(`
       Destructive action

--- a/packages/cli/src/commands/pg/upgrade/cancel.ts
+++ b/packages/cli/src/commands/pg/upgrade/cancel.ts
@@ -12,7 +12,7 @@ import {nls} from '../../../nls'
 export default class Upgrade extends Command {
   static topic = 'pg';
   static description = heredoc(`
-    cancels a prepared upgrade, doesn't cancel an active upgrade.
+    cancels a scheduled upgrade. You can't cancel a version upgrade that's in progress.
   `)
 
   static flags = {
@@ -34,15 +34,15 @@ export default class Upgrade extends Command {
       ux.error(`You can only use ${color.cmd('pg:upgrade:*')} commands on Essential-* and higher plans.`)
 
     if (essentialNumPlan(db))
-      ux.error(`You can't use ${color.cmd('pg:upgrade:cancel')} on Essential tier databases. You can only use this command on Standard-tier and higher leader databases.`)
+      ux.error(`You can't use ${color.cmd('pg:upgrade:cancel')} on Essential-tier databases. You can only use this command on Standard-tier and higher leader databases.`)
 
     const {body: replica} = await this.heroku.get<PgDatabase>(`/client/v11/databases/${db.id}`, {hostname: pgHost()})
     if (replica.following)
-      ux.error(`You can't use ${color.cmd('pg:upgrade:cancel')} on follower databases.  You can only use this command on Standard-tier and higher leader databases.`)
+      ux.error(`You can't use ${color.cmd('pg:upgrade:cancel')} on follower databases. You can only use this command on Standard-tier and higher leader databases.`)
 
     await confirmCommand(app, confirm, heredoc(`
       Destructive action
-      You're cancelling the version upgrade for ${color.addon(db.name)}.
+      You're canceling the scheduled version upgrade for ${color.addon(db.name)}.
 
       You can't undo this action.
     `))

--- a/packages/cli/src/commands/pg/upgrade/cancel.ts
+++ b/packages/cli/src/commands/pg/upgrade/cancel.ts
@@ -1,0 +1,59 @@
+import color from '@heroku-cli/color'
+import {Command, flags} from '@heroku-cli/command'
+import {Args, ux} from '@oclif/core'
+import heredoc from 'tsheredoc'
+import {getAddon} from '../../../lib/pg/fetcher'
+import pgHost from '../../../lib/pg/host'
+import {legacyEssentialPlan, essentialNumPlan, formatResponseWithCommands} from '../../../lib/pg/util'
+import {PgDatabase, PgUpgradeError, PgUpgradeResponse} from '../../../lib/pg/types'
+import confirmCommand from '../../../lib/confirmCommand'
+import {nls} from '../../../nls'
+
+export default class Upgrade extends Command {
+  static topic = 'pg';
+  static description = heredoc(`
+    cancels a prepared upgrade, doesn't cancel an active upgrade.
+  `)
+
+  static flags = {
+    confirm: flags.string({char: 'c'}),
+    app: flags.app({required: true}),
+  }
+
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
+  }
+
+  public async run(): Promise<void> {
+    const {flags, args} = await this.parse(Upgrade)
+    const {app, confirm} = flags
+    const {database} = args
+
+    const db = await getAddon(this.heroku, app, database)
+    if (legacyEssentialPlan(db))
+      ux.error(`You can only use ${color.cmd('pg:upgrade:*')} commands on Essential-* and higher plans.`)
+
+    if (essentialNumPlan(db))
+      ux.error(`You can't use ${color.cmd('pg:upgrade:cancel')} on Essential tier databases. You can only use this command on Standard-tier and higher leader databases.`)
+
+    const {body: replica} = await this.heroku.get<PgDatabase>(`/client/v11/databases/${db.id}`, {hostname: pgHost()})
+    if (replica.following)
+      ux.error(`You can't use ${color.cmd('pg:upgrade:prepare')} on follower databases.  You can only use this command on Standard-tier and higher leader databases.`)
+
+    await confirmCommand(app, confirm, heredoc(`
+      Destructive action
+      You're cancelling the version upgrade for ${color.addon(db.name)}.
+
+      You can't undo this action.
+    `))
+
+    try {
+      ux.action.start(`Cancelling upgrade on ${color.addon(db.name)}`)
+      const response = await this.heroku.post<PgUpgradeResponse>(`/client/v11/databases/${db.id}/upgrade/cancel`, {hostname: pgHost(), body: {}})
+      ux.action.stop('done\n' + formatResponseWithCommands(response.body.message))
+    } catch (error) {
+      const response = error as PgUpgradeError
+      ux.error(formatResponseWithCommands(response.body.message) + `\n\nError ID: ${response.body.id}`)
+    }
+  }
+}

--- a/packages/cli/test/unit/commands/pg/upgrade/cancel.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/upgrade/cancel.unit.test.ts
@@ -12,7 +12,7 @@ import * as sinon from 'sinon'
 
 const stripAnsi = require('strip-ansi')
 
-describe.only('pg:upgrade:cancel', function () {
+describe('pg:upgrade:cancel', function () {
   const addon = fixtures.addons['dwh-db']
   let uxWarnStub: sinon.SinonStub
   let uxPromptStub: sinon.SinonStub
@@ -148,13 +148,6 @@ describe.only('pg:upgrade:cancel', function () {
       .post(`/client/v11/databases/${addon.id}/upgrade/cancel`)
       .reply(422, {id: "bad_request", message: "You haven't scheduled an upgrade on your database. Run `pg:upgrade:prepare` to schedule an upgrade."})
 
-    const message = heredoc(`
-      Destructive action
-      You're cancelling the version upgrade for ${addon.name}.
-
-      You can't undo this action.
-    `)
-
     await runCommand(Cmd, [
       '--app',
       'myapp',
@@ -185,13 +178,6 @@ describe.only('pg:upgrade:cancel', function () {
     nock('https://api.data.heroku.com')
       .post(`/client/v11/databases/${addon.id}/upgrade/cancel`)
       .reply(422, {id: "bad_request", message: "You can't cancel the upgrade because it's currently in progress."})
-
-    const message = heredoc(`
-      Destructive action
-      You're cancelling the version upgrade for ${addon.name}.
-
-      You can't undo this action.
-    `)
 
     await runCommand(Cmd, [
       '--app',

--- a/packages/cli/test/unit/commands/pg/upgrade/cancel.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/upgrade/cancel.unit.test.ts
@@ -165,7 +165,7 @@ describe('pg:upgrade:cancel', function () {
     })
   })
 
-  it ('errors when upgrade is not cancelable', async function () {
+  it('errors when upgrade is not cancelable', async function () {
     nock('https://api.heroku.com')
       .post('/actions/addon-attachments/resolve')
       .reply(200, [{addon}])

--- a/packages/cli/test/unit/commands/pg/upgrade/cancel.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/upgrade/cancel.unit.test.ts
@@ -69,7 +69,7 @@ describe('pg:upgrade:cancel', function () {
       '--confirm',
       'myapp',
     ]).catch(error => {
-      expect(error.message).to.equal(`You can't use ${color.cmd('pg:upgrade:cancel')} on Essential tier databases. You can only use this command on Standard-tier and higher leader databases.`)
+      expect(error.message).to.equal(`You can't use ${color.cmd('pg:upgrade:cancel')} on Essential-tier databases. You can only use this command on Standard-tier and higher leader databases.`)
     })
   })
 
@@ -93,7 +93,7 @@ describe('pg:upgrade:cancel', function () {
       'myapp',
     ]).catch(error => {
       expectOutput(error.message, heredoc(`
-      You can't use ${color.cmd('pg:upgrade:cancel')} on follower databases.  You can only use this command on Standard-tier and higher leader databases.
+      You can't use ${color.cmd('pg:upgrade:cancel')} on follower databases. You can only use this command on Standard-tier and higher leader databases.
     `))
     })
   })
@@ -114,7 +114,7 @@ describe('pg:upgrade:cancel', function () {
 
     const message = heredoc(`
       Destructive action
-      You're cancelling the version upgrade for ${addon.name}.
+      You're canceling the scheduled version upgrade for ${addon.name}.
       
       You can't undo this action.
     `)
@@ -156,6 +156,7 @@ describe('pg:upgrade:cancel', function () {
     ]).catch(error => {
       expectOutput(error.message, heredoc(`
       You haven't scheduled an upgrade on your database. Run ${color.cmd('pg:upgrade:prepare')} to schedule an upgrade.
+
       Error ID: bad_request
     `))
 
@@ -187,6 +188,7 @@ describe('pg:upgrade:cancel', function () {
     ]).catch(error => {
       expectOutput(error.message, heredoc(`
       You can't cancel the upgrade because it's currently in progress.
+
       Error ID: bad_request
     `))
 

--- a/packages/cli/test/unit/commands/pg/upgrade/cancel.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/upgrade/cancel.unit.test.ts
@@ -1,0 +1,212 @@
+import {stderr} from 'stdout-stderr'
+import Cmd from '../../../../../src/commands/pg/upgrade/cancel'
+import runCommand from '../../../../helpers/runCommand'
+import expectOutput from '../../../../helpers/utils/expectOutput'
+import {expect} from 'chai'
+import * as nock from 'nock'
+import heredoc from 'tsheredoc'
+import * as fixtures from '../../../../fixtures/addons/fixtures'
+import color from '@heroku-cli/color'
+import {ux} from '@oclif/core'
+import * as sinon from 'sinon'
+
+const stripAnsi = require('strip-ansi')
+
+describe.only('pg:upgrade:cancel', function () {
+  const addon = fixtures.addons['dwh-db']
+  let uxWarnStub: sinon.SinonStub
+  let uxPromptStub: sinon.SinonStub
+
+  before(function () {
+    uxWarnStub = sinon.stub(ux, 'warn')
+    uxPromptStub = sinon.stub(ux, 'prompt').resolves('myapp')
+  })
+
+  beforeEach(async function () {
+    uxWarnStub.resetHistory()
+    uxPromptStub.resetHistory()
+  })
+
+  afterEach(async function () {
+    nock.cleanAll()
+  })
+
+  after(function () {
+    uxWarnStub.restore()
+    uxPromptStub.restore()
+  })
+
+  it('refuses to cancel upgrade on legacy essential dbs', async function () {
+    const hobbyAddon = fixtures.addons['www-db']
+
+    nock('https://api.heroku.com')
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, [{addon: hobbyAddon}])
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+      '--confirm',
+      'myapp',
+    ]).catch(error => {
+      expectOutput(error.message, heredoc(`
+      You can only use ${color.cmd('pg:upgrade:*')} commands on Essential-* and higher plans.
+    `))
+    })
+  })
+
+  it('refuses to cancel upgrade on essential tier dbs', async function () {
+    const essentialAddon = {
+      name: 'postgres-1', plan: {name: 'heroku-postgresql:essential-0'},
+    }
+
+    nock('https://api.heroku.com')
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, [{addon: essentialAddon}])
+
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+      '--confirm',
+      'myapp',
+    ]).catch(error => {
+      expect(error.message).to.equal(`You can't use ${color.cmd('pg:upgrade:cancel')} on Essential tier databases. You can only use this command on Standard-tier and higher leader databases.`)
+    })
+  })
+
+  it('refuses to cancel upgrade on follower dbs', async function () {
+    nock('https://api.heroku.com')
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, [{addon: addon}])
+    nock('https://api.data.heroku.com')
+      .get(`/client/v11/databases/${addon.id}`)
+      .reply(200, {
+        following: 'postgres://xxx.com:5432/abcdefghijklmn',
+        leader: {
+          addon_id: '5ba2ba8b-07a9-4a65-a808-585a50e37f98',
+          name: 'postgresql-leader',
+        },
+      })
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+      '--confirm',
+      'myapp',
+    ]).catch(error => {
+      expectOutput(error.message, heredoc(`
+      You can't use ${color.cmd('pg:upgrade:cancel')} on follower databases.  You can only use this command on Standard-tier and higher leader databases.
+    `))
+    })
+  })
+
+  it('cancels upgrade on a leader db', async function () {
+    nock('https://api.heroku.com')
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, [{addon}])
+    nock('https://api.heroku.com')
+      .get('/apps/myapp/config-vars')
+      .reply(200, {DATABASE_URL: 'postgres://db1'})
+    nock('https://api.data.heroku.com')
+      .get(`/client/v11/databases/${addon.id}`)
+      .reply(200)
+    nock('https://api.data.heroku.com')
+      .post(`/client/v11/databases/${addon.id}/upgrade/cancel`)
+      .reply(200, {message: 'You canceled the upgrade.'})
+
+    const message = heredoc(`
+      Destructive action
+      You're cancelling the version upgrade for ${addon.name}.
+      
+      You can't undo this action.
+    `)
+
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+    ])
+
+    expect(stripAnsi(uxPromptStub.args[0].toString())).contains('To proceed, type myapp')
+    expect(stripAnsi(uxWarnStub.args[0].toString())).to.eq(message)
+
+    expectOutput(stderr.output, heredoc(`
+      Cancelling upgrade on ${addon.name}...
+      Cancelling upgrade on ${addon.name}... done
+      You canceled the upgrade.
+    `))
+  })
+
+  it('errors when there is no upgrade prepared', async function () {
+    nock('https://api.heroku.com')
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, [{addon}])
+    nock('https://api.heroku.com')
+      .get('/apps/myapp/config-vars')
+      .reply(200, {DATABASE_URL: 'postgres://db1'})
+    nock('https://api.data.heroku.com')
+      .get(`/client/v11/databases/${addon.id}`)
+      .reply(200)
+    nock('https://api.data.heroku.com')
+      .post(`/client/v11/databases/${addon.id}/upgrade/cancel`)
+      .reply(422, {id: "bad_request", message: "You haven't scheduled an upgrade on your database. Run `pg:upgrade:prepare` to schedule an upgrade."})
+
+    const message = heredoc(`
+      Destructive action
+      You're cancelling the version upgrade for ${addon.name}.
+
+      You can't undo this action.
+    `)
+
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+      '--confirm',
+      'myapp',
+    ]).catch(error => { 
+      expectOutput(error.message, heredoc(`
+      You haven't scheduled an upgrade on your database. Run ${color.cmd('pg:upgrade:prepare')} to schedule an upgrade.
+      Error ID: bad_request
+    `))
+
+    expectOutput(stderr.output, heredoc(`
+      Cancelling upgrade on ${addon.name}...
+    `))
+    })
+  })
+
+  it ('errors when upgrade is not cancelable', async function () {
+    nock('https://api.heroku.com')
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, [{addon}])
+    nock('https://api.heroku.com')
+      .get('/apps/myapp/config-vars')
+      .reply(200, {DATABASE_URL: 'postgres://db1'})
+    nock('https://api.data.heroku.com')
+      .get(`/client/v11/databases/${addon.id}`)
+      .reply(200)
+    nock('https://api.data.heroku.com')
+      .post(`/client/v11/databases/${addon.id}/upgrade/cancel`)
+      .reply(422, {id: "bad_request", message: "You can't cancel the upgrade because it's currently in progress."})
+
+    const message = heredoc(`
+      Destructive action
+      You're cancelling the version upgrade for ${addon.name}.
+
+      You can't undo this action.
+    `)
+
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+      '--confirm',
+      'myapp',
+    ]).catch(error => {
+      expectOutput(error.message, heredoc(`
+      You can't cancel the upgrade because it's currently in progress.
+      Error ID: bad_request
+    `))
+
+    expectOutput(stderr.output, heredoc(`
+      Cancelling upgrade on ${addon.name}...
+    `))
+    })
+  })
+})

--- a/packages/cli/test/unit/commands/pg/upgrade/cancel.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/upgrade/cancel.unit.test.ts
@@ -146,22 +146,22 @@ describe('pg:upgrade:cancel', function () {
       .reply(200)
     nock('https://api.data.heroku.com')
       .post(`/client/v11/databases/${addon.id}/upgrade/cancel`)
-      .reply(422, {id: "bad_request", message: "You haven't scheduled an upgrade on your database. Run `pg:upgrade:prepare` to schedule an upgrade."})
+      .reply(422, {id: 'bad_request', message: "You haven't scheduled an upgrade on your database. Run `pg:upgrade:prepare` to schedule an upgrade."})
 
     await runCommand(Cmd, [
       '--app',
       'myapp',
       '--confirm',
       'myapp',
-    ]).catch(error => { 
+    ]).catch(error => {
       expectOutput(error.message, heredoc(`
       You haven't scheduled an upgrade on your database. Run ${color.cmd('pg:upgrade:prepare')} to schedule an upgrade.
       Error ID: bad_request
     `))
 
-    expectOutput(stderr.output, heredoc(`
-      Cancelling upgrade on ${addon.name}...
-    `))
+      expectOutput(stderr.output, heredoc(`
+        Cancelling upgrade on ${addon.name}...
+      `))
     })
   })
 
@@ -177,7 +177,7 @@ describe('pg:upgrade:cancel', function () {
       .reply(200)
     nock('https://api.data.heroku.com')
       .post(`/client/v11/databases/${addon.id}/upgrade/cancel`)
-      .reply(422, {id: "bad_request", message: "You can't cancel the upgrade because it's currently in progress."})
+      .reply(422, {id: 'bad_request', message: "You can't cancel the upgrade because it's currently in progress."})
 
     await runCommand(Cmd, [
       '--app',
@@ -190,9 +190,9 @@ describe('pg:upgrade:cancel', function () {
       Error ID: bad_request
     `))
 
-    expectOutput(stderr.output, heredoc(`
-      Cancelling upgrade on ${addon.name}...
-    `))
+      expectOutput(stderr.output, heredoc(`
+        Cancelling upgrade on ${addon.name}...
+      `))
     })
   })
 })


### PR DESCRIPTION
This PR creates the `pg:upgrade:cancel` command. 

Work item: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002BNrJ4YAL/view

Please refer to [this doc](https://docs.google.com/document/d/1FEIQPkWRggz_XWzU3PRI6pFg00TwUKIjqft4IGzCOsY/edit?usp=sharing) for more information related to the new pg:upgrade:* commands

## Testing
**Scenario 1:**
pg:upgrade:cancel on essential tier db
<img width="1822" alt="Screenshot 2025-04-02 at 4 40 06 PM" src="https://github.com/user-attachments/assets/6cd077af-2225-42a1-9971-66a094b5f242" />

**Scenario 2:**
pg:upgrade:cancel on follower db
<img width="1737" alt="Screenshot 2025-04-02 at 4 40 28 PM" src="https://github.com/user-attachments/assets/3c1b18aa-8e0a-4ed2-9a94-7493dfbc696b" />

**Scenario 3:**
pg:upgrade:cancel on leader db with no upgrade scheduled
<img width="1612" alt="Screenshot 2025-04-02 at 4 41 05 PM" src="https://github.com/user-attachments/assets/7e26c77e-4416-4aaa-98fd-69d56541e9e5" />

**Scenario 4:**
pg:upgrade:cancel on leader db with upgrade scheduled but not actively running
<img width="1692" alt="Screenshot 2025-04-02 at 4 41 29 PM" src="https://github.com/user-attachments/assets/68309a20-80f1-47b4-b2d5-6ad2e8eb7677" />

**Scenario 5:**
pg:upgrade:cancel on leader db with upgrade actively running
<img width="1413" alt="Screenshot 2025-04-02 at 4 43 43 PM" src="https://github.com/user-attachments/assets/ca8fdd8d-65f2-4288-bc31-111f2bd3dcc3" />

**Scenario 6:**
help on pg:upgrade:cancel
<img width="2532" alt="Screenshot 2025-04-02 at 4 48 51 PM" src="https://github.com/user-attachments/assets/3f71d7d2-7b4c-44e5-8a66-31c64ac13f6e" />


