### PR TITLE
fix: change addon text to add-on, add description to flags

### DIFF
--- a/packages/cli/src/commands/usage/addons.ts
+++ b/packages/cli/src/commands/usage/addons.ts
@@ -28,10 +28,10 @@ interface AppInfo extends Record<string, unknown> {
 
 export default class UsageAddons extends Command {
   static topic = 'usage'
-  static description = 'list usage values for metered addons associated with a given app or team'
+  static description = 'list usage for metered add-ons attached to an app or apps within a team'
   static flags = {
-    app: flags.string(),
-    team: flags.string(),
+    app: flags.string({char: 'a', description: 'app to list metered add-ons usage for'}),
+    team: flags.team({description: 'team to list metered add-ons usage for'}),
   }
 
   private displayAppUsage(app: string, usageAddons: AppUsage['addons'], appAddons: Heroku.AddOn[]): void {
@@ -45,7 +45,7 @@ export default class UsageAddons extends Command {
 
     ux.styledHeader(`Usage for ${color.app(app)}`)
     ux.table(metersArray, {
-      Addon: {
+      'Add-on': {
         get: row => {
           const matchingAddon = appAddons.find(a => a.id === row.addonId)
           return matchingAddon?.name || row.addonId

--- a/packages/cli/test/unit/commands/usage/addons.unit.test.ts
+++ b/packages/cli/test/unit/commands/usage/addons.unit.test.ts
@@ -47,7 +47,7 @@ describe('usage:addons', function () {
 
       expectOutput(stdout.output, heredoc(`
         === Usage for ⬢ ${app}
-         Addon     Meter        Quantity
+         Add-on     Meter        Quantity
          ───────── ──────────── ────────
          redis-123 Data Storage 2.5
          redis-123 Connections  100
@@ -126,12 +126,12 @@ describe('usage:addons', function () {
 
       expectOutput(stdout.output, heredoc(`
         === Usage for ⬢ App One
-         Addon     Meter        Quantity
+         Add-on     Meter        Quantity
          ───────── ──────────── ────────
          redis-123 Data Storage 2.5
 
         === Usage for ⬢ App Two
-         Addon     Meter        Quantity
+         Add-on     Meter        Quantity
          ───────── ──────────── ────────
          redis-456 Data Storage 5
       `))

--- a/packages/cli/test/unit/commands/usage/addons.unit.test.ts
+++ b/packages/cli/test/unit/commands/usage/addons.unit.test.ts
@@ -47,7 +47,7 @@ describe('usage:addons', function () {
 
       expectOutput(stdout.output, heredoc(`
         === Usage for ⬢ ${app}
-         Add-on     Meter        Quantity
+         Add-on    Meter        Quantity
          ───────── ──────────── ────────
          redis-123 Data Storage 2.5
          redis-123 Connections  100
@@ -126,12 +126,12 @@ describe('usage:addons', function () {
 
       expectOutput(stdout.output, heredoc(`
         === Usage for ⬢ App One
-         Add-on     Meter        Quantity
+         Add-on    Meter        Quantity
          ───────── ──────────── ────────
          redis-123 Data Storage 2.5
 
         === Usage for ⬢ App Two
-         Add-on     Meter        Quantity
+         Add-on    Meter        Quantity
          ───────── ──────────── ────────
          redis-456 Data Storage 5
       `))


### PR DESCRIPTION
[W-18240297](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002CR1oSYAT/view)

### Description

This updates CLI copy based on cx feedback from https://github.com/heroku/cli/pull/3263. It also adds descriptions for the `--app` and `--team` flags.


### Testing

1. Pull down and `yarn build`
2. Run `./bin/run usage:addons --help` and see the correct copy