### PR TITLE
fix: add alias for heroku-pg-extras

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -367,6 +367,7 @@
       "heroku-cli-plugin-generator": null,
       "heroku-container-registry": null,
       "heroku-event-log": "@heroku/event-log",
+      "heroku-pg-extras": "@heroku-cli/heroku-pg-extras",
       "heroku-pipelines": null,
       "heroku-ps-wait": null,
       "heroku-redis": null,


### PR DESCRIPTION
We've released a new version of the heroku-pg-extras package as [@heroku-cli/heroku-pg-extras](https://www.npmjs.com/package/@heroku-cli/heroku-pg-extras). Adding this alias allows users to continue to install the plugin as `heroku-pg-extras` instead of requiring them to use `@heroku-cli/heroku-pg-extras`.

## Testing
1. Check out this branch and run `yarn && yarn build`
2. Run `heroku plugins` and make sure you do not currently have `heroku-pg-extras` installed
    - If you do, run `heroku plugins:uninstall heroku-pg-extras` to uninstall it.
3. Run `./bin/run plugins:install heroku-pg-extras`
4. Run `heroku plugins` and verify that v1.3.0 of the @heroku-cli/heroku-pg-extras plugin is installed.

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
