### PR TITLE
chore: update devcenter workflow

### DIFF
--- a/.github/workflows/devcenter-doc-update.yml
+++ b/.github/workflows/devcenter-doc-update.yml
@@ -43,4 +43,6 @@ jobs:
       - name: Compile documentation and push to devcenter
         run: |
           cd packages/cli
-          devcenter help
+          ./scripts/postrelease/dev_center_docs
+        env:
+          HEROKU_DEVCENTER_API_KEY: ${{ secrets.HEROKU_DEVCENTER_API_KEY }}

--- a/.github/workflows/devcenter-doc-update.yml
+++ b/.github/workflows/devcenter-doc-update.yml
@@ -28,18 +28,20 @@ jobs:
         with:
           node-version: 16.x
           cache: yarn
+      - name: Use Ruby 3.2.8
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2.8
       - name: Install package deps
         run: yarn --immutable --network-timeout 1000000
       - name: Install Devcenter CLI
         run: |
           gem install devcenter --user-install
-          export PATH="$PATH:$HOME/.local/share/gem/ruby/3.2.0/bin"
+          export PATH="$PATH:$HOME/.local/share/gem/ruby/3.2.8/bin"
           devcenter help
       - name: Build CLI
         run: yarn build
       - name: Compile documentation and push to devcenter
         run: |
+          pwd
           cd packages/cli
-          ./scripts/postrelease/dev_center_docs
-        env:
-          HEROKU_DEVCENTER_API_KEY: ${{ secrets.HEROKU_DEVCENTER_API_KEY }}

--- a/.github/workflows/devcenter-doc-update.yml
+++ b/.github/workflows/devcenter-doc-update.yml
@@ -28,10 +28,11 @@ jobs:
         with:
           node-version: 16.x
           cache: yarn
-      - name: Use Ruby 3.2.8
+      - name: Use Ruby 3.2.x
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2.8
+          ruby-version: 3.2
+          bundler-cache: true
       - name: Install package deps
         run: yarn --immutable --network-timeout 1000000
       - name: Install Devcenter CLI

--- a/.github/workflows/devcenter-doc-update.yml
+++ b/.github/workflows/devcenter-doc-update.yml
@@ -32,16 +32,15 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.2
-          bundler-cache: true
       - name: Install package deps
         run: yarn --immutable --network-timeout 1000000
       - name: Install Devcenter CLI
         run: |
-          gem install devcenter --user-install
+          gem install devcenter
           devcenter help
       - name: Build CLI
         run: yarn build
       - name: Compile documentation and push to devcenter
         run: |
-          ls
           cd packages/cli
+          devcenter help

--- a/.github/workflows/devcenter-doc-update.yml
+++ b/.github/workflows/devcenter-doc-update.yml
@@ -37,11 +37,10 @@ jobs:
       - name: Install Devcenter CLI
         run: |
           gem install devcenter --user-install
-          export PATH="$PATH:$HOME/.local/share/gem/ruby/3.2.8/bin"
           devcenter help
       - name: Build CLI
         run: yarn build
       - name: Compile documentation and push to devcenter
         run: |
-          pwd
+          ls
           cd packages/cli


### PR DESCRIPTION
## Description
[WI Card](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002CUYuNYAX/view)

This PR fixes the currently failing `devcenter-doc-update` workflow by using a more conventional approach to Ruby installs.

## Testing
[This passing workflow](https://github.com/heroku/cli/actions/runs/14742808689/job/41384378201) demonstrates the nature of the required script needed to update the devcenter documentation.