### PR TITLE
fix: Disable attestations and SBOMs for Heroku's container registry

### DIFF
--- a/packages/cli/src/commands/container/push.ts
+++ b/packages/cli/src/commands/container/push.ts
@@ -113,7 +113,7 @@ export default class Push extends Command {
           hux.styledHeader(`Pushing ${job.name} (${job.dockerfile})`)
         }
 
-        await DockerHelper.pushImage(job.resource)
+        await DockerHelper.pushImage(job.resource, this.config.arch)
       }
 
       const plural = jobs.length !== 1

--- a/packages/cli/src/lib/container/docker_helper.ts
+++ b/packages/cli/src/lib/container/docker_helper.ts
@@ -184,7 +184,7 @@ export const buildImage = async function ({dockerfile, resource, buildArgs, path
   // adding it here when necessary to allow for pushing a docker build from m1/m2 Macs.
   if (arch === 'arm64' || arch === 'aarch64') args.push('--platform', 'linux/amd64')
 
-  // newer docker versions support attestations and SBOMS, so we want to disable them to save time/space
+  // newer docker versions support attestations and software bill of materials, so we want to disable them to save time/space
   // Heroku's container registry doesn't support pushing them right now
   if (await version() >= [24, 0, 0]) {
     args.push('--provenance', 'false')


### PR DESCRIPTION
- disable attestations and SBOMs if the docker version is >= 24.0.0
- enforcing amd64 images coming from non-amd64 machines (aarch64)
- enforce amd64 on push in addition to build

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

[W-18012763](https://gus.lightning.force.com/a07EE00002Aut5yYAB)
