### PR TITLE
Fix display and update of grpc vs httpc transport protocol

### DIFF
--- a/packages/cli/src/commands/telemetry/info.ts
+++ b/packages/cli/src/commands/telemetry/info.ts
@@ -20,6 +20,6 @@ export default class Info extends Command {
         Accept: 'application/vnd.heroku+json; version=3.sdk',
       },
     })
-    displayTelemetryDrain(telemetryDrain)
+    await displayTelemetryDrain(telemetryDrain, this.heroku)
   }
 }

--- a/packages/cli/src/commands/telemetry/update.ts
+++ b/packages/cli/src/commands/telemetry/update.ts
@@ -49,7 +49,7 @@ export default class Update extends Command {
       }
 
       if (transport) {
-        exporter.type = `otlp${transport}`
+        exporter.type = (transport === 'grpc') ? 'otlp' : 'otlphttp'
       }
 
       drainConfig.exporter = exporter
@@ -64,6 +64,6 @@ export default class Update extends Command {
     })
     ux.action.stop()
 
-    displayTelemetryDrain(telemetryDrain)
+    await displayTelemetryDrain(telemetryDrain, this.heroku)
   }
 }

--- a/packages/cli/src/lib/types/telemetry.d.ts
+++ b/packages/cli/src/lib/types/telemetry.d.ts
@@ -9,7 +9,6 @@ export type TelemetryDrain = {
 
 type TelemetryDrainOwner = {
   id: string;
-  name?: string;
   type: 'app' | 'space';
 }
 

--- a/packages/cli/test/fixtures/telemetry/fixtures.ts
+++ b/packages/cli/test/fixtures/telemetry/fixtures.ts
@@ -2,7 +2,7 @@ import {TelemetryDrain} from '../../../src/lib/types/telemetry'
 
 export const spaceTelemetryDrain1: TelemetryDrain = {
   id: '44444321-5717-4562-b3fc-2c963f66afa6',
-  owner: {id: '12345678-5717-4562-b3fc-2c963f66afa6', type: 'space', name: 'myspace'},
+  owner: {id: '12345678-5717-4562-b3fc-2c963f66afa6', type: 'space'},
   signals: ['traces', 'metrics', 'logs'],
   exporter: {
     type: 'otlphttp',
@@ -16,7 +16,7 @@ export const spaceTelemetryDrain1: TelemetryDrain = {
 
 export const appTelemetryDrain1: TelemetryDrain = {
   id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-  owner: {id: '87654321-5717-4562-b3fc-2c963f66afa6', type: 'app', name: 'myapp'},
+  owner: {id: '87654321-5717-4562-b3fc-2c963f66afa6', type: 'app'},
   signals: ['traces', 'metrics'],
   exporter: {
     type: 'otlphttp',
@@ -30,7 +30,7 @@ export const appTelemetryDrain1: TelemetryDrain = {
 
 export const appTelemetryDrain2: TelemetryDrain = {
   id: '55555f64-5717-4562-b3fc-2c963f66afa6',
-  owner: {id: '87654321-5717-4562-b3fc-2c963f66afa6', type: 'app', name: 'myapp'},
+  owner: {id: '87654321-5717-4562-b3fc-2c963f66afa6', type: 'app'},
   signals: ['logs'],
   exporter: {
     type: 'otlp',
@@ -44,7 +44,7 @@ export const appTelemetryDrain2: TelemetryDrain = {
 
 export const grpcAppTelemetryDrain: TelemetryDrain = {
   id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-  owner: {id: '745c1486-ad78-4de7-8da7-20d4f8b15b71', type: 'app', name: 'myapp'},
+  owner: {id: '745c1486-ad78-4de7-8da7-20d4f8b15b71', type: 'app'},
   signals: ['traces', 'metrics', 'logs'],
   exporter: {
     type: 'otlp',

--- a/packages/cli/test/unit/commands/telemetry/info.unit.test.ts
+++ b/packages/cli/test/unit/commands/telemetry/info.unit.test.ts
@@ -15,7 +15,7 @@ describe('telemetry:info', function () {
   beforeEach(function () {
     spaceTelemetryDrain = {
       id: '44444321-5717-4562-b3fc-2c963f66afa6',
-      owner: {id: spaceId, type: 'space', name: 'myspace'},
+      owner: {id: spaceId, type: 'space'},
       signals: ['traces', 'metrics', 'logs'],
       exporter: {
         type: 'otlphttp',
@@ -28,7 +28,7 @@ describe('telemetry:info', function () {
     }
     appTelemetryDrain = {
       id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-      owner: {id: appId, type: 'app', name: 'myapp'},
+      owner: {id: appId, type: 'app'},
       signals: ['traces', 'metrics'],
       exporter: {
         type: 'otlphttp',
@@ -50,16 +50,20 @@ describe('telemetry:info', function () {
       .get(`/telemetry-drains/${spaceTelemetryDrain.id}`)
       .reply(200, spaceTelemetryDrain)
 
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      .get(`/spaces/${spaceTelemetryDrain.owner.id}`)
+      .reply(200, {id: spaceTelemetryDrain.owner.id, name: 'myspace'})
+
     await runCommand(Cmd, [
       spaceTelemetryDrain.id,
     ])
     expectOutput(stdout.output, heredoc(`
       === ${spaceTelemetryDrain.id}
-      Space:    ${spaceTelemetryDrain.owner.name}
-      Signals:  ${spaceTelemetryDrain.signals.join(', ')}
-      Endpoint: ${spaceTelemetryDrain.exporter.endpoint}
-      Kind:     ${spaceTelemetryDrain.exporter.type}
-      Headers:  x-honeycomb-team: 'your-api-key', x-honeycomb-dataset: 'your-dataset'
+      Space:     myspace
+      Signals:   ${spaceTelemetryDrain.signals.join(', ')}
+      Endpoint:  ${spaceTelemetryDrain.exporter.endpoint}
+      Transport: HTTP
+      Headers:   {"x-honeycomb-team":"your-api-key","x-honeycomb-dataset":"your-dataset"}
     `))
   })
 
@@ -68,16 +72,20 @@ describe('telemetry:info', function () {
       .get(`/telemetry-drains/${appTelemetryDrain.id}`)
       .reply(200, appTelemetryDrain)
 
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      .get(`/apps/${appTelemetryDrain.owner.id}`)
+      .reply(200, {id: appTelemetryDrain.owner.id, name: 'myapp'})
+
     await runCommand(Cmd, [
       appTelemetryDrain.id,
     ])
     expectOutput(stdout.output, heredoc(`
       === ${appTelemetryDrain.id}
-      App:      ${appTelemetryDrain.owner.name}
-      Signals:  ${appTelemetryDrain.signals.join(', ')}
-      Endpoint: ${appTelemetryDrain.exporter.endpoint}
-      Kind:     ${appTelemetryDrain.exporter.type}
-      Headers:  x-honeycomb-team: 'your-api-key', x-honeycomb-dataset: 'your-dataset'
+      App:       myapp
+      Signals:   ${appTelemetryDrain.signals.join(', ')}
+      Endpoint:  ${appTelemetryDrain.exporter.endpoint}
+      Transport: HTTP
+      Headers:   {"x-honeycomb-team":"your-api-key","x-honeycomb-dataset":"your-dataset"}
     `))
   })
 })

--- a/packages/cli/test/unit/commands/telemetry/update.unit.test.ts
+++ b/packages/cli/test/unit/commands/telemetry/update.unit.test.ts
@@ -18,6 +18,10 @@ describe('telemetry:update', function () {
       .patch(`/telemetry-drains/${appTelemetryDrain1.id}`, {signals: ['logs']})
       .reply(200, updatedAppTelemetryDrain)
 
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      .get(`/apps/${appTelemetryDrain1.owner.id}`)
+      .reply(200, {id: appTelemetryDrain1.owner.id, name: 'myapp'})
+
     await runCommand(Cmd, [
       appTelemetryDrain1.id,
       '--signals',
@@ -29,11 +33,11 @@ describe('telemetry:update', function () {
     `))
     expectOutput(stdout.output, heredoc(`
       === ${updatedAppTelemetryDrain.id}
-      App:      ${updatedAppTelemetryDrain.owner.name}
-      Signals:  ${updatedAppTelemetryDrain.signals.join(', ')}
-      Endpoint: ${updatedAppTelemetryDrain.exporter.endpoint}
-      Kind:     ${updatedAppTelemetryDrain.exporter.type}
-      Headers:  x-honeycomb-team: 'your-api-key', x-honeycomb-dataset: 'your-dataset'
+      App:       myapp
+      Signals:   ${updatedAppTelemetryDrain.signals.join(', ')}
+      Endpoint:  ${updatedAppTelemetryDrain.exporter.endpoint}
+      Transport: HTTP
+      Headers:   {"x-honeycomb-team":"your-api-key","x-honeycomb-dataset":"your-dataset"}
     `))
   })
 
@@ -43,7 +47,7 @@ describe('telemetry:update', function () {
       signals: ['logs'],
       exporter: {
         endpoint: 'https://api-new.honeycomb.io/',
-        type: 'otlpgrpc',
+        type: 'otlp',
         headers: {
           'x-honeycomb-team': 'your-api-key',
           'x-honeycomb-dataset': 'your-dataset',
@@ -55,10 +59,14 @@ describe('telemetry:update', function () {
         signals: ['logs'],
         exporter: {
           endpoint: 'https://api-new.honeycomb.io/',
-          type: 'otlpgrpc',
+          type: 'otlp',
         },
       })
       .reply(200, updatedAppTelemetryDrain)
+
+    nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      .get(`/apps/${appTelemetryDrain1.owner.id}`)
+      .reply(200, {id: appTelemetryDrain1.owner.id, name: 'myapp'})
 
     await runCommand(Cmd, [
       appTelemetryDrain1.id,
@@ -75,11 +83,11 @@ describe('telemetry:update', function () {
     `))
     expectOutput(stdout.output, heredoc(`
       === ${updatedAppTelemetryDrain.id}
-      App:      ${updatedAppTelemetryDrain.owner.name}
-      Signals:  ${updatedAppTelemetryDrain.signals.join(', ')}
-      Endpoint: ${updatedAppTelemetryDrain.exporter.endpoint}
-      Kind:     ${updatedAppTelemetryDrain.exporter.type}
-      Headers:  x-honeycomb-team: 'your-api-key', x-honeycomb-dataset: 'your-dataset'
+      App:       myapp
+      Signals:   ${updatedAppTelemetryDrain.signals.join(', ')}
+      Endpoint:  ${updatedAppTelemetryDrain.exporter.endpoint}
+      Transport: gRPC
+      Headers:   {"x-honeycomb-team":"your-api-key","x-honeycomb-dataset":"your-dataset"}
     `))
   })
 


### PR DESCRIPTION
[W-17329013](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE0000265iheYAA/view)

### Description

This fixes a few issues with `telemetry:info` and `telemetry:update`

1. Fixes `telemetry:info` and `telemetry:update` so that it displays the `transport` attribute instead of `kind`, aligning with how our command flags are structured
2. `telemetry:info` and `telemetry:update` will now display the name of the app or space associated with a telemetry drain
3. `telemtry:info` and `telemetry:update` now display header data as a json structure surrounded by `{}` instead of just key/values
4. `telemetry:update` will now appropriately send `otlp` for grpc transport drains instead of `otlpgrpc`

### Testing

1. Pull down branch and `yarn build`
2. Run `./bin/run telemetry:info TELEMETRY_ID` where TELEMETRY_ID is the id of an already created telemetry drain
3. Run `./bin/run telemetry:update TELEMETRY_ID --transport grpc` where TELEMETRY_ID is the id of an already created telemetry drain set up with http transport