### PR TITLE
fix: cx updates for pg:upgrade:* commands

### DIFF
--- a/packages/cli/src/commands/pg/upgrade/dryrun.ts
+++ b/packages/cli/src/commands/pg/upgrade/dryrun.ts
@@ -12,8 +12,7 @@ import {nls} from '../../../nls'
 export default class Upgrade extends Command {
   static topic = 'pg';
   static description = heredoc(`
-    simulates a Postgres version upgrade on a Standard-tier and higher leader database by creating and upgrading a follower database.
-    Heroku sends the results of the test upgrade via email.
+    simulates a Postgres version upgrade on a Standard-tier and higher leader database by creating and upgrading a follower database. Heroku sends the results of the test upgrade via email.
   `)
 
   static flags = {

--- a/packages/cli/src/commands/pg/upgrade/prepare.ts
+++ b/packages/cli/src/commands/pg/upgrade/prepare.ts
@@ -12,7 +12,7 @@ import {nls} from '../../../nls'
 export default class Upgrade extends Command {
   static topic = 'pg';
   static description = heredoc(`
-    Prepares the upgrade for Standard-tier and higher leader databases and schedules it for the next available maintenance window. To start a version upgrade on Essential-tier and follower databases, use ${color.cmd('heroku pg:upgrade:run')} instead.
+    prepares the upgrade for Standard-tier and higher leader databases and schedules it for the next available maintenance window. To start a version upgrade on Essential-tier and follower databases, use ${color.cmd('heroku pg:upgrade:run')} instead.
   `)
 
   static flags = {

--- a/packages/cli/src/commands/pg/upgrade/run.ts
+++ b/packages/cli/src/commands/pg/upgrade/run.ts
@@ -13,6 +13,8 @@ import {nls} from '../../../nls'
 export default class Upgrade extends Command {
   static topic = 'pg';
   static description = heredoc(`
+    starts a Postgres version upgrade
+
     On Essential-tier databases, this command upgrades the database's Postgres version.
 
     On Standard-tier and higher leader databases, this command runs a previously scheduled Postgres version upgrade. You must run ${color.cmd('pg:upgrade:prepare')} before this command to schedule a version upgrade.


### PR DESCRIPTION
This PR makes some tiny changes to the messages displayed in the new pg:upgrade:* commands as recommended by the cx team.

Refer to https://docs.google.com/document/d/1FEIQPkWRggz_XWzU3PRI6pFg00TwUKIjqft4IGzCOsY/edit?usp=sharing for more info on the pg:upgrade:* commands.

## Testing

```
kpremkumar@kpremku-ltm9a2z cli % ./bin/run pg:upgrade:dryrun --help                               
simulates a Postgres version upgrade on a Standard-tier and higher leader database by creating and upgrading a follower database. Heroku sends the results of the test upgrade via email.

USAGE
  $ heroku pg:upgrade:dryrun [DATABASE] -a <value> [-c <value>] [-v <value>]

ARGUMENTS
  DATABASE  config var containing the connection string, unique name, ID, or alias of the database. To access another app's database, prepend the app name to the config var or alias with `APP_NAME::` . If omitted, we use
            DATABASE_URL.

FLAGS
  -a, --app=<value>      (required) app to run command against
  -c, --confirm=<value>
  -v, --version=<value>  Postgres version to upgrade to

DESCRIPTION
  simulates a Postgres version upgrade on a Standard-tier and higher leader database by creating and upgrading a follower database. Heroku sends the results of the test upgrade via email.
```
```

kpremkumar@kpremku-ltm9a2z cli % ./bin/run pg:upgrade:run --help 
starts a Postgres version upgrade

USAGE
  $ heroku pg:upgrade:run [DATABASE] -a <value> [-c <value>] [-v <value>] [-r <value>]

ARGUMENTS
  DATABASE  config var containing the connection string, unique name, ID, or alias of the database. To access another app's database, prepend the app name to the config var or alias with `APP_NAME::` . If omitted, we use
            DATABASE_URL.

FLAGS
  -a, --app=<value>      (required) app to run command against
  -c, --confirm=<value>
  -r, --remote=<value>   git remote of app to use
  -v, --version=<value>  Postgres version to upgrade to

DESCRIPTION
  starts a Postgres version upgrade

  On Essential-tier databases, this command upgrades the database's Postgres version.

  On Standard-tier and higher leader databases, this command runs a previously scheduled Postgres version upgrade. You must run pg:upgrade:prepare before this command to schedule a version upgrade.

  On follower databases, this command unfollows the leader database before upgrading the follower's Postgres version.


EXAMPLES
  # Upgrade an Essential-tier database to a specific version

    $ heroku pg:upgrade:run postgresql-curved-12345 --version 14 --app myapp

  # Upgrade a Standard-tier follower database to the latest supported version

    $ heroku pg:upgrade:run HEROKU_POSTGRESQL_BLUE_URL --app myapp

  # Run a previously scheduled upgrade on a Standard-tier leader database

    $ heroku pg:upgrade:run DATABASE_URL --app myapp
```
```
kpremkumar@kpremku-ltm9a2z cli % ./bin/run pg:upgrade:prepare --help 
prepares the upgrade for Standard-tier and higher leader databases and schedules it for the next available maintenance window. To start a version upgrade on Essential-tier and follower databases, use heroku pg:upgrade:run instead.

USAGE
  $ heroku pg:upgrade:prepare [DATABASE] -a <value> [-c <value>] [-v <value>]

ARGUMENTS
  DATABASE  config var containing the connection string, unique name, ID, or alias of the database. To access another app's database, prepend the app name to the config var or alias with `APP_NAME::` . If omitted, we use
            DATABASE_URL.

FLAGS
  -a, --app=<value>      (required) app to run command against
  -c, --confirm=<value>
  -v, --version=<value>  Postgres version to upgrade to

DESCRIPTION
  prepares the upgrade for Standard-tier and higher leader databases and schedules it for the next available maintenance window. To start a version upgrade on Essential-tier and follower databases, use heroku pg:upgrade:run
  instead.
```

```
kpremkumar@kpremku-ltm9a2z cli % ./bin/run pg:upgrade --help      
We're deprecating this command. To upgrade your database's Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.

USAGE
  $ heroku pg:upgrade [DATABASE] -a <value> [-c <value>] [-v <value>] [-r <value>]

ARGUMENTS
  DATABASE  config var containing the connection string, unique name, ID, or alias of the database. To access another app's database, prepend the app name to the config var or alias with `APP_NAME::` . If omitted, we use
            DATABASE_URL.

FLAGS
  -a, --app=<value>      (required) app to run command against
  -c, --confirm=<value>
  -r, --remote=<value>   git remote of app to use
  -v, --version=<value>  Postgres version to upgrade to

DESCRIPTION
  We're deprecating this command. To upgrade your database's Postgres version, use the new pg:upgrade:* subcommands. See https://devcenter.heroku.com/changelog-items/3179.

  For an Essential-tier plan, this command upgrades the database's Postgres version. For a Standard-tier and higher plan, this command unfollows the leader database before upgrading the Postgres version.


COMMANDS
  pg:upgrade:cancel   cancels a scheduled upgrade. You can't cancel a version upgrade that's in progress.
  pg:upgrade:dryrun   simulates a Postgres version upgrade on a Standard-tier and higher leader database by creating and upgrading a follower database. Heroku sends the results of the test upgrade via email.
  pg:upgrade:prepare  prepares the upgrade for Standard-tier and higher leader databases and schedules it for the next available maintenance window. To start a version upgrade on Essential-tier and follower databases, use heroku
                      pg:upgrade:run instead.
  pg:upgrade:run      starts a Postgres version upgrade
  pg:upgrade:wait     provides the status of an upgrade and blocks it until the operation is complete

kpremkumar@kpremku-ltm9a2z cli % 
```