### PR TITLE
refactor: convert authorizations esm

### DIFF
--- a/packages/cli/src/commands/authorizations/create.ts
+++ b/packages/cli/src/commands/authorizations/create.ts
@@ -1,11 +1,10 @@
-/*
 import {Command, flags} from '@heroku-cli/command'
-import {ScopeCompletion} from '@heroku-cli/command/lib/completions'
+import {ScopeCompletion} from '@heroku-cli/command/lib/completions.js'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
 import {hux} from '@heroku/heroku-cli-util'
 
-import {display} from '../../lib/authorizations/authorizations'
+import {display} from '../../lib/authorizations/authorizations.js'
 
 export default class AuthorizationsCreate extends Command {
   static description = 'create a new OAuth authorization'
@@ -38,7 +37,7 @@ export default class AuthorizationsCreate extends Command {
     ux.action.stop()
 
     if (flags.short) {
-      ux.log(auth.access_token && auth.access_token.token)
+      ux.stdout(auth.access_token && auth.access_token.token)
     } else if (flags.json) {
       hux.styledJSON(auth)
     } else {
@@ -46,4 +45,3 @@ export default class AuthorizationsCreate extends Command {
     }
   }
 }
-*/

--- a/packages/cli/src/commands/authorizations/index.ts
+++ b/packages/cli/src/commands/authorizations/index.ts
@@ -1,10 +1,8 @@
-/*
-import color from '@heroku-cli/color'
+import {color} from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
 import {hux} from '@heroku/heroku-cli-util'
-const {sortBy} = require('lodash')
 
 export default class AuthorizationsIndex extends Command {
   static description = 'list OAuth authorizations'
@@ -20,22 +18,18 @@ export default class AuthorizationsIndex extends Command {
   async run() {
     const {flags} = await this.parse(AuthorizationsIndex)
 
-    let {body: authorizations} = await this.heroku.get<Array<Heroku.OAuthAuthorization>>('/oauth/authorizations')
-
-    authorizations = sortBy(authorizations, 'description')
+    const {body: authorizations} = await this.heroku.get<Array<Heroku.OAuthAuthorization>>('/oauth/authorizations')
 
     if (flags.json) {
-      hux.styledJSON(authorizations)
+      hux.styledJSON(authorizations.sort((a, b) => a.description.localeCompare(b.description)))
     } else if (authorizations.length === 0) {
-      ux.log('No OAuth authorizations.')
+      ux.stdout('No OAuth authorizations.')
     } else {
-      const printLine: typeof this.log = (...args) => this.log(...args)
       hux.table(authorizations, {
-        description: {get: (v: any) => color.green(v.description)},
-        id: {},
-        scope: {get: (v: any) => v.scope.join(',')},
-      }, {'no-header': true, printLine})
+        Description: {get: (v: any) => color.green(v.description)},
+        ID: {get: (v: any) => v.id},
+        Scope: {get: (v: any) => v.scope.join(',')},
+      }, {sort: {Description: 'asc'}})
     }
   }
 }
-*/

--- a/packages/cli/src/commands/authorizations/info.ts
+++ b/packages/cli/src/commands/authorizations/info.ts
@@ -1,10 +1,9 @@
-/*
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {Args} from '@oclif/core'
 import {hux} from '@heroku/heroku-cli-util'
 
-import {display} from '../../lib/authorizations/authorizations'
+import {display} from '../../lib/authorizations/authorizations.js'
 
 export default class AuthorizationsInfo extends Command {
   static description = 'show an existing OAuth authorization'
@@ -31,4 +30,3 @@ export default class AuthorizationsInfo extends Command {
     }
   }
 }
-*/

--- a/packages/cli/src/commands/authorizations/revoke.ts
+++ b/packages/cli/src/commands/authorizations/revoke.ts
@@ -1,5 +1,4 @@
-/*
-import color from '@heroku-cli/color'
+import {color} from '@heroku-cli/color'
 import {Command} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {Args, ux} from '@oclif/core'
@@ -27,4 +26,3 @@ export default class AuthorizationsRevoke extends Command {
     ux.action.stop(`done, revoked authorization from ${color.cyan(auth.description)}`)
   }
 }
-*/

--- a/packages/cli/src/commands/authorizations/rotate.ts
+++ b/packages/cli/src/commands/authorizations/rotate.ts
@@ -1,9 +1,8 @@
-/*
 import {Command} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {Args, ux} from '@oclif/core'
 
-import {display} from '../../lib/authorizations/authorizations'
+import {display} from '../../lib/authorizations/authorizations.js'
 
 export default class AuthorizationsRotate extends Command {
   static description = 'updates an OAuth authorization token'
@@ -24,4 +23,3 @@ export default class AuthorizationsRotate extends Command {
     display(authorization)
   }
 }
-*/

--- a/packages/cli/src/commands/authorizations/update.ts
+++ b/packages/cli/src/commands/authorizations/update.ts
@@ -1,9 +1,8 @@
-/*
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {Args, ux} from '@oclif/core'
 
-import {display} from '../../lib/authorizations/authorizations'
+import {display} from '../../lib/authorizations/authorizations.js'
 
 export default class AuthorizationsUpdate extends Command {
   static description = 'updates an OAuth authorization'
@@ -46,4 +45,3 @@ export default class AuthorizationsUpdate extends Command {
     display(authentication)
   }
 }
-*/

--- a/packages/cli/src/lib/authorizations/authorizations.ts
+++ b/packages/cli/src/lib/authorizations/authorizations.ts
@@ -1,7 +1,7 @@
 'use strict'
 
 import * as Heroku from '@heroku-cli/schema'
-// import {hux} from '@heroku/heroku-cli-util'
+import {hux} from '@heroku/heroku-cli-util'
 import {formatDistanceToNow, addSeconds} from 'date-fns'
 
 export function display(auth: Heroku.OAuthAuthorization) {
@@ -17,10 +17,10 @@ export function display(auth: Heroku.OAuthAuthorization) {
   }
 
   const obj: StyledObject = {
+    Client: '<none>',
     ID: auth.id,
     Description: auth.description,
     Scope: auth.scope ? auth.scope.join(',') : undefined,
-    Client: '<none>',
   }
 
   if (auth.client) {
@@ -40,14 +40,14 @@ export function display(auth: Heroku.OAuthAuthorization) {
     }
   }
 
-  // hux.styledObject(obj, [
-  //   'Client',
-  //   'Redirect URI',
-  //   'ID',
-  //   'Description',
-  //   'Scope',
-  //   'Token',
-  //   'Expires at',
-  //   'Updated at',
-  // ])
+  hux.styledObject(obj, [
+    'Client',
+    'Redirect URI',
+    'ID',
+    'Description',
+    'Scope',
+    'Token',
+    'Expires at',
+    'Updated at',
+  ])
 }

--- a/packages/cli/test/unit/commands/authorizations/create.unit.test.ts
+++ b/packages/cli/test/unit/commands/authorizations/create.unit.test.ts
@@ -9,7 +9,6 @@ const testWithAuthorizationsCreate = (requestBody = {}) =>
         .reply(201, {scope: ['global'], access_token: {token: 'secrettoken'}})
     })
 
-/*
 describe('authorizations:create', function () {
   testWithAuthorizationsCreate({description: 'awesome'})
     .command(['authorizations:create', '--description', 'awesome'])
@@ -41,5 +40,3 @@ describe('authorizations:create', function () {
       })
   })
 })
-
-*/

--- a/packages/cli/test/unit/commands/authorizations/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/authorizations/index.unit.test.ts
@@ -1,6 +1,6 @@
 import {expect, test} from '@oclif/test'
+import removeAllWhitespace from '../../../helpers/utils/remove-whitespaces.js'
 
-/*
 describe('authorizations', function () {
   const exampleAuthorization1 = {
     description: 'b description',
@@ -23,10 +23,14 @@ describe('authorizations', function () {
   testWithAuthorizations()
     .command(['authorizations'])
     .it('lists the authorizations alphabetically by description', ctx => {
-      expect(ctx.stdout).to.equal(
-        ' awesome       f6e8d969-129f-42d2-854b-c2eca9d5a42e app,user \n' +
-        ' b description aBcD1234-129f-42d2-854b-dEf123abc123 global   \n',
-      )
+      const actual = removeAllWhitespace(ctx.stdout)
+      const expected = removeAllWhitespace(`
+        awesome       f6e8d969-129f-42d2-854b-c2eca9d5a42e app,user
+        b description aBcD1234-129f-42d2-854b-dEf123abc123 global`)
+      // console.log('Actual stdout:', ctx.stdout)
+      // expect(actual).to.include(removeAllWhitespace('awesome       f6e8d969-129f-42d2-854b-c2eca9d5a42e app,user'))
+      // expect(actual).to.include(removeAllWhitespace('b description aBcD1234-129f-42d2-854b-dEf123abc123 global'))
+      expect(actual).to.include(expected)
     })
 
   context('with json flag', function () {
@@ -48,5 +52,3 @@ describe('authorizations', function () {
       })
   })
 })
-
-*/

--- a/packages/cli/test/unit/commands/authorizations/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/authorizations/index.unit.test.ts
@@ -27,9 +27,6 @@ describe('authorizations', function () {
       const expected = removeAllWhitespace(`
         awesome       f6e8d969-129f-42d2-854b-c2eca9d5a42e app,user
         b description aBcD1234-129f-42d2-854b-dEf123abc123 global`)
-      // console.log('Actual stdout:', ctx.stdout)
-      // expect(actual).to.include(removeAllWhitespace('awesome       f6e8d969-129f-42d2-854b-c2eca9d5a42e app,user'))
-      // expect(actual).to.include(removeAllWhitespace('b description aBcD1234-129f-42d2-854b-dEf123abc123 global'))
       expect(actual).to.include(expected)
     })
 

--- a/packages/cli/test/unit/commands/authorizations/info.unit.test.ts
+++ b/packages/cli/test/unit/commands/authorizations/info.unit.test.ts
@@ -1,6 +1,6 @@
 import {expect, test} from '@oclif/test'
 import {formatDistanceToNow} from 'date-fns'
-/*
+
 describe('authorizations:info', function () {
   const authorizationID = '4UTHOri24tIoN-iD-3X4mPl3'
   const authorization = {
@@ -60,5 +60,3 @@ describe('authorizations:info', function () {
       })
   })
 })
-
-*/

--- a/packages/cli/test/unit/commands/authorizations/revoke.unit.test.ts
+++ b/packages/cli/test/unit/commands/authorizations/revoke.unit.test.ts
@@ -1,6 +1,5 @@
 import {expect, test} from '@oclif/test'
 
-/*
 describe('authorizations:revoke', function () {
   const authorizationID = '4UTHOri24tIoN-iD-3X4mPl3'
 
@@ -25,5 +24,3 @@ describe('authorizations:revoke', function () {
       .it('shows required ID error')
   })
 })
-
-*/

--- a/packages/cli/test/unit/commands/authorizations/revoke.unit.test.ts
+++ b/packages/cli/test/unit/commands/authorizations/revoke.unit.test.ts
@@ -11,7 +11,7 @@ describe('authorizations:revoke', function () {
     .command(['authorizations:revoke', authorizationID])
     .it('revokes the authorization', ctx => {
       expect(ctx.stderr).to.contain(
-        'done, revoked authorization from Example Auth\n',
+        'done, revoked authorization from Example Auth',
       )
     })
 

--- a/packages/cli/test/unit/commands/authorizations/rotate.unit.test.ts
+++ b/packages/cli/test/unit/commands/authorizations/rotate.unit.test.ts
@@ -1,6 +1,5 @@
 import {expect, test} from '@oclif/test'
 
-/*
 describe('authorizations:rotate', function () {
   const authorizationID = '4UTHOri24tIoN-iD-3X4mPl3'
 
@@ -20,5 +19,3 @@ describe('authorizations:rotate', function () {
       expect(ctx.stderr).to.contain('Rotating OAuth Authorization... done')
     })
 })
-
-*/

--- a/packages/cli/test/unit/commands/authorizations/update.unit.test.ts
+++ b/packages/cli/test/unit/commands/authorizations/update.unit.test.ts
@@ -1,6 +1,5 @@
 import {expect, test} from '@oclif/test'
 
-/*
 describe('authorizations:update', function () {
   const authorizationID = '4UTHOri24tIoN-iD-3X4mPl3'
 
@@ -30,5 +29,3 @@ describe('authorizations:update', function () {
       )
     })
 })
-
-*/

--- a/packages/cli/test/unit/lib/authorizations/authorizations.unit.test.ts
+++ b/packages/cli/test/unit/lib/authorizations/authorizations.unit.test.ts
@@ -8,7 +8,6 @@ const setupDisplay = (auth: Heroku.OAuthAuthorization) =>
     .stdout()
     .do(() => display(auth))
 
-/*
 describe('display', function () {
   const authId = 'f6e8d969-129f-42d2-854b-c2eca9d5a42e'
   const authDesc = 'a cool auth'
@@ -94,5 +93,3 @@ describe('display', function () {
       })
   })
 })
-
-*/


### PR DESCRIPTION
[W-18575900](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002EkBPOYA3/view)

### Description

This uncomments authorizations commands and make them compatible with oclif/core v4, converting to esm.

### Testing

1. Pull down branch and yarn build
2. `./bin/run authorizations`
3. `./bin/run authorizations:info AUTHORIZATION_ID`
5. test other authorizations commands as you see fit (bear in mind you will change your production authorizations through this)

