### PR TITLE
refactor: convert clients to esm

### DIFF
--- a/packages/cli/src/commands/clients/create.ts
+++ b/packages/cli/src/commands/clients/create.ts
@@ -1,10 +1,9 @@
-/*
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {Args, ux} from '@oclif/core'
 import {hux} from '@heroku/heroku-cli-util'
 
-import {validateURL} from '../../lib/clients/clients'
+import {validateURL} from '../../lib/clients/clients.js'
 
 export default class ClientsCreate extends Command {
   static description = 'create a new OAuth client'
@@ -40,9 +39,8 @@ export default class ClientsCreate extends Command {
     if (flags.json) {
       hux.styledJSON(client)
     } else {
-      ux.log(`HEROKU_OAUTH_ID=${client.id}`)
-      ux.log(`HEROKU_OAUTH_SECRET=${client.secret}`)
+      ux.stdout(`HEROKU_OAUTH_ID=${client.id}`)
+      ux.stdout(`HEROKU_OAUTH_SECRET=${client.secret}`)
     }
   }
 }
-*/

--- a/packages/cli/src/commands/clients/destroy.ts
+++ b/packages/cli/src/commands/clients/destroy.ts
@@ -1,5 +1,4 @@
-/*
-import color from '@heroku-cli/color'
+import {color} from '@heroku-cli/color'
 import {Command} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {Args, ux} from '@oclif/core'
@@ -23,4 +22,3 @@ export default class ClientsDestroy extends Command {
     ux.action.stop()
   }
 }
-*/

--- a/packages/cli/src/commands/clients/index.ts
+++ b/packages/cli/src/commands/clients/index.ts
@@ -1,10 +1,8 @@
-/*
-import color from '@heroku-cli/color'
+import {color} from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
 import {hux} from '@heroku/heroku-cli-util'
-const {sortBy} = require('lodash')
 
 export default class ClientsIndex extends Command {
   static description = 'list your OAuth clients'
@@ -16,22 +14,21 @@ export default class ClientsIndex extends Command {
   async run() {
     const {flags} = await this.parse(ClientsIndex)
 
-    let {body: clients} = await this.heroku.get<Array<Heroku.OAuthClient>>('/oauth/clients')
-
-    clients = sortBy(clients, 'name')
+    const {body: clients} = await this.heroku.get<Array<Heroku.OAuthClient>>('/oauth/clients')
 
     if (flags.json) {
-      hux.styledJSON(clients)
+      const sortedClients = clients.sort((a, b) => (a.name || '').localeCompare(b.name || ''))
+      hux.styledJSON(sortedClients)
     } else if (clients.length === 0) {
-      ux.log('No OAuth clients.')
+      ux.stdout('No OAuth clients.')
     } else {
-      const printLine: typeof this.log = (...args) => this.log(...args)
       hux.table(clients, {
         name: {get: (w: any) => color.green(w.name)},
         id: {},
         redirect_uri: {},
-      }, {'no-header': true, printLine})
+      }, {
+        sort: {name: 'asc'},
+      })
     }
   }
 }
-*/

--- a/packages/cli/src/commands/clients/info.ts
+++ b/packages/cli/src/commands/clients/info.ts
@@ -1,4 +1,3 @@
-/*
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {Args, ux} from '@oclif/core'
@@ -28,12 +27,11 @@ export default class ClientsInfo extends Command {
     if (flags.json) {
       hux.styledJSON(client)
     } else if (flags.shell) {
-      ux.log(`HEROKU_OAUTH_ID=${client.id}`)
-      ux.log(`HEROKU_OAUTH_SECRET=${client.secret}`)
+      ux.stdout(`HEROKU_OAUTH_ID=${client.id}`)
+      ux.stdout(`HEROKU_OAUTH_SECRET=${client.secret}`)
     } else {
       hux.styledHeader(`${client.name}`)
       hux.styledObject(client)
     }
   }
 }
-*/

--- a/packages/cli/src/commands/clients/rotate.ts
+++ b/packages/cli/src/commands/clients/rotate.ts
@@ -1,5 +1,4 @@
-/*
-import color from '@heroku-cli/color'
+import {color} from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {Args, ux} from '@oclif/core'
@@ -31,12 +30,11 @@ export default class ClientsRotate extends Command {
     if (flags.json) {
       hux.styledJSON(client)
     } else if (flags.shell) {
-      ux.log(`HEROKU_OAUTH_ID=${client.id}`)
-      ux.log(`HEROKU_OAUTH_SECRET=${client.secret}`)
+      ux.stdout(`HEROKU_OAUTH_ID=${client.id}`)
+      ux.stdout(`HEROKU_OAUTH_SECRET=${client.secret}`)
     } else {
       hux.styledHeader(`${client.name}`)
       hux.styledObject(client)
     }
   }
 }
-*/

--- a/packages/cli/src/commands/clients/update.ts
+++ b/packages/cli/src/commands/clients/update.ts
@@ -1,10 +1,9 @@
-/*
-import color from '@heroku-cli/color'
+import {color} from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {Args, ux} from '@oclif/core'
 
-import {validateURL} from '../../lib/clients/clients'
+import {validateURL} from '../../lib/clients/clients.js'
 
 interface Updates {
   redirect_uri?: string;
@@ -54,4 +53,3 @@ export default class ClientsUpdate extends Command {
     ux.action.stop()
   }
 }
-*/

--- a/packages/cli/test/unit/commands/clients/create.unit.test.ts
+++ b/packages/cli/test/unit/commands/clients/create.unit.test.ts
@@ -1,6 +1,5 @@
 import {expect, test} from '@oclif/test'
 
-/*
 describe('clients:create', function () {
   const createResponse = {
     name: 'awesome',
@@ -25,8 +24,7 @@ describe('clients:create', function () {
       expect(ctx.stdout).to.equal(
         'HEROKU_OAUTH_ID=f6e8d969-129f-42d2-854b-c2eca9d5a42e\nHEROKU_OAUTH_SECRET=clientsecret\n',
       )
-    // TODO: Not currently testable due to a cli-ux mocking issue
-    // expect(ctx.stderr).to.contain('Creating awesome... done\n')
+      expect(ctx.stderr).to.contain('Creating awesome... done\n')
     })
 
   testWithClientCreate()
@@ -36,5 +34,3 @@ describe('clients:create', function () {
       expect(ctx.stderr).to.contain('Creating awesome... done\n')
     })
 })
-
-*/

--- a/packages/cli/test/unit/commands/clients/destroy.unit.test.ts
+++ b/packages/cli/test/unit/commands/clients/destroy.unit.test.ts
@@ -1,6 +1,5 @@
 import {expect, test} from '@oclif/test'
 
-/*
 describe('clients:destroy', function () {
   test
     .stdout()
@@ -14,4 +13,3 @@ describe('clients:destroy', function () {
     })
 })
 
-*/

--- a/packages/cli/test/unit/commands/clients/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/clients/index.unit.test.ts
@@ -1,4 +1,5 @@
 import {expect, test} from '@oclif/test'
+import removeAllWhitespace from '../../../helpers/utils/remove-whitespaces.js'
 
 describe('clients', function () {
   describe('with clients', function () {
@@ -17,7 +18,9 @@ describe('clients', function () {
     testWithClients()
       .command(['clients'])
       .it('lists the clients', ctx => {
-        expect(ctx.stdout).to.contain('awesome f6e8d969-129f-42d2-854b-c2eca9d5a42e https://myapp.com \n')
+        const actual = removeAllWhitespace(ctx.stdout)
+        const expected = removeAllWhitespace('awesome f6e8d969-129f-42d2-854b-c2eca9d5a42e https://myapp.com')
+        expect(actual).to.include(expected)
       })
 
     testWithClients()

--- a/packages/cli/test/unit/commands/clients/index.unit.test.ts
+++ b/packages/cli/test/unit/commands/clients/index.unit.test.ts
@@ -1,6 +1,5 @@
 import {expect, test} from '@oclif/test'
 
-/*
 describe('clients', function () {
   describe('with clients', function () {
     const exampleClient1 = {
@@ -40,5 +39,3 @@ describe('clients', function () {
       })
   })
 })
-
-*/

--- a/packages/cli/test/unit/commands/clients/info.unit.test.ts
+++ b/packages/cli/test/unit/commands/clients/info.unit.test.ts
@@ -1,6 +1,5 @@
 import {expect, test} from '@oclif/test'
 
-/*
 describe('clients:info', function () {
   const id = 'f6e8d969-129f-42d2-854b-c2eca9d5a42e'
   const client = {name: 'awesome', id, redirect_uri: 'https://myapp.com', secret: 'supersecretkey'}
@@ -42,5 +41,3 @@ describe('clients:info', function () {
       })
   })
 })
-
-*/

--- a/packages/cli/test/unit/commands/clients/rotate.unit.test.ts
+++ b/packages/cli/test/unit/commands/clients/rotate.unit.test.ts
@@ -1,6 +1,5 @@
 import {expect, test} from '@oclif/test'
 
-/*
 describe('clients:rotate', function () {
   const id = 'f6e8d969-129f-42d2-854b-c2eca9d5a42e'
   const client = {name: 'awesome', id, redirect_uri: 'https://myapp.com', secret: 'supersecretkey'}
@@ -46,5 +45,3 @@ describe('clients:rotate', function () {
       })
   })
 })
-
-*/

--- a/packages/cli/test/unit/commands/clients/update.unit.test.ts
+++ b/packages/cli/test/unit/commands/clients/update.unit.test.ts
@@ -1,6 +1,5 @@
 import {expect, test} from '@oclif/test'
 
-/*
 describe('clients:update', function () {
   context('with a name flag', function () {
     test
@@ -48,5 +47,3 @@ describe('clients:update', function () {
       .it('errors with no changes provided')
   })
 })
-
-*/


### PR DESCRIPTION
[W-18575907](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Ek54BYAR/view)

### Description

This converts the `clients` commands to esm and makes them availabe in the v11 branch.

### Testing

For destructive actions (e.g., `certs:add`) please make sure to use a test app. We don't want to make certs changes to production or staging apps.

1. Pull down this branch and `yarn build`
2. `./bin/run clients:create "FAKE" fake-callback.com
3. `./bin/run clients
4. `./bin/run clients:destroy ID where ID is the ID of the fake oauth client you created in step 1

