### PR TITLE
refactor: switch ux functions to hux

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "@heroku-cli/schema": "^1.0.25",
     "@heroku/buildpack-registry": "^1.0.1",
     "@heroku/eventsource": "^1.0.7",
-    "@heroku/heroku-cli-util": "^8.0.13",
+    "@heroku/heroku-cli-util": "^9.0.1-beta.2",
     "@heroku/http-call": "^5.4.0",
     "@inquirer/prompts": "^5.0.5",
     "@oclif/core": "^2.16.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "@heroku-cli/schema": "^1.0.25",
     "@heroku/buildpack-registry": "^1.0.1",
     "@heroku/eventsource": "^1.0.7",
-    "@heroku/heroku-cli-util": "^9.0.1-beta.2",
+    "@heroku/heroku-cli-util": "^9.0.1",
     "@heroku/http-call": "^5.4.0",
     "@inquirer/prompts": "^5.0.5",
     "@oclif/core": "^2.16.0",

--- a/packages/cli/src/commands/access/index.ts
+++ b/packages/cli/src/commands/access/index.ts
@@ -2,6 +2,7 @@ import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {HerokuAPIError} from '@heroku-cli/command/lib/api-client'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 import * as _ from 'lodash'
 import {isTeamApp, getOwner} from '../../lib/teamUtils'
@@ -58,7 +59,7 @@ function printAccess(app: Heroku.App, collaborators: any[]) {
     .value()
 
   const tableColumns = buildTableColumns(showPermissions)
-  ux.table(
+  hux.table(
     collaborators,
     tableColumns,
   )

--- a/packages/cli/src/commands/accounts/current.ts
+++ b/packages/cli/src/commands/accounts/current.ts
@@ -1,5 +1,6 @@
 import {Command} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {current} from '../../lib/accounts/accounts'
 import color from '@heroku-cli/color'
 
@@ -11,7 +12,7 @@ export default class Current extends Command {
   async run() {
     const account = current()
     if (account) {
-      ux.styledHeader(`Current account is ${account}`)
+      hux.styledHeader(`Current account is ${account}`)
     } else {
       ux.error(`You haven't set an account. Run ${color.cmd('heroku accounts:add <account-name>')} to add an account to your cache or ${color.cmd('heroku accounts:set <account-name>')} to set the current account.`)
     }

--- a/packages/cli/src/commands/addons/index.ts
+++ b/packages/cli/src/commands/addons/index.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {APIClient, Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 import {formatPrice, grandfatheredPrice, formatState} from '../../lib/addons/util'
 import {groupBy, some, sortBy, values} from 'lodash'
@@ -82,7 +83,7 @@ function displayAll(addons: Heroku.AddOn[]) {
     return
   }
 
-  ux.table(
+  hux.table(
     addons,
     {
       'Owning App': {
@@ -176,7 +177,7 @@ function displayForApp(app: string, addons: Heroku.AddOn[]) {
 
   addons = sortBy(addons, isForeignApp, 'plan.name', 'name')
   ux.log()
-  ux.table(
+  hux.table(
     addons,
     {
       'Add-on': {get: presentAddon},

--- a/packages/cli/src/commands/addons/info.ts
+++ b/packages/cli/src/commands/addons/info.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
+import {Args} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 import {grandfatheredPrice, formatPrice, formatState} from '../../lib/addons/util'
 import {resolveAddon} from '../../lib/addons/resolve'
@@ -29,9 +30,9 @@ export default class Info extends Command {
 
     addon.plan.price = grandfatheredPrice(addon)
     addon.attachments = attachments
-    ux.styledHeader(color.magenta(addon.name ?? ''))
+    hux.styledHeader(color.magenta(addon.name ?? ''))
 
-    ux.styledObject({
+    hux.styledObject({
       Plan: addon.plan.name,
       Price: formatPrice({price: addon.plan.price, hourly: true}),
       'Max Price': formatPrice({price: addon.plan.price, hourly: false}),

--- a/packages/cli/src/commands/addons/plans.ts
+++ b/packages/cli/src/commands/addons/plans.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
+import {Args} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {formatPrice} from '../../lib/addons/util'
 import * as _ from 'lodash'
 import {Plan} from '@heroku-cli/schema'
@@ -39,9 +40,9 @@ export default class Plans extends Command {
     })
     plans = _.sortBy(plans, ['price.contract', 'price.cents'])
     if (flags.json) {
-      ux.styledJSON(plans)
+      hux.styledJSON(plans)
     } else {
-      ux.table(plans, {
+      hux.table(plans, {
         default: {
           header: '',
           get: (plan: any) => plan.default ? 'default' : '',

--- a/packages/cli/src/commands/addons/services.ts
+++ b/packages/cli/src/commands/addons/services.ts
@@ -1,33 +1,34 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 
 export default class Services extends Command {
-    static topic = 'addons';
-    static description = 'list all available add-on services';
-    static flags = {
-      json: flags.boolean({description: 'output in json format'}),
-    };
+  static topic = 'addons';
+  static description = 'list all available add-on services';
+  static flags = {
+    json: flags.boolean({description: 'output in json format'}),
+  };
 
-    public async run(): Promise<void> {
-      const {flags} = await this.parse(Services)
-      const {body: services} = await this.heroku.get<Heroku.AddOnService[]>('/addon-services')
-      if (flags.json) {
-        ux.styledJSON(services)
-      } else {
-        ux.table(services, {
-          name: {
-            header: 'Slug',
-          },
-          human_name: {
-            header: 'Name',
-          },
-          state: {
-            header: 'State',
-          },
-        })
-        ux.log(`\nSee plans with ${color.blue('heroku addons:plans SERVICE')}`)
-      }
+  public async run(): Promise<void> {
+    const {flags} = await this.parse(Services)
+    const {body: services} = await this.heroku.get<Heroku.AddOnService[]>('/addon-services')
+    if (flags.json) {
+      hux.styledJSON(services)
+    } else {
+      hux.table(services, {
+        name: {
+          header: 'Slug',
+        },
+        human_name: {
+          header: 'Name',
+        },
+        state: {
+          header: 'State',
+        },
+      })
+      ux.log(`\nSee plans with ${color.blue('heroku addons:plans SERVICE')}`)
     }
+  }
 }

--- a/packages/cli/src/commands/apps/create.ts
+++ b/packages/cli/src/commands/apps/create.ts
@@ -9,6 +9,7 @@ import {
   StackCompletion,
 } from '@heroku-cli/command/lib/completions'
 import {Args, Interfaces, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import color from '@heroku-cli/color'
 import * as Heroku from '@heroku-cli/schema'
 import {get} from 'lodash'
@@ -98,7 +99,7 @@ async function configureGitRemote(context: ParserOutput<Create>, app: Heroku.App
 
 function printAppSummary(context: ParserOutput<Create>, app: Heroku.App, remoteUrl: string) {
   if (context.flags.json) {
-    ux.styledJSON(app)
+    hux.styledJSON(app)
   } else {
     ux.log(`${color.cyan(app.web_url || '')} | ${color.green(remoteUrl)}`)
   }

--- a/packages/cli/src/commands/apps/errors.ts
+++ b/packages/cli/src/commands/apps/errors.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {HTTP} from '@heroku/http-call'
 import {sum} from 'lodash'
 import errorInfo from '../../lib/apps/error_info'
@@ -119,7 +120,7 @@ export default class Errors extends Command {
     }
 
     if (flags.json) {
-      ux.styledJSON(errors)
+      hux.styledJSON(errors)
     } else {
       let t = buildErrorTable(errors.router, 'router')
       for (const type of Object.keys(errors.dyno)) {
@@ -129,8 +130,8 @@ export default class Errors extends Command {
       if (t.length === 0) {
         ux.log(`No errors on ${color.app(flags.app)} in the last ${hours} hours`)
       } else {
-        ux.styledHeader(`Errors on ${color.app(flags.app)} in the last ${hours} hours`)
-        ux.table(t, {
+        hux.styledHeader(`Errors on ${color.app(flags.app)} in the last ${hours} hours`)
+        hux.table(t, {
           source: {},
           name: {get: ({name, level}) => colorize(level, name)},
           level: {get: ({level}) => colorize(level, level)},

--- a/packages/cli/src/commands/apps/favorites/index.ts
+++ b/packages/cli/src/commands/apps/favorites/index.ts
@@ -1,4 +1,5 @@
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Favorites} from '../../../lib/types/favorites'
 
@@ -18,9 +19,9 @@ export default class Index extends Command {
     )
 
     if (flags.json) {
-      ux.styledJSON(favorites)
+      hux.styledJSON(favorites)
     } else {
-      ux.styledHeader('Favorited Apps')
+      hux.styledHeader('Favorited Apps')
       for (const f of favorites) {
         ux.log(f.resource_name)
       }

--- a/packages/cli/src/commands/apps/index.ts
+++ b/packages/cli/src/commands/apps/index.ts
@@ -1,4 +1,5 @@
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import * as _ from 'lodash'
@@ -38,15 +39,15 @@ function print(apps: Heroku.App, user: Heroku.Account, space?: string, team?: st
     else if (team) ux.log(`There are no apps in team ${color.magenta(team)}.`)
     else ux.log('You have no apps.')
   } else if (space) {
-    ux.styledHeader(`Apps in space ${color.green(space)}`)
+    hux.styledHeader(`Apps in space ${color.green(space)}`)
     listApps(apps)
   } else if (team) {
-    ux.styledHeader(`Apps in team ${color.magenta(team)}`)
+    hux.styledHeader(`Apps in team ${color.magenta(team)}`)
     listApps(apps)
   } else {
     apps = _.partition(apps, (app: App) => app.owner.email === user.email)
     if (apps[0].length > 0) {
-      ux.styledHeader(`${color.cyan(user.email!)} Apps`)
+      hux.styledHeader(`${color.cyan(user.email!)} Apps`)
       listApps(apps[0])
     }
 
@@ -56,8 +57,8 @@ function print(apps: Heroku.App, user: Heroku.Account, space?: string, team?: st
     }
 
     if (apps[1].length > 0) {
-      ux.styledHeader('Collaborated Apps')
-      ux.table(apps[1], columns, {'no-header': true})
+      hux.styledHeader('Collaborated Apps')
+      hux.table(apps[1], columns, {'no-header': true})
     }
   }
 }
@@ -116,7 +117,7 @@ export default class AppsIndex extends Command {
     }
 
     if (flags.json) {
-      ux.styledJSON(apps)
+      hux.styledJSON(apps)
     } else {
       print(apps, user, space, team)
     }

--- a/packages/cli/src/commands/apps/info.ts
+++ b/packages/cli/src/commands/apps/info.ts
@@ -1,10 +1,12 @@
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import * as util from 'util'
 import * as _ from 'lodash'
 import {filesize} from 'filesize'
 import {getGeneration} from '../../lib/apps/generation'
+
 const {countBy, snakeCase} = _
 
 function formatDate(date: Date) {
@@ -85,8 +87,8 @@ function print(info: Heroku.App, addons: Heroku.AddOn[], collaborators: Heroku.C
     return stack
   })(info.app)
 
-  ux.styledHeader(info.app.name)
-  ux.styledObject(data)
+  hux.styledHeader(info.app.name)
+  hux.styledObject(data)
 
   if (extended) {
     ux.log('\n\n--- Extended Information ---\n\n')
@@ -170,7 +172,7 @@ repo_size=5000000
     if (flags.shell) {
       shell()
     } else if (flags.json) {
-      ux.styledJSON(info)
+      hux.styledJSON(info)
     } else {
       print(info, addons, collaborators, flags.extended)
     }

--- a/packages/cli/src/commands/apps/stacks/index.ts
+++ b/packages/cli/src/commands/apps/stacks/index.ts
@@ -1,4 +1,5 @@
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as _ from 'lodash'
 import color from '@heroku-cli/color'
@@ -34,7 +35,7 @@ export default class StacksIndex extends Command {
     const stacks = stackResponse.body
     const sortedStacks = _.sortBy(stacks, 'name')
 
-    ux.styledHeader(`${color.app(app.name!)} Available Stacks`)
+    hux.styledHeader(`${color.app(app.name!)} Available Stacks`)
     for (const stack of sortedStacks) {
       if (stack.name === app.stack!.name) {
         ux.log(color.green('* ' + updateCedarName(stack.name!)))

--- a/packages/cli/src/commands/authorizations/create.ts
+++ b/packages/cli/src/commands/authorizations/create.ts
@@ -2,6 +2,7 @@ import {Command, flags} from '@heroku-cli/command'
 import {ScopeCompletion} from '@heroku-cli/command/lib/completions'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 import {display} from '../../lib/authorizations/authorizations'
 
@@ -38,7 +39,7 @@ export default class AuthorizationsCreate extends Command {
     if (flags.short) {
       ux.log(auth.access_token && auth.access_token.token)
     } else if (flags.json) {
-      ux.styledJSON(auth)
+      hux.styledJSON(auth)
     } else {
       display(auth)
     }

--- a/packages/cli/src/commands/authorizations/index.ts
+++ b/packages/cli/src/commands/authorizations/index.ts
@@ -2,6 +2,7 @@ import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 const {sortBy} = require('lodash')
 
 export default class AuthorizationsIndex extends Command {
@@ -23,12 +24,12 @@ export default class AuthorizationsIndex extends Command {
     authorizations = sortBy(authorizations, 'description')
 
     if (flags.json) {
-      ux.styledJSON(authorizations)
+      hux.styledJSON(authorizations)
     } else if (authorizations.length === 0) {
       ux.log('No OAuth authorizations.')
     } else {
       const printLine: typeof this.log = (...args) => this.log(...args)
-      ux.table(authorizations, {
+      hux.table(authorizations, {
         description: {get: (v: any) => color.green(v.description)},
         id: {},
         scope: {get: (v: any) => v.scope.join(',')},

--- a/packages/cli/src/commands/authorizations/info.ts
+++ b/packages/cli/src/commands/authorizations/info.ts
@@ -1,6 +1,7 @@
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
-import {Args, ux} from '@oclif/core'
+import {Args} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 import {display} from '../../lib/authorizations/authorizations'
 
@@ -23,7 +24,7 @@ export default class AuthorizationsInfo extends Command {
     )
 
     if (flags.json) {
-      ux.styledJSON(authentication)
+      hux.styledJSON(authentication)
     } else {
       display(authentication)
     }

--- a/packages/cli/src/commands/autocomplete/doctor.ts
+++ b/packages/cli/src/commands/autocomplete/doctor.ts
@@ -1,5 +1,6 @@
 import {flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
+import {Args} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {FlagInput} from '@oclif/core/lib/interfaces/parser'
 import * as fs from 'fs-extra'
 import * as path from 'path'
@@ -64,7 +65,7 @@ export default class Doctor extends AutocompleteBase {
 
     data.push({name: 'apps completion cache', value: appsCacheValue})
 
-    ux.table(data, {
+    hux.table(data, {
       name: {},
       value: {},
     }, {'no-header': true, printLine})

--- a/packages/cli/src/commands/buildpacks/index.ts
+++ b/packages/cli/src/commands/buildpacks/index.ts
@@ -1,5 +1,5 @@
 import {Command, flags as Flags} from '@heroku-cli/command'
-import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {App} from '../../lib/types/fir'
 import color from '@heroku-cli/color'
 
@@ -35,7 +35,7 @@ export default class Index extends Command {
         header += ` Classic ${pluralizedBuildpacks} (from the Heroku Buildpack Registry)`
       }
 
-      ux.styledHeader(header)
+      hux.styledHeader(header)
       buildpacksCommand.display(buildpacks, '')
     }
   }

--- a/packages/cli/src/commands/buildpacks/info.ts
+++ b/packages/cli/src/commands/buildpacks/info.ts
@@ -1,5 +1,6 @@
 import {Command} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {Result} from 'true-myth'
 
 import {BuildpackRegistry} from '@heroku/buildpack-registry'
@@ -28,8 +29,8 @@ export default class Info extends Command {
     const result = await registry.info(args.buildpack)
     Result.match({
       Ok: buildpack => {
-        ux.styledHeader(args.buildpack)
-        ux.styledObject(buildpack, ['description', 'category', 'license', 'support', 'source', 'readme'])
+        hux.styledHeader(args.buildpack)
+        hux.styledObject(buildpack, ['description', 'category', 'license', 'support', 'source', 'readme'])
       },
       Err: err => {
         if (err.status === 404) {

--- a/packages/cli/src/commands/buildpacks/search.ts
+++ b/packages/cli/src/commands/buildpacks/search.ts
@@ -1,5 +1,6 @@
 import {Command, flags as Flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 import {BuildpackBody, BuildpackRegistry, Category} from '@heroku/buildpack-registry'
 
@@ -51,7 +52,7 @@ export default class Search extends Command {
       }
     })
     const displayTable = (buildpacks: TableRow[]) => {
-      ux.table(buildpacks, {
+      hux.table(buildpacks, {
         buildpack: {
           header: 'Buildpack',
         },

--- a/packages/cli/src/commands/buildpacks/versions.ts
+++ b/packages/cli/src/commands/buildpacks/versions.ts
@@ -1,5 +1,6 @@
 import {Command} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
+import {Args} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {Result} from 'true-myth'
 
 import {BuildpackRegistry, RevisionBody} from '@heroku/buildpack-registry'
@@ -33,7 +34,7 @@ export default class Versions extends Command {
     const result = await registry.listVersions(args.buildpack)
     Result.match({
       Ok: versions => {
-        ux.table(versions.sort((a: RevisionBody, b: RevisionBody) => {
+        hux.table(versions.sort((a: RevisionBody, b: RevisionBody) => {
           return a.release > b.release ? -1 : 1
         }), {
           release: {

--- a/packages/cli/src/commands/certs/add.ts
+++ b/packages/cli/src/commands/certs/add.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {APIClient, Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 import {waitForDomains} from '../../lib/certs/domains'
 import {prompt} from 'inquirer'
@@ -15,7 +16,7 @@ async function configureDomains(app: string, heroku: APIClient, cert: SniEndpoin
   const appDomains = apiDomains?.map((domain: Heroku.Domain) => domain.hostname as string)
   const matchedDomains = matchDomains(certDomains, appDomains ?? [])
   if (matchedDomains.length > 0) {
-    ux.styledHeader('Almost done! Which of these domains on this application would you like this certificate associated with?')
+    hux.styledHeader('Almost done! Which of these domains on this application would you like this certificate associated with?')
     const selections = await prompt<{domains: string[]}>([{
       type: 'checkbox',
       name: 'domains',

--- a/packages/cli/src/commands/certs/auto/enable.ts
+++ b/packages/cli/src/commands/certs/auto/enable.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {getDomains, waitForDomains, printDomains, waitForCertIssuedOnDomains} from '../../../lib/domains/domains'
 import notify from '../../../lib/notify'
 
@@ -31,7 +32,7 @@ export default class Enable extends Command {
           notify('heroku certs:auto:enable', 'Certificate issued to all domains')
         } catch (error) {
           notify('heroku certs:auto:enable', 'An error occurred', false)
-          ux.styledHeader(`${color.red('Error')}: The certificate could not be issued to all domains. See status with ${color.cmd('heroku certs:auto')}.`)
+          hux.styledHeader(`${color.red('Error')}: The certificate could not be issued to all domains. See status with ${color.cmd('heroku certs:auto')}.`)
           throw error
         }
       } else {
@@ -48,7 +49,7 @@ export default class Enable extends Command {
       if (domains.length === 0 || changedCnames.length > 0) {
         printDomains(changedCnames, message)
       } else {
-        ux.styledHeader(message)
+        hux.styledHeader(message)
       }
     }
 }

--- a/packages/cli/src/commands/certs/auto/index.ts
+++ b/packages/cli/src/commands/certs/auto/index.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 import {displayCertificateDetails} from '../../../lib/certs/certificate_details'
 import {waitForCertIssuedOnDomains} from '../../../lib/domains/domains'
@@ -53,11 +54,11 @@ export default class Index extends Command {
     ])
 
     if (!app.acm) {
-      ux.styledHeader(`Automatic Certificate Management is ${color.yellow('disabled')} on ${flags.app}`)
+      hux.styledHeader(`Automatic Certificate Management is ${color.yellow('disabled')} on ${flags.app}`)
       return
     }
 
-    ux.styledHeader(`Automatic Certificate Management is ${color.green('enabled')} on ${flags.app}`)
+    hux.styledHeader(`Automatic Certificate Management is ${color.green('enabled')} on ${flags.app}`)
 
     if (sniEndpoints.length === 1 && sniEndpoints[0].ssl_cert.acm) {
       displayCertificateDetails(sniEndpoints[0])
@@ -86,7 +87,7 @@ export default class Index extends Command {
     }
 
     if (domains.length > 0) {
-      ux.table<Record<keyof Domain, unknown>>(
+      hux.table<Record<keyof Domain, unknown>>(
         domains,
         {
           Domain: {
@@ -112,7 +113,7 @@ export default class Index extends Command {
     }
 
     if (message) {
-      ux.styledHeader(message)
+      hux.styledHeader(message)
     }
   }
 }

--- a/packages/cli/src/commands/ci/config/index.ts
+++ b/packages/cli/src/commands/ci/config/index.ts
@@ -1,5 +1,6 @@
 import {Command, flags as cmdFlags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import color from '@heroku-cli/color'
 import * as Heroku from '@heroku-cli/schema'
 import * as shellescape from 'shell-escape'
@@ -33,14 +34,14 @@ export default class CiConfig extends Command {
         ux.log(`${key}=${shellescape([config[key]])}`)
       })
     } else if (flags.json) {
-      ux.styledJSON(config)
+      hux.styledJSON(config)
     } else {
-      ux.styledHeader(`${pipeline.name} test config vars`)
+      hux.styledHeader(`${pipeline.name} test config vars`)
       const formattedConfig: Heroku.Pipeline = {}
       Object.keys(config).forEach(key => {
         formattedConfig[color.green(key)] = config[key]
       })
-      ux.styledObject(formattedConfig)
+      hux.styledObject(formattedConfig)
     }
   }
 }

--- a/packages/cli/src/commands/ci/config/set.ts
+++ b/packages/cli/src/commands/ci/config/set.ts
@@ -1,4 +1,5 @@
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {getPipeline} from '../../../lib/ci/pipelines'
 import {Command, flags} from '@heroku-cli/command'
 import {setPipelineConfigVars} from '../../../lib/api'
@@ -51,7 +52,7 @@ export default class CiConfigSet extends Command {
     await setPipelineConfigVars(this.heroku, pipeline.id, vars)
     ux.action.stop()
 
-    ux.styledObject(
+    hux.styledObject(
       Object.keys(vars).reduce((memo: Record<string, string>, key: string) => {
         memo[color.green(key)] = vars[key]
         return memo

--- a/packages/cli/src/commands/clients/create.ts
+++ b/packages/cli/src/commands/clients/create.ts
@@ -1,6 +1,7 @@
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 import {validateURL} from '../../lib/clients/clients'
 
@@ -36,7 +37,7 @@ export default class ClientsCreate extends Command {
     ux.action.stop()
 
     if (flags.json) {
-      ux.styledJSON(client)
+      hux.styledJSON(client)
     } else {
       ux.log(`HEROKU_OAUTH_ID=${client.id}`)
       ux.log(`HEROKU_OAUTH_SECRET=${client.secret}`)

--- a/packages/cli/src/commands/clients/index.ts
+++ b/packages/cli/src/commands/clients/index.ts
@@ -2,6 +2,7 @@ import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 const {sortBy} = require('lodash')
 
 export default class ClientsIndex extends Command {
@@ -19,12 +20,12 @@ export default class ClientsIndex extends Command {
     clients = sortBy(clients, 'name')
 
     if (flags.json) {
-      ux.styledJSON(clients)
+      hux.styledJSON(clients)
     } else if (clients.length === 0) {
       ux.log('No OAuth clients.')
     } else {
       const printLine: typeof this.log = (...args) => this.log(...args)
-      ux.table(clients, {
+      hux.table(clients, {
         name: {get: (w: any) => color.green(w.name)},
         id: {},
         redirect_uri: {},

--- a/packages/cli/src/commands/clients/info.ts
+++ b/packages/cli/src/commands/clients/info.ts
@@ -1,6 +1,7 @@
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 export default class ClientsInfo extends Command {
   static description = 'show details of an oauth client'
@@ -24,13 +25,13 @@ export default class ClientsInfo extends Command {
     const {body: client} = await this.heroku.get<Heroku.OAuthClient>(`/oauth/clients/${args.id}`)
 
     if (flags.json) {
-      ux.styledJSON(client)
+      hux.styledJSON(client)
     } else if (flags.shell) {
       ux.log(`HEROKU_OAUTH_ID=${client.id}`)
       ux.log(`HEROKU_OAUTH_SECRET=${client.secret}`)
     } else {
-      ux.styledHeader(`${client.name}`)
-      ux.styledObject(client)
+      hux.styledHeader(`${client.name}`)
+      hux.styledObject(client)
     }
   }
 }

--- a/packages/cli/src/commands/clients/rotate.ts
+++ b/packages/cli/src/commands/clients/rotate.ts
@@ -2,6 +2,7 @@ import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 export default class ClientsRotate extends Command {
   static description = 'rotate OAuth client secret'
@@ -27,13 +28,13 @@ export default class ClientsRotate extends Command {
     ux.action.stop()
 
     if (flags.json) {
-      ux.styledJSON(client)
+      hux.styledJSON(client)
     } else if (flags.shell) {
       ux.log(`HEROKU_OAUTH_ID=${client.id}`)
       ux.log(`HEROKU_OAUTH_SECRET=${client.secret}`)
     } else {
-      ux.styledHeader(`${client.name}`)
-      ux.styledObject(client)
+      hux.styledHeader(`${client.name}`)
+      hux.styledObject(client)
     }
   }
 }

--- a/packages/cli/src/commands/config/edit.ts
+++ b/packages/cli/src/commands/config/edit.ts
@@ -2,6 +2,8 @@ import {color} from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
+
 import * as _ from 'lodash'
 
 import {parse, quote} from '../../lib/config/quote'
@@ -132,7 +134,7 @@ $ VISUAL="atom --wait" heroku config:edit`,
     ux.log('Config Diff:')
     showDiff(original, newConfig)
     ux.log()
-    return ux.confirm(`Update config on ${color.app(this.app)} with these values?`)
+    return hux.confirm(`Update config on ${color.app(this.app)} with these values?`)
   }
 
   private async verifyUnchanged(original: Config) {

--- a/packages/cli/src/commands/config/index.ts
+++ b/packages/cli/src/commands/config/index.ts
@@ -2,6 +2,7 @@ import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as _ from 'lodash'
 
 import {quote} from '../../lib/config/quote'
@@ -23,10 +24,10 @@ export class ConfigIndex extends Command {
       Object.entries(config)
         .forEach(([k, v]) => ux.log(`${k}=${quote(v)}`))
     } else if (flags.json) {
-      ux.styledJSON(config)
+      hux.styledJSON(config)
     } else {
-      ux.styledHeader(`${flags.app} Config Vars`)
-      ux.styledObject(_.mapKeys(config, (_, k) => color.configVar(k)))
+      hux.styledHeader(`${flags.app} Config Vars`)
+      hux.styledObject(_.mapKeys(config, (_, k) => color.configVar(k)))
     }
   }
 }

--- a/packages/cli/src/commands/config/set.ts
+++ b/packages/cli/src/commands/config/set.ts
@@ -2,6 +2,7 @@ import color from '@heroku-cli/color'
 import {Command, flags, APIClient} from '@heroku-cli/command'
 import {mapKeys, pickBy} from 'lodash'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 
 const lastRelease = async (client: APIClient, app: string) => {
@@ -62,7 +63,7 @@ RACK_ENV:  staging`,
 
     config = pickBy(config, (_, k) => vars[k])
     config = mapKeys(config, (_, k) => color.green(k))
-    ux.styledObject(config)
+    hux.styledObject(config)
     await this.config.runHook('recache', {type: 'config', app: flags.app})
   }
 }

--- a/packages/cli/src/commands/container/pull.ts
+++ b/packages/cli/src/commands/container/pull.ts
@@ -1,5 +1,5 @@
 import {Command, flags} from '@heroku-cli/command'
-import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as DockerHelper from '../../lib/container/docker_helper'
 import {ensureContainerStack} from '../../lib/container/helpers'
 import {debug} from '../../lib/container/debug'
@@ -43,7 +43,7 @@ export default class Pull extends Command {
 
     for (const process of argv as string[]) {
       const tag = `${registry}/${app}/${process}`
-      ux.styledHeader(`Pulling ${process} as ${tag}`)
+      hux.styledHeader(`Pulling ${process} as ${tag}`)
       await DockerHelper.pullImage(tag)
     }
   }

--- a/packages/cli/src/commands/container/push.ts
+++ b/packages/cli/src/commands/container/push.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as DockerHelper from '../../lib/container/docker_helper'
 import {ensureContainerStack} from '../../lib/container/helpers'
 import {debug} from '../../lib/container/debug'
@@ -87,9 +88,9 @@ export default class Push extends Command {
     try {
       for (const job of jobs) {
         if (job.name === 'standard') {
-          ux.styledHeader(`Building ${processTypes} (${job.dockerfile})`)
+          hux.styledHeader(`Building ${processTypes} (${job.dockerfile})`)
         } else {
-          ux.styledHeader(`Building ${job.name} (${job.dockerfile})`)
+          hux.styledHeader(`Building ${job.name} (${job.dockerfile})`)
         }
 
         await DockerHelper.buildImage({
@@ -107,9 +108,9 @@ export default class Push extends Command {
     try {
       for (const job of jobs) {
         if (job.name === 'standard') {
-          ux.styledHeader(`Pushing ${processTypes} (${job.dockerfile})`)
+          hux.styledHeader(`Pushing ${processTypes} (${job.dockerfile})`)
         } else {
-          ux.styledHeader(`Pushing ${job.name} (${job.dockerfile})`)
+          hux.styledHeader(`Pushing ${job.name} (${job.dockerfile})`)
         }
 
         await DockerHelper.pushImage(job.resource)

--- a/packages/cli/src/commands/container/run.ts
+++ b/packages/cli/src/commands/container/run.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as DockerHelper from '../../lib/container/docker_helper'
 import {ensureContainerStack} from '../../lib/container/helpers'
 import {debug} from '../../lib/container/debug'
@@ -63,9 +64,9 @@ export default class Run extends Command {
     const job = jobs[0]
 
     if (command.length === 0) {
-      ux.styledHeader(`Running ${job.resource}`)
+      hux.styledHeader(`Running ${job.resource}`)
     } else {
-      ux.styledHeader(`Running '${command}' on ${job.resource}`)
+      hux.styledHeader(`Running '${command}' on ${job.resource}`)
     }
 
     try {

--- a/packages/cli/src/commands/domains/add.ts
+++ b/packages/cli/src/commands/domains/add.ts
@@ -2,6 +2,7 @@ import {color} from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import Spinner from '@oclif/core/lib/cli-ux/action/spinner'
 import {prompt} from 'inquirer'
 import * as shellescape from 'shell-escape'
@@ -111,7 +112,7 @@ export default class DomainsAdd extends Command {
       })
 
       if (flags.json) {
-        ux.styledJSON(domain)
+        hux.styledJSON(domain)
       } else {
         ux.log(`Configure your app's DNS provider to point to the DNS Target ${color.green(domain.cname || '')}.
     For help, see https://devcenter.heroku.com/articles/custom-domains`)

--- a/packages/cli/src/commands/domains/index.ts
+++ b/packages/cli/src/commands/domains/index.ts
@@ -2,6 +2,7 @@ import {Command, flags} from '@heroku-cli/command'
 import color from '@heroku-cli/color'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Uri from 'urijs'
 import {confirm} from '@inquirer/prompts'
 import {paginateRequest} from '../../lib/utils/paginator'
@@ -120,9 +121,9 @@ www.example.com  CNAME            www.example.herokudns.com
     }
 
     if (flags.json) {
-      ux.styledJSON(domains)
+      hux.styledJSON(domains)
     } else {
-      ux.styledHeader(`${flags.app} Heroku Domain`)
+      hux.styledHeader(`${flags.app} Heroku Domain`)
       ux.log(herokuDomain && herokuDomain.hostname)
       if (customDomains && customDomains.length > 0) {
         ux.log()
@@ -137,8 +138,8 @@ www.example.com  CNAME            www.example.herokudns.com
         }
 
         ux.log()
-        ux.styledHeader(`${flags.app} Custom Domains`)
-        ux.table(customDomains, this.tableConfig(true), {
+        hux.styledHeader(`${flags.app} Custom Domains`)
+        hux.table(customDomains, this.tableConfig(true), {
           ...flags,
           'no-truncate': true,
         })

--- a/packages/cli/src/commands/domains/info.ts
+++ b/packages/cli/src/commands/domains/info.ts
@@ -1,6 +1,7 @@
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
-import {Args, ux} from '@oclif/core'
+import {Args} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 export default class DomainsInfo extends Command {
   static description = 'show detailed information for a domain on an app'
@@ -26,6 +27,6 @@ export default class DomainsInfo extends Command {
       ...res,
       app: res.app && res.app.name,
     }
-    ux.styledObject(domain)
+    hux.styledObject(domain)
   }
 }

--- a/packages/cli/src/commands/drains/index.ts
+++ b/packages/cli/src/commands/drains/index.ts
@@ -1,4 +1,5 @@
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import color from '@heroku-cli/color'
 import * as Heroku from '@heroku-cli/schema'
 import {flags, Command} from '@heroku-cli/command'
@@ -31,11 +32,11 @@ export default class Drains extends Command {
     const {body: drains} = await this.heroku.get<Heroku.LogDrain[]>(path)
 
     if (flags.json) {
-      ux.styledJSON(drains)
+      hux.styledJSON(drains)
     } else {
       const [drainsWithAddons, drainsWithoutAddons] = partition<Heroku.LogDrain>(drains, 'addon')
       if (drainsWithoutAddons.length > 0) {
-        ux.styledHeader('Drains')
+        hux.styledHeader('Drains')
         drainsWithoutAddons.forEach((drain: Heroku.LogDrain) => {
           styledDrain(drain.url || '', color.green(drain.token || ''), drain)
         })
@@ -45,7 +46,7 @@ export default class Drains extends Command {
         const addons = await Promise.all(
           drainsWithAddons.map((d: Heroku.LogDrain) => this.heroku.get<Heroku.AddOn>(`/apps/${flags.app}/addons/${d.addon?.name}`)),
         )
-        ux.styledHeader('Add-on Drains')
+        hux.styledHeader('Add-on Drains')
         addons.forEach(({body: addon}, i) => {
           styledDrain(color.yellow(addon.plan?.name || ''), color.green(addon.name || ''), drainsWithAddons[i])
         })

--- a/packages/cli/src/commands/features/index.ts
+++ b/packages/cli/src/commands/features/index.ts
@@ -1,4 +1,5 @@
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import color from '@heroku-cli/color'
 import * as Heroku from '@heroku-cli/schema'
 import {flags, Command} from '@heroku-cli/command'
@@ -21,9 +22,9 @@ export default class Features extends Command {
     features = sortBy(features, 'name')
 
     if (json) {
-      ux.styledJSON(features)
+      hux.styledJSON(features)
     } else {
-      ux.styledHeader(`App Features ${color.app(app)}`)
+      hux.styledHeader(`App Features ${color.app(app)}`)
       const longest = Math.max.apply(null, features.map(f => f.name?.length || 0))
 
       for (const f of features) {

--- a/packages/cli/src/commands/features/info.ts
+++ b/packages/cli/src/commands/features/info.ts
@@ -1,4 +1,5 @@
-import {Args, ux} from '@oclif/core'
+import {Args} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import color from '@heroku-cli/color'
 import * as Heroku from '@heroku-cli/schema'
 import {flags, Command} from '@heroku-cli/command'
@@ -22,10 +23,10 @@ export default class Info extends Command {
     const {body: feature} = await this.heroku.get<Heroku.AppFeature>(`/apps/${app}/features/${args.feature}`)
 
     if (json) {
-      ux.styledJSON(feature)
+      hux.styledJSON(feature)
     } else {
-      ux.styledHeader(feature.name || '')
-      ux.styledObject({
+      hux.styledHeader(feature.name || '')
+      hux.styledObject({
         Description: feature.description,
         Enabled: feature.enabled ? color.green('true') : color.red('false'),
         Docs: feature.doc_url,

--- a/packages/cli/src/commands/keys/add.ts
+++ b/packages/cli/src/commands/keys/add.ts
@@ -1,4 +1,5 @@
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import color from '@heroku-cli/color'
 import {flags, Command} from '@heroku-cli/command'
 import * as  inquirer from 'inquirer'
@@ -23,7 +24,7 @@ async function confirmPrompt(message: string) {
     }])
   }
 
-  const data = await ux.prompt(message + ' [Y/n]')
+  const data = await hux.prompt(message + ' [Y/n]')
   return {yes: /^y(es)?/i.test(data)}
 }
 

--- a/packages/cli/src/commands/keys/index.ts
+++ b/packages/cli/src/commands/keys/index.ts
@@ -1,4 +1,5 @@
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import color from '@heroku-cli/color'
 import * as Heroku from '@heroku-cli/schema'
 import {flags, Command} from '@heroku-cli/command'
@@ -19,11 +20,11 @@ export default class Keys extends Command {
     const {flags} = await this.parse(Keys)
     const {body: keys} = await this.heroku.get<Heroku.Key[]>('/account/keys')
     if (flags.json) {
-      ux.styledJSON(keys)
+      hux.styledJSON(keys)
     } else if (keys.length === 0) {
       ux.warn('You have no SSH keys.')
     } else {
-      ux.styledHeader(`${color.cyan(keys[0].email || '')} keys`)
+      hux.styledHeader(`${color.cyan(keys[0].email || '')} keys`)
       if (flags.long) {
         keys.forEach(k => ux.log(k.public_key))
       } else {

--- a/packages/cli/src/commands/labs/disable.ts
+++ b/packages/cli/src/commands/labs/disable.ts
@@ -2,13 +2,14 @@ import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {FlagInput} from '@oclif/core/lib/interfaces/parser'
 
 const SecurityExceptionFeatures: any = {
   'spaces-strict-tls': {
     async prompt(app: string): Promise<string> {
       ux.warn('Insecure Action')
-      const name = await ux.prompt(`You are enabling an older security protocol, TLS 1.0, which some organizations may not deem secure.
+      const name = await hux.prompt(`You are enabling an older security protocol, TLS 1.0, which some organizations may not deem secure.
 To proceed, type ${app} or re-run this command with --confirm ${app}`)
       return name
     },

--- a/packages/cli/src/commands/labs/index.ts
+++ b/packages/cli/src/commands/labs/index.ts
@@ -2,6 +2,7 @@ import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {sortBy} from 'lodash'
 
 interface Features {
@@ -67,11 +68,11 @@ export default class LabsIndex extends Command {
     if (flags.json) {
       printJSON({app, user})
     } else {
-      ux.styledHeader(`User Features ${color.cyan(features.currentUser.email!)}`)
+      hux.styledHeader(`User Features ${color.cyan(features.currentUser.email!)}`)
       printFeatures(features.user)
       if (features.app) {
         ux.log()
-        ux.styledHeader(`App Features ${color.app(flags.app!)}`)
+        hux.styledHeader(`App Features ${color.app(flags.app!)}`)
         printFeatures(features.app)
       }
     }

--- a/packages/cli/src/commands/labs/info.ts
+++ b/packages/cli/src/commands/labs/info.ts
@@ -2,10 +2,11 @@ import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 function print(feature: Record<string, string>) {
-  ux.styledHeader(feature.name)
-  ux.styledObject({
+  hux.styledHeader(feature.name)
+  hux.styledObject({
     Description: feature.description,
     Enabled: feature.enabled ? color.green(feature.enabled) : color.red(feature.enabled),
     Docs: feature.doc_url,
@@ -42,7 +43,7 @@ export default class LabsInfo extends Command {
     }
 
     if (flags.json) {
-      ux.styledJSON(feature)
+      hux.styledJSON(feature)
     } else {
       print(feature)
     }

--- a/packages/cli/src/commands/members/index.ts
+++ b/packages/cli/src/commands/members/index.ts
@@ -2,6 +2,7 @@ import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {RoleCompletion} from '@heroku-cli/command/lib/completions'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 
 const _ = require('lodash')
@@ -79,7 +80,7 @@ export default class MembersIndex extends Command {
         ux.log(msg)
       } else {
         const tableColumns = buildTableColumns(teamInvites)
-        ux.table(
+        hux.table(
           members,
           tableColumns,
         )

--- a/packages/cli/src/commands/notifications/index.ts
+++ b/packages/cli/src/commands/notifications/index.ts
@@ -2,13 +2,14 @@ import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import color from '@heroku-cli/color'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {Notifications} from '../../lib/types/notifications'
 import * as time from '../../lib/time'
 import * as wrap from 'word-wrap'
 
 function displayNotifications(notifications: Notifications, app: Heroku.App | null, readNotification: boolean) {
   const read = readNotification ? 'Read' : 'Unread'
-  ux.styledHeader(app ? `${read} Notifications for ${color.app(app.name!)}` : `${read} Notifications`)
+  hux.styledHeader(app ? `${read} Notifications for ${color.app(app.name!)}` : `${read} Notifications`)
   for (const n of notifications) {
     ux.log(color.yellow(`\n${n.title}\n`))
     ux.log(wrap(`\n${color.dim(time.ago(new Date(n.created_at)))}\n${n.body}`, {width: 80}))
@@ -45,7 +46,7 @@ export default class NotificationsIndex extends Command {
     }
 
     if (flags.json) {
-      ux.styledJSON(notifications)
+      hux.styledJSON(notifications)
       return
     }
 

--- a/packages/cli/src/commands/pg/backups/index.ts
+++ b/packages/cli/src/commands/pg/backups/index.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import backupsFactory from '../../../lib/pg/backups'
 import host from '../../../lib/pg/host'
 import type {BackupTransfer} from '../../../lib/pg/types'
@@ -45,11 +46,11 @@ export default class Index extends Command {
   private displayBackups(transfers: BackupTransfer[], app: string) {
     const backups = transfers.filter(backupTransfer => backupTransfer.from_type === 'pg_dump' && backupTransfer.to_type === 'gof3r')
     const {name, status, filesize} = backupsFactory(app, this.heroku)
-    ux.styledHeader('Backups')
+    hux.styledHeader('Backups')
     if (backups.length === 0) {
       ux.log(`No backups. Capture one with ${color.cyan.bold('heroku pg:backups:capture')}`)
     } else {
-      ux.table<BackupTransfer>(backups, {
+      hux.table<BackupTransfer>(backups, {
         ID: {
           get: (transfer: BackupTransfer) => color.cyan(name(transfer)),
         },
@@ -76,11 +77,11 @@ export default class Index extends Command {
       .filter(t => t.from_type !== 'pg_dump' && t.to_type === 'pg_restore')
       .slice(0, 10) // first 10 only
     const {name, status, filesize} = backupsFactory(app, this.heroku)
-    ux.styledHeader('Restores')
+    hux.styledHeader('Restores')
     if (restores.length === 0) {
       ux.log(`No restores found. Use ${color.cyan.bold('heroku pg:backups:restore')} to restore a backup`)
     } else {
-      ux.table(restores, {
+      hux.table(restores, {
         ID: {
           get: (transfer: BackupTransfer) => color.cyan(name(transfer)),
         },
@@ -105,11 +106,11 @@ export default class Index extends Command {
   private displayCopies(transfers: BackupTransfer[], app: string) {
     const {name, status, filesize} = backupsFactory(app, this.heroku)
     const copies = transfers.filter(t => t.from_type === 'pg_dump' && t.to_type === 'pg_restore').slice(0, 10)
-    ux.styledHeader('Copies')
+    hux.styledHeader('Copies')
     if (copies.length === 0) {
       ux.log(`No copies found. Use ${color.cyan.bold('heroku pg:copy')} to copy a database to another`)
     } else {
-      ux.table(copies, {
+      hux.table(copies, {
         ID: {
           get: (transfer: BackupTransfer) => color.cyan(name(transfer)),
         },

--- a/packages/cli/src/commands/pg/backups/info.ts
+++ b/packages/cli/src/commands/pg/backups/info.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import pgHost from '../../../lib/pg/host'
 import pgBackupsApi from '../../../lib/pg/backups'
 import {sortBy} from 'lodash'
@@ -67,8 +68,8 @@ export default class Info extends Command {
 
   displayBackup = (backup: BackupTransfer, app: string) => {
     const {filesize, name} = pgBackupsApi(app, this.heroku)
-    ux.styledHeader(`Backup ${color.cyan(name(backup))}`)
-    ux.styledObject({
+    hux.styledHeader(`Backup ${color.cyan(name(backup))}`)
+    hux.styledObject({
       Database: color.green(backup.from_name),
       'Started at': backup.started_at,
       'Finished at': backup.finished_at,
@@ -80,7 +81,7 @@ export default class Info extends Command {
   }
 
   displayLogs = (backup: BackupTransfer) => {
-    ux.styledHeader('Backup Logs')
+    hux.styledHeader('Backup Logs')
     for (const log of backup.logs)
       ux.log(`${log.created_at} ${log.message}`)
     ux.log()

--- a/packages/cli/src/commands/pg/backups/schedules.ts
+++ b/packages/cli/src/commands/pg/backups/schedules.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import pgHost from '../../../lib/pg/host'
 import {arbitraryAppDB} from '../../../lib/pg/fetcher'
 import type {TransferSchedule} from '../../../lib/pg/types'
@@ -21,7 +22,7 @@ export default class Schedules extends Command {
     if (schedules.length === 0) {
       ux.warn(`No backup schedules found on ${color.app(app)}\nUse ${color.cyan.bold('heroku pg:backups:schedule')} to set one up`)
     } else {
-      ux.styledHeader('Backup Schedules')
+      hux.styledHeader('Backup Schedules')
       for (const s of schedules) {
         ux.log(`${color.green(s.name)}: daily at ${s.hour}:00 ${s.timezone}`)
       }

--- a/packages/cli/src/commands/pg/credentials.ts
+++ b/packages/cli/src/commands/pg/credentials.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
+import {Args} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 import pghost from '../../lib/pg/host'
 import {getAddon} from '../../lib/pg/fetcher'
@@ -48,7 +49,7 @@ export default class Credentials extends Command {
       return presentCredentialAttachments(app, credAttachments, sortedCredentials, cred.name)
     }
 
-    ux.table(credentials, {
+    hux.table(credentials, {
       Credential: {
         get: presentCredential,
       },

--- a/packages/cli/src/commands/pg/diagnose.ts
+++ b/packages/cli/src/commands/pg/diagnose.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {table} from '@oclif/core/lib/cli-ux/styled/table'
 import {capitalize} from '@oclif/core/lib/util'
 import heredoc from 'tsheredoc'
@@ -56,7 +57,7 @@ export default class Diagnose extends Command {
 
   private displayReport(report: PGDiagnoseResponse, json: boolean) {
     if (json) {
-      ux.styledJSON(report)
+      hux.styledJSON(report)
       return
     }
 
@@ -86,7 +87,7 @@ export default class Diagnose extends Command {
             get: (row: PGDiagnoseResult): string => row[key],
           }
         })
-        ux.table(check.results, cols)
+        hux.table(check.results, cols)
       } else {
         const [key] = resultsKeys
         ux.log(`${key.split('_')

--- a/packages/cli/src/commands/pg/info.ts
+++ b/packages/cli/src/commands/pg/info.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 import pghost from '../../lib/pg/host'
 import {getAddon, all} from '../../lib/pg/fetcher'
@@ -17,10 +18,10 @@ type DBObject = {
 
 function displayDB(db: DBObject, app: string) {
   if (db.addon.attachment_names) {
-    ux.styledHeader(db.addon.attachment_names.map((c: string) => color.green(c + '_URL'))
+    hux.styledHeader(db.addon.attachment_names.map((c: string) => color.green(c + '_URL'))
       .join(', '))
   } else {
-    ux.styledHeader(db.configVars?.map(c => color.green(c))
+    hux.styledHeader(db.configVars?.map(c => color.green(c))
       .join(', ') || '')
   }
 
@@ -43,7 +44,7 @@ function displayDB(db: DBObject, app: string) {
     }
   })
   const keys = db.dbInfo?.info.map(i => i.name)
-  ux.styledObject(info, keys)
+  hux.styledObject(info, keys)
   ux.log()
 }
 

--- a/packages/cli/src/commands/pg/links/index.ts
+++ b/packages/cli/src/commands/pg/links/index.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {getAddon, all} from '../../../lib/pg/fetcher'
 import pgHost from '../../../lib/pg/host'
 import type {Link} from '../../../lib/pg/types'
@@ -40,7 +41,7 @@ export default class Index extends Command {
         ux.log()
       else
         once = true
-      ux.styledHeader(color.yellow(db.name))
+      hux.styledHeader(color.yellow(db.name))
       if (db.links.message)
         return ux.log(db.links.message)
       if (db.links.length === 0)
@@ -50,7 +51,7 @@ export default class Index extends Command {
         const remoteAttachmentName = link.remote?.attachment_name || ''
         const remoteName = link.remote?.name || ''
         const remoteLinkText = `${color.green(remoteAttachmentName)} (${color.yellow(remoteName)})`
-        ux.styledObject({
+        hux.styledObject({
           created_at: link.created_at,
           remote: remoteLinkText,
         })

--- a/packages/cli/src/commands/pg/settings/index.ts
+++ b/packages/cli/src/commands/pg/settings/index.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {SettingKey, SettingsResponse} from '../../../lib/pg/types'
 import {addonResolver} from '../../../lib/addons/resolve'
 import {essentialPlan} from '../../../lib/pg/util'
@@ -27,11 +28,11 @@ export default class Index extends Command {
     if (essentialPlan(db)) ux.error('You can’t perform this operation on Essential-tier databases.')
 
     const {body: settings} = await this.heroku.get<SettingsResponse>(`/postgres/v0/databases/${db.id}/config`, {hostname: host()})
-    ux.styledHeader(db.name)
+    hux.styledHeader(db.name)
     const remapped: Record<string, unknown> = {}
     Object.keys(settings).forEach(k => {
       remapped[k.replace(/_/g, '-')] = settings[k as SettingKey].value
     })
-    ux.styledObject(remapped)
+    hux.styledObject(remapped)
   }
 }

--- a/packages/cli/src/commands/pipelines/diff.ts
+++ b/packages/cli/src/commands/pipelines/diff.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import HTTP from '@heroku/http-call'
 
 import {getCoupling, getPipeline, getReleases, listPipelineApps, SDK_HEADER} from '../../lib/api'
@@ -50,7 +51,7 @@ async function diff(targetApp: AppInfo, downstreamApp: AppInfo, githubToken: str
     const {body: githubDiff} = await HTTP.get<GitHubDiff>(`https://api.github.com/repos/${path}`, {headers})
 
     ux.log('')
-    ux.styledHeader(`${color.app(targetApp.name)} is ahead of ${color.app(downstreamApp.name)} by ${githubDiff.ahead_by} commit${githubDiff.ahead_by === 1 ? '' : 's'}`)
+    hux.styledHeader(`${color.app(targetApp.name)} is ahead of ${color.app(downstreamApp.name)} by ${githubDiff.ahead_by} commit${githubDiff.ahead_by === 1 ? '' : 's'}`)
     const mapped = githubDiff.commits.map((commit: Commit) => {
       return {
         sha: commit.sha.slice(0, 7),
@@ -59,7 +60,7 @@ async function diff(targetApp: AppInfo, downstreamApp: AppInfo, githubToken: str
         message: commit.commit.message.split('\n')[0],
       }
     }).reverse()
-    ux.table(mapped, {
+    hux.table(mapped, {
       sha: {
         header: 'SHA',
       },

--- a/packages/cli/src/commands/pipelines/index.ts
+++ b/packages/cli/src/commands/pipelines/index.ts
@@ -1,6 +1,7 @@
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 export default class Pipelines extends Command {
   static description = 'list pipelines you have access to'
@@ -19,9 +20,9 @@ export default class Pipelines extends Command {
     const {body: pipelines} = await this.heroku.get<Heroku.Pipeline[]>('/pipelines')
 
     if (flags.json) {
-      ux.styledJSON(pipelines)
+      hux.styledJSON(pipelines)
     } else {
-      ux.styledHeader('My Pipelines')
+      hux.styledHeader('My Pipelines')
       for (const pipeline of pipelines) {
         ux.log(pipeline.name)
       }

--- a/packages/cli/src/commands/pipelines/info.ts
+++ b/packages/cli/src/commands/pipelines/info.ts
@@ -1,6 +1,7 @@
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
-import {Args, ux} from '@oclif/core'
+import {Args} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 import {listPipelineApps} from '../../lib/api'
 import disambiguate from '../../lib/pipelines/disambiguate'
@@ -36,7 +37,7 @@ export default class PipelinesInfo extends Command {
     const pipelineApps = await listPipelineApps(this.heroku, pipeline.id!)
 
     if (flags.json) {
-      ux.styledJSON({pipeline, apps: pipelineApps})
+      hux.styledJSON({pipeline, apps: pipelineApps})
     } else {
       await renderPipeline(this.heroku, pipeline, pipelineApps, {
         withOwners: flags['with-owners'],

--- a/packages/cli/src/commands/pipelines/promote.ts
+++ b/packages/cli/src/commands/pipelines/promote.ts
@@ -2,6 +2,7 @@ import color from '@heroku-cli/color'
 import {APIClient, Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as assert from 'assert'
 import fetch from 'node-fetch'
 import * as Stream from 'stream'
@@ -260,6 +261,6 @@ export default class Promote extends Command {
       ux.warn('\nPromotion to some apps failed')
     }
 
-    ux.styledObject(styledTargets)
+    hux.styledObject(styledTargets)
   }
 }

--- a/packages/cli/src/commands/pipelines/transfer.ts
+++ b/packages/cli/src/commands/pipelines/transfer.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {APIClient, Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 import {createPipelineTransfer, getAccountInfo, getTeam, listPipelineApps} from '../../lib/api'
 import disambiguate from '../../lib/pipelines/disambiguate'
@@ -59,7 +60,7 @@ export default class PipelinesTransfer extends Command {
       ux.log('')
       ux.warn(`This will transfer ${color.pipeline(pipeline.name!)} and all of the listed apps to the ${args.owner} ${displayType}`)
       ux.warn(`to proceed, type ${color.red(pipeline.name!)} or re-run this command with ${color.red('--confirm')} ${pipeline.name}`)
-      confirmName = await ux.prompt('', {})
+      confirmName = await hux.prompt('', {})
     }
 
     if (confirmName !== pipeline.name) {

--- a/packages/cli/src/commands/ps/index.ts
+++ b/packages/cli/src/commands/ps/index.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {ago} from '../../lib/time'
 import {APIClient} from '@heroku-cli/command'
 import {AccountQuota} from '../../lib/types/account_quota'
@@ -57,7 +58,7 @@ function truncate(s: string) {
 function printExtended(dynos: DynoExtended[]) {
   const sortedDynos = dynos.sort(byProcessTypeAndNumber)
 
-  ux.table<DynoExtended>(
+  hux.table<DynoExtended>(
     sortedDynos,
     {
       ID: {get: (dyno: DynoExtended) => dyno.id},
@@ -153,7 +154,7 @@ function printDynos(dynos: DynoExtended[]) : void {
 
   // Print one-off dynos
   if (oneOffs.length > 0) {
-    ux.styledHeader(`${color.green('run')}: one-off processes (${color.yellow(oneOffs.length.toString())})`)
+    hux.styledHeader(`${color.green('run')}: one-off processes (${color.yellow(oneOffs.length.toString())})`)
     oneOffs.forEach(dyno => ux.log(decorateOneOffDyno(dyno)))
     ux.log()
   }
@@ -165,7 +166,7 @@ function printDynos(dynos: DynoExtended[]) : void {
     // eslint-disable-next-line unicorn/explicit-length-check
     const size = commandDynos[0].size || '1X'
 
-    ux.styledHeader(`${color.green(type)} (${color.cyan(size)}): ${command} (${color.yellow(commandDynos.length.toString())})`)
+    hux.styledHeader(`${color.green(type)} (${color.cyan(size)}): ${command} (${color.yellow(commandDynos.length.toString())})`)
     for (const dyno of commandDynos)
       ux.log(decorateCommandDyno(dyno))
     ux.log()
@@ -236,7 +237,7 @@ export default class Index extends Command {
     selectedDynos = selectedDynos.sort(byProcessName)
 
     if (json)
-      ux.styledJSON(selectedDynos)
+      hux.styledJSON(selectedDynos)
     else if (extended)
       printExtended(selectedDynos)
     else {

--- a/packages/cli/src/commands/ps/type.ts
+++ b/packages/cli/src/commands/ps/type.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {APIClient, Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 import {sortBy, compact} from 'lodash'
 import heredoc from 'tsheredoc'
@@ -109,8 +110,8 @@ const displayFormation = async (heroku: APIClient, app: string) => {
     throw emptyFormationErr(app)
   }
 
-  ux.styledHeader('Process Types')
-  ux.table(formationTableData, {
+  hux.styledHeader('Process Types')
+  hux.table(formationTableData, {
     type: {},
     size: {},
     qty: {},
@@ -118,8 +119,8 @@ const displayFormation = async (heroku: APIClient, app: string) => {
     'max cost/month': {},
   })
   ux.log()
-  ux.styledHeader('Dyno Totals')
-  ux.table(dynoTotalsTableData, {
+  hux.styledHeader('Dyno Totals')
+  hux.table(dynoTotalsTableData, {
     type: {},
     total: {},
   })

--- a/packages/cli/src/commands/ps/wait.ts
+++ b/packages/cli/src/commands/ps/wait.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 import {Dyno, Release} from '@heroku-cli/schema'
 
@@ -83,7 +84,7 @@ export default class Wait extends Command {
 
       ux.action.status = releasedFraction
 
-      await ux.wait(interval * 1000)
+      await hux.wait(interval * 1000)
     }
   }
 }

--- a/packages/cli/src/commands/regions.ts
+++ b/packages/cli/src/commands/regions.ts
@@ -1,7 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
-import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as _ from 'lodash'
 
 export default class Regions extends Command {
@@ -27,9 +27,9 @@ export default class Regions extends Command {
     regions = _.sortBy(regions, ['private_capable', 'name'])
 
     if (flags.json) {
-      ux.styledJSON(regions)
+      hux.styledJSON(regions)
     } else {
-      ux.table(regions, {
+      hux.table(regions, {
         name: {
           header: 'ID',
           get: ({name}: any) => color.green(name),

--- a/packages/cli/src/commands/releases/index.ts
+++ b/packages/cli/src/commands/releases/index.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {truncate} from 'lodash'
 import * as Heroku from '@heroku-cli/schema'
 import * as statusHelper from '../../lib/releases/status_helper'
@@ -141,8 +142,8 @@ export default class Index extends Command {
         header += ' - ' + color.cyan(`Current: v${currentRelease.version}`)
       }
 
-      ux.styledHeader(header)
-      ux.table(
+      hux.styledHeader(header)
+      hux.table(
         releases,
         columns,
         {'no-header': true, 'no-truncate': true,  extended},

--- a/packages/cli/src/commands/releases/info.ts
+++ b/packages/cli/src/commands/releases/info.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 import * as shellescape from 'shell-escape'
 const {forEach} = require('lodash')
@@ -28,7 +29,7 @@ export default class Info extends Command {
       const release = await findByLatestOrId(this.heroku, app, args.release)
 
       if (json) {
-        ux.styledJSON(release)
+        hux.styledJSON(release)
       } else {
         let releaseChange = release.description
         const status = description(release)
@@ -40,8 +41,8 @@ export default class Info extends Command {
           releaseChange += ' (' + color[statusColor](status) + ')'
         }
 
-        ux.styledHeader(`Release ${color.cyan('v' + release.version)}`)
-        ux.styledObject({
+        hux.styledHeader(`Release ${color.cyan('v' + release.version)}`)
+        hux.styledObject({
           'Add-ons': release.addon_plan_names,
           Change: releaseChange,
           By: userEmail,
@@ -49,13 +50,13 @@ export default class Info extends Command {
           When: release.created_at,
         })
         ux.log()
-        ux.styledHeader(`${color.cyan('v' + release.version)} Config vars`)
+        hux.styledHeader(`${color.cyan('v' + release.version)} Config vars`)
         if (shell) {
           forEach(config, (v: string, k: string) => {
             ux.log(`${k}=${shellescape([v])}`)
           })
         } else {
-          ux.styledObject(config)
+          hux.styledObject(config)
         }
       }
     }

--- a/packages/cli/src/commands/sessions/index.ts
+++ b/packages/cli/src/commands/sessions/index.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 import {OAuthSession} from '../../lib/sessions/sessions'
 const {sortBy} = require('lodash')
@@ -20,12 +21,12 @@ export default class SessionsIndex extends Command {
     sessions = sortBy(sessions, 'description')
 
     if (flags.json) {
-      ux.styledJSON(sessions)
+      hux.styledJSON(sessions)
     } else if (sessions.length === 0) {
       ux.log('No OAuth sessions.')
     } else {
       const printLine: typeof this.log = (...args) => this.log(...args)
-      ux.table(sessions, {
+      hux.table(sessions, {
         description: {get: (v: any) => color.green(v.description)},
         id: {},
       }, {'no-header': true, printLine})

--- a/packages/cli/src/commands/spaces/create.ts
+++ b/packages/cli/src/commands/spaces/create.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {Space} from '../../lib/types/fir'
 import heredoc from 'tsheredoc'
 import {displayShieldState} from '../../lib/spaces/spaces'
@@ -87,8 +88,8 @@ export default class Create extends Command {
     ux.warn(`${color.bold('Spend Alert.')} Each Heroku ${spaceType} Private Space costs ~${dollarAmountHourly}/hour (max ${dollarAmountMonthly}/month), pro-rated to the second.`)
     ux.warn(`Use ${color.cmd('heroku spaces:wait')} to track allocation.`)
 
-    ux.styledHeader(space.name)
-    ux.styledObject({
+    hux.styledHeader(space.name)
+    hux.styledObject({
       ID: space.id, Team: space.team.name, Region: space.region.name, CIDR: space.cidr, 'Data CIDR': space.data_cidr, State: space.state, Shield: displayShieldState(space), Generation: getGeneration(space), 'Created at': space.created_at,
     }, ['ID', 'Team', 'Region', 'CIDR', 'Data CIDR', 'State', 'Shield', 'Generation', 'Created at'])
   }

--- a/packages/cli/src/commands/spaces/index.ts
+++ b/packages/cli/src/commands/spaces/index.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags as Flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {Space} from '../../lib/types/fir'
 import {getGeneration} from '../../lib/apps/generation'
 
@@ -52,7 +53,7 @@ export default class Index extends Command {
   }
 
   protected display(spaces: SpaceArray) {
-    ux.table(
+    hux.table(
       spaces,
       {
         Name: {get: space => space.name},

--- a/packages/cli/src/commands/spaces/ps.ts
+++ b/packages/cli/src/commands/spaces/ps.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 import {ago} from '../../lib/time'
 
@@ -45,7 +46,7 @@ export default class Ps extends Command {
     }
 
     if (flags.json) {
-      ux.styledJSON(spaceDynos)
+      hux.styledJSON(spaceDynos)
     } else {
       this.render(spaceDynos)
     }
@@ -81,7 +82,7 @@ export default class Ps extends Command {
     }
 
     for (const [key, dynos] of dynosByCommand) {
-      ux.styledHeader(`${appName} ${key} (${color.yellow(dynos.length)})`)
+      hux.styledHeader(`${appName} ${key} (${color.yellow(dynos.length)})`)
       dynos.sort((a, b) => getProcessNum(a) - getProcessNum(b))
       for (const dyno of dynos) {
         ux.log(dyno)

--- a/packages/cli/src/commands/spaces/topology.ts
+++ b/packages/cli/src/commands/spaces/topology.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 import heredoc from 'tsheredoc'
 import color from '@heroku-cli/color'
@@ -57,7 +58,7 @@ export default class Topology extends Command {
 
   protected render(topology: SpaceTopology, appInfo: Heroku.App[], json: boolean) {
     if (json) {
-      ux.styledJSON(topology)
+      hux.styledJSON(topology)
     } else if (topology.apps) {
       topology.apps.forEach(app => {
         const formations: string[] = []
@@ -95,8 +96,8 @@ export default class Topology extends Command {
           header += ` (${color.cyan(formations.join(', '))})`
         }
 
-        ux.styledHeader(header || '')
-        ux.styledObject({
+        hux.styledHeader(header || '')
+        hux.styledObject({
           Domains: domains, Dynos: dynos,
         }, ['Domains', 'Dynos'])
         ux.log()

--- a/packages/cli/src/commands/spaces/trusted-ips/index.ts
+++ b/packages/cli/src/commands/spaces/trusted-ips/index.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 import heredoc from 'tsheredoc'
 
@@ -42,12 +43,12 @@ export default class Index extends Command {
 
   private displayRules(space: string, ruleset: Required<Heroku.InboundRuleset>) {
     if (ruleset.rules.length > 0) {
-      ux.styledHeader('Trusted IP Ranges')
+      hux.styledHeader('Trusted IP Ranges')
       for (const rule of ruleset.rules) {
         ux.log(rule.source)
       }
     } else {
-      ux.styledHeader(`${space} has no trusted IP ranges. All inbound web requests to dynos are blocked.`)
+      hux.styledHeader(`${space} has no trusted IP ranges. All inbound web requests to dynos are blocked.`)
     }
   }
 }

--- a/packages/cli/src/commands/spaces/vpn/config.ts
+++ b/packages/cli/src/commands/spaces/vpn/config.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
+import {Args} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 import {displayVPNConfigInfo} from '../../../lib/spaces/vpn-connections'
 import heredoc from 'tsheredoc'
@@ -49,7 +50,7 @@ export default class Config extends Command {
 
     const {body: vpnConnection} = await this.heroku.get<Heroku.PrivateSpacesVpn>(`/spaces/${space}/vpn-connections/${name}`)
     if (json) {
-      ux.styledJSON(vpnConnection)
+      hux.styledJSON(vpnConnection)
     } else {
       displayVPNConfigInfo(space, name, vpnConnection)
     }

--- a/packages/cli/src/commands/spaces/vpn/connections.ts
+++ b/packages/cli/src/commands/spaces/vpn/connections.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 import heredoc from 'tsheredoc'
 import {displayVPNStatus} from '../../../lib/spaces/format'
@@ -30,7 +31,7 @@ export default class Connections extends Command {
 
   protected render(space: string, connections: Required<Heroku.PrivateSpacesVpn>[], json: boolean) {
     if (json) {
-      ux.styledJSON(connections)
+      hux.styledJSON(connections)
     } else {
       this.displayVPNConnections(space, connections)
     }
@@ -42,9 +43,9 @@ export default class Connections extends Command {
       return
     }
 
-    ux.styledHeader(`${space} VPN Connections`)
+    hux.styledHeader(`${space} VPN Connections`)
 
-    ux.table(
+    hux.table(
       connections,
       {
         Name: {

--- a/packages/cli/src/commands/spaces/vpn/info.ts
+++ b/packages/cli/src/commands/spaces/vpn/info.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
+import {Args} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 import heredoc from 'tsheredoc'
 import {displayCIDR, displayVPNStatus} from '../../../lib/spaces/format'
@@ -49,8 +50,8 @@ export default class Info extends Command {
   }
 
   private displayVPNInfo(name: string, vpnConnection: Heroku.PrivateSpacesVpn) {
-    ux.styledHeader(`${name} VPN Info`)
-    ux.styledObject({
+    hux.styledHeader(`${name} VPN Info`)
+    hux.styledObject({
       Name: name,
       ID: vpnConnection.id,
       'Public IP': vpnConnection.public_ip,
@@ -62,8 +63,8 @@ export default class Info extends Command {
     vpnConnectionTunnels.forEach((val, i) => {
       val.tunnel_id = 'Tunnel ' + (i + 1)
     })
-    ux.styledHeader(`${name} VPN Tunnel Info`)
-    ux.table(vpnConnectionTunnels, {
+    hux.styledHeader(`${name} VPN Tunnel Info`)
+    hux.table(vpnConnectionTunnels, {
       tunnel_id: {header: 'VPN Tunnel'},
       ip: {header: 'IP Address'},
       status: {
@@ -77,7 +78,7 @@ export default class Info extends Command {
 
   private render(name: string, vpnConnection: Heroku.PrivateSpacesVpn, json: boolean) {
     if (json) {
-      ux.styledJSON(vpnConnection)
+      hux.styledJSON(vpnConnection)
     } else {
       this.displayVPNInfo(name, vpnConnection)
     }

--- a/packages/cli/src/commands/spaces/vpn/wait.ts
+++ b/packages/cli/src/commands/spaces/vpn/wait.ts
@@ -1,6 +1,7 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 import {displayVPNConfigInfo} from '../../../lib/spaces/vpn-connections'
 import heredoc from 'tsheredoc'
@@ -68,7 +69,7 @@ export default class Wait extends Command {
       ux.action.stop()
       const {body: newVpnConnection} = await this.heroku.get<Heroku.PrivateSpacesVpn>(`/spaces/${space}/vpn-connections/${name}`)
       if (json) {
-        ux.styledJSON(newVpnConnection)
+        hux.styledJSON(newVpnConnection)
       } else {
         displayVPNConfigInfo(space, name, newVpnConnection)
       }

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,5 +1,6 @@
 import color from '@heroku-cli/color'
 import {Command, Flags, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {capitalize} from '@oclif/core/lib/util'
 import {formatDistanceToNow} from 'date-fns'
 import HTTP from '@heroku/http-call'
@@ -32,7 +33,7 @@ export default class Status extends Command {
     const {body} = await HTTP.get<any>(host + apiPath)
 
     if (flags.json) {
-      ux.styledJSON(body)
+      hux.styledJSON(body)
       return
     }
 
@@ -44,7 +45,7 @@ export default class Status extends Command {
 
     for (const incident of body.incidents) {
       ux.log()
-      ux.styledHeader(`${incident.title} ${color.yellow(incident.created_at)} ${color.cyan(incident.full_url)}`)
+      hux.styledHeader(`${incident.title} ${color.yellow(incident.created_at)} ${color.cyan(incident.full_url)}`)
 
       const padding = maxBy(incident.updates, (i: any) => i.update_type.length).update_type.length + 0
       for (const u of incident.updates) {

--- a/packages/cli/src/commands/teams/index.ts
+++ b/packages/cli/src/commands/teams/index.ts
@@ -1,6 +1,6 @@
 import color from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
-import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 
 export default class Index extends Command {
@@ -15,9 +15,9 @@ export default class Index extends Command {
     const {body: teams} = await this.heroku.get<Heroku.Team[]>('/teams')
 
     if (flags.json)
-      ux.styledJSON(teams)
+      hux.styledJSON(teams)
     else {
-      ux.table(teams.sort((a: Heroku.Team, b: Heroku.Team) => {
+      hux.table(teams.sort((a: Heroku.Team, b: Heroku.Team) => {
         const aName = a?.name || ''
         const bName = b?.name || ''
         return (aName > bName) ? 1 : ((bName > aName) ? -1 : 0)

--- a/packages/cli/src/commands/telemetry/index.ts
+++ b/packages/cli/src/commands/telemetry/index.ts
@@ -1,5 +1,6 @@
 import {Command, flags as Flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {TelemetryDrains} from '../../lib/types/telemetry'
 
 export default class Index extends Command {
@@ -39,8 +40,8 @@ export default class Index extends Command {
     if (telemetryDrains.length === 0) {
       ux.log(`There are no telemetry drains in ${owner}`)
     } else {
-      ux.styledHeader(`${owner} Telemetry Drains`)
-      ux.table(
+      hux.styledHeader(`${owner} Telemetry Drains`)
+      hux.table(
         telemetryDrains,
         {
           ID: {get: telemetryDrain => telemetryDrain.id},

--- a/packages/cli/src/commands/usage/addons.ts
+++ b/packages/cli/src/commands/usage/addons.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 import color from '@heroku-cli/color'
 
@@ -43,8 +44,8 @@ export default class UsageAddons extends Command {
       })),
     )
 
-    ux.styledHeader(`Usage for ${color.app(app)}`)
-    ux.table(metersArray, {
+    hux.styledHeader(`Usage for ${color.app(app)}`)
+    hux.table(metersArray, {
       'Add-on': {
         get: row => {
           const matchingAddon = appAddons.find(a => a.id === row.addonId)

--- a/packages/cli/src/commands/webhooks/add.ts
+++ b/packages/cli/src/commands/webhooks/add.ts
@@ -1,5 +1,6 @@
 import {flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import Spinner from '@oclif/core/lib/cli-ux/action/spinner'
 
 import BaseCommand from '../../lib/webhooks/base'
@@ -41,7 +42,7 @@ export default class WebhooksAdd extends BaseCommand {
 
     const secret = response.headers && response.headers['heroku-webhook-secret'] as string
     if (secret) {
-      ux.styledHeader('Webhooks Signing Secret')
+      hux.styledHeader('Webhooks Signing Secret')
       this.log(secret)
     } else {
       ux.warn('no secret found')

--- a/packages/cli/src/commands/webhooks/deliveries/index.ts
+++ b/packages/cli/src/commands/webhooks/deliveries/index.ts
@@ -1,5 +1,5 @@
 import {flags} from '@heroku-cli/command'
-import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 import BaseCommand from '../../../lib/webhooks/base'
 
@@ -51,7 +51,7 @@ export default class Deliveries extends BaseCommand {
       }
 
       const printLine: typeof this.log = (...args) => this.log(...args)
-      ux.table(deliveries, {
+      hux.table(deliveries, {
         id: {
           header: 'Delivery ID',
         },

--- a/packages/cli/src/commands/webhooks/deliveries/info.ts
+++ b/packages/cli/src/commands/webhooks/deliveries/info.ts
@@ -1,5 +1,6 @@
 import {flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
+import {Args} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 import BaseCommand from '../../../lib/webhooks/base'
 
@@ -41,10 +42,10 @@ export default class DeliveriesInfo extends BaseCommand {
       'Next Attempt': delivery.next_attempt_at,
     }
 
-    ux.styledHeader(delivery.id)
-    ux.styledObject(obj)
+    hux.styledHeader(delivery.id)
+    hux.styledObject(obj)
 
-    ux.styledHeader('Event Payload')
-    ux.styledJSON(event.payload)
+    hux.styledHeader('Event Payload')
+    hux.styledJSON(event.payload)
   }
 }

--- a/packages/cli/src/commands/webhooks/events/index.ts
+++ b/packages/cli/src/commands/webhooks/events/index.ts
@@ -1,5 +1,6 @@
 import {flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 import BaseCommand from '../../../lib/webhooks/base'
 
@@ -31,7 +32,7 @@ export default class EventsIndex extends BaseCommand {
 
       const printLine: typeof this.log = (...args) => this.log(...args)
 
-      ux.table(events, {
+      hux.table(events, {
         id: {
           header: 'Event ID',
         },

--- a/packages/cli/src/commands/webhooks/events/info.ts
+++ b/packages/cli/src/commands/webhooks/events/info.ts
@@ -1,5 +1,6 @@
 import {flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 import BaseCommand from '../../../lib/webhooks/base'
 
@@ -32,7 +33,7 @@ export default class Info extends BaseCommand {
       payload: JSON.stringify(webhookEvent.payload, null, 2),
     }
 
-    ux.styledHeader(webhookEvent.id)
-    ux.styledObject(obj)
+    hux.styledHeader(webhookEvent.id)
+    hux.styledObject(obj)
   }
 }

--- a/packages/cli/src/commands/webhooks/index.ts
+++ b/packages/cli/src/commands/webhooks/index.ts
@@ -1,6 +1,6 @@
 import color from '@heroku-cli/color'
 import {flags} from '@heroku-cli/command'
-import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 import BaseCommand from '../../lib/webhooks/base'
 
@@ -34,7 +34,7 @@ export default class Webhooks extends BaseCommand {
     webhooks.sort((a: any, b: any) => Date.parse(a.created_at) - Date.parse(b.created_at))
 
     const printLine: typeof this.log = (...args) => this.log(...args)
-    ux.table(webhooks, {
+    hux.table(webhooks, {
       id: {
         header: 'Webhook ID',
       },

--- a/packages/cli/src/commands/webhooks/info.ts
+++ b/packages/cli/src/commands/webhooks/info.ts
@@ -1,5 +1,6 @@
 import {flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
+import {Args} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 import BaseCommand from '../../lib/webhooks/base'
 
@@ -31,7 +32,7 @@ export default class WebhooksInfo extends BaseCommand {
       Level: webhook.level,
     }
 
-    ux.styledHeader(webhook.id)
-    ux.styledObject(obj)
+    hux.styledHeader(webhook.id)
+    hux.styledObject(obj)
   }
 }

--- a/packages/cli/src/lib/authorizations/authorizations.ts
+++ b/packages/cli/src/lib/authorizations/authorizations.ts
@@ -1,7 +1,7 @@
 'use strict'
 
 import * as Heroku from '@heroku-cli/schema'
-import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {formatDistanceToNow, addSeconds} from 'date-fns'
 
 export function display(auth: Heroku.OAuthAuthorization) {
@@ -40,7 +40,7 @@ export function display(auth: Heroku.OAuthAuthorization) {
     }
   }
 
-  ux.styledObject(obj, [
+  hux.styledObject(obj, [
     'Client',
     'Redirect URI',
     'ID',

--- a/packages/cli/src/lib/certs/certificate_details.ts
+++ b/packages/cli/src/lib/certs/certificate_details.ts
@@ -1,5 +1,6 @@
 import formatDate from './format_date'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {color} from '@heroku-cli/color'
 import {SniEndpoint} from '../types/sni_endpoint'
 
@@ -26,7 +27,7 @@ export const displayCertificateDetails = function (sniEndpoint: SniEndpoint, mes
     tableObject['Domain(s)'] = sniEndpoint.domains
   }
 
-  ux.styledObject(tableObject)
+  hux.styledObject(tableObject)
 
   if (sniEndpoint.ssl_cert['ca_signed?']) {
     ux.log('SSL certificate is verified by a root authority.')

--- a/packages/cli/src/lib/certs/display_table.ts
+++ b/packages/cli/src/lib/certs/display_table.ts
@@ -1,4 +1,4 @@
-import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import formatDate from './format_date'
 import {SniEndpoint} from '../types/sni_endpoint'
 
@@ -55,5 +55,5 @@ export default function (endpoints: SniEndpoint[]) {
     columns.associated_domains = {header: 'Domains'}
   }
 
-  ux.table(mapped, columns)
+  hux.table(mapped, columns)
 }

--- a/packages/cli/src/lib/ci/test-run.ts
+++ b/packages/cli/src/lib/ci/test-run.ts
@@ -2,6 +2,7 @@ import color from '@heroku-cli/color'
 import {Command} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as http from 'http'
 import {get, RequestOptions} from 'https'
 import {randomUUID} from 'node:crypto'
@@ -105,7 +106,7 @@ function draw(testRuns: Heroku.TestRun[], watchOption = false, jsonOption = fals
   const latestTestRuns = sort(testRuns).slice(0, count)
 
   if (jsonOption) {
-    ux.styledJSON(latestTestRuns)
+    hux.styledJSON(latestTestRuns)
     return
   }
 
@@ -127,7 +128,7 @@ function draw(testRuns: Heroku.TestRun[], watchOption = false, jsonOption = fals
     )
   })
 
-  ux.table(
+  hux.table(
     data,
     {
       iconStatus: {
@@ -152,7 +153,7 @@ export async function renderList(command: Command, testRuns: Heroku.TestRun[], p
 
   if (!jsonOption) {
     const header = `${watchOption ? 'Watching' : 'Showing'} latest test runs for the ${pipeline.name} pipeline`
-    ux.styledHeader(header)
+    hux.styledHeader(header)
   }
 
   draw(testRuns, watchOption, jsonOption)

--- a/packages/cli/src/lib/confirmCommand.ts
+++ b/packages/cli/src/lib/confirmCommand.ts
@@ -1,5 +1,6 @@
 import color from '@heroku-cli/color'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 export default async function confirmCommand(app: string, confirm?: string, message?: string) {
   if (confirm) {
@@ -14,7 +15,7 @@ This command will affect the app ${color.bold.red(app)}`
 
   ux.warn(message)
   console.error()
-  const entered = await ux.prompt(
+  const entered = await hux.prompt(
     `To proceed, type ${color.bold.red(app)} or re-run this command with ${color.bold.red('--confirm', app)}`,
     {required: true},
   )

--- a/packages/cli/src/lib/domains/domains.ts
+++ b/packages/cli/src/lib/domains/domains.ts
@@ -2,6 +2,7 @@ import {APIClient} from '@heroku-cli/command'
 import {parse, ParsedDomain, ParseError} from 'psl'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import color from '@heroku-cli/color'
 
 const wait = function (ms: number) {
@@ -61,11 +62,11 @@ export function printDomains(domains: Required<Heroku.Domain>[], message: string
   const domains_with_type: (Required<Heroku.Domain> & { type: string })[] = domains.map(domain => Object.assign({}, domain, {type: type(domain)}))
 
   if (domains_with_type.length === 0) {
-    ux.styledHeader(`${message}  Add a custom domain to your app by running ${color.cmd('heroku domains:add <yourdomain.com>')}`)
+    hux.styledHeader(`${message}  Add a custom domain to your app by running ${color.cmd('heroku domains:add <yourdomain.com>')}`)
   } else {
-    ux.styledHeader(`${message}  Update your application's DNS settings as follows`)
+    hux.styledHeader(`${message}  Update your application's DNS settings as follows`)
 
-    ux.table(domains_with_type,
+    hux.table(domains_with_type,
       {
         domain: {
           get: ({hostname}) => hostname,

--- a/packages/cli/src/lib/domains/wait-for-domain.ts
+++ b/packages/cli/src/lib/domains/wait-for-domain.ts
@@ -1,7 +1,7 @@
 import {color} from '@heroku-cli/color'
 import {APIClient} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
-import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import Spinner from '@oclif/core/lib/cli-ux/action/spinner'
 
 export default async function waitForDomain(app: string, heroku: APIClient, domain: Heroku.Domain) {
@@ -9,7 +9,7 @@ export default async function waitForDomain(app: string, heroku: APIClient, doma
 
   action.start(`Waiting for ${color.green(domain.hostname || 'domain')}`)
   while (domain.status === 'pending') {
-    await ux.wait(5000)
+    await hux.wait(5000)
     const {body: updatedDomain} = await heroku.get<Heroku.Domain>(`/apps/${app}/domains/${domain.id}`)
     domain = updatedDomain
   }

--- a/packages/cli/src/lib/orgs/utils.ts
+++ b/packages/cli/src/lib/orgs/utils.ts
@@ -1,4 +1,5 @@
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 import * as _ from 'lodash'
 import color from '@heroku-cli/color'
@@ -7,7 +8,7 @@ export const printGroups = function (teams: Heroku.Team[], type: {label: string}
   const typeLabel = type.label ? type.label : 'Team'
   teams = _.sortBy(teams, 'name')
 
-  ux.table(
+  hux.table(
     teams,
     {
       name: {

--- a/packages/cli/src/lib/pipelines/render-pipeline.ts
+++ b/packages/cli/src/lib/pipelines/render-pipeline.ts
@@ -2,6 +2,7 @@ import color from '@heroku-cli/color'
 import {APIClient} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {sortBy} from 'lodash'
 
 import {getOwner, warnMixedOwnership} from './ownership'
@@ -13,7 +14,7 @@ export default async function renderPipeline(
   pipelineApps: Array<AppWithPipelineCoupling>,
   // eslint-disable-next-line unicorn/no-object-as-default-parameter
   {withOwners, showOwnerWarning} = {withOwners: false, showOwnerWarning: false}) {
-  ux.styledHeader(pipeline.name!)
+  hux.styledHeader(pipeline.name!)
 
   let owner
 
@@ -58,7 +59,7 @@ export default async function renderPipeline(
   const productionApps = sortBy(pipelineApps.filter(app => app.pipelineCoupling.stage === 'production'), ['name'])
   const apps = developmentApps.concat(reviewApps).concat(stagingApps).concat(productionApps)
 
-  ux.table(apps, columns)
+  hux.table(apps, columns)
 
   if (showOwnerWarning && pipeline.owner) {
     warnMixedOwnership(pipelineApps, pipeline, owner)

--- a/packages/cli/src/lib/pipelines/setup/get-ci-settings.ts
+++ b/packages/cli/src/lib/pipelines/setup/get-ci-settings.ts
@@ -1,4 +1,4 @@
-import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 export default async function getCISettings(yes: any, organization: any) {
   const settings = {
@@ -11,7 +11,7 @@ export default async function getCISettings(yes: any, organization: any) {
     return settings
   }
 
-  settings.ci = await ux.confirm('Enable automatic Heroku CI test runs?')
+  settings.ci = await hux.confirm('Enable automatic Heroku CI test runs?')
 
   if (settings.ci && organization) {
     settings.organization = organization

--- a/packages/cli/src/lib/pipelines/setup/get-name-and-repo.ts
+++ b/packages/cli/src/lib/pipelines/setup/get-name-and-repo.ts
@@ -1,4 +1,5 @@
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 import {pipelineName, repoName} from './validate'
 
@@ -24,7 +25,7 @@ export default async function getNameAndRepo(args: any) {
   }
 
   if (!args.name) {
-    const name = await ux.prompt('Pipeline name', {
+    const name = await hux.prompt('Pipeline name', {
       required: true,
     })
 
@@ -38,7 +39,7 @@ export default async function getNameAndRepo(args: any) {
   }
 
   if (!args.repo) {
-    const repo = await ux.prompt('GitHub repository to connect to (e.g. rails/rails)', {
+    const repo = await hux.prompt('GitHub repository to connect to (e.g. rails/rails)', {
       required: true,
     })
 

--- a/packages/cli/src/lib/pipelines/setup/get-settings.ts
+++ b/packages/cli/src/lib/pipelines/setup/get-settings.ts
@@ -1,4 +1,4 @@
-import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 const DEFAULT_SETTINGS = {
   auto_deploy: true,
@@ -25,20 +25,20 @@ export default async function getSettings(yes: any, branch: any) {
     },
   }
 
-  settings.auto_deploy = await ux.confirm(`Automatically deploy the ${branch} branch to staging?`)
+  settings.auto_deploy = await hux.confirm(`Automatically deploy the ${branch} branch to staging?`)
 
   if (settings.auto_deploy) {
-    settings.wait_for_ci = await ux.confirm(`Wait for CI to pass before deploying the ${branch} branch to staging?`)
+    settings.wait_for_ci = await hux.confirm(`Wait for CI to pass before deploying the ${branch} branch to staging?`)
   }
 
-  settings.pull_requests.enabled = await ux.confirm('Enable review apps?')
+  settings.pull_requests.enabled = await hux.confirm('Enable review apps?')
 
   if (settings.pull_requests.enabled) {
-    settings.pull_requests.auto_deploy = await ux.confirm('Automatically create review apps for every PR?')
+    settings.pull_requests.auto_deploy = await hux.confirm('Automatically create review apps for every PR?')
   }
 
   if (settings.pull_requests.enabled) {
-    settings.pull_requests.auto_destroy = await ux.confirm('Automatically destroy idle review apps after 5 days?')
+    settings.pull_requests.auto_destroy = await hux.confirm('Automatically destroy idle review apps after 5 days?')
   }
 
   return settings

--- a/packages/cli/src/lib/redis/api.ts
+++ b/packages/cli/src/lib/redis/api.ts
@@ -1,5 +1,6 @@
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {APIClient} from '@heroku-cli/command'
 
 export type RedisFormationResponse = {
@@ -174,7 +175,7 @@ export default (app: string, database: string | undefined, json: boolean, heroku
           redii.push(filteredRedis)
         }
 
-        ux.styledJSON(redii)
+        hux.styledJSON(redii)
         return
       }
 
@@ -191,8 +192,8 @@ export default (app: string, database: string | undefined, json: boolean, heroku
         }
 
         if (uxHeader) {
-          ux.styledHeader(uxHeader)
-          ux.styledObject(
+          hux.styledHeader(uxHeader)
+          hux.styledObject(
             // eslint-disable-next-line unicorn/no-array-reduce
             redis.info.reduce(function (memo: { [x: string]: any }, row: { name: string | number; values: any }) {
               memo[row.name] = row.values

--- a/packages/cli/src/lib/spaces/hosts.ts
+++ b/packages/cli/src/lib/spaces/hosts.ts
@@ -1,4 +1,5 @@
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {hostStatus} from './format'
 
 export type Host = {
@@ -10,8 +11,8 @@ export type Host = {
 }
 
 export function displayHosts(space: string, hosts: Host[]) {
-  ux.styledHeader(`${space} Hosts`)
-  ux.table(hosts, {
+  hux.styledHeader(`${space} Hosts`)
+  hux.table(hosts, {
     host_id: {
       header: 'Host ID',
     },

--- a/packages/cli/src/lib/spaces/outbound-rules.ts
+++ b/packages/cli/src/lib/spaces/outbound-rules.ts
@@ -44,7 +44,7 @@ export function displayRulesAsJSON(ruleset: Heroku.OutboundRuleset) {
 }
 
 function display(rules: Heroku.OutboundRuleset['rules']) {
-  ux.table(lined(rules), {
+  hux.table(lined(rules), {
     line: {
       header: 'Rule Number',
     },

--- a/packages/cli/src/lib/spaces/outbound-rules.ts
+++ b/packages/cli/src/lib/spaces/outbound-rules.ts
@@ -1,4 +1,6 @@
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
+
 import * as Heroku from '@heroku-cli/schema'
 
 export function parsePorts(protocol: string, port: string = '') {
@@ -30,10 +32,10 @@ export function parsePorts(protocol: string, port: string = '') {
 export function displayRules(space: string, ruleset: Heroku.OutboundRuleset) {
   const rules = ruleset.rules || []
   if (rules.length > 0) {
-    ux.styledHeader('Outbound Rules')
+    hux.styledHeader('Outbound Rules')
     display(ruleset.rules)
   } else {
-    ux.styledHeader(`${space} has no Outbound Rules. Your Dynos cannot communicate with hosts outside of ${space}.`)
+    hux.styledHeader(`${space} has no Outbound Rules. Your Dynos cannot communicate with hosts outside of ${space}.`)
   }
 }
 

--- a/packages/cli/src/lib/spaces/peering.ts
+++ b/packages/cli/src/lib/spaces/peering.ts
@@ -1,10 +1,11 @@
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {displayCIDR, peeringStatus} from './format'
 import {Peering, PeeringInfo} from '@heroku-cli/schema'
 
 export function displayPeeringInfo(space: string, info: PeeringInfo) {
-  ux.styledHeader(`${space} Peering Info`)
-  ux.styledObject({
+  hux.styledHeader(`${space} Peering Info`)
+  hux.styledObject({
     'AWS Account ID': info.aws_account_id,
     'AWS Region': info.aws_region,
     'AWS VPC ID': info.vpc_id,
@@ -19,8 +20,8 @@ export function displayPeeringsAsJSON(peerings: Peering[]) {
 }
 
 export function displayPeerings(space: string, peerings: Peering[]) {
-  ux.styledHeader(`${space} Peerings`)
-  ux.table<Peering>(peerings, {
+  hux.styledHeader(`${space} Peerings`)
+  hux.table<Peering>(peerings, {
     pcx_id: {
       header: 'PCX ID',
     },

--- a/packages/cli/src/lib/spaces/spaces.ts
+++ b/packages/cli/src/lib/spaces/spaces.ts
@@ -1,5 +1,6 @@
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {SpaceNat} from '../types/fir'
 import {SpaceWithOutboundIps} from '../types/spaces'
 import {getGeneration} from '../apps/generation'
@@ -18,8 +19,8 @@ export function renderInfo(space: SpaceWithOutboundIps, json: boolean) {
   if (json) {
     ux.log(JSON.stringify(space, null, 2))
   } else {
-    ux.styledHeader(space.name || '')
-    ux.styledObject(
+    hux.styledHeader(space.name || '')
+    hux.styledObject(
       {
         ID: space.id,
         Team: space.team?.name,

--- a/packages/cli/src/lib/spaces/vpn-connections.ts
+++ b/packages/cli/src/lib/spaces/vpn-connections.ts
@@ -1,15 +1,15 @@
 import {PrivateSpacesVpn} from '@heroku-cli/schema'
-import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 
 export function displayVPNConfigInfo(space: string, name: string, config: PrivateSpacesVpn) {
-  ux.styledHeader(`${name} VPN Tunnels`)
+  hux.styledHeader(`${name} VPN Tunnels`)
   const configTunnels = config.tunnels || []
   configTunnels.forEach((val, i) => {
     val.tunnel_id = 'Tunnel ' + (i + 1)
     val.routable_cidr = config.space_cidr_block
     val.ike_version = config.ike_version
   })
-  ux.table(configTunnels, {
+  hux.table(configTunnels, {
     tunnel_id: {header: 'VPN Tunnel'},
     customer_ip: {header: 'Customer Gateway'},
     ip: {header: 'VPN Gateway'},

--- a/packages/cli/src/lib/telemetry/util.ts
+++ b/packages/cli/src/lib/telemetry/util.ts
@@ -1,4 +1,5 @@
 import {ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
 import {TelemetryDrain} from '../types/telemetry'
 import * as Heroku from '@heroku-cli/schema'
 import {APIClient} from '@heroku-cli/command'
@@ -25,7 +26,7 @@ export function validateAndFormatSignals(signalInput: string | undefined): strin
 }
 
 export async function displayTelemetryDrain(telemetryDrain: TelemetryDrain, heroku: APIClient) {
-  ux.styledHeader(telemetryDrain.id)
+  hux.styledHeader(telemetryDrain.id)
   const displayObject: TelemetryDisplayObject = {
     Signals: telemetryDrain.signals.join(', '),
     Endpoint: telemetryDrain.exporter.endpoint,
@@ -52,5 +53,5 @@ export async function displayTelemetryDrain(telemetryDrain: TelemetryDrain, hero
     displayObject.Headers = JSON.stringify(telemetryDrain.exporter.headers)
   }
 
-  ux.styledObject(displayObject, ['App', 'Space', 'Signals', 'Endpoint', 'Transport', 'Headers'])
+  hux.styledObject(displayObject, ['App', 'Space', 'Signals', 'Endpoint', 'Transport', 'Headers'])
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1763,19 +1763,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@heroku/heroku-cli-util@npm:^9.0.1-beta.2":
-  version: 9.0.1-beta.2
-  resolution: "@heroku/heroku-cli-util@npm:9.0.1-beta.2"
+"@heroku/heroku-cli-util@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "@heroku/heroku-cli-util@npm:9.0.1"
   dependencies:
     "@heroku-cli/color": ^2.0.4
     "@heroku-cli/command": ^11.5.0
     "@heroku/http-call": ^5.4.0
     "@oclif/core": ^2.16.0
+    "@types/chai": ^4.3.13
+    chai: ^4.4.1
     debug: ^4.4.0
     nock: ^13.2.9
     stdout-stderr: ^0.1.13
     tunnel-ssh: 4.1.6
-  checksum: 5fd48145ab4136144d46638beed70863514fcb70447afed8e0ace5dbb63fabf04b38ded677d277743904f0dd744f10ebc826d178311c8ca2d92aad545dcc70dd
+  checksum: 11fecd61bd7f9104340d8c87c01963c2a24d158fc22d7a5c2f025c9a76a59d2941e4e852cb1cfacebeefda86afe9d512cbf88b5a06c3694232611c727eefe121
   languageName: node
   linkType: hard
 
@@ -4985,6 +4987,13 @@ __metadata:
   version: 4.1.7
   resolution: "@types/chai@npm:4.1.7"
   checksum: 55b3d33a9a7b8a6993342e801d3f65381ee327e5838b390bfe97c4b84a3dfeaf7cdadbedf6d81443d49dbfdf39c858342eb17179e513f4668f2f9fe666ec7069
+  languageName: node
+  linkType: hard
+
+"@types/chai@npm:^4.3.13":
+  version: 4.3.20
+  resolution: "@types/chai@npm:4.3.20"
+  checksum: 7c5b0c9148f1a844a8d16cb1e16c64f2e7749cab2b8284155b9e494a6b34054846e22fb2b38df6b290f9bf57e6beebb2e121940c5896bc086ad7bab7ed429f06
   languageName: node
   linkType: hard
 
@@ -10384,7 +10393,7 @@ __metadata:
     "@heroku-cli/schema": ^1.0.25
     "@heroku/buildpack-registry": ^1.0.1
     "@heroku/eventsource": ^1.0.7
-    "@heroku/heroku-cli-util": ^9.0.1-beta.2
+    "@heroku/heroku-cli-util": ^9.0.1
     "@heroku/http-call": ^5.4.0
     "@inquirer/prompts": ^5.0.5
     "@istanbuljs/nyc-config-typescript": ^1.0.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -1607,6 +1607,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@heroku-cli/color@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@heroku-cli/color@npm:2.0.4"
+  dependencies:
+    ansi-styles: ^4.3.0
+    chalk: ^4.1.2
+    supports-color: ^7.2.0
+    tslib: ^1.9.3
+  checksum: af82e9f45e703a3a44314d7b24a3e9bb1dd25f2e165acea483f612f29de165c07ed47f297e7818ec39a8ac92b4a60bb4d3e7c699bbe3650a952727853c019b27
+  languageName: node
+  linkType: hard
+
 "@heroku-cli/command@npm:^11.5.0":
   version: 11.5.0
   resolution: "@heroku-cli/command@npm:11.5.0"
@@ -1748,6 +1760,22 @@ __metadata:
     tslib: ^1.9.0
     tunnel-agent: ^0.6.0
   checksum: 0ecc8e0c0928a7064f59cdce8991aedb8016b2c7e73a10715c2be54cd546d9a27feba9983afab9a5dadfd997542d35de70051e767164a79b9b82f1dc1ff27098
+  languageName: node
+  linkType: hard
+
+"@heroku/heroku-cli-util@npm:^9.0.1-beta.2":
+  version: 9.0.1-beta.2
+  resolution: "@heroku/heroku-cli-util@npm:9.0.1-beta.2"
+  dependencies:
+    "@heroku-cli/color": ^2.0.4
+    "@heroku-cli/command": ^11.5.0
+    "@heroku/http-call": ^5.4.0
+    "@oclif/core": ^2.16.0
+    debug: ^4.4.0
+    nock: ^13.2.9
+    stdout-stderr: ^0.1.13
+    tunnel-ssh: 4.1.6
+  checksum: 5fd48145ab4136144d46638beed70863514fcb70447afed8e0ace5dbb63fabf04b38ded677d277743904f0dd744f10ebc826d178311c8ca2d92aad545dcc70dd
   languageName: node
   linkType: hard
 
@@ -10356,7 +10384,7 @@ __metadata:
     "@heroku-cli/schema": ^1.0.25
     "@heroku/buildpack-registry": ^1.0.1
     "@heroku/eventsource": ^1.0.7
-    "@heroku/heroku-cli-util": ^8.0.13
+    "@heroku/heroku-cli-util": ^9.0.1-beta.2
     "@heroku/http-call": ^5.4.0
     "@inquirer/prompts": ^5.0.5
     "@istanbuljs/nyc-config-typescript": ^1.0.2
@@ -12851,6 +12879,17 @@ __metadata:
     lower-case: ^2.0.2
     tslib: ^2.0.3
   checksum: 0b2ebc113dfcf737d48dde49cfebf3ad2d82a8c3188e7100c6f375e30eafbef9e9124aadc3becef237b042fd5eb0aad2fd78669c20972d045bbe7fea8ba0be5c
+  languageName: node
+  linkType: hard
+
+"nock@npm:^13.2.9":
+  version: 13.5.6
+  resolution: "nock@npm:13.5.6"
+  dependencies:
+    debug: ^4.1.0
+    json-stringify-safe: ^5.0.1
+    propagate: ^2.0.0
+  checksum: 82d31ef7a428e8a6bc430b2772745ecb1f9c8835170789bbcc29c9036614adf3b7112daeb6d59edd93f4340a9a96acee401021572d469a7a0e09a669679f2794
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
[W-18293429](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002CuJeuYAF/view)

### Description

This replace direct references to certain oclif `ux` functions with `hux` functions imported from `heroku-cli-util`. At the moment, `hux` just wraps oclif's `ux` functions, so there will be no impact to user experience.

### Testing

Test a few of the affected commands by pulling down this branch and running the affected commands with `./bin/run`