### PR TITLE
Add MCP version to telemetry

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -391,7 +391,7 @@
     "test:acceptance": "yarn pretest && mocha --forbid-only \"test/**/*.acceptance.test.ts\" && node ./bin/bats-test-runner",
     "test:integration": "yarn pretest && mocha --forbid-only \"test/**/*.integration.test.ts\"",
     "test:smoke": "yarn pretest && mocha --forbid-only \"test/**/smoke.acceptance.test.ts\"",
-    "test:unit:justTest:local": "nyc mocha \"test/**/*.unit.test.ts\"",
+    "test:unit:justTest:local": "mocha \"test/**/*.unit.test.ts\"",
     "test:unit:justTest:ci": "nyc --reporter=lcov --reporter=text-summary mocha --forbid-only \"test/**/*.unit.test.ts\"",
     "test": "yarn pretest && yarn test:unit:justTest:ci",
     "test:local": "yarn pretest && yarn test:unit:justTest:local",

--- a/packages/cli/src/analytics.ts
+++ b/packages/cli/src/analytics.ts
@@ -48,6 +48,8 @@ export default class AnalyticsCommand {
 
   async record(opts: RecordOpts) {
     await this.initialize
+    const mcpMode = process.env.HEROKU_MCP_MODE === 'true'
+    const mcpServerVersion = process.env.HEROKU_MCP_SERVER_VERSION || 'unknown'
     const plugin = opts.Command.plugin
     if (!plugin) {
       debug('no plugin found for analytics')
@@ -63,7 +65,7 @@ export default class AnalyticsCommand {
         cli: this.config.name,
         command: opts.Command.id,
         completion: await this._acAnalytics(opts.Command.id),
-        version: this.config.version,
+        version: `${this.config.version}${mcpMode ? ` (MCP ${mcpServerVersion})` : ''}`,
         plugin: plugin.name,
         plugin_version: plugin.version,
         os: this.config.platform,

--- a/packages/cli/src/global_telemetry.ts
+++ b/packages/cli/src/global_telemetry.ts
@@ -91,11 +91,13 @@ export function setupTelemetry(config: any, opts: any) {
   const now = new Date()
   const cmdStartTime = now.getTime()
   const isRegularCmd = Boolean(opts.Command)
+  const mcpMode = process.env.HEROKU_MCP_MODE === 'true'
+  const mcpServerVersion = process.env.HEROKU_MCP_SERVER_VERSION || 'unknown'
 
   const irregularTelemetryObject = {
     command: opts.id,
     os: config.platform,
-    version: config.version,
+    version: `${config.version}${mcpMode ? ` (MCP ${mcpServerVersion})` : ''}`,
     exitCode: 0,
     exitState: 'successful',
     cliRunDuration: 0,

--- a/packages/cli/test/unit/analytics.unit.test.ts
+++ b/packages/cli/test/unit/analytics.unit.test.ts
@@ -202,6 +202,27 @@ describe('analytics (backboard has an error) with authorizationToken', function 
       await runAnalyticsTest((d: AnalyticsInterface) => d.properties.install_id, 'abcde')
     })
 
+    it('includes MCP version in version string when in MCP mode', async function () {
+      // Save original env vars
+      const originalMcpMode = process.env.HEROKU_MCP_MODE
+      const originalMcpVersion = process.env.HEROKU_MCP_SERVER_VERSION
+
+      // Set MCP mode and version
+      process.env.HEROKU_MCP_MODE = 'true'
+      process.env.HEROKU_MCP_SERVER_VERSION = '1.2.3'
+
+      try {
+        await runAnalyticsTest(
+          (d: AnalyticsInterface) => d.properties.version,
+          '1 (MCP 1.2.3)', // '1' is the version set in runAnalyticsTest
+        )
+      } finally {
+        // Restore original env vars
+        process.env.HEROKU_MCP_MODE = originalMcpMode
+        process.env.HEROKU_MCP_SERVER_VERSION = originalMcpVersion
+      }
+    })
+
     after(function () {
       sandbox.restore()
     })

--- a/packages/cli/test/unit/global_telemetry.unit.test.ts
+++ b/packages/cli/test/unit/global_telemetry.unit.test.ts
@@ -96,6 +96,21 @@ describe('telemetry', function () {
     reportCmdNotFoundTest(mockConfig)
   })
 
+  it('confirms version string includes MCP info when in MCP mode', function () {
+    // Mock MCP mode and version
+    const originalMcpMode = process.env.HEROKU_MCP_MODE
+    const originalMcpVersion = process.env.HEROKU_MCP_SERVER_VERSION
+    process.env.HEROKU_MCP_MODE = 'true'
+    process.env.HEROKU_MCP_SERVER_VERSION = '1.2.3'
+
+    const result = telemetry.setupTelemetry(mockConfig, mockOpts)
+    expect(result!.version).to.equal(`${version} (MCP 1.2.3)`)
+
+    // Restore original env vars
+    process.env.HEROKU_MCP_MODE = originalMcpMode
+    process.env.HEROKU_MCP_SERVER_VERSION = originalMcpVersion
+  })
+
   it('confirms successful request to honeycomb', async function () {
     const mockTelemetry = telemetry.setupTelemetry(mockConfig, mockOpts)
     telemetry.initializeInstrumentation()


### PR DESCRIPTION
## Description

Here we change the CLI version string reported to our analytics (Backboard) and telemetry (Honeycomb) services to add the Heroku MCP Server version when running in MCP mode.

## Testing
- Checkout this branch and run ```yarn && yarn build```.
- Verify you're logged-in to the Heroku CLI.
- Run the following command: ```HEROKU_MCP_MODE="true" HEROKU_MCP_SERVER_VERSION="1.2.3" DEBUG=http ./bin/run whoami```.

To check that the correct version is being sent to Backboard, copy the value assigned to the `data` query param on the request to Backboard (`GET https://backboard.heroku.com/hamurai?data=eyJzb3V...`) and decode the Base64 data with ```echo -n "eyJzb3V..." | base64 -d && echo```. In the decoded JSON data the `properties.version` value should be "10.4.1 (MCP 1.2.3)".

To check that the correct version is being sent to Honeycomb, log-in to Honeycomb and open the following [query results]( https://ui.honeycomb.io/heroku/datasets/front-end-metrics-production?query=%7B%22time_range%22%3A7200%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22heroku_client.version%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%2210.4.1%20(MCP%201.2.3)%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%5D%2C%22havings%22%3A%5B%5D%2C%22trace_joins%22%3A%5B%5D%2C%22limit%22%3A1000%7D). Check that a span containing the expected version was received by the time the `heroku` command was executed.

## SOC2 Compliance
[GUS Work Item](https://gus.lightning.force.com/a07EE00002CCpQVYA1)
