### PR TITLE
feat: create pg:upgrade:dryrun command

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -67,6 +67,7 @@ direwolf
 displayer
 dockerfiles
 dropdb
+dryrun
 DVCS
 dxxxxxxxxxxxx
 dyno

--- a/packages/cli/src/commands/pg/upgrade/dryrun.ts
+++ b/packages/cli/src/commands/pg/upgrade/dryrun.ts
@@ -1,0 +1,66 @@
+import color from '@heroku-cli/color'
+import {Command, flags} from '@heroku-cli/command'
+import {Args, ux} from '@oclif/core'
+import heredoc from 'tsheredoc'
+import {getAddon} from '../../../lib/pg/fetcher'
+import pgHost from '../../../lib/pg/host'
+import {legacyEssentialPlan, essentialNumPlan, formatResponseWithCommands} from '../../../lib/pg/util'
+import {PgDatabase, PgUpgradeError, PgUpgradeResponse} from '../../../lib/pg/types'
+import confirmCommand from '../../../lib/confirmCommand'
+import {nls} from '../../../nls'
+
+export default class Upgrade extends Command {
+  static topic = 'pg';
+  static description = heredoc(`
+    simulates a Postgres version upgrade on a Standard-tier and higher leader database by creating and upgrading a follower database.
+    Heroku sends the results of the test upgrade via email.
+  `)
+
+  static flags = {
+    confirm: flags.string({char: 'c'}),
+    version: flags.string({char: 'v', description: 'Postgres version to upgrade to'}),
+    app: flags.app({required: true}),
+  }
+
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
+  }
+
+  public async run(): Promise<void> {
+    const {flags, args} = await this.parse(Upgrade)
+    const {app, version, confirm} = flags
+    const {database} = args
+
+    const db = await getAddon(this.heroku, app, database)
+    if (legacyEssentialPlan(db))
+      ux.error(`You can only use ${color.cmd('pg:upgrade:*')} commands on Essential-* and higher plans.`)
+
+    if (essentialNumPlan(db))
+      ux.error(`You can't use ${color.cmd('pg:upgrade:dryrun')} on Essential tier databases. You can only use this command on Standard-tier and higher leader databases.`)
+
+    const {body: replica} = await this.heroku.get<PgDatabase>(`/client/v11/databases/${db.id}`, {hostname: pgHost()})
+    if (replica.following)
+      ux.error(`You can't use ${color.cmd('pg:upgrade:dryrun')} on follower databases.  You can only use this command on Standard-tier and higher leader databases.`)
+
+    if (version)
+      await confirmCommand(app, confirm, heredoc(`
+          Destructive action
+          This command starts a test upgrade for ${color.addon(db.name)} to Postgres version ${version}.
+      `))
+    else
+      await confirmCommand(app, confirm, heredoc(`
+        Destructive action
+        This command starts a test upgrade for ${color.addon(db.name)} to the latest supported Postgres version.
+      `))
+
+    try {
+      const data = {version}
+      ux.action.start(`Starting a test upgrade on ${color.addon(db.name)}`)
+      const response = await this.heroku.post<PgUpgradeResponse>(`/client/v11/databases/${db.id}/upgrade/dry_run`, {hostname: pgHost(), body: data})
+      ux.action.stop('done\n' + formatResponseWithCommands(response.body.message))
+    } catch (error) {
+      const response = error as PgUpgradeError
+      ux.error(formatResponseWithCommands(response.body.message) + `\n\nError ID: ${response.body.id}`)
+    }
+  }
+}

--- a/packages/cli/src/commands/pg/upgrade/dryrun.ts
+++ b/packages/cli/src/commands/pg/upgrade/dryrun.ts
@@ -36,22 +36,17 @@ export default class Upgrade extends Command {
       ux.error(`You can only use ${color.cmd('pg:upgrade:*')} commands on Essential-* and higher plans.`)
 
     if (essentialNumPlan(db))
-      ux.error(`You can't use ${color.cmd('pg:upgrade:dryrun')} on Essential tier databases. You can only use this command on Standard-tier and higher leader databases.`)
+      ux.error(`You can't use ${color.cmd('pg:upgrade:dryrun')} on Essential-tier databases. You can only use this command on Standard-tier and higher leader databases.`)
 
+    const versionPhrase = version ? heredoc(`Postgres version ${version}`) : heredoc('the latest supported Postgres version')
     const {body: replica} = await this.heroku.get<PgDatabase>(`/client/v11/databases/${db.id}`, {hostname: pgHost()})
     if (replica.following)
       ux.error(`You can't use ${color.cmd('pg:upgrade:dryrun')} on follower databases. You can only use this command on Standard-tier and higher leader databases.`)
 
-    if (version)
-      await confirmCommand(app, confirm, heredoc(`
-          Destructive action
-          This command starts a test upgrade for ${color.addon(db.name)} to Postgres version ${version}.
-      `))
-    else
-      await confirmCommand(app, confirm, heredoc(`
+    await confirmCommand(app, confirm, heredoc(`
         Destructive action
-        This command starts a test upgrade for ${color.addon(db.name)} to the latest supported Postgres version.
-      `))
+        This command starts a test upgrade for ${color.addon(db.name)} to ${versionPhrase}.
+    `))
 
     try {
       const data = {version}

--- a/packages/cli/src/commands/pg/upgrade/dryrun.ts
+++ b/packages/cli/src/commands/pg/upgrade/dryrun.ts
@@ -40,7 +40,7 @@ export default class Upgrade extends Command {
 
     const {body: replica} = await this.heroku.get<PgDatabase>(`/client/v11/databases/${db.id}`, {hostname: pgHost()})
     if (replica.following)
-      ux.error(`You can't use ${color.cmd('pg:upgrade:dryrun')} on follower databases.  You can only use this command on Standard-tier and higher leader databases.`)
+      ux.error(`You can't use ${color.cmd('pg:upgrade:dryrun')} on follower databases. You can only use this command on Standard-tier and higher leader databases.`)
 
     if (version)
       await confirmCommand(app, confirm, heredoc(`

--- a/packages/cli/test/unit/commands/pg/upgrade/dryrun.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/upgrade/dryrun.unit.test.ts
@@ -1,0 +1,195 @@
+import {stderr} from 'stdout-stderr'
+import Cmd from '../../../../../src/commands/pg/upgrade/dryrun'
+import runCommand from '../../../../helpers/runCommand'
+import expectOutput from '../../../../helpers/utils/expectOutput'
+import {expect} from 'chai'
+import * as nock from 'nock'
+import heredoc from 'tsheredoc'
+import * as fixtures from '../../../../fixtures/addons/fixtures'
+import color from '@heroku-cli/color'
+import {ux} from '@oclif/core'
+import * as sinon from 'sinon'
+const stripAnsi = require('strip-ansi')
+
+describe('pg:upgrade:dryrun', function () {
+  const addon = fixtures.addons['dwh-db']
+  let uxWarnStub: sinon.SinonStub
+  let uxPromptStub: sinon.SinonStub
+
+  before(function () {
+    uxWarnStub = sinon.stub(ux, 'warn')
+    uxPromptStub = sinon.stub(ux, 'prompt').resolves('myapp')
+  })
+
+  beforeEach(async function () {
+    uxWarnStub.resetHistory()
+    uxPromptStub.resetHistory()
+  })
+
+  afterEach(async function () {
+    nock.cleanAll()
+  })
+
+  after(function () {
+    uxWarnStub.restore()
+    uxPromptStub.restore()
+  })
+
+  it('refuses to start test upgrade on legacy essential dbs', async function () {
+    const hobbyAddon = fixtures.addons['www-db']
+
+    nock('https://api.heroku.com')
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, [{addon: hobbyAddon}])
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+      '--confirm',
+      'myapp',
+    ]).catch(error => {
+      expectOutput(error.message, heredoc(`
+      You can only use ${color.cmd('pg:upgrade:*')} commands on Essential-* and higher plans.
+    `))
+    })
+  })
+
+  it('refuses to start test upgrade on essential tier dbs', async function () {
+    const essentialAddon = {
+      name: 'postgres-1', plan: {name: 'heroku-postgresql:essential-0'},
+    }
+
+    nock('https://api.heroku.com')
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, [{addon: essentialAddon}])
+
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+      '--confirm',
+      'myapp',
+    ]).catch(error => {
+      expect(error.message).to.equal(`You can't use ${color.cmd('pg:upgrade:dryrun')} on Essential tier databases. You can only use this command on Standard-tier and higher leader databases.`)
+    })
+  })
+
+  it('refuses to start test upgrade on follower dbs', async function () {
+    nock('https://api.heroku.com')
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, [{addon: addon}])
+    nock('https://api.data.heroku.com')
+      .get(`/client/v11/databases/${addon.id}`)
+      .reply(200, {
+        following: 'postgres://xxx.com:5432/abcdefghijklmn',
+        leader: {
+          addon_id: '5ba2ba8b-07a9-4a65-a808-585a50e37f98',
+          name: 'postgresql-leader',
+        },
+      })
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+      '--confirm',
+      'myapp',
+    ]).catch(error => {
+      expectOutput(error.message, heredoc(`
+      You can't use ${color.cmd('pg:upgrade:dryrun')} on follower databases.  You can only use this command on Standard-tier and higher leader databases.    `))
+    })
+  })
+
+  it('starts test upgrade on a db with version flag', async function () {
+    nock('https://api.heroku.com')
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, [{addon}])
+    nock('https://api.heroku.com')
+      .get('/apps/myapp/config-vars')
+      .reply(200, {DATABASE_URL: 'postgres://db1'})
+    nock('https://api.data.heroku.com')
+      .get(`/client/v11/databases/${addon.id}`)
+      .reply(200)
+    nock('https://api.data.heroku.com')
+      .post(`/client/v11/databases/${addon.id}/upgrade/dry_run`)
+      .reply(200, {message: "Started test upgrade. We'll notify you via email when it's complete."})
+
+    const message = heredoc(`
+      Destructive action
+      This command starts a test upgrade for ${addon.name} to Postgres version 15.
+      `)
+
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+      '--version',
+      '15',
+    ])
+
+    expect(stripAnsi(uxPromptStub.args[0].toString())).contains('To proceed, type myapp')
+    expect(stripAnsi(uxWarnStub.args[0].toString())).to.eq(message)
+
+    expectOutput(stderr.output, heredoc(`
+      Starting a test upgrade on ${addon.name}...
+      Starting a test upgrade on ${addon.name}... done
+      Started test upgrade. We'll notify you via email when it's complete.
+    `))
+  })
+
+  it('starts test upgrade on a db without a version flag', async function () {
+    nock('https://api.heroku.com')
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, [{addon}])
+    nock('https://api.heroku.com')
+      .get('/apps/myapp/config-vars')
+      .reply(200, {DATABASE_URL: 'postgres://db1'})
+    nock('https://api.data.heroku.com')
+      .get(`/client/v11/databases/${addon.id}`)
+      .reply(200)
+    nock('https://api.data.heroku.com')
+      .post(`/client/v11/databases/${addon.id}/upgrade/dry_run`)
+      .reply(200, {message: "Started test upgrade. We'll notify you via email when it's complete."})
+
+    const message = heredoc(`
+      Destructive action
+      This command starts a test upgrade for ${addon.name} to the latest supported Postgres version.
+      `)
+
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+    ])
+
+    expect(stripAnsi(uxPromptStub.args[0].toString())).contains('To proceed, type myapp')
+    expect(stripAnsi(uxWarnStub.args[0].toString())).to.eq(message)
+
+    expectOutput(stderr.output, heredoc(`
+      Starting a test upgrade on ${addon.name}...
+      Starting a test upgrade on ${addon.name}... done
+      Started test upgrade. We'll notify you via email when it's complete.
+    `))
+  })
+
+  it('errors if version upgrade task is running', async function () {
+    nock('https://api.heroku.com')
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, [{addon}])
+    nock('https://api.heroku.com')
+      .get('/apps/myapp/config-vars')
+      .reply(200, {DATABASE_URL: 'postgres://db1'})
+    nock('https://api.data.heroku.com')
+      .get(`/client/v11/databases/${addon.id}`)
+      .reply(200)
+    nock('https://api.data.heroku.com')
+      .post(`/client/v11/databases/${addon.id}/upgrade/dry_run`)
+      .reply(422, {id: 'unprocessable_entity', message: 'database is in the middle of a version upgrade. To perform this action, wait until the upgrade is complete and try again.'})
+
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+      '--confirm',
+      'myapp',
+    ]).catch(error => {
+      expect(error.message).to.equal(heredoc(`
+      database is in the middle of a version upgrade. To perform this action, wait until the upgrade is complete and try again.
+      
+      Error ID: unprocessable_entity`))
+    })
+  })
+})

--- a/packages/cli/test/unit/commands/pg/upgrade/dryrun.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/upgrade/dryrun.unit.test.ts
@@ -92,7 +92,7 @@ describe('pg:upgrade:dryrun', function () {
       'myapp',
     ]).catch(error => {
       expectOutput(error.message, heredoc(`
-      You can't use ${color.cmd('pg:upgrade:dryrun')} on follower databases.  You can only use this command on Standard-tier and higher leader databases.    `))
+      You can't use ${color.cmd('pg:upgrade:dryrun')} on follower databases. You can only use this command on Standard-tier and higher leader databases.`))
     })
   })
 

--- a/packages/cli/test/unit/commands/pg/upgrade/dryrun.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/upgrade/dryrun.unit.test.ts
@@ -68,7 +68,7 @@ describe('pg:upgrade:dryrun', function () {
       '--confirm',
       'myapp',
     ]).catch(error => {
-      expect(error.message).to.equal(`You can't use ${color.cmd('pg:upgrade:dryrun')} on Essential tier databases. You can only use this command on Standard-tier and higher leader databases.`)
+      expect(error.message).to.equal(`You can't use ${color.cmd('pg:upgrade:dryrun')} on Essential-tier databases. You can only use this command on Standard-tier and higher leader databases.`)
     })
   })
 


### PR DESCRIPTION
This PR creates the pg:upgrade:dryrun command.

Work item: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002BO2UbYAL/view

Please refer to [this doc](https://docs.google.com/document/d/1FEIQPkWRggz_XWzU3PRI6pFg00TwUKIjqft4IGzCOsY/edit?usp=sharing) for more information related to the new pg:upgrade:* commands

## Testing
**pg:upgrade:dryrun on essential tier db**
<img width="1657" alt="Screenshot 2025-04-03 at 2 36 48 PM" src="https://github.com/user-attachments/assets/114f4a78-ee1f-4839-8d31-01d52b4fd741" />

**pg:upgrade:dryrun on follower db**
<img width="1594" alt="Screenshot 2025-04-03 at 2 46 02 PM" src="https://github.com/user-attachments/assets/56a81be4-0e12-4be9-823d-b893419171d4" />


**pg:upgrade:dryrun on leader db with version flag**
<img width="1324" alt="Screenshot 2025-04-03 at 2 36 58 PM" src="https://github.com/user-attachments/assets/6e66b1d0-d8bd-4b8e-a0a8-8cfec6e66ca9" />

**pg:upgrade:dryrun on leader db without version flag**
<img width="1298" alt="Screenshot 2025-04-03 at 2 37 10 PM" src="https://github.com/user-attachments/assets/9e513636-008c-46cb-9e86-d2edb647a54c" />


**pg:upgrade:dryrun on leader db when version upgrade is going on**
<img width="1480" alt="Screenshot 2025-04-03 at 2 37 25 PM" src="https://github.com/user-attachments/assets/a3cf99de-6747-4b40-9043-e91b92a88cde" />

**pg:upgrade:dryrun help**
<img width="1728" alt="Screenshot 2025-04-03 at 2 38 57 PM" src="https://github.com/user-attachments/assets/080d612f-a139-4a78-8c3e-b969971666e4" />
