### PR TITLE
feat: updating pg:upgrade with deprecation warning

### DIFF
--- a/packages/cli/src/commands/pg/upgrade/index.ts
+++ b/packages/cli/src/commands/pg/upgrade/index.ts
@@ -14,9 +14,9 @@ export default class Upgrade extends Command {
   static topic = 'pg';
   static description = heredoc(`
     We’re deprecating this command. To upgrade your Postgres version, use the new ${color.cmd('pg:upgrade:*')} subcommands. See https://devcenter.heroku.com/changelog-items/3179.
-
+    
     For an Essential-* plan, this command upgrades the database's Postgres version. For a Standard-tier and higher plan, this command unfollows the leader database before upgrading the Postgres version.
-    To upgrade to another Postgres version, use pg:copy instead.
+    To upgrade to another Postgres version, use ${color.cmd('pg:copy')} instead.
     `)
 
   static flags = {

--- a/packages/cli/src/commands/pg/upgrade/index.ts
+++ b/packages/cli/src/commands/pg/upgrade/index.ts
@@ -15,7 +15,8 @@ export default class Upgrade extends Command {
   static description = heredoc(`
     We’re deprecating this command. To upgrade your Postgres version, use the new ${color.cmd('pg:upgrade:*')} subcommands. See https://devcenter.heroku.com/changelog-items/3179.
 
-    For an Essential-* plan, this command upgrades the database's Postgres version. For a Standard-tier and higher plan, this command unfollows the leader database before upgrading the Postgres version. To upgrade to another Postgres version, use pg:copy instead.
+    For an Essential-* plan, this command upgrades the database's Postgres version. For a Standard-tier and higher plan, this command unfollows the leader database before upgrading the Postgres version.
+    To upgrade to another Postgres version, use pg:copy instead.
     `)
 
   static flags = {
@@ -38,13 +39,13 @@ export default class Upgrade extends Command {
     if (legacyEssentialPlan(db))
       ux.error(`You can only use ${color.cmd('heroku pg:upgrade')} on Essential-* databases and follower databases on Standard-tier and higher plans.`)
 
-    const versionPhrase = version ? heredoc(`Postgres version ${version}`) : heredoc(`the latest supported Postgres version`)
+    const versionPhrase = version ? heredoc(`Postgres version ${version}`) : heredoc('the latest supported Postgres version')
     const {body: replica} = await this.heroku.get<PgDatabase>(`/client/v11/databases/${db.id}`, {hostname: pgHost()})
 
     if (replica.following) {
       const {body: configVars} = await this.heroku.get<Heroku.ConfigVars>(`/apps/${app}/config-vars`)
       const origin = databaseNameFromUrl(replica.following, configVars)
-      
+
       await confirmCommand(app, confirm, heredoc(`
         We’re deprecating this command. To upgrade your Postgres version, use the new ${color.cmd('pg:upgrade:*')} subcommands. See https://devcenter.heroku.com/changelog-items/3179.
 
@@ -53,7 +54,7 @@ export default class Upgrade extends Command {
 
         This cannot be undone.
       `))
-    } else if (essentialNumPlan(db)){
+    } else if (essentialNumPlan(db)) {
       await confirmCommand(app, confirm, heredoc(`
         We’re deprecating this command. To upgrade your Postgres version, use the new ${color.cmd('pg:upgrade:*')} subcommands. See https://devcenter.heroku.com/changelog-items/3179.
 
@@ -64,7 +65,7 @@ export default class Upgrade extends Command {
       `))
     } else {
       ux.warn(heredoc(`
-        We’re deprecating this command. To upgrade your Postgres version, use the new ${color.cmd('pg:upgrade:*')} subcommands. See https://devcenter.heroku.com/changelog-items/3179.`
+        We’re deprecating this command. To upgrade your Postgres version, use the new ${color.cmd('pg:upgrade:*')} subcommands. See https://devcenter.heroku.com/changelog-items/3179.`,
       ))
       ux.error(`You can only use ${color.cmd('heroku pg:upgrade')} on Essential-* databases and follower databases on Standard-tier and higher plans.`)
     }

--- a/packages/cli/src/commands/pg/upgrade/index.ts
+++ b/packages/cli/src/commands/pg/upgrade/index.ts
@@ -13,10 +13,9 @@ import {nls} from '../../../nls'
 export default class Upgrade extends Command {
   static topic = 'pg';
   static description = heredoc(`
-    We’re deprecating this command. To upgrade your Postgres version, use the new ${color.cmd('pg:upgrade:*')} subcommands. See https://devcenter.heroku.com/changelog-items/3179.
+    We’re deprecating this command. To upgrade your database's Postgres version, use the new ${color.cmd('pg:upgrade:*')} subcommands. See https://devcenter.heroku.com/changelog-items/3179.
     
     For an Essential-* plan, this command upgrades the database's Postgres version. For a Standard-tier and higher plan, this command unfollows the leader database before upgrading the Postgres version.
-    To upgrade to another Postgres version, use ${color.cmd('pg:copy')} instead.
     `)
 
   static flags = {
@@ -37,7 +36,7 @@ export default class Upgrade extends Command {
 
     const db = await getAddon(this.heroku, app, database)
     if (legacyEssentialPlan(db))
-      ux.error(`You can only use ${color.cmd('heroku pg:upgrade')} on Essential-* databases and follower databases on Standard-tier and higher plans.`)
+      ux.error(`You can only use ${color.cmd('heroku pg:upgrade')} on Essential-tier databases and follower databases on Standard-tier and higher plans.`)
 
     const versionPhrase = version ? heredoc(`Postgres version ${version}`) : heredoc('the latest supported Postgres version')
     const {body: replica} = await this.heroku.get<PgDatabase>(`/client/v11/databases/${db.id}`, {hostname: pgHost()})
@@ -47,7 +46,7 @@ export default class Upgrade extends Command {
       const origin = databaseNameFromUrl(replica.following, configVars)
 
       await confirmCommand(app, confirm, heredoc(`
-        We’re deprecating this command. To upgrade your Postgres version, use the new ${color.cmd('pg:upgrade:*')} subcommands. See https://devcenter.heroku.com/changelog-items/3179.
+        We’re deprecating this command. To upgrade your database's Postgres version, use the new ${color.cmd('pg:upgrade:*')} subcommands. See https://devcenter.heroku.com/changelog-items/3179.
 
         Destructive action
         You're upgrading ${color.addon(db.name)} to ${versionPhrase}. The database will stop following ${origin} and become writable.
@@ -56,7 +55,7 @@ export default class Upgrade extends Command {
       `))
     } else if (essentialNumPlan(db)) {
       await confirmCommand(app, confirm, heredoc(`
-        We’re deprecating this command. To upgrade your Postgres version, use the new ${color.cmd('pg:upgrade:*')} subcommands. See https://devcenter.heroku.com/changelog-items/3179.
+        We’re deprecating this command. To upgrade your database's Postgres version, use the new ${color.cmd('pg:upgrade:*')} subcommands. See https://devcenter.heroku.com/changelog-items/3179.
 
         Destructive action
         You're upgrading ${color.addon(db.name)} to ${versionPhrase}.
@@ -65,9 +64,9 @@ export default class Upgrade extends Command {
       `))
     } else {
       ux.warn(heredoc(`
-        We’re deprecating this command. To upgrade your Postgres version, use the new ${color.cmd('pg:upgrade:*')} subcommands. See https://devcenter.heroku.com/changelog-items/3179.`,
+        We’re deprecating this command. To upgrade your database's Postgres version, use the new ${color.cmd('pg:upgrade:*')} subcommands. See https://devcenter.heroku.com/changelog-items/3179.`,
       ))
-      ux.error(`You can only use ${color.cmd('heroku pg:upgrade')} on Essential-* databases and follower databases on Standard-tier and higher plans.`)
+      ux.error(`You can only use ${color.cmd('heroku pg:upgrade')} on Essential-tier databases and follower databases on Standard-tier and higher plans.`)
     }
 
     try {

--- a/packages/cli/src/commands/pg/upgrade/index.ts
+++ b/packages/cli/src/commands/pg/upgrade/index.ts
@@ -4,8 +4,8 @@ import {Args, ux} from '@oclif/core'
 import heredoc from 'tsheredoc'
 import {getAddon} from '../../../lib/pg/fetcher'
 import pgHost from '../../../lib/pg/host'
-import {legacyEssentialPlan, databaseNameFromUrl} from '../../../lib/pg/util'
-import {PgDatabase} from '../../../lib/pg/types'
+import {legacyEssentialPlan, databaseNameFromUrl, essentialNumPlan, formatResponseWithCommands} from '../../../lib/pg/util'
+import {PgDatabase, PgUpgradeError, PgUpgradeResponse} from '../../../lib/pg/types'
 import * as Heroku from '@heroku-cli/schema'
 import confirmCommand from '../../../lib/confirmCommand'
 import {nls} from '../../../nls'
@@ -13,13 +13,14 @@ import {nls} from '../../../nls'
 export default class Upgrade extends Command {
   static topic = 'pg';
   static description = heredoc(`
-    For an Essential-* plan, this command upgrades the database's PostgreSQL version. For a Standard-tier and higher plan, this command unfollows the leader database before upgrading the PostgreSQL version.
-    To upgrade to another PostgreSQL version, use pg:copy instead
-  `)
+    We’re deprecating this command. To upgrade your Postgres version, use the new ${color.cmd('pg:upgrade:*')} subcommands. See https://devcenter.heroku.com/changelog-items/3179.
+
+    For an Essential-* plan, this command upgrades the database's Postgres version. For a Standard-tier and higher plan, this command unfollows the leader database before upgrading the Postgres version. To upgrade to another Postgres version, use pg:copy instead.
+    `)
 
   static flags = {
     confirm: flags.string({char: 'c'}),
-    version: flags.string({char: 'v', description: 'PostgreSQL version to upgrade to'}),
+    version: flags.string({char: 'v', description: 'Postgres version to upgrade to'}),
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
@@ -35,29 +36,47 @@ export default class Upgrade extends Command {
 
     const db = await getAddon(this.heroku, app, database)
     if (legacyEssentialPlan(db))
-      ux.error('pg:upgrade is only available for Essential-* databases and follower databases on Standard-tier and higher plans.')
+      ux.error(`You can only use ${color.cmd('heroku pg:upgrade')} on Essential-* databases and follower databases on Standard-tier and higher plans.`)
+
+    const versionPhrase = version ? heredoc(`Postgres version ${version}`) : heredoc(`the latest supported Postgres version`)
     const {body: replica} = await this.heroku.get<PgDatabase>(`/client/v11/databases/${db.id}`, {hostname: pgHost()})
+
     if (replica.following) {
       const {body: configVars} = await this.heroku.get<Heroku.ConfigVars>(`/apps/${app}/config-vars`)
       const origin = databaseNameFromUrl(replica.following, configVars)
+      
       await confirmCommand(app, confirm, heredoc(`
+        We’re deprecating this command. To upgrade your Postgres version, use the new ${color.cmd('pg:upgrade:*')} subcommands. See https://devcenter.heroku.com/changelog-items/3179.
+
         Destructive action
-        ${color.addon(db.name)} will be upgraded to a newer PostgreSQL version, stop following ${origin}, and become writable.
+        You're upgrading ${color.addon(db.name)} to ${versionPhrase}. The database will stop following ${origin} and become writable.
+
+        This cannot be undone.
+      `))
+    } else if (essentialNumPlan(db)){
+      await confirmCommand(app, confirm, heredoc(`
+        We’re deprecating this command. To upgrade your Postgres version, use the new ${color.cmd('pg:upgrade:*')} subcommands. See https://devcenter.heroku.com/changelog-items/3179.
+
+        Destructive action
+        You're upgrading ${color.addon(db.name)} to ${versionPhrase}.
 
         This cannot be undone.
       `))
     } else {
-      await confirmCommand(app, confirm, heredoc(`
-        Destructive action
-        ${color.addon(db.name)} will be upgraded to a newer PostgreSQL version.
-
-        This cannot be undone.
-      `))
+      ux.warn(heredoc(`
+        We’re deprecating this command. To upgrade your Postgres version, use the new ${color.cmd('pg:upgrade:*')} subcommands. See https://devcenter.heroku.com/changelog-items/3179.`
+      ))
+      ux.error(`You can only use ${color.cmd('heroku pg:upgrade')} on Essential-* databases and follower databases on Standard-tier and higher plans.`)
     }
 
-    const data = {version}
-    ux.action.start(`Starting upgrade of ${color.addon(db.name)}`)
-    await this.heroku.post(`/client/v11/databases/${db.id}/upgrade`, {hostname: pgHost(), body: data})
-    ux.action.stop(`Use ${color.cmd('heroku pg:wait')} to track status`)
+    try {
+      const data = {version}
+      ux.action.start(`Starting upgrade on ${color.addon(db.name)}`)
+      const response = await this.heroku.post<PgUpgradeResponse>(`/client/v11/databases/${db.id}/upgrade`, {hostname: pgHost(), body: data})
+      ux.action.stop(heredoc(`done\n${formatResponseWithCommands(response.body.message)}`))
+    } catch (error) {
+      const response = error as PgUpgradeError
+      ux.error(heredoc(`${formatResponseWithCommands(response.body.message)}\n\nError ID: ${response.body.id}`))
+    }
   }
 }

--- a/packages/cli/test/acceptance/commands-output.ts
+++ b/packages/cli/test/acceptance/commands-output.ts
@@ -206,7 +206,7 @@ pg:settings:log-min-duration-statement         The duration of each completed st
 pg:settings:log-statement                      log_statement controls which SQL statements are logged.
 pg:settings:track-functions                    track_functions controls tracking of function call counts and time used. Default is none.
 pg:unfollow                                    stop a replica from following and make it a writeable database
-pg:upgrade                                     We’re deprecating this command. To upgrade your Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.
+pg:upgrade                                     We’re deprecating this command. To upgrade your database's Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.
 pg:vacuum-stats                                show dead rows and whether an automatic vacuum is expected to be triggered
 pg:wait                                        blocks until database is available
 pipelines                                      list pipelines you have access to

--- a/packages/cli/test/acceptance/commands-output.ts
+++ b/packages/cli/test/acceptance/commands-output.ts
@@ -206,7 +206,7 @@ pg:settings:log-min-duration-statement         The duration of each completed st
 pg:settings:log-statement                      log_statement controls which SQL statements are logged.
 pg:settings:track-functions                    track_functions controls tracking of function call counts and time used. Default is none.
 pg:unfollow                                    stop a replica from following and make it a writeable database
-pg:upgrade                                     We’re deprecating this command. To upgrade your Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.For an Essential-* plan, this command upgrades the database's Postgres version. For a Standard-tier and higher plan, this command unfollows the leader database before upgrading the Postgres version. To upgrade to another Postgres version, use pg:copy instead.
+pg:upgrade                                     We’re deprecating this command. To upgrade your Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.
 pg:vacuum-stats                                show dead rows and whether an automatic vacuum is expected to be triggered
 pg:wait                                        blocks until database is available
 pipelines                                      list pipelines you have access to

--- a/packages/cli/test/acceptance/commands-output.ts
+++ b/packages/cli/test/acceptance/commands-output.ts
@@ -206,7 +206,7 @@ pg:settings:log-min-duration-statement         The duration of each completed st
 pg:settings:log-statement                      log_statement controls which SQL statements are logged.
 pg:settings:track-functions                    track_functions controls tracking of function call counts and time used. Default is none.
 pg:unfollow                                    stop a replica from following and make it a writeable database
-pg:upgrade                                     For an Essential-* plan, this command upgrades the database's PostgreSQL version. For a Standard-tier and higher plan, this command unfollows the leader database before upgrading the PostgreSQL version.
+pg:upgrade                                     We’re deprecating this command. To upgrade your Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.For an Essential-* plan, this command upgrades the database's Postgres version. For a Standard-tier and higher plan, this command unfollows the leader database before upgrading the Postgres version. To upgrade to another Postgres version, use pg:copy instead.
 pg:vacuum-stats                                show dead rows and whether an automatic vacuum is expected to be triggered
 pg:wait                                        blocks until database is available
 pipelines                                      list pipelines you have access to

--- a/packages/cli/test/unit/commands/pg/upgrade/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/upgrade/index.unit.test.ts
@@ -47,7 +47,7 @@ describe('pg:upgrade', function () {
       '--confirm',
       'myapp',
     ]).catch(error => {
-      expect(error.message).to.equal(`You can only use ${color.cmd('heroku pg:upgrade')} on Essential-* databases and follower databases on Standard-tier and higher plans.`)
+      expect(error.message).to.equal(`You can only use ${color.cmd('heroku pg:upgrade')} on Essential-tier databases and follower databases on Standard-tier and higher plans.`)
     })
   })
 
@@ -68,7 +68,7 @@ describe('pg:upgrade', function () {
       '--confirm',
       'myapp',
     ]).catch(error => {
-      expect(error.message).to.equal(`You can only use ${color.cmd('heroku pg:upgrade')} on Essential-* databases and follower databases on Standard-tier and higher plans.`)
+      expect(error.message).to.equal(`You can only use ${color.cmd('heroku pg:upgrade')} on Essential-tier databases and follower databases on Standard-tier and higher plans.`)
     })
   })
 
@@ -87,7 +87,7 @@ describe('pg:upgrade', function () {
       .reply(200, {message: 'Upgrading'})
 
     const message = heredoc(`
-      We’re deprecating this command. To upgrade your Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.
+      We’re deprecating this command. To upgrade your database's Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.
 
       Destructive action
       You're upgrading ${addon.name} to Postgres version 15. The database will stop following DATABASE and become writable.
@@ -126,7 +126,7 @@ describe('pg:upgrade', function () {
       .reply(200, {message: 'Upgrading'})
 
     const message = heredoc(`
-      We’re deprecating this command. To upgrade your Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.
+      We’re deprecating this command. To upgrade your database's Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.
 
       Destructive action
       You're upgrading ${addon.name} to the latest supported Postgres version. The database will stop following DATABASE and become writable.
@@ -167,7 +167,7 @@ describe('pg:upgrade', function () {
       .reply(200, {message: 'Upgrading'})
 
     const message = heredoc(`
-      We’re deprecating this command. To upgrade your Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.
+      We’re deprecating this command. To upgrade your database's Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.
 
       Destructive action
       You're upgrading ${essentialAddon.name} to the latest supported Postgres version.

--- a/packages/cli/test/unit/commands/pg/upgrade/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/upgrade/index.unit.test.ts
@@ -1,18 +1,40 @@
 import {stderr} from 'stdout-stderr'
-import Cmd from '../../../../../src/commands/pg/upgrade'
+import Cmd from '../../../../../src/commands/pg/upgrade/index'
 import runCommand from '../../../../helpers/runCommand'
 import expectOutput from '../../../../helpers/utils/expectOutput'
 import {expect} from 'chai'
 import * as nock from 'nock'
 import heredoc from 'tsheredoc'
 import * as fixtures from '../../../../fixtures/addons/fixtures'
+import color from '@heroku-cli/color'
+import {ux} from '@oclif/core'
+import * as sinon from 'sinon'
+const stripAnsi = require('strip-ansi')
 
 describe('pg:upgrade', function () {
   const hobbyAddon = fixtures.addons['www-db']
+  const essentialAddon = fixtures.addons['www-db-3']
   const addon = fixtures.addons['dwh-db']
+  let uxWarnStub: sinon.SinonStub
+  let uxPromptStub: sinon.SinonStub
 
-  afterEach(function () {
+  before(function () {
+    uxWarnStub = sinon.stub(ux, 'warn')
+    uxPromptStub = sinon.stub(ux, 'prompt').resolves('myapp')
+  })
+
+  beforeEach(async function () {
+    uxWarnStub.resetHistory()
+    uxPromptStub.resetHistory()
+  })
+
+  afterEach(async function () {
     nock.cleanAll()
+  })
+
+  after(function () {
+    uxWarnStub.restore()
+    uxPromptStub.restore()
   })
 
   it('refuses to upgrade legacy essential dbs', async function () {
@@ -25,11 +47,32 @@ describe('pg:upgrade', function () {
       '--confirm',
       'myapp',
     ]).catch(error => {
-      expect(error.message).to.equal('pg:upgrade is only available for Essential-* databases and follower databases on Standard-tier and higher plans.')
+      expect(error.message).to.equal(`You can only use ${color.cmd('heroku pg:upgrade')} on Essential-* databases and follower databases on Standard-tier and higher plans.`)
     })
   })
 
-  it('upgrades db', async function () {
+  it('refuses to upgrade standard tier leader db', async function () {
+    nock('https://api.heroku.com')
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, [{addon: addon}])
+    nock('https://api.heroku.com')
+      .get('/apps/myapp/config-vars')
+      .reply(200, {DATABASE_URL: 'postgres://db1'})
+    nock('https://api.data.heroku.com')
+      .get(`/client/v11/databases/${addon.id}`)
+      .reply(200)
+
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+      '--confirm',
+      'myapp',
+    ]).catch(error => {
+      expect(error.message).to.equal(`You can only use ${color.cmd('heroku pg:upgrade')} on Essential-* databases and follower databases on Standard-tier and higher plans.`)
+    })
+  })
+
+  it('upgrades follower db with version flag', async function () {
     nock('https://api.heroku.com')
       .post('/actions/addon-attachments/resolve')
       .reply(200, [{addon}])
@@ -39,22 +82,37 @@ describe('pg:upgrade', function () {
     nock('https://api.data.heroku.com')
       .get(`/client/v11/databases/${addon.id}`)
       .reply(200, {following: 'postgres://db1'})
+    nock('https://api.data.heroku.com')
       .post(`/client/v11/databases/${addon.id}/upgrade`)
-      .reply(200)
+      .reply(200, {message: 'Upgrading'})
+
+    const message = heredoc(`
+      We’re deprecating this command. To upgrade your Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.
+
+      Destructive action
+      You're upgrading ${addon.name} to Postgres version 15. The database will stop following DATABASE and become writable.
+
+      This cannot be undone.
+    `)
 
     await runCommand(Cmd, [
       '--app',
       'myapp',
-      '--confirm',
-      'myapp',
+      '--version',
+      '15',
     ])
+
+    expect(stripAnsi(uxPromptStub.args[0].toString())).contains('To proceed, type myapp')
+    expect(stripAnsi(uxWarnStub.args[0].toString())).to.eq(message)
+
     expectOutput(stderr.output, heredoc(`
-      Starting upgrade of ${addon.name}...
-      Starting upgrade of ${addon.name}... Use heroku pg:wait to track status
+      Starting upgrade on ${addon.name}...
+      Starting upgrade on ${addon.name}... done
+      Upgrading
     `))
   })
 
-  it('upgrades db with version flag', async function () {
+  it('upgrades follower db without version flag', async function () {
     nock('https://api.heroku.com')
       .post('/actions/addon-attachments/resolve')
       .reply(200, [{addon}])
@@ -64,21 +122,71 @@ describe('pg:upgrade', function () {
     nock('https://api.data.heroku.com')
       .get(`/client/v11/databases/${addon.id}`)
       .reply(200, {following: 'postgres://db1'})
-    nock('https://api.data.heroku.com')
       .post(`/client/v11/databases/${addon.id}/upgrade`)
-      .reply(200)
+      .reply(200, {message: 'Upgrading'})
+
+    const message = heredoc(`
+      We’re deprecating this command. To upgrade your Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.
+
+      Destructive action
+      You're upgrading ${addon.name} to the latest supported Postgres version. The database will stop following DATABASE and become writable.
+
+      This cannot be undone.
+    `)
 
     await runCommand(Cmd, [
       '--app',
       'myapp',
-      '--confirm',
-      'myapp',
-      '--version',
-      '9.6',
     ])
+
+    expect(stripAnsi(uxPromptStub.args[0].toString())).contains('To proceed, type myapp')
+    expect(stripAnsi(uxWarnStub.args[0].toString())).to.eq(message)
+
     expectOutput(stderr.output, heredoc(`
-      Starting upgrade of ${addon.name}...
-      Starting upgrade of ${addon.name}... Use heroku pg:wait to track status
+      Starting upgrade on ${addon.name}...
+      Starting upgrade on ${addon.name}... done
+      Upgrading
+    `))
+  })
+
+  it('upgrades essential db', async function () {
+    const essentialAddon = {
+      name: 'postgres-1', plan: {name: 'heroku-postgresql:essential-0'}, id: 'b68d8f51-6577-4a46-a617-c5f36f1bb031',
+    }
+
+    nock('https://api.heroku.com')
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, [{addon: essentialAddon}])
+    nock('https://api.heroku.com')
+      .get('/apps/myapp/config-vars')
+      .reply(200, {DATABASE_URL: 'postgres://db1'})
+    nock('https://api.data.heroku.com')
+      .get(`/client/v11/databases/${essentialAddon.id}`)
+      .reply(200)
+      .post(`/client/v11/databases/${essentialAddon.id}/upgrade`)
+      .reply(200, {message: 'Upgrading'})
+
+    const message = heredoc(`
+      We’re deprecating this command. To upgrade your Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.
+
+      Destructive action
+      You're upgrading ${essentialAddon.name} to the latest supported Postgres version.
+
+      This cannot be undone.
+    `)
+
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+    ])
+
+    expect(stripAnsi(uxPromptStub.args[0].toString())).contains('To proceed, type myapp')
+    expect(stripAnsi(uxWarnStub.args[0].toString())).to.eq(message)
+
+    expectOutput(stderr.output, heredoc(`
+      Starting upgrade on ${essentialAddon.name}...
+      Starting upgrade on ${essentialAddon.name}... done
+      Upgrading
     `))
   })
 })


### PR DESCRIPTION
[Work item
](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002BNj79YAD/view)

This PR updates the `pg:upgrade` command. It also adds a couple of new error messages and formatting.

Please refer to [this doc](https://docs.google.com/document/d/1FEIQPkWRggz_XWzU3PRI6pFg00TwUKIjqft4IGzCOsY/edit?usp=sharing) for more information related to [pg:upgrade](https://docs.google.com/document/d/1FEIQPkWRggz_XWzU3PRI6pFg00TwUKIjqft4IGzCOsY/edit?tab=t.0).

Based from the [pg:upgrade:prepare PR](https://github.com/heroku/cli/pull/3265)

## Testing
Check out this branch and run `yarn && yarn build`
1. Run `./bin/run pg:upgrade` on a Standard-Tier leader DB 
```
nmuthu@nmuthu-ltm8kcc cli % ./bin/run pg:upgrade DATABASE_URL -a pg-upgrade-test-app
 ›   Warning: We’re deprecating this command. To upgrade your Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.
 ›   Error: You can only use heroku pg:upgrade on Essential-tier databases and follower databases on Standard-tier and higher plans.
```
2. Run `./bin/run pg:upgrade` on a Essential-tier DB with version flag
```
nmuthu@nmuthu-ltm8kcc cli % ./bin/run pg:upgrade HEROKU_POSTGRESQL_WHITE_URL -a pg-upgrade-test-app --version 15
 ›   Warning: We’re deprecating this command. To upgrade your Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.
 ›
 ›   Destructive action
 ›   You're upgrading postgresql-rigid-84643 to Postgres version 15.
 ›
 ›   This cannot be undone.
 ›

To proceed, type pg-upgrade-test-app or re-run this command with --confirm pg-upgrade-test-app: pg-upgrade-test-app
Starting upgrade on postgresql-rigid-84643... done
Upgrading
```
3. Run `./bin/run pg:upgrade` on an Essential-tier DB without a version flag
```
nmuthu@nmuthu-ltm8kcc cli % ./bin/run pg:upgrade HEROKU_POSTGRESQL_WHITE_URL -a pg-upgrade-test-app
 ›   Warning: We’re deprecating this command. To upgrade your database's Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.
 ›
 ›   Destructive action
 ›   You're upgrading postgresql-rigid-84643 to the latest supported Postgres version.
 ›
 ›   This cannot be undone.
 ›

To proceed, type pg-upgrade-test-app or re-run this command with --confirm pg-upgrade-test-app: pg-upgrade-test-app
Starting upgrade on postgresql-rigid-84643... done
Upgrading
```
4. Run `./bin/run pg:upgrade` on already upgraded Standard-Tier follower DB
```
nmuthu@nmuthu-ltm8kcc cli % ./bin/run pg:upgrade HEROKU_POSTGRESQL_TEAL_URL -a pg-upgrade-test-app
 ›   Warning: We’re deprecating this command. To upgrade your database's Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.
 ›
 ›   Destructive action
 ›   You're upgrading postgresql-cubed-74474 to the latest supported Postgres version. The database will stop following DATABASE and become writable.
 ›
 ›   This cannot be undone.
 ›

To proceed, type pg-upgrade-test-app or re-run this command with --confirm pg-upgrade-test-app: pg-upgrade-test-app
Starting upgrade on postgresql-cubed-74474... !
 ›   Error: database is using a version of Postgres that is not upgradeable at this time.
 ›
 ›   Error ID: unprocessable_entity
```
5. Run `./bin/run pg:upgrade` on a Standard-Tier follower DB
```
nmuthu@nmuthu-ltm8kcc cli % ./bin/run pg:upgrade HEROKU_POSTGRESQL_SILVER_URL -a pg-upgrade-test-app
 ›   Warning: Warning: We’re deprecating this command. To upgrade your database's Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.
 ›
 ›   Destructive action
 ›   You're upgrading postgresql-curved-69780 to the latest supported Postgres version. The database will stop following HEROKU_POSTGRESQL_BRONZE and become writable.
 ›
 ›   This cannot be undone.
 ›

To proceed, type pg-upgrade-test-app or re-run this command with --confirm pg-upgrade-test-app: pg-upgrade-test-app
Starting upgrade on postgresql-curved-69780... done
Upgrading
```
6. `heroku help pg:upgrade`
```
nmuthu@nmuthu-ltm8kcc cli % ./bin/run help pg:upgrade
We’re deprecating this command. To upgrade your database's Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.

USAGE
  $ heroku pg:upgrade [DATABASE] -a <value> [-c <value>] [-v <value>] [-r <value>]

ARGUMENTS
  DATABASE  config var containing the connection string, unique name, ID, or alias of the database. To access another app's database, prepend the app name to the config var or alias with
            `APP_NAME::` . If omitted, we use DATABASE_URL.

FLAGS
  -a, --app=<value>      (required) app to run command against
  -c, --confirm=<value>
  -r, --remote=<value>   git remote of app to use
  -v, --version=<value>  Postgres version to upgrade to

DESCRIPTION
  Warning: We’re deprecating this command. To upgrade your database's Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.

  For an Essential-tier plan, this command upgrades the database's Postgres version. For a Standard-tier and higher plan, this command unfollows the leader database before upgrading the Postgres version.

COMMANDS
  pg:upgrade:prepare  Prepares the upgrade for Standard-tier and higher leader databases and schedules it for the next available maintenance window. Use heroku pg:upgrade:run for
                      Essential-tier or follower databases instead.

```

