### PR TITLE
fix: install cli on ubuntu 25.04 without using apt-key

### DIFF
--- a/install-ubuntu.sh
+++ b/install-ubuntu.sh
@@ -33,8 +33,8 @@
     mkdir -p /etc/apt/keyrings
 
     # We use the --dearmor flag to convert the ASCII key to GPG format. 
-    # This is necessary because the we need to point `signed-by` in the apt sources 
-    # list to a GPG formatted key.
+    # This is necessary because we need to point `signed-by` (in the apt sources 
+    # list) to a GPG formatted key.
     gpg --dearmor < /tmp/heroku-archive-keyring.asc > /etc/apt/keyrings/heroku-archive-keyring.gpg
     echo "deb [signed-by=/etc/apt/keyrings/heroku-archive-keyring.gpg] https://cli-assets.heroku.com/channels/stable/apt ./" > /etc/apt/sources.list.d/heroku.list
   fi


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Overview

This PR updates the Heroku CLI installation process in `install-ubuntu.sh` to improve compatibility with newer versions of Ubuntu. It replaces the deprecated apt-key method with a conditional approach: if apt-key is available, it is used; otherwise, the script installs the GPG package, converts the release key to GPG format, and configures the repository to use the keyring method. This ensures the script works on both older and newer Ubuntu systems.

## Risk
Low. The changes are limited to the Heroku CLI installation logic and add compatibility for newer systems while preserving support for older ones. Existing functionality is maintained, and no other parts of the script or project are affected.

## Compliance
[GUS Ticket](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002DZQ33YAH/view)