### PR TITLE
chore: renaming setting explain_data_connector_details 

### DIFF
--- a/docs/pg.md
+++ b/docs/pg.md
@@ -52,7 +52,7 @@ manage postgresql databases
 * [`heroku pg:settings:auto-explain:log-nested-statements [DATABASE] [VALUE]`](#heroku-pgsettingsauto-explainlog-nested-statements-database-value)
 * [`heroku pg:settings:auto-explain:log-triggers [DATABASE] [VALUE]`](#heroku-pgsettingsauto-explainlog-triggers-database-value)
 * [`heroku pg:settings:auto-explain:log-verbose [DATABASE] [VALUE]`](#heroku-pgsettingsauto-explainlog-verbose-database-value)
-* [`heroku pg:settings:explain-data-connector-details [DATABASE] [VALUE]`](#heroku-pgsettingsexplain-data-connector-details-database-value)
+* [`heroku pg:settings:data-connector-details-logs [DATABASE] [VALUE]`](#heroku-pgsettingsdata-connector-details-logs-database-value)
 * [`heroku pg:settings:log-connections [DATABASE] [VALUE]`](#heroku-pgsettingslog-connections-database-value)
 * [`heroku pg:settings:log-lock-waits [DATABASE] [VALUE]`](#heroku-pgsettingslog-lock-waits-database-value)
 * [`heroku pg:settings:log-min-duration-statement [DATABASE] [VALUE]`](#heroku-pgsettingslog-min-duration-statement-database-value)
@@ -1340,13 +1340,13 @@ DESCRIPTION
 
 _See code: [src/commands/pg/settings/auto-explain/log-verbose.ts](https://github.com/heroku/cli/blob/v10.11.0/packages/cli/src/commands/pg/settings/auto-explain/log-verbose.ts)_
 
-## `heroku pg:settings:explain-data-connector-details [DATABASE] [VALUE]`
+## `heroku pg:settings:data-connector-details-logs [DATABASE] [VALUE]`
 
 displays stats on replication slots on your database, the default value is "off"
 
 ```
 USAGE
-  $ heroku pg:settings:explain-data-connector-details [DATABASE] [VALUE] -a <value> [-r <value>]
+  $ heroku pg:settings:data-connector-details-logs [DATABASE] [VALUE] -a <value> [-r <value>]
 
 ARGUMENTS
   DATABASE  config var containing the connection string, unique name, ID, or alias of the database. To access another
@@ -1362,7 +1362,7 @@ DESCRIPTION
   displays stats on replication slots on your database, the default value is "off"
 ```
 
-_See code: [src/commands/pg/settings/explain-data-connector-details.ts](https://github.com/heroku/cli/blob/v10.11.0/packages/cli/src/commands/pg/settings/explain-data-connector-details.ts)_
+_See code: [src/commands/pg/settings/data-connector-details-logs.ts](https://github.com/heroku/cli/blob/v10.10.0/packages/cli/src/commands/pg/settings/data-connector-details-logs.ts)_
 
 ## `heroku pg:settings:log-connections [DATABASE] [VALUE]`
 

--- a/packages/cli/src/commands/pg/settings/data-connector-details-logs.ts
+++ b/packages/cli/src/commands/pg/settings/data-connector-details-logs.ts
@@ -5,7 +5,7 @@ import {type BooleanAsString, booleanConverter, PGSettingsCommand} from '../../.
 import type {Setting, SettingKey} from '../../../lib/pg/types'
 import {nls} from '../../../nls'
 
-export default class ExplainDataConnectorDetails extends PGSettingsCommand {
+export default class DataConnectorDetailsLogs extends PGSettingsCommand {
   static description = heredoc(`
   displays stats on replication slots on your database, the default value is "off"
   `)
@@ -20,7 +20,7 @@ export default class ExplainDataConnectorDetails extends PGSettingsCommand {
     value: Args.string({description: 'boolean indicating if data replication slot details get logged'}),
   }
 
-  protected settingKey:SettingKey = 'explain_data_connector_details'
+  protected settingKey:SettingKey = 'data_connector_details_logs'
 
   protected convertValue(val: BooleanAsString): boolean {
     return booleanConverter(val)

--- a/packages/cli/src/lib/pg/types.ts
+++ b/packages/cli/src/lib/pg/types.ts
@@ -234,7 +234,7 @@ export type SettingKey =
   | 'pgbouncer_max_client_conn'
   | 'pg_bouncer_max_db_conns'
   | 'pg_bouncer_default_pool_size'
-  | 'explain_data_connector_details'
+  | 'data_connector_details_logs'
   | 'auto_explain'
   | 'auto_explain.log_min_duration'
   | 'auto_explain.log_analyze'

--- a/packages/cli/test/unit/commands/pg/settings/data-connector-details-logs.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/settings/data-connector-details-logs.unit.test.ts
@@ -3,13 +3,14 @@ import * as nock from 'nock'
 import {stdout} from 'stdout-stderr'
 import heredoc from 'tsheredoc'
 import runCommand from '../../../../helpers/runCommand'
-import Cmd from '../../../../../src/commands/pg/settings/explain-data-connector-details'
+import Cmd from '../../../../../src/commands/pg/settings/data-connector-details-logs'
 import * as fixtures from '../../../../fixtures/addons/fixtures'
 
-describe('pg:explain-data-connector-details', function () {
-  const addon = fixtures.addons['dwh-db']
+describe('pg:data-connector-details-logs', function () {
+  let addon: any
 
   beforeEach(function () {
+    addon = fixtures.addons['dwh-db']
     nock('https://api.heroku.com')
       .post('/actions/addons/resolve', {
         app: 'myapp',
@@ -21,22 +22,22 @@ describe('pg:explain-data-connector-details', function () {
     nock.cleanAll()
   })
 
-  it('turns on explain-data-connector-details option', async function () {
+  it('turns on data-connector-details-logs option', async function () {
     nock('https://api.data.heroku.com')
-      .get(`/postgres/v0/databases/${addon.id}/config`).reply(200, {explain_data_connector_details: {value: 'on'}})
+      .get(`/postgres/v0/databases/${addon.id}/config`).reply(200, {data_connector_details_logs: {value: 'on'}})
     await runCommand(Cmd, ['--app', 'myapp', 'test-database'])
     expect(stdout.output).to.equal(heredoc(`
-      explain-data-connector-details is set to on for ${addon.name}.
+      data-connector-details-logs is set to on for ${addon.name}.
       Data replication slot details will be logged.
     `))
   })
 
-  it('turns off explain-data-connector-details option', async function () {
+  it('turns off data-connector-details-logs option', async function () {
     nock('https://api.data.heroku.com')
-      .get(`/postgres/v0/databases/${addon.id}/config`).reply(200, {explain_data_connector_details: {value: ''}})
+      .get(`/postgres/v0/databases/${addon.id}/config`).reply(200, {data_connector_details_logs: {value: ''}})
     await runCommand(Cmd, ['--app', 'myapp', 'test-database'])
     expect(stdout.output).to.equal(heredoc(`
-      explain-data-connector-details is set to  for ${addon.name}.
+      data-connector-details-logs is set to  for ${addon.name}.
       Data replication slot details will no longer be logged.
     `))
   })


### PR DESCRIPTION
# renaming setting explain_data_connector_details

## Description
This PR renames the pg:setting explain_data_connector_details to data_connector_details_logs

## GUS
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002BpMjhYAF/view
related shogun backend PR: https://github.com/heroku/shogun/pull/20599
related staging doc updates: https://salesforce-internal.slack.com/archives/CCS6NJYG2/p1743180785156639?thread_ts=1742919403.551169&cid=CCS6NJYG2

## Why
we noticed that the Dev Center and our code are not aligned on the name of the PGSetting to enable emitting Streaming Data Connectors replication metrics to the Heroku Postgres metrics logs. We're not documenting the right name of the setting to be used.This feature was built for British Airways to have visibility on the spill files and disk usage caused by Streaming Data Connectors, and apparently hasn't been used by any other customers.

HCE and Product discussed this briefly through https://salesforce-internal.slack.com/archives/CCS6NJYG2/p1742942119820559?thread_ts=1742919403.551169&cid=CCS6NJYG2.

The Dev Center currently calls this setting "pg-replication-slot-logs" (https://devcenter.heroku.com/articles/heroku-postgres-settings#pg-replication-slot-logs). However, in reality it is called "explain-data-connector-details".

While discussing fixing the Dev Center article to include the right setting name, we wondered if it makes sense to rename the setting name to try avoid confusion. The current name, "explain-data-connector-details", might sound similar to a PG EXPLAIN, especially given that we document auto-explain on the same page.

Assuming this setting isn't being used, and after discussing with Product, we consider renaming the setting to "data-connector-details-logs". The risk is low, as noted in the thread BA was the only customer utilizing this setting. 

## Testing
- [x] Verify documentation matches new setting name
- [x] Check all links are correct if there are any
- [x] Point local CLI to my staging shogun with backend changes: https://github.com/heroku/shogun/pull/20566, and run the new command
```bash
./bin/run pg:settings:data-connector-details-logs postgresql-bjones-rigid-84072 on -a bjones-test
data-connector-details-logs has been set to true for postgresql-bjones-rigid-84072.
Data replication slot details will be logged.

./bin/run pg:settings:data-connector-details-logs postgresql-bjones-rigid-84072 off -a bjones-test
data-connector-details-logs has been set to false for postgresql-bjones-rigid-84072.
Data replication slot details will no longer be logged.

# Ensure old command fails
./bin/run pg:settings:explain-data-connector-details postgresql-bjones-rigid-84072 on -a bjones-test
 ›   Warning: pg:settings:explain-data-connector-details is not a heroku command.
Did you mean pg:settings:data-connector-details-logs? [y/n]: y
data-connector-details-logs has been set to true for postgresql-bjones-rigid-84072.
Data replication slot details will be logged.
```
- [x] Ensure the command still works