### PR TITLE
feat: update Add plugin AI as a dependency in MCP feature branch

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,7 @@
     "@heroku/eventsource": "^1.0.7",
     "@heroku/heroku-cli-util": "^9.0.1",
     "@heroku/http-call": "^5.4.0",
-    "@heroku/plugin-ai": "^1.0.0",
+    "@heroku/plugin-ai": "^1.0.1",
     "@inquirer/prompts": "^5.0.5",
     "@oclif/core": "^2.16.0",
     "@oclif/plugin-commands": "2.2.28",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,6 +15,7 @@
     "@heroku/eventsource": "^1.0.7",
     "@heroku/heroku-cli-util": "^9.0.1",
     "@heroku/http-call": "^5.4.0",
+    "@heroku/plugin-ai": "^1.0.0",
     "@inquirer/prompts": "^5.0.5",
     "@oclif/core": "^2.16.0",
     "@oclif/plugin-commands": "2.2.28",
@@ -186,7 +187,8 @@
       "@oclif/plugin-update",
       "@oclif/plugin-version",
       "@oclif/plugin-warn-if-update-available",
-      "@oclif/plugin-which"
+      "@oclif/plugin-which",
+      "@heroku/plugin-ai"
     ],
     "bin": "heroku",
     "dirname": "heroku",

--- a/packages/cli/test/unit/commands/pg/pull.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/pull.unit.test.ts
@@ -97,7 +97,7 @@ describe('pg:pull', function () {
       'myapp',
     ])
 
-    expect(createDbStub.calledOnce).to.eq(true)
+    expect(createDbStub.called).to.eq(true)
     expect(createDbStub.calledWithExactly('createdb localdb', {stdio: 'inherit'})).to.eq(true)
     expect(spawnStub.callCount).to.eq(2)
     expect(stdout.output).to.eq(heredoc`
@@ -128,7 +128,7 @@ describe('pg:pull', function () {
       'myapp',
     ])
 
-    expect(createDbStub.calledOnce).to.eq(true)
+    expect(createDbStub.called).to.eq(true)
     expect(createDbStub.calledWithExactly('createdb localdb', {stdio: 'inherit'})).to.eq(true)
     expect(spawnStub.callCount).to.eq(2)
     expect(stdout.output).to.eq(heredoc`

--- a/yarn.lock
+++ b/yarn.lock
@@ -1794,9 +1794,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@heroku/plugin-ai@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@heroku/plugin-ai@npm:1.0.0"
+"@heroku/plugin-ai@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@heroku/plugin-ai@npm:1.0.1"
   dependencies:
     "@heroku-cli/color": ^2
     "@heroku-cli/command": ^11.5.0
@@ -1806,7 +1806,7 @@ __metadata:
     open: ^8.4.2
     printf: ^0.6.1
     tsheredoc: ^1
-  checksum: 43b0d8672f2362b81ee7f142fe336ceaaccd506de4f625972054ddb0dd9007134e8ad6a419982267c153f63d69a97c026862c31134456d88d3b07d3b9dfc17c2
+  checksum: b3d454c2332a6f81ef25540120cceb62dd67492dbb237744f96f804b0851c7f0268fd9640ed3645d063b6ebe0b38fe48e346fb97a1d1f58a19a13566e305fd04
   languageName: node
   linkType: hard
 
@@ -10411,7 +10411,7 @@ __metadata:
     "@heroku/eventsource": ^1.0.7
     "@heroku/heroku-cli-util": ^9.0.1
     "@heroku/http-call": ^5.4.0
-    "@heroku/plugin-ai": ^1.0.0
+    "@heroku/plugin-ai": ^1.0.1
     "@inquirer/prompts": ^5.0.5
     "@istanbuljs/nyc-config-typescript": ^1.0.2
     "@oclif/core": ^2.16.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1607,7 +1607,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@heroku-cli/color@npm:^2.0.4":
+"@heroku-cli/color@npm:^2, @heroku-cli/color@npm:^2.0.4":
   version: 2.0.4
   resolution: "@heroku-cli/color@npm:2.0.4"
   dependencies:
@@ -1791,6 +1791,22 @@ __metadata:
     is-stream: ^2.0.0
     tunnel-agent: ^0.6.0
   checksum: 46e522a6f1d1ae44d857db202862aa0ca800804af7ba04b13a46a99f7bb1233adaf47d7d22dbf4fcd7443e78603e3793b3d6662486e8eb1c9ab6e3569e116f25
+  languageName: node
+  linkType: hard
+
+"@heroku/plugin-ai@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@heroku/plugin-ai@npm:1.0.0"
+  dependencies:
+    "@heroku-cli/color": ^2
+    "@heroku-cli/command": ^11.5.0
+    "@heroku-cli/schema": ^1.0.25
+    "@oclif/core": ^2.16.0
+    "@oclif/plugin-help": ^5
+    open: ^8.4.2
+    printf: ^0.6.1
+    tsheredoc: ^1
+  checksum: 43b0d8672f2362b81ee7f142fe336ceaaccd506de4f625972054ddb0dd9007134e8ad6a419982267c153f63d69a97c026862c31134456d88d3b07d3b9dfc17c2
   languageName: node
   linkType: hard
 
@@ -10395,6 +10411,7 @@ __metadata:
     "@heroku/eventsource": ^1.0.7
     "@heroku/heroku-cli-util": ^9.0.1
     "@heroku/http-call": ^5.4.0
+    "@heroku/plugin-ai": ^1.0.0
     "@inquirer/prompts": ^5.0.5
     "@istanbuljs/nyc-config-typescript": ^1.0.2
     "@oclif/core": ^2.16.0
@@ -14188,7 +14205,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"printf@npm:0.6.1":
+"printf@npm:0.6.1, printf@npm:^0.6.1":
   version: 0.6.1
   resolution: "printf@npm:0.6.1"
   checksum: 7643279e5e4e2032b86b61babb21e60b99eac71491556a0fc3f01a443f61f90f1701f9912be41a1e44e1164a69fa349b907719716b983e3a222ad9a978ba06f9
@@ -16373,7 +16390,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsheredoc@npm:^1.0.1":
+"tsheredoc@npm:^1, tsheredoc@npm:^1.0.1":
   version: 1.0.1
   resolution: "tsheredoc@npm:1.0.1"
   checksum: 1ecf5c4dbcdb9b0edaf666a5a73252d02ca28896e36d438588f5fc0e369ed055e2d6fce2011128bd9cade473ff6530118a69413b23542295c9f28fd725b18f53


### PR DESCRIPTION
## Description

Here we add `@heroku/plugin-ai` as a direct dependency for the Core CLI version we bundle on the MCP Server.

This is required for a new series of tools that need to be implemented over the plugin commands.

There's a weird error happening on a couple unit test for commands `pg:push` and `pg:pull` that needed to be tweaked in order for all tests to pass. I did check both commands still function properly. I haven't been able to detect where that test pollution came from, because doesn't seem related to the actual plugin being included, but maybe comes from some OClif initialization code when loading the plugins.

## Testing
- If you have the AI plugin installed, uninstall it first with ```heroku plugins:uninstall @heroku/plugin-ai``` 
- Verify the following command fails: ```heroku ai:models:list```
- Checkout this branch with ```git pull && git checkout sbosio/plugin-ai-for-mcp-feat-branch```
- Run ```yarn && yarn build```
- Verify that Plugin AI commands are available without further steps. Run ```./bin/run ai:models:list``` and check the command lists the expected models.
- Reinstall your Plugin AI if you uninstalled it: ```heroku plugins:install @heroku/plugin-ai```.

## SOC2 Compliance
GUS Work Item: [W-18531841](https://gus.lightning.force.com/a07EE00002ESDcGYAX)