### PR TITLE
fix: Allow to use NodeJS 22.x as well

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -140,7 +140,7 @@
     "typescript": "4.8.4"
   },
   "engines": {
-    "node": "20.x"
+    "node": ">=20 <23"
   },
   "files": [
     "/autocomplete-scripts",


### PR DESCRIPTION
This makes it easier to install heroku cli globally. I tested with NodeJS 22 and so far everything worked.

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
