### PR TITLE
feat: adding pg:upgrade:wait command

### DIFF
--- a/packages/cli/src/commands/pg/upgrade/wait.ts
+++ b/packages/cli/src/commands/pg/upgrade/wait.ts
@@ -1,0 +1,94 @@
+import color from '@heroku-cli/color'
+import {Command, flags} from '@heroku-cli/command'
+import {Args, ux} from '@oclif/core'
+import debug from 'debug'
+import heredoc from 'tsheredoc'
+import {getAddon} from '../../../lib/pg/fetcher'
+import pgHost from '../../../lib/pg/host'
+import notify from '../../../lib/notify'
+import {AddOnAttachmentWithConfigVarsAndPlan, AddOnWithRelatedData, PgUpgradeStatus} from '../../../lib/pg/types'
+import {HTTPError} from '@heroku/http-call'
+import {nls} from '../../../nls'
+
+const wait = (ms: number) => new Promise(resolve => {
+  setTimeout(resolve, ms)
+})
+
+export default class Wait extends Command {
+  static topic = 'pg'
+  static description = 'blocks until database is available'
+  static flags = {
+    'wait-interval': flags.string({description: 'how frequently to poll in seconds (to avoid rate limiting)'}),
+    'no-notify': flags.boolean({description: 'do not show OS notification'}),
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+  }
+
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:all-dbs:suffix')}`}),
+  }
+
+  public async run(): Promise<void> {
+    const {flags, args} = await this.parse(Wait)
+    const {app, 'wait-interval': waitInterval} = flags
+    const dbName = args.database
+    const pgDebug = debug('pg')
+
+    const waitFor = async (db: AddOnAttachmentWithConfigVarsAndPlan | AddOnWithRelatedData) => {
+      let interval = waitInterval && Number.parseInt(waitInterval, 10)
+      if (!interval || interval < 0) interval = 5
+      let status
+      let waiting = false
+      let retries = 20
+      const notFoundMessage = 'Waiting to provision...'
+
+      while (true) {
+        try {
+          ({body: status} = await this.heroku.get<PgUpgradeStatus>(
+            `/client/v11/databases/${db.id}/upgrade/wait_status`,
+            {hostname: pgHost()},
+          ))
+        } catch (error) {
+          const httpError = error as HTTPError
+          pgDebug(httpError)
+          if (!retries || httpError.statusCode !== 404) throw httpError
+          retries--
+          status = {'waiting?': true, message: notFoundMessage}
+        }
+
+        if (status['error?']) {
+          notify('error', `${db.name} ${status.message}`, false)
+          ux.error(status.message || '', {exit: 1})
+        }
+
+        if (!status['waiting?']) {
+          if (waiting) {
+            ux.action.stop(status.message)
+          }
+
+          return
+        }
+
+        if (!waiting) {
+          waiting = true
+          ux.action.start(`Waiting for upgrade on database ${color.yellow(db.name)}`, status.message)
+        }
+
+        ux.action.status = status.message
+
+        await wait(interval * 1000)
+      }
+    }
+
+    let dbs: AddOnAttachmentWithConfigVarsAndPlan[] | AddOnWithRelatedData[] | [] = []
+    if (dbName) {
+      dbs = [await getAddon(this.heroku, app, dbName)]
+    } else {
+      ux.error(heredoc('Please provide a database.'))
+    }
+
+    for (const db of dbs) {
+      await waitFor(db)
+    }
+  }
+}

--- a/packages/cli/src/commands/pg/upgrade/wait.ts
+++ b/packages/cli/src/commands/pg/upgrade/wait.ts
@@ -70,7 +70,7 @@ export default class Wait extends Command {
           if (waiting) {
             ux.action.stop(message)
           } else {
-            ux.log(message)
+            ux.log(heredoc(`Waiting for database ${color.yellow(db.name)}... ${message}`))
           }
 
           return

--- a/packages/cli/src/lib/pg/types.ts
+++ b/packages/cli/src/lib/pg/types.ts
@@ -135,6 +135,7 @@ export type PgUpgradeStatus = {
   'waiting?': boolean
   'error?': boolean
   message: string
+  step: string
 }
 
 type TenantInfoNames =

--- a/packages/cli/src/lib/pg/types.ts
+++ b/packages/cli/src/lib/pg/types.ts
@@ -131,6 +131,12 @@ export type PgStatus = {
   message: string
 }
 
+export type PgUpgradeStatus = {
+  'waiting?': boolean
+  'error?': boolean
+  message: string
+}
+
 type TenantInfoNames =
   'Plan'
   | 'Status'

--- a/packages/cli/test/unit/commands/pg/upgrade/wait.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/upgrade/wait.unit.test.ts
@@ -1,0 +1,79 @@
+import {stdout, stderr} from 'stdout-stderr'
+import {expect} from 'chai'
+import * as nock from 'nock'
+import * as proxyquire from 'proxyquire'
+import heredoc from 'tsheredoc'
+import {CLIError} from '@oclif/core/lib/errors'
+import runCommand from '../../../../helpers/runCommand'
+import expectOutput from '../../../../helpers/utils/expectOutput'
+
+const all = [
+  {id: 1, name: 'postgres-1', plan: {name: 'heroku-postgresql:hobby-dev'}},
+  {id: 2, name: 'postgres-2', plan: {name: 'heroku-postgresql:hobby-dev'}},
+]
+const fetcher =  {
+  all: () => Promise.resolve(all),
+  getAddon: () => Promise.resolve(all[0]),
+}
+
+const {default: Cmd} = proxyquire('../../../../../src/commands/pg/upgrade/wait', {
+  '../../../lib/pg/fetcher': fetcher,
+})
+
+describe('pg:upgrade:wait', function () {
+  let pg: nock.Scope
+
+  beforeEach(function () {
+    pg = nock('https://api.data.heroku.com')
+  })
+
+  afterEach(function () {
+    pg.done()
+    nock.cleanAll()
+  })
+
+  it('waits till upgrade is finished', async function () {
+    pg
+      .get('/client/v11/databases/1/upgrade/wait_status').reply(200, {'waiting?': true, message: 'preparing upgrade service'})
+      .get('/client/v11/databases/1/upgrade/wait_status').reply(200, {'waiting?': false, message: 'recreating followers', step: '(7/7)'})
+
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+      '--wait-interval',
+      '1',
+      'DATABASE_URL',
+    ])
+    expect(stdout.output).to.equal('')
+    expectOutput(stderr.output, heredoc(`
+      Waiting for database postgres-1... preparing upgrade service
+      Waiting for database postgres-1... (7/7) recreating followers
+    `))
+  })
+
+  it('requires a database', async function () {
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+    ]).catch(error => {
+      expectOutput(error.message, heredoc(`
+      You must provide a database. Run \`--help\` for more information on the command.
+    `))
+    })
+  })
+
+  it('displays errors', async function () {
+    pg
+      .get('/client/v11/databases/1/upgrade/wait_status').reply(200, {'error?': true, message: 'this is an error message'})
+
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+      'DATABASE_URL',
+    ]).catch(error => {
+      const {message, oclif} = error as CLIError
+      expect(message).to.equal('this is an error message')
+      expect(oclif.exit).to.equal(1)
+    })
+  })
+})

--- a/packages/cli/test/unit/commands/pg/upgrade/wait.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/upgrade/wait.unit.test.ts
@@ -62,7 +62,7 @@ describe('pg:upgrade:wait', function () {
       '1',
       'DATABASE_URL',
     ])
-    expect(stdout.output).to.equal('upgrade is scheduled on 2025-04-17 20:30:00 UTC. You could also run the upgrade immediately using heroku pg:upgrade:run.\n')
+    expect(stdout.output).to.equal('Waiting for database postgres-1... upgrade is scheduled on 2025-04-17 20:30:00 UTC. You could also run the upgrade immediately using heroku pg:upgrade:run.\n')
   })
 
   it('requires a database', async function () {

--- a/packages/cli/test/unit/commands/pg/upgrade/wait.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/upgrade/wait.unit.test.ts
@@ -35,7 +35,7 @@ describe('pg:upgrade:wait', function () {
   it('waits till upgrade is finished', async function () {
     pg
       .get('/client/v11/databases/1/upgrade/wait_status').reply(200, {'waiting?': true, message: 'preparing upgrade service'})
-      .get('/client/v11/databases/1/upgrade/wait_status').reply(200, {'waiting?': false, message: 'recreating followers', step: '(7/7)'})
+      .get('/client/v11/databases/1/upgrade/wait_status').reply(200, {'waiting?': false, message: 'recreating followers', step: '7/7'})
 
     await runCommand(Cmd, [
       '--app',
@@ -49,6 +49,20 @@ describe('pg:upgrade:wait', function () {
       Waiting for database postgres-1... preparing upgrade service
       Waiting for database postgres-1... (7/7) recreating followers
     `))
+  })
+
+  it('displays when the upgrade has been scheduled', async function () {
+    pg
+      .get('/client/v11/databases/1/upgrade/wait_status').reply(200, {'waiting?': false, message: 'upgrade is scheduled on 2025-04-17 20:30:00 UTC. You could also run the upgrade immediately using `heroku pg:upgrade:run`.'})
+
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+      '--wait-interval',
+      '1',
+      'DATABASE_URL',
+    ])
+    expect(stdout.output).to.equal('upgrade is scheduled on 2025-04-17 20:30:00 UTC. You could also run the upgrade immediately using heroku pg:upgrade:run.\n')
   })
 
   it('requires a database', async function () {

--- a/packages/cli/test/unit/commands/pg/wait.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/wait.unit.test.ts
@@ -77,4 +77,23 @@ describe('pg:wait', function () {
       expect(oclif.exit).to.equal(1)
     })
   })
+
+  it('receives steps but does not display them', async function () {
+    pg
+      .get('/client/v11/databases/1/wait_status').reply(200, {'waiting?': true, message: 'upgrading', step: '1/3'})
+      .get('/client/v11/databases/1/wait_status').reply(200, {'waiting?': false, message: 'available'})
+
+    await runCommand(Cmd, [
+      '--app',
+      'myapp',
+      '--wait-interval',
+      '1',
+      'DATABASE_URL',
+    ])
+    expect(stdout.output).to.equal('')
+    expectOutput(stderr.output, heredoc(`
+      Waiting for database postgres-1... upgrading
+      Waiting for database postgres-1... available
+    `))
+  })
 })


### PR DESCRIPTION
[Work item
](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002BO0O1YAL/view)

This PR creates the `pg:upgrade:wait` command.

Please refer to [this doc](https://docs.google.com/document/d/1FEIQPkWRggz_XWzU3PRI6pFg00TwUKIjqft4IGzCOsY/edit?usp=sharing) for more information related to [pg:upgrade:wait](https://docs.google.com/document/d/1FEIQPkWRggz_XWzU3PRI6pFg00TwUKIjqft4IGzCOsY/edit?tab=t.0#bookmark=id.bww98j4t3jb1).

## Testing
Check out this branch and run `yarn && yarn build`
1. Run `./bin/run pg:upgrade:prepare` on a Standard-Tier leader DB and then `pg:upgrade:wait` to see it prepare
```
nmuthu@nmuthu-ltm8kcc cli % ./bin/run pg:upgrade:prepare HEROKU_POSTGRESQL_PUCE_URL -a pg-upgrade-test-app
 ›   Warning: Destructive action
 ›   This command prepares the upgrade for postgresql-flat-28316 to the latest supported Postgres version and schedules to upgrade it during the next available maintenance window.
 ›

To proceed, type pg-upgrade-test-app or re-run this command with --confirm pg-upgrade-test-app: pg-upgrade-test-app
Preparing upgrade on postgresql-flat-28316... done
Your database is scheduled for upgrade during your next available maintenance window.
Run heroku pg:upgrade:wait to track its status.
You can also run this upgrade manually before the maintenance window with heroku pg:upgrade:run. Note: You can only run the upgrade after it's fully prepared, which can take up to a day.

nmuthu@nmuthu-ltm8kcc cli % ./bin/run pg:upgrade:wait HEROKU_POSTGRESQL_PUCE_URL -a pg-upgrade-test-app
Waiting for database postgresql-flat-28316... ⡿ preparing service for upgrade
```
2. Run `./bin/run pg:upgrade:run` on a Standard-Tier leader DB with an upgrade prepared and then `pg:upgrade:wait` to see it run

https://github.com/user-attachments/assets/63aea477-9409-4295-99f2-f0299a03d6d1

3. Run `./bin/run pg:upgrade:wait` after starting an upgrade on essential db
```
nmuthu@nmuthu-ltm8kcc cli % ./bin/run pg:upgrade:wait HEROKU_POSTGRESQL_PURPLE_URL -a pg-upgrade-test-app
Waiting for database postgresql-flat-11475... ⣟ version upgrade: provisioning
```
5. Run `./bin/run pg:upgrade:wait` with no database argument
```
nmuthu@nmuthu-ltm8kcc cli % ./bin/run pg:upgrade:wait -a pg-upgrade-test-app
 ›   Error: You must provide a database. Run `--help` for more information on the command.
```
6. `pg:upgrade:wait` when upgrade has been scheduled (shouldn't wait)
```
nmuthu@nmuthu-ltm8kcc cli % ./bin/run pg:upgrade:wait HEROKU_POSTGRESQL_PUCE_URL -a pg-upgrade-test-app
Waiting for database postgresql-flat-11475... upgrade is scheduled on 2025-04-17 20:30:00 UTC. You could also run the upgrade immediately using the pg:upgrade:run.
```
7.`heroku help pg:upgrade:wait`
```
nmuthu@nmuthu-ltm8kcc cli % ./bin/run help pg:upgrade:wait
provides the status of an upgrade and blocks it until the operation is complete

USAGE
  $ heroku pg:upgrade:wait [DATABASE] -a <value> [--wait-interval <value>] [--no-notify] [-r <value>]

ARGUMENTS
  DATABASE  config var containing the connection string, unique name, ID, or alias of the database. To access another app's database, prepend the app name to the config var or alias with
            `APP_NAME::`

FLAGS
  -a, --app=<value>        (required) app to run command against
  -r, --remote=<value>     git remote of app to use
  --no-notify              do not show OS notification
  --wait-interval=<value>  how frequently to poll in seconds (to avoid rate limiting)

DESCRIPTION
  provides the status of an upgrade and blocks it until the operation is complete
```

