### PR TITLE
remove fir pilot language, fix node engine definition

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -137,7 +137,7 @@
     "typescript": "4.8.4"
   },
   "engines": {
-    "node": "~20.x"
+    "node": "20.x"
   },
   "files": [
     "/autocomplete-scripts",

--- a/packages/cli/src/commands/spaces/create.ts
+++ b/packages/cli/src/commands/spaces/create.ts
@@ -63,21 +63,6 @@ export default class Create extends Command {
     const dollarAmountHourly = shield ? '$4.17' : '$1.39'
     const spaceType = shield ? 'Shield' : 'Standard'
 
-    if (generation === 'fir') {
-      ux.warn(heredoc`
-        Fir Pilot Features
-        Fir is currently a pilot service that is subject to the Beta Services Terms
-        (https://www.salesforce.com/company/legal/) or a written Unified Pilot Agreement
-        if executed by Customer, and applicable terms in the Product Terms Directory
-        (https://ptd.salesforce.com/?_ga=2.247987783.1372150065.1709219475-629000709.1639001992).
-        Use of this pilot or beta service is at the Customer's sole discretion.
-
-        Please note that we’re actively developing and adding new features, and not all
-        existing features are currently available. See the Dev Center
-        (https://devcenter.heroku.com/articles/generations) for more info.
-      `)
-    }
-
     ux.action.start(`Creating space ${color.green(spaceName as string)} in team ${color.cyan(team as string)}`)
     const {body: space} = await this.heroku.post<Required<Space>>('/spaces', {
       headers: {

--- a/packages/cli/test/unit/commands/spaces/create.unit.test.ts
+++ b/packages/cli/test/unit/commands/spaces/create.unit.test.ts
@@ -259,7 +259,6 @@ describe('spaces:create', function () {
       '--generation',
       getGeneration(firSpace)!,
     ])
-    expect(stderr.output).to.include('Fir is currently a pilot service')
     expect(stdout.output).to.eq(heredoc`
       === ${firSpace.name}
 


### PR DESCRIPTION
[W-18414050](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Dk2QRYAZ/view)

### Description

This does two things:

1. Remove the fir pilot warning language when a user creates a fir space. fir is now GA.
2. Slightly modifies the node engines definition in `package.json` to ensure we are asking for the latest `20.x` node version.

### Testing

1. Pull this branch down and `yarn build`
2. `./bin/run spaces:create --space SPACE_NAME --team TEAM_NAME --generation fir`
3. See that no pilot warning message appears