### PR TITLE
feat: add team option to usage:addons command

### DIFF
--- a/packages/cli/src/commands/usage/addons.ts
+++ b/packages/cli/src/commands/usage/addons.ts
@@ -89,7 +89,7 @@ export default class UsageAddons extends Command {
     const usageAddons = usageData.addons
 
     if (usageAddons.length === 0) {
-      ux.log(`No usage found for ${app}`)
+      ux.log(`No usage found for app ${color.app(app)}`)
       return
     }
 
@@ -111,7 +111,7 @@ export default class UsageAddons extends Command {
     ux.log()
 
     if (!usageData.apps || usageData.apps.length === 0) {
-      ux.log(`No usage found for team ${team}`)
+      ux.log(`No usage found for team ${color.magenta(team)}`)
       return
     }
 
@@ -143,7 +143,7 @@ export default class UsageAddons extends Command {
     const {flags} = await this.parse(UsageAddons)
     const {app, team} = flags
     if (!app && !team) {
-      this.error('Specify an app with --app or a team with --team')
+      ux.error('Specify an app with --app or a team with --team')
     }
 
     if (app) {

--- a/packages/cli/src/commands/usage/addons.ts
+++ b/packages/cli/src/commands/usage/addons.ts
@@ -18,32 +18,11 @@ export default class UsageAddons extends Command {
   static topic = 'usage'
   static description = 'list usage values for metered addons associated with a given app'
   static flags = {
-    app: flags.app({required: true}),
+    app: flags.string(),
+    team: flags.string(),
   }
 
-  public async run(): Promise<void> {
-    const {flags} = await this.parse(UsageAddons)
-    const {app} = flags
-    ux.action.start('Gathering usage data')
-    const [usageResponse, {body: appAddons}] = await Promise.all([
-      this.heroku.get<unknown>(`/apps/${app}/usage`, {
-        headers: {
-          Accept: 'application/vnd.heroku+json; version=3.sdk',
-        },
-      }),
-      this.heroku.get<Heroku.AddOn[]>(`/apps/${app}/addons`),
-    ])
-    ux.action.stop()
-    ux.log()
-    const usageApp = usageResponse.body
-    const usageData: AppUsage = typeof usageApp === 'string' ? JSON.parse(usageApp) : usageApp
-    const usageAddons = usageData.addons
-
-    if (usageAddons.length === 0) {
-      ux.log(`No usage found for ${app}`)
-      return
-    }
-
+  private displayAppUsage(app: string, usageAddons: AppUsage['addons'], appAddons: Heroku.AddOn[]): void {
     const metersArray = usageAddons.flatMap(addon =>
       Object.entries(addon.meters).map(([label, data]) => ({
         label,
@@ -67,5 +46,84 @@ export default class UsageAddons extends Command {
         get: row => row.quantity,
       },
     })
+  }
+
+  private async fetchAndDisplayAppUsageData(app: string, team?: string): Promise<void> {
+    let usageResponse
+    let appAddons
+    ux.action.start('Gathering usage data')
+    if (team) {
+      [usageResponse, {body: appAddons}] = await Promise.all([
+        this.heroku.get<unknown>(`/teams/${team}/apps/${app}/usage`, {
+          headers: {
+            Accept: 'application/vnd.heroku+json; version=3.sdk',
+          },
+        }),
+        this.heroku.get<Heroku.AddOn[]>(`/apps/${app}/addons`),
+      ])
+    } else {
+      [usageResponse, {body: appAddons}] = await Promise.all([
+        this.heroku.get<unknown>(`/apps/${app}/usage`, {
+          headers: {
+            Accept: 'application/vnd.heroku+json; version=3.sdk',
+          },
+        }),
+        this.heroku.get<Heroku.AddOn[]>(`/apps/${app}/addons`),
+      ])
+    }
+
+    ux.action.stop()
+    ux.log()
+    const usageApp = usageResponse.body
+    const usageData: AppUsage = typeof usageApp === 'string' ? JSON.parse(usageApp) : usageApp
+    const usageAddons = usageData.addons
+
+    if (usageAddons.length === 0) {
+      ux.log(`No usage found for ${app}`)
+      return
+    }
+
+    this.displayAppUsage(app, usageAddons, appAddons)
+  }
+
+  private async fetchAndDisplayTeamUsageData(team: string): Promise<void> {
+    ux.action.start('Gathering usage data')
+    const [usageResponse, {body: teamAddons}] = await Promise.all([
+      this.heroku.get<unknown>(`/teams/${team}/usage`, {
+        headers: {
+          Accept: 'application/vnd.heroku+json; version=3.sdk',
+        },
+      }),
+      this.heroku.get<Heroku.AddOn[]>(`/teams/${team}/addons`),
+    ])
+
+    ux.action.stop()
+    ux.log()
+    const usageData = typeof usageResponse.body === 'string' ? JSON.parse(usageResponse.body) : usageResponse.body
+
+    if (!usageData.apps || usageData.apps.length === 0) {
+      ux.log(`No usage found for team ${team}`)
+      return
+    }
+
+    // Display usage for each app
+    usageData.apps.forEach((app: { id: string; addons: any[] }) => {
+      this.displayAppUsage(app.id, app.addons, teamAddons)
+      ux.log() // Add spacing between apps
+    })
+  }
+
+  public async run(): Promise<void> {
+    const {flags} = await this.parse(UsageAddons)
+    const {app, team} = flags
+    if (!app && !team) {
+      this.error('Specify an app with --app or a team with --team')
+    }
+
+    if (app) {
+      await this.fetchAndDisplayAppUsageData(app, team)
+    } else if (team) {
+      await this.fetchAndDisplayTeamUsageData(team)
+    }
   }
 }

--- a/packages/cli/test/unit/commands/usage/addons.unit.test.ts
+++ b/packages/cli/test/unit/commands/usage/addons.unit.test.ts
@@ -15,63 +15,148 @@ describe('usage:addons', function () {
     nock.cleanAll()
   })
 
-  it('shows usage for metered addons', async function () {
-    const app = 'myapp'
-    const usage = {
-      addons: [{
-        id: 'redis-123',
-        meters: {
-          'Data Storage': {
-            quantity: 2.5,
+  describe('app usage', function () {
+    it('shows usage for metered addons', async function () {
+      const app = 'myapp'
+      const usage = {
+        addons: [{
+          id: 'redis-123',
+          meters: {
+            'Data Storage': {
+              quantity: 2.5,
+            },
+            Connections: {
+              quantity: 100,
+            },
           },
-          Connections: {
-            quantity: 100,
-          },
-        },
-      }],
-    }
+        }],
+      }
 
-    nock('https://api.heroku.com')
-      .get(`/apps/${app}/usage`)
-      .reply(200, usage)
+      nock('https://api.heroku.com')
+        .get(`/apps/${app}/usage`)
+        .reply(200, usage)
 
-    nock('https://api.heroku.com')
-      .get(`/apps/${app}/addons`)
-      .reply(200, [redisAddon])
+      nock('https://api.heroku.com')
+        .get(`/apps/${app}/addons`)
+        .reply(200, [redisAddon])
 
-    await runCommand(Cmd, [
-      '--app',
-      app,
-    ])
+      await runCommand(Cmd, [
+        '--app',
+        app,
+      ])
 
-    expectOutput(stdout.output, heredoc(`
-      === Usage for ⬢ ${app}
-       Addon     Meter        Quantity
-       ───────── ──────────── ────────
-       redis-123 Data Storage 2.5
-       redis-123 Connections  100
-    `))
+      expectOutput(stdout.output, heredoc(`
+        === Usage for ⬢ ${app}
+         Addon     Meter        Quantity
+         ───────── ──────────── ────────
+         redis-123 Data Storage 2.5
+         redis-123 Connections  100
+      `))
+    })
+
+    it('handles apps with no usage', async function () {
+      const app = 'myapp'
+      const usage = {
+        addons: [],
+      }
+
+      nock('https://api.heroku.com')
+        .get(`/apps/${app}/usage`)
+        .reply(200, usage)
+
+      nock('https://api.heroku.com')
+        .get(`/apps/${app}/addons`)
+        .reply(200, [])
+
+      await runCommand(Cmd, [
+        '--app',
+        app,
+      ])
+
+      expectOutput(stdout.output, `No usage found for app ⬢ ${app}`)
+    })
   })
 
-  it('handles apps with no usage', async function () {
-    const app = 'myapp'
-    const usage = {
-      addons: [],
-    }
+  describe('team usage', function () {
+    it('shows usage for team apps with metered addons', async function () {
+      const team = 'myteam'
+      const app1 = 'app1'
+      const app2 = 'app2'
+      const usage = {
+        apps: [{
+          id: app1,
+          addons: [{
+            id: 'redis-123',
+            meters: {
+              'Data Storage': {
+                quantity: 2.5,
+              },
+            },
+          }],
+        }, {
+          id: app2,
+          addons: [{
+            id: 'redis-456',
+            meters: {
+              'Data Storage': {
+                quantity: 5,
+              },
+            },
+          }],
+        }],
+      }
 
-    nock('https://api.heroku.com')
-      .get(`/apps/${app}/usage`)
-      .reply(200, usage)
+      const teamAddons = [
+        {...redisAddon, id: 'redis-1', name: 'redis-123', app: {id: app1, name: 'App One'}},
+        {...redisAddon, id: 'redis-2', name: 'redis-456', app: {id: app2, name: 'App Two'}},
+      ]
 
-    nock('https://api.heroku.com')
-      .get(`/apps/${app}/addons`)
-      .reply(200, [])
+      nock('https://api.heroku.com')
+        .get(`/teams/${team}/usage`)
+        .reply(200, usage)
 
-    await runCommand(Cmd, [
-      '--app',
-      app,
-    ])
+      nock('https://api.heroku.com')
+        .get(`/teams/${team}/addons`)
+        .reply(200, teamAddons)
 
-    expectOutput(stdout.output, `No usage found for ${app}`)
+      await runCommand(Cmd, [
+        '--team',
+        team,
+      ])
+
+      expectOutput(stdout.output, heredoc(`
+        === Usage for ⬢ App One
+         Addon     Meter        Quantity
+         ───────── ──────────── ────────
+         redis-123 Data Storage 2.5
+
+        === Usage for ⬢ App Two
+         Addon     Meter        Quantity
+         ───────── ──────────── ────────
+         redis-456 Data Storage 5
+      `))
+    })
+
+    it('handles teams with no usage', async function () {
+      const team = 'myteam'
+      const usage = {
+        apps: [],
+      }
+
+      nock('https://api.heroku.com')
+        .get(`/teams/${team}/usage`)
+        .reply(200, usage)
+
+      nock('https://api.heroku.com')
+        .get(`/teams/${team}/addons`)
+        .reply(200, [])
+
+      await runCommand(Cmd, [
+        '--team',
+        team,
+      ])
+
+      expectOutput(stdout.output, `No usage found for team ${team}`)
+    })
   })
 })


### PR DESCRIPTION
[W-18033605](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002B2o29YAB/view)

### Description

This adds the `--team` option to the `usage:addons` command. It will list all the apps and any metered addons with their values:

<img width="474" alt="Screenshot 2025-04-04 at 1 40 53 PM" src="https://github.com/user-attachments/assets/2e00a3b3-90d7-471f-9a50-7a8fe3605fdf" />


### Testing

1. Pull down branch and `yarn build`
2. `./bin/run  usage:addons --team TEAM` where team is a heroku team that has metered addons in one or more of its apps
3. `./bin/run  usage:addons --team TEAM` where team is a heroku team that has no metered addons
