### PR TITLE
fix: show metered for metered addons in addons:info and addons:index

### DIFF
--- a/packages/cli/src/commands/addons/index.ts
+++ b/packages/cli/src/commands/addons/index.ts
@@ -15,6 +15,7 @@ async function addonGetter(api: APIClient, app?: string) {
     addonsResponse = api.get<Heroku.AddOn[]>(`/apps/${app}/addons`, {
       headers: {
         'Accept-Expansion': 'addon_service,plan',
+        Accept: 'application/vnd.heroku+json; version=3.sdk',
       },
     })
     const sudoHeaders = JSON.parse(process.env.HEROKU_HEADERS || '{}')
@@ -32,6 +33,7 @@ async function addonGetter(api: APIClient, app?: string) {
     addonsResponse = api.get<Heroku.AddOn[]>('/addons', {
       headers: {
         'Accept-Expansion': 'addon_service,plan',
+        Accept: 'application/vnd.heroku+json; version=3.sdk',
       },
     })
   }

--- a/packages/cli/src/lib/addons/resolve.ts
+++ b/packages/cli/src/lib/addons/resolve.ts
@@ -5,7 +5,7 @@ import {HerokuAPIError} from '@heroku-cli/command/lib/api-client'
 import type {AddOnAttachmentWithConfigVarsAndPlan} from '../pg/types'
 
 const addonHeaders = {
-  Accept: 'application/vnd.heroku+json; version=3.actions',
+  Accept: 'application/vnd.heroku+json; version=3.sdk',
   'Accept-Expansion': 'addon_service,plan',
 }
 

--- a/packages/cli/src/lib/addons/resolve.ts
+++ b/packages/cli/src/lib/addons/resolve.ts
@@ -67,7 +67,7 @@ const filter = function (app: string | undefined, addonService: AddOnAttachment[
 }
 
 const attachmentHeaders: Readonly<{ Accept: string, 'Accept-Inclusion': string }> = {
-  Accept: 'application/vnd.heroku+json; version=3.actions',
+  Accept: 'application/vnd.heroku+json; version=3.sdk',
   'Accept-Inclusion': 'addon:plan,config_vars',
 }
 

--- a/packages/cli/test/unit/commands/addons/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/addons/index.unit.test.ts
@@ -19,7 +19,10 @@ describe('addons', function () {
 
     context('with add-ons', function () {
       beforeEach(function () {
-        nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan', Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+        nock('https://api.heroku.com', {reqheaders: {
+          'Accept-Expansion': 'addon_service,plan',
+          Accept: 'application/vnd.heroku+json; version=3.sdk',
+        }})
           .get('/addons')
           .reply(200, addons)
       })

--- a/packages/cli/test/unit/commands/addons/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/addons/index.unit.test.ts
@@ -19,7 +19,7 @@ describe('addons', function () {
 
     context('with add-ons', function () {
       beforeEach(function () {
-        nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
+        nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan', Accept: 'application/vnd.heroku+json; version=3.sdk'}})
           .get('/addons')
           .reply(200, addons)
       })
@@ -52,6 +52,7 @@ describe('addons', function () {
         addon.billed_price = {cents: 10000}
         nock('https://api.heroku.com', {reqheaders: {
           'Accept-Expansion': 'addon_service,plan',
+          Accept: 'application/vnd.heroku+json; version=3.sdk',
         }})
           .get('/addons')
           .reply(200, [addon])
@@ -70,6 +71,7 @@ describe('addons', function () {
         addon.billed_price = {cents: 0, contract: true}
         nock('https://api.heroku.com', {reqheaders: {
           'Accept-Expansion': 'addon_service,plan',
+          Accept: 'application/vnd.heroku+json; version=3.sdk',
         }})
           .get('/addons')
           .reply(200, [addon])
@@ -96,6 +98,7 @@ describe('addons', function () {
     function mockAPI(appName: string, addons: Heroku.AddOn[] = [], attachments: Heroku.AddOnAttachment[] = []) {
       nock('https://api.heroku.com', {reqheaders: {
         'Accept-Expansion': 'addon_service,plan',
+        Accept: 'application/vnd.heroku+json; version=3.sdk',
       }})
         .get(`/apps/${appName}/addons`)
         .reply(200, addons)

--- a/packages/cli/test/unit/commands/addons/info.unit.test.ts
+++ b/packages/cli/test/unit/commands/addons/info.unit.test.ts
@@ -18,7 +18,10 @@ describe('addons:info', function () {
 
   context('with add-ons', function () {
     beforeEach(function () {
-      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan', Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      nock('https://api.heroku.com', {reqheaders: {
+        'Accept-Expansion': 'addon_service,plan',
+        Accept: 'application/vnd.heroku+json; version=3.sdk',
+      }})
         .post('/actions/addons/resolve', {app: null, addon: 'www-db'})
         .reply(200, [fixtures.addons['www-db']])
       nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
@@ -48,7 +51,10 @@ State:        created\n
 
   context('with app add-ons', function () {
     beforeEach(function () {
-      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan', Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      nock('https://api.heroku.com', {reqheaders: {
+        'Accept-Expansion': 'addon_service,plan',
+        Accept: 'application/vnd.heroku+json; version=3.sdk',
+      }})
         .post('/actions/addons/resolve', {app: 'example', addon: 'www-db'})
         .reply(200, [fixtures.addons['www-db']])
       nock('https://api.heroku.com', {reqheaders: {
@@ -82,7 +88,10 @@ State:        created\n
   })
   context('with app but not an app add-on', function () {
     beforeEach(function () {
-      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan', Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      nock('https://api.heroku.com', {reqheaders: {
+        'Accept-Expansion': 'addon_service,plan',
+        Accept: 'application/vnd.heroku+json; version=3.sdk',
+      }})
         .post('/actions/addons/resolve', {app: 'example', addon: 'www-db'})
         .reply(200, [fixtures.addons['www-db']])
       nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
@@ -122,7 +131,10 @@ State:        created\n
     beforeEach(function () {
       const addon = fixtures.addons['dwh-db']
       addon.billed_price = {cents: 10000}
-      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan', Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      nock('https://api.heroku.com', {reqheaders: {
+        'Accept-Expansion': 'addon_service,plan',
+        Accept: 'application/vnd.heroku+json; version=3.sdk',
+      }})
         .post('/actions/addons/resolve', {app: null, addon: 'dwh-db'})
         .reply(200, [addon])
       nock('https://api.heroku.com', {reqheaders: {
@@ -156,7 +168,10 @@ State:        created\n
     beforeEach(function () {
       const addon = fixtures.addons['dwh-db']
       addon.billed_price = {cents: 0, contract: true}
-      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan', Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      nock('https://api.heroku.com', {reqheaders: {
+        'Accept-Expansion': 'addon_service,plan',
+        Accept: 'application/vnd.heroku+json; version=3.sdk',
+      }})
         .post('/actions/addons/resolve', {app: null, addon: 'dwh-db'})
         .reply(200, [addon])
       nock('https://api.heroku.com', {reqheaders: {
@@ -189,7 +204,10 @@ State:        created\n
   context('provisioning add-on', function () {
     beforeEach(function () {
       const provisioningAddon = fixtures.addons['www-redis']
-      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan', Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      nock('https://api.heroku.com', {reqheaders: {
+        'Accept-Expansion': 'addon_service,plan',
+        Accept: 'application/vnd.heroku+json; version=3.sdk',
+      }})
         .post('/actions/addons/resolve', {app: null, addon: 'www-redis'})
         .reply(200, [provisioningAddon])
       nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
@@ -220,7 +238,10 @@ State:        creating\n
   context('deprovisioning add-on', function () {
     beforeEach(function () {
       const deprovisioningAddon = fixtures.addons['www-redis-2']
-      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan', Accept: 'application/vnd.heroku+json; version=3.sdk'}})
+      nock('https://api.heroku.com', {reqheaders: {
+        'Accept-Expansion': 'addon_service,plan',
+        Accept: 'application/vnd.heroku+json; version=3.sdk',
+      }})
         .post('/actions/addons/resolve', {app: null, addon: 'www-redis-2'})
         .reply(200, [deprovisioningAddon])
       nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})

--- a/packages/cli/test/unit/commands/addons/info.unit.test.ts
+++ b/packages/cli/test/unit/commands/addons/info.unit.test.ts
@@ -18,7 +18,7 @@ describe('addons:info', function () {
 
   context('with add-ons', function () {
     beforeEach(function () {
-      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
+      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan', Accept: 'application/vnd.heroku+json; version=3.sdk'}})
         .post('/actions/addons/resolve', {app: null, addon: 'www-db'})
         .reply(200, [fixtures.addons['www-db']])
       nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
@@ -48,7 +48,7 @@ State:        created\n
 
   context('with app add-ons', function () {
     beforeEach(function () {
-      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
+      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan', Accept: 'application/vnd.heroku+json; version=3.sdk'}})
         .post('/actions/addons/resolve', {app: 'example', addon: 'www-db'})
         .reply(200, [fixtures.addons['www-db']])
       nock('https://api.heroku.com', {reqheaders: {
@@ -82,7 +82,7 @@ State:        created\n
   })
   context('with app but not an app add-on', function () {
     beforeEach(function () {
-      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
+      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan', Accept: 'application/vnd.heroku+json; version=3.sdk'}})
         .post('/actions/addons/resolve', {app: 'example', addon: 'www-db'})
         .reply(200, [fixtures.addons['www-db']])
       nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
@@ -122,7 +122,7 @@ State:        created\n
     beforeEach(function () {
       const addon = fixtures.addons['dwh-db']
       addon.billed_price = {cents: 10000}
-      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
+      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan', Accept: 'application/vnd.heroku+json; version=3.sdk'}})
         .post('/actions/addons/resolve', {app: null, addon: 'dwh-db'})
         .reply(200, [addon])
       nock('https://api.heroku.com', {reqheaders: {
@@ -156,7 +156,7 @@ State:        created\n
     beforeEach(function () {
       const addon = fixtures.addons['dwh-db']
       addon.billed_price = {cents: 0, contract: true}
-      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
+      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan', Accept: 'application/vnd.heroku+json; version=3.sdk'}})
         .post('/actions/addons/resolve', {app: null, addon: 'dwh-db'})
         .reply(200, [addon])
       nock('https://api.heroku.com', {reqheaders: {
@@ -189,7 +189,7 @@ State:        created\n
   context('provisioning add-on', function () {
     beforeEach(function () {
       const provisioningAddon = fixtures.addons['www-redis']
-      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
+      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan', Accept: 'application/vnd.heroku+json; version=3.sdk'}})
         .post('/actions/addons/resolve', {app: null, addon: 'www-redis'})
         .reply(200, [provisioningAddon])
       nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
@@ -220,7 +220,7 @@ State:        creating\n
   context('deprovisioning add-on', function () {
     beforeEach(function () {
       const deprovisioningAddon = fixtures.addons['www-redis-2']
-      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})
+      nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan', Accept: 'application/vnd.heroku+json; version=3.sdk'}})
         .post('/actions/addons/resolve', {app: null, addon: 'www-redis-2'})
         .reply(200, [deprovisioningAddon])
       nock('https://api.heroku.com', {reqheaders: {'Accept-Expansion': 'addon_service,plan'}})


### PR DESCRIPTION
[W-18257668](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002CaZ4lYAF/view)

### Description

Metered addons pricing currently shows as `free` in `addons:info` and `addons:index`. This corrects that behavior by switching to the `3.sdk` variant, which is necessary to get the additional `metered: true` data.

### Testing

1. Pull down this branch and `yarn build`
2. Run `./bin/run addons --app APP` where APP has a metered usage addon
3. Run `./bin/run addons:info ADDON --app APP` where ADDON is a metered usage addon that is owned by APP