### PR TITLE
chore: comment out heroku members test

### DIFF
--- a/scripts/postrelease/test_release
+++ b/scripts/postrelease/test_release
@@ -44,7 +44,7 @@ declare -a COMMANDS=(
   "$CMD_BIN labs"
   "$CMD_BIN local:version"
   "$CMD_BIN maintenance --app heroku-cli-test-staging"
-  "$CMD_BIN members --team heroku-front-end"
+  # "$CMD_BIN members --team heroku-front-end"
   "$CMD_BIN notifications"
   "$CMD_BIN orgs"
   "$CMD_BIN pg:backups --app particleboard-staging"


### PR DESCRIPTION
Comments out a test that has been causing our pre-release test runs to fail. The Heroku account we use for these tests no longer has the access needed in order to run this test. Long-term we will need to figure out a better way of testing this command as part of our release process, but for now this should allow our release tests to pass.

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
