### PR TITLE
fix: hide repl and prompt commands temporarily

### DIFF
--- a/packages/cli/src/commands/prompt.ts
+++ b/packages/cli/src/commands/prompt.ts
@@ -3,6 +3,8 @@ import {Command, ux} from '@oclif/core'
 export default class Prompt extends Command {
   static description = 'interactively prompt for command arguments and flags'
 
+  static hidden = true
+
   static examples = [
     '$ heroku apps:info --prompt',
     '$ heroku config:set --prompt',

--- a/packages/cli/src/commands/repl.ts
+++ b/packages/cli/src/commands/repl.ts
@@ -3,6 +3,8 @@ import {Command, ux} from '@oclif/core'
 export default class Repl extends Command {
   static description = 'enter an interactive REPL session to run Heroku CLI commands'
 
+  static hidden = true
+
   static examples = [
     '$ heroku --repl',
   ]


### PR DESCRIPTION
Hiding these commands temporarily until we can fix an issue with the custom docs created for them.

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
