### PR TITLE
refactor: Use ux.log instead of ux.info, replace ux.debug with debug

### DIFF
--- a/packages/cli/src/commands/keys/add.ts
+++ b/packages/cli/src/commands/keys/add.ts
@@ -79,7 +79,7 @@ Uploading SSH public key /my/key.pub... done`
 
       if (keys.length === 1) {
         const key = keys[0]
-        ux.info(`Found an SSH public key at ${color.cyan(key)}`)
+        ux.log(`Found an SSH public key at ${color.cyan(key)}`)
 
         if (!flags.yes) {
           const resp = await confirmPrompt('Would you like to upload it to Heroku?')

--- a/packages/cli/src/lib/ci/source.ts
+++ b/packages/cli/src/lib/ci/source.ts
@@ -1,8 +1,10 @@
 import {Command} from '@heroku-cli/command'
 import * as fs from 'async-file'
-import {ux} from '@oclif/core'
 import * as git from './git'
 import got from 'got'
+import debug from 'debug'
+
+const ciDebug = debug('ci')
 
 async function uploadArchive(url: string, filePath: string) {
   const request = got.stream.put(url, {
@@ -37,7 +39,7 @@ export async function createSourceBlob(ref: any, command: Command) {
     }
   } catch (error) {
     // the commit isn't in the repo, we will package the local git commit instead
-    ux.debug(`Commit not found in pipeline repository: ${error}`)
+    ciDebug('Commit not found in pipeline repository', error)
   }
 
   const sourceBlob = await prepareSource(ref, command)


### PR DESCRIPTION
[W-18293488](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Ctf1wYAB/view)

### Description

This replaces usage of `ux.info` with `ux.log` in the `keys:add` command. There is no functional difference in the case where we are using `ux.info`.

This also replaces our use of `ux.debug` with `debug` in a `ci` lib function when an expected error condition occurs. The impact here is that the debug output inside this error condition will show up when `DEBUG=*` (or whatever i set via https://github.com/debug-js/debug) rather than the `--debug` option. `--debug` is not used anywhere else in the CLI (we use the debug package instead) and is completely deprecated/removed in future versions of oclif.
