### PR TITLE
fix: speed up unit test execution

### DIFF
--- a/packages/cli/test/helpers/testInstances.ts
+++ b/packages/cli/test/helpers/testInstances.ts
@@ -1,10 +1,14 @@
 import {APIClient} from '@heroku-cli/command'
 import {Config} from '@oclif/core'
 
+const pjsonPath = require.resolve('../../package.json')
+let conf: Config
 export const getConfig = async () => {
-  const pjsonPath = require.resolve('../../package.json')
-  const conf = new Config({root: pjsonPath})
-  await conf.load()
+  if (!conf) {
+    conf = new Config({root: pjsonPath})
+    await conf.load()
+  }
+
   return conf
 }
 


### PR DESCRIPTION
This PR speeds up unit test executions by caching the `Config` instance in the `runCommand` function