### PR TITLE
feat(W-19005486): add support for SF Trust API to status command

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -9,6 +9,7 @@ allkeys
 amyapp
 amannn
 aname
+APAC
 appname
 apresharedkey
 armel
@@ -38,6 +39,7 @@ buildpack
 buildpacks
 buildpath
 cachecompl
+CEDARPRIVATESPACES
 ckey
 clearsign
 clientsecret
@@ -77,6 +79,7 @@ ECCN
 echoerr
 Edmonds
 elif
+EMEA
 envfile
 envl
 eventsource
@@ -88,6 +91,7 @@ favoriteid
 favoriting
 filebase
 filesize
+FIRPRIVATESPACES
 flagscompletions
 fooapp
 fooexample

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -31,6 +31,7 @@ const printStatus = (status: string) => {
 
 const getTrustStatus = async () => {
   const trustHost = process.env.SF_TRUST_STAGING ? 'https://status-api-stg.test.edgekey.net/v1' : 'https://api.status.salesforce.com/v1'
+  const currentDateTime = new Date(Date.now()).toISOString()
   let instances: TrustInstance[] = []
   let activeIncidents: TrustIncident[] = []
   let maintenances: TrustMaintenance[] = []
@@ -40,7 +41,7 @@ const getTrustStatus = async () => {
     const [instanceResponse, activeIncidentsResponse, maintenancesResponse, localizationsResponse] = await Promise.all([
       HTTP.get<TrustInstance[]>(`${trustHost}/instances?products=Heroku`),
       HTTP.get<TrustIncident[]>(`${trustHost}/incidents/active`),
-      HTTP.get<TrustMaintenance[]>(`${trustHost}/maintenances?limit=10&offset=0&product=Heroku&locale=en`),
+      HTTP.get<TrustMaintenance[]>(`${trustHost}/maintenances?startTime=${currentDateTime}&limit=10&offset=0&product=Heroku&locale=en`),
       HTTP.get<Localization[]>(`${trustHost}/localizations?locale=en`),
     ])
     instances = instanceResponse.body

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -78,13 +78,14 @@ const formatTrustResponse = (instances: TrustInstance[], activeIncidents: TrustI
     return incident.instanceKeys.some(key => instanceKeyArray.has(key))
   })
   const toolsIncidents = herokuActiveIncidents.filter(incident => {
-    return incident.instanceKeys.includes('TOOLS' || 'Tools' || 'CLI' || 'Dashboard' || 'Platform API')
+    const tools = ['TOOLS', 'Tools', 'CLI', 'Dashboard', 'Platform API']
+    return tools.some(tool => incident.serviceKeys.includes(tool))
   })
   const appsIncidents = herokuActiveIncidents.filter(incident => {
-    return incident.serviceKeys.includes('HerokuApps' || 'Apps')
+    return incident.serviceKeys.includes('HerokuApps') || incident.serviceKeys.includes('Apps')
   })
   const dataIncidents = herokuActiveIncidents.filter(incident => {
-    return incident.serviceKeys.includes('HerokuData' || 'Data')
+    return incident.serviceKeys.includes('HerokuData') || incident.serviceKeys.includes('Data')
   })
 
   if (appsIncidents.length > 0) {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -86,14 +86,6 @@ const formatTrustResponse = (instances: TrustInstance[], activeIncidents: TrustI
     return incident.serviceKeys.includes('HerokuData' || 'Data')
   })
 
-  if (toolsIncidents.length > 0) {
-    const severity = determineIncidentSeverity(toolsIncidents)
-    systemStatus.push({system: 'Tools', status: severity})
-    incidents.push(...toolsIncidents)
-  } else {
-    systemStatus.push({system: 'Tools', status: 'green'})
-  }
-
   if (appsIncidents.length > 0) {
     const severity = determineIncidentSeverity(appsIncidents)
     systemStatus.push({system: 'Apps', status: severity})
@@ -103,11 +95,19 @@ const formatTrustResponse = (instances: TrustInstance[], activeIncidents: TrustI
   }
 
   if (dataIncidents.length > 0) {
-    const severity = determineIncidentSeverity(appsIncidents)
+    const severity = determineIncidentSeverity(dataIncidents)
     systemStatus.push({system: 'Data', status: severity})
     incidents.push(...dataIncidents)
   } else {
     systemStatus.push({system: 'Data', status: 'green'})
+  }
+
+  if (toolsIncidents.length > 0) {
+    const severity = determineIncidentSeverity(toolsIncidents)
+    systemStatus.push({system: 'Tools', status: severity})
+    incidents.push(...toolsIncidents)
+  } else {
+    systemStatus.push({system: 'Tools', status: 'green'})
   }
 
   if (maintenances.length > 0) scheduled.push(...maintenances)

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -12,6 +12,7 @@ import {
   FormattedTrustStatus, SystemStatus,
 } from '../lib/types/status'
 
+import {getMaxUpdateTypeLength} from '../lib/status/util'
 
 const errorMessage = 'Heroku platform status is unavailable at this time. Refer to https://status.salesforce.com/products/Heroku or try again later.'
 
@@ -197,7 +198,7 @@ export default class Status extends Command {
       ux.log()
       hux.styledHeader(`${incident.title} ${color.yellow(incident.created_at)} ${color.cyan(incident.full_url)}`)
 
-      const padding = maxBy(incident.updates, (i: any) => i.update_type.length).update_type.length + 0
+      const padding = getMaxUpdateTypeLength(incident.updates)
       for (const u of incident.updates) {
         ux.log(`${color.yellow(u.update_type.padEnd(padding))} ${new Date(u.updated_at).toISOString()} (${formatDistanceToNow(new Date(u.updated_at))} ago)`)
         ux.log(`${u.contents}\n`)

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -143,7 +143,7 @@ export default class Status extends Command {
     if (!herokuStatus && !formattedTrustStatus) ux.error(errorMessage, {exit: 1})
 
     if (flags.json) {
-      hux.styledJSON(body)
+      hux.styledJSON(herokuStatus ?? formattedTrustStatus)
       return
     }
 

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -147,10 +147,16 @@ export default class Status extends Command {
       return
     }
 
-    for (const item of body.status) {
-      const message = printStatus(item.status)
+    const systemStatus = herokuStatus ? herokuStatus.status : formattedTrustStatus?.status
 
-      this.log(`${(item.system + ':').padEnd(11)}${message}`)
+    if (systemStatus) {
+      for (const item of systemStatus) {
+        const message = printStatus(item.status)
+
+        this.log(`${(item.system + ':').padEnd(11)}${message}`)
+      }
+    } else {
+      ux.error(errorMessage, {exit: 1})
     }
 
     for (const incident of body.incidents) {

--- a/packages/cli/src/lib/status/util.ts
+++ b/packages/cli/src/lib/status/util.ts
@@ -1,11 +1,16 @@
-export function maxBy<T>(arr: T[], fn: (i: T) => number): T | undefined {
-  let max: {element: T; i: number} | undefined
-  for (const cur of arr) {
-    const i = fn(cur)
-    if (!max || i > max.i) {
-      max = {i, element: cur}
+type Update = {
+  update_type: string,
+  updated_at: string,
+  contents: string,
+}
+
+export function getMaxUpdateTypeLength(updatesArray: Update[]): number {
+  let max = 0
+  for (const update of updatesArray) {
+    if (!max || update.update_type.length > max) {
+      max = update.update_type.length
     }
   }
 
-  return max && max.element
+  return max
 }

--- a/packages/cli/src/lib/status/util.ts
+++ b/packages/cli/src/lib/status/util.ts
@@ -1,14 +1,8 @@
-type Update = {
-  update_type: string,
-  updated_at: string,
-  contents: string,
-}
-
-export function getMaxUpdateTypeLength(updatesArray: Update[]): number {
+export function getMaxUpdateTypeLength(updateTypes: string[]): number {
   let max = 0
-  for (const update of updatesArray) {
-    if (!max || update.update_type.length > max) {
-      max = update.update_type.length
+  for (const update of updateTypes) {
+    if (!max || update.length > max) {
+      max = update.length
     }
   }
 

--- a/packages/cli/src/lib/types/status.d.ts
+++ b/packages/cli/src/lib/types/status.d.ts
@@ -1,7 +1,13 @@
-export type FormattedStatus = {
-  status: HerokuStatus[]
-  incidents: HerokuIncident[] | TrustIncident[] | []
-  scheduled: HerokuScheduledMaintenance[] | TrustMaintenance[] | []
+export type HerokuStatus = {
+  status: SystemStatus[]
+  incidents: HerokuIncident[] | []
+  scheduled: HerokuScheduledMaintenance[] | []
+}
+
+export type FormattedTrustStatus = {
+  status: SystemStatus[]
+  incidents: TrustIncident[]
+  scheduled: TrustMaintenance[]
 }
 
 /*
@@ -74,8 +80,9 @@ type TrustIncidentImpact = {
   id: number;
   startTime: string;
   endTime?: string;
-  serviceIssue: string;
-  endUserImpact: string;
+  serviceIssue?: string;
+  endUserImpact?: string;
+  severity?: string;
   type: string;
   createdAt: string;
   updatedAt: string;
@@ -125,7 +132,7 @@ type TrustTag = {
 Heroku Status API
  */
 
-type HerokuStatus = {
+type SystemStatus = {
   system: string;
   status: string;
 }

--- a/packages/cli/src/lib/types/status.d.ts
+++ b/packages/cli/src/lib/types/status.d.ts
@@ -1,0 +1,146 @@
+export type FormattedStatus = {
+  status: HerokuStatus[]
+  incidents: HerokuIncident[] | TrustIncident[] | []
+  scheduled: HerokuScheduledMaintenance[] | TrustMaintenance[] | []
+}
+
+/*
+SF Trust API
+ */
+export type TrustInstance = {
+  key: string;
+  location: string;
+  environment: string;
+  releaseVersion: string;
+  releaseNumber: string;
+  status: string;
+  isActive: boolean;
+  city: string;
+  stateName: string;
+  stateCode: string;
+  countryName: string;
+  countryCode: string;
+  maintenanceWindow: string;
+  Services: TrustService[];
+  Products: TrustProduct[];
+  Incidents: TrustIncident[];
+  tags: TrustTag[];
+}
+
+export type TrustIncident = {
+  id: number;
+  message?: {
+    pathToResolution?: string;
+    actionPlan?: string;
+    rootCause?: string;
+  },
+  externalId?: string;
+  affectsAll: boolean;
+  isCore: boolean;
+  additionalInformation?: string;
+  serviceKeys: string[];
+  instanceKeys: string[];
+  IncidentImpacts: TrustIncidentImpact[]
+  IncidentEvents: TrustIncidentEvent[]
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type TrustMaintenance = {
+  id: number;
+  message?: {
+    maintenanceType?: string;
+    availability?: string;
+    eventStatus?: confirmed;
+  }
+  externalId?: string;
+  name?: string;
+  externalMaintenanceType?: string;
+  releaseType?: string;
+  substrate?: string;
+  affectsAll: boolean;
+  isCore: boolean;
+  plannedStartTime?: string;
+  plannedEndTime?: string;
+  additionalInformation?: string;
+  serviceKeys: string[];
+  instanceKeys: string[];
+  MaintenanceImpacts: TrustMaintenanceImpact[]
+  createdAt: string;
+  updatedAt: string;
+}
+
+type TrustIncidentImpact = {
+  id: number;
+  startTime: string;
+  endTime?: string;
+  serviceIssue: string;
+  endUserImpact: string;
+  type: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+type TrustIncidentEvent = {
+  id: number;
+  type: string;
+  message: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+type TrustMaintenanceImpact = {
+  id: number;
+  startTime: string;
+  endTime?: string;
+  type: string;
+  systemAvailability: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+type TrustService = {
+  key: string;
+  order: number;
+  isCore: boolean;
+}
+
+type TrustProduct = {
+  key: string;
+  order: number;
+  isActive: boolean;
+  name: string;
+  altDisplayName: string;
+  url: string;
+}
+
+type TrustTag = {
+  id: number;
+  value: string;
+  type: string;
+  Instances: string[];
+}
+
+/*
+Heroku Status API
+ */
+
+type HerokuStatus = {
+  system: string;
+  status: string;
+}
+
+type HerokuIncident = {
+  title: string;
+  created_at: string;
+  full_url: string;
+  updates: HerokuIncidentUpdate[]
+}
+
+type HerokuIncidentUpdate = {
+  update_type: string;
+  updated_at: string;
+  contents: string;
+}
+
+type HerokuScheduledMaintenance = Record<string, unknown>

--- a/packages/cli/src/lib/types/status.d.ts
+++ b/packages/cli/src/lib/types/status.d.ts
@@ -76,6 +76,15 @@ export type TrustMaintenance = {
   updatedAt: string;
 }
 
+export type Localization = {
+  id: number;
+  modelName: string;
+  modelKey: string;
+  modelAttribute: string;
+  text: string;
+  locale: string;
+}
+
 type TrustIncidentImpact = {
   id: number;
   startTime: string;
@@ -94,6 +103,7 @@ type TrustIncidentEvent = {
   message: string;
   createdAt: string;
   updatedAt: string;
+  localizedType?: string;
 }
 
 type TrustMaintenanceImpact = {
@@ -137,7 +147,7 @@ type SystemStatus = {
   status: string;
 }
 
-type HerokuIncident = {
+export type HerokuIncident = {
   title: string;
   created_at: string;
   full_url: string;

--- a/packages/cli/src/lib/types/status.d.ts
+++ b/packages/cli/src/lib/types/status.d.ts
@@ -30,24 +30,24 @@ export type TrustInstance = {
   Services: TrustService[];
   Products: TrustProduct[];
   Incidents: TrustIncident[];
-  tags: TrustTag[];
+  Tags: TrustTag[];
 }
 
 export type TrustIncident = {
   id: number;
   message?: {
-    pathToResolution?: string;
-    actionPlan?: string;
-    rootCause?: string;
+    pathToResolution?: string | null;
+    actionPlan?: string | null;
+    rootCause?: string | null;
   },
-  externalId?: string;
+  externalId?: string | null;
   affectsAll: boolean;
   isCore: boolean;
   additionalInformation?: string;
   serviceKeys: string[];
   instanceKeys: string[];
   IncidentImpacts: TrustIncidentImpact[]
-  IncidentEvents: TrustIncidentEvent[]
+  IncidentEvents: TrustEvent[]
   createdAt: string;
   updatedAt: string;
 }
@@ -61,9 +61,9 @@ export type TrustMaintenance = {
   }
   externalId?: string;
   name?: string;
-  externalMaintenanceType?: string;
-  releaseType?: string;
-  substrate?: string;
+  externalMaintenanceType?: string | null;
+  releaseType?: string | null;
+  substrate?: string | null;
   affectsAll: boolean;
   isCore: boolean;
   plannedStartTime?: string;
@@ -72,6 +72,7 @@ export type TrustMaintenance = {
   serviceKeys: string[];
   instanceKeys: string[];
   MaintenanceImpacts: TrustMaintenanceImpact[]
+  MaintenanceEvents: TrustEvent[]
   createdAt: string;
   updatedAt: string;
 }
@@ -88,16 +89,20 @@ export type Localization = {
 type TrustIncidentImpact = {
   id: number;
   startTime: string;
-  endTime?: string;
+  endTime?: string | null;
   serviceIssue?: string;
   endUserImpact?: string;
   severity?: string;
   type: string;
   createdAt: string;
   updatedAt: string;
+  startTimeCreatedAt: string;
+  startTimeModifiedAt: string | null;
+  endTimeCreatedAt: string | null;
+  endTimeModifiedAt: string | null;
 }
 
-type TrustIncidentEvent = {
+type TrustEvent = {
   id: number;
   type: string;
   message: string;
@@ -111,9 +116,14 @@ type TrustMaintenanceImpact = {
   startTime: string;
   endTime?: string;
   type: string;
-  systemAvailability: string;
+  systemAvailability?: string;
   createdAt: string;
   updatedAt: string;
+  severity?: string;
+  startTimeCreatedAt: string;
+  startTimeModifiedAt: string | null;
+  endTimeCreatedAt: string | null;
+  endTimeModifiedAt: string | null;
 }
 
 type TrustService = {

--- a/packages/cli/test/fixtures/status/fixtures.ts
+++ b/packages/cli/test/fixtures/status/fixtures.ts
@@ -10,7 +10,7 @@ export const fixtureNowISO = new Date(fixtureNow).toISOString()
 
 export const instancesResponse: TrustInstance[] = [
   {
-    key: 'CEDARPRIVATESPACES-VIRGINIA',
+    key: 'Heroku London',
     location: 'NA',
     environment: 'production',
     releaseVersion: '',
@@ -49,7 +49,7 @@ export const instancesResponse: TrustInstance[] = [
     Tags: [],
   },
   {
-    key: 'CEDARPRIVATESPACES-TOKYO',
+    key: 'Heroku Tokyo',
     location: 'APAC',
     environment: 'production',
     releaseVersion: '',
@@ -88,7 +88,7 @@ export const instancesResponse: TrustInstance[] = [
     Tags: [],
   },
   {
-    key: 'FIRPRIVATESPACES-DUBLIN',
+    key: 'Heroku Europe',
     location: 'EMEA',
     environment: 'production',
     releaseVersion: '',
@@ -127,7 +127,7 @@ export const instancesResponse: TrustInstance[] = [
     Tags: [],
   },
   {
-    key: 'FIRPRIVATESPACES-FRANKFURT',
+    key: 'Heroku Asia',
     location: 'EMEA',
     environment: 'production',
     releaseVersion: '',
@@ -166,7 +166,7 @@ export const instancesResponse: TrustInstance[] = [
     Tags: [],
   },
   {
-    key: 'TOOLS',
+    key: 'Heroku North America',
     location: 'NA',
     environment: 'production',
     releaseVersion: '',
@@ -232,7 +232,7 @@ export const herokuMaintenanceResponse: TrustMaintenance[] = [
     createdAt: '2025-08-07T16:00:22.214Z',
     updatedAt: '2025-08-07T16:00:22.226Z',
     instanceKeys: [
-      'CEDARPRIVATESPACES-VIRGINIA',
+      'Heroku North America',
     ],
     serviceKeys: [
       'HerokuApps',
@@ -370,10 +370,10 @@ const herokuDataIncident: TrustIncident = {
   createdAt: `${fixtureNowISO}`,
   updatedAt: '2025-08-21T08:53:30.069Z',
   instanceKeys: [
-    'CEDARPRIVATESPACES-VIRGINIA',
+    'Heroku North America',
   ],
   serviceKeys: [
-    'HerokuData',
+    'Data',
   ],
   IncidentImpacts: [
     {
@@ -429,10 +429,10 @@ const herokuAppsIncident: TrustIncident = {
   createdAt: `${fixtureNowISO}`,
   updatedAt: '2025-08-21T08:53:30.069Z',
   instanceKeys: [
-    'CEDARPRIVATESPACES-VIRGINIA',
+    'Heroku Europe',
   ],
   serviceKeys: [
-    'HerokuApps',
+    'Apps',
   ],
   IncidentImpacts: [
     {
@@ -488,7 +488,7 @@ const herokuToolsIncident: TrustIncident = {
   createdAt: `${fixtureNowISO}`,
   updatedAt: '2025-08-21T08:53:30.069Z',
   instanceKeys: [
-    'TOOLS',
+    'Heroku Asia',
   ],
   serviceKeys: [
     'Dashboard',

--- a/packages/cli/test/fixtures/status/fixtures.ts
+++ b/packages/cli/test/fixtures/status/fixtures.ts
@@ -1,0 +1,546 @@
+import {
+  TrustInstance,
+  TrustIncident,
+  TrustMaintenance,
+  Localization,
+} from '../../../src/lib/types/status'
+
+export const fixtureNow = Date.now()
+export const fixtureNowISO = new Date(fixtureNow).toISOString()
+
+export const instancesResponse: TrustInstance[] = [
+  {
+    key: 'CEDARPRIVATESPACES-VIRGINIA',
+    location: 'NA',
+    environment: 'production',
+    releaseVersion: '',
+    releaseNumber: '',
+    status: 'OK',
+    isActive: true,
+    city: '',
+    stateName: '',
+    stateCode: '',
+    countryName: '',
+    countryCode: '',
+    maintenanceWindow: '',
+    Services: [
+      {
+        key: 'HerokuApps',
+        order: 1,
+        isCore: false,
+      },
+      {
+        key: 'HerokuData',
+        order: 5,
+        isCore: false,
+      },
+    ],
+    Products: [
+      {
+        key: 'Heroku',
+        order: 60,
+        isActive: true,
+        name: 'Heroku',
+        altDisplayName: 'Heroku',
+        url: '/products/Heroku',
+      },
+    ],
+    Incidents: [],
+    Tags: [],
+  },
+  {
+    key: 'CEDARPRIVATESPACES-TOKYO',
+    location: 'APAC',
+    environment: 'production',
+    releaseVersion: '',
+    releaseNumber: '',
+    status: 'OK',
+    isActive: true,
+    city: '',
+    stateName: '',
+    stateCode: '',
+    countryName: '',
+    countryCode: '',
+    maintenanceWindow: '',
+    Services: [
+      {
+        key: 'HerokuApps',
+        order: 1,
+        isCore: false,
+      },
+      {
+        key: 'HerokuData',
+        order: 5,
+        isCore: false,
+      },
+    ],
+    Products: [
+      {
+        key: 'Heroku',
+        order: 60,
+        isActive: true,
+        name: 'Heroku',
+        altDisplayName: 'Heroku',
+        url: '/products/Heroku',
+      },
+    ],
+    Incidents: [],
+    Tags: [],
+  },
+  {
+    key: 'FIRPRIVATESPACES-DUBLIN',
+    location: 'EMEA',
+    environment: 'production',
+    releaseVersion: '',
+    releaseNumber: '',
+    status: 'OK',
+    isActive: true,
+    city: '',
+    stateName: '',
+    stateCode: '',
+    countryName: '',
+    countryCode: '',
+    maintenanceWindow: '',
+    Services: [
+      {
+        key: 'HerokuApps',
+        order: 1,
+        isCore: false,
+      },
+      {
+        key: 'HerokuData',
+        order: 5,
+        isCore: false,
+      },
+    ],
+    Products: [
+      {
+        key: 'Heroku',
+        order: 60,
+        isActive: true,
+        name: 'Heroku',
+        altDisplayName: 'Heroku',
+        url: '/products/Heroku',
+      },
+    ],
+    Incidents: [],
+    Tags: [],
+  },
+  {
+    key: 'FIRPRIVATESPACES-FRANKFURT',
+    location: 'EMEA',
+    environment: 'production',
+    releaseVersion: '',
+    releaseNumber: '',
+    status: 'OK',
+    isActive: true,
+    city: '',
+    stateName: '',
+    stateCode: '',
+    countryName: '',
+    countryCode: '',
+    maintenanceWindow: '',
+    Services: [
+      {
+        key: 'HerokuApps',
+        order: 1,
+        isCore: false,
+      },
+      {
+        key: 'HerokuData',
+        order: 5,
+        isCore: false,
+      },
+    ],
+    Products: [
+      {
+        key: 'Heroku',
+        order: 60,
+        isActive: true,
+        name: 'Heroku',
+        altDisplayName: 'Heroku',
+        url: '/products/Heroku',
+      },
+    ],
+    Incidents: [],
+    Tags: [],
+  },
+  {
+    key: 'TOOLS',
+    location: 'NA',
+    environment: 'production',
+    releaseVersion: '',
+    releaseNumber: '',
+    status: 'OK',
+    isActive: true,
+    city: '',
+    stateName: '',
+    stateCode: '',
+    countryName: '',
+    countryCode: '',
+    maintenanceWindow: '',
+    Services: [
+      {
+        key: 'CLI',
+        order: 20,
+        isCore: false,
+      },
+      {
+        key: 'Dashboard',
+        order: 10,
+        isCore: false,
+      },
+      {
+        key: 'PlatformAPI',
+        order: 1,
+        isCore: false,
+      },
+    ],
+    Products: [
+      {
+        key: 'Heroku',
+        order: 60,
+        isActive: true,
+        name: 'Heroku',
+        altDisplayName: 'Heroku',
+        url: '/products/Heroku',
+      },
+    ],
+    Incidents: [],
+    Tags: [],
+  },
+]
+
+export const herokuMaintenanceResponse: TrustMaintenance[] = [
+  {
+    id: 20745576,
+    message: {
+      maintenanceType: 'scheduledMaintenance',
+      eventStatus: 'resolved',
+      availability: 'available',
+    },
+    externalId: '12345',
+    name: 'test',
+    externalMaintenanceType: null,
+    substrate: null,
+    releaseType: null,
+    plannedStartTime: '2025-08-01T16:00:00.000Z',
+    plannedEndTime: '2025-08-01T16:05:00.000Z',
+    additionalInformation: '',
+    isCore: false,
+    affectsAll: false,
+    createdAt: '2025-08-07T16:00:22.214Z',
+    updatedAt: '2025-08-07T16:00:22.226Z',
+    instanceKeys: [
+      'CEDARPRIVATESPACES-VIRGINIA',
+    ],
+    serviceKeys: [
+      'HerokuApps',
+      'HerokuData',
+    ],
+    MaintenanceImpacts: [
+      {
+        id: 20034313,
+        startTime: '2025-08-01T16:00:00.000Z',
+        endTime: '2025-08-01T16:05:00.000Z',
+        type: 'deployingRelease',
+        severity: 'maintenance',
+        createdAt: '2025-08-07T16:00:22.273Z',
+        updatedAt: '2025-08-07T16:00:22.281Z',
+        startTimeCreatedAt: '2025-08-07T16:00:22.273Z',
+        startTimeModifiedAt: null,
+        endTimeCreatedAt: '2025-08-07T16:00:22.275Z',
+        endTimeModifiedAt: null,
+      },
+    ],
+    MaintenanceEvents: [
+      {
+        id: 21634955,
+        type: 'scheduled',
+        message: 'This maintenance has been scheduled.',
+        createdAt: '2025-08-07T16:00:22.266Z',
+        updatedAt: '2025-08-07T16:00:22.270Z',
+      },
+    ],
+  },
+]
+
+export const trustLocalizationsResponse: Localization[] = [
+  {
+    id: 123,
+    modelName: 'incidentEventType',
+    modelKey: 'herokuIncident',
+    modelAttribute: 'label',
+    text: 'Heroku - Incident',
+    locale: 'en',
+  },
+  {
+    id: 123,
+    modelName: 'incidentEventType',
+    modelKey: 'herokuIncidentInvestigating',
+    modelAttribute: 'label',
+    text: 'Heroku Update - Investigating',
+    locale: 'en',
+  },
+  {
+    id: 123,
+    modelName: 'incidentEventType',
+    modelKey: 'herokuIncidentMonitoring',
+    modelAttribute: 'label',
+    text: 'Heroku Incident - Monitoring',
+    locale: 'en',
+  },
+]
+
+/*
+SF Trust API incident responses
+ */
+const nonHerokuIncident: TrustIncident = {
+  id: 12345,
+  externalId: '12345',
+  message: {
+    pathToResolution: null,
+    actionPlan: null,
+    rootCause: null,
+  },
+  additionalInformation: 'TEST',
+  isCore: false,
+  affectsAll: false,
+  createdAt: `${fixtureNowISO}`,
+  updatedAt: '2025-08-21T08:53:30.069Z',
+  instanceKeys: [
+    'KEY1',
+    'KEY2',
+  ],
+  serviceKeys: [
+    'Service1',
+    'Service2',
+  ],
+  IncidentImpacts: [
+    {
+      id: 20011917,
+      startTime: '2025-08-21T08:52:00.000Z',
+      endTime: null,
+      type: 'featurePerfDegradation',
+      severity: 'minor',
+      createdAt: '2025-08-21T08:53:01.799Z',
+      updatedAt: '2025-08-21T08:53:01.808Z',
+      startTimeCreatedAt: '2025-08-21T08:53:01.800Z',
+      startTimeModifiedAt: null,
+      endTimeCreatedAt: null,
+      endTimeModifiedAt: null,
+    },
+  ],
+  IncidentEvents: [
+    {
+      id: 20008740,
+      type: 'issueIsolatedDatabaseTier',
+      message: 'Incident update 1',
+      createdAt: '2025-08-21T08:54:00.000Z',
+      updatedAt: '2025-08-21T08:57:47.859Z',
+    },
+    {
+      id: 20008739,
+      type: 'issueIsolatedDatabaseTier',
+      message: 'Incident update 2',
+      createdAt: '2025-08-21T08:53:00.000Z',
+      updatedAt: '2025-08-21T08:53:53.787Z',
+    },
+    {
+      id: 20008738,
+      type: 'investigatingCauseOfIssue',
+      message: 'Incident update 3',
+      createdAt: '2025-08-21T08:53:00.000Z',
+      updatedAt: '2025-08-21T08:53:30.112Z',
+    },
+  ],
+}
+
+const herokuDataIncident: TrustIncident = {
+  id: 12345,
+  externalId: '12345',
+  message: {
+    pathToResolution: null,
+    actionPlan: null,
+    rootCause: null,
+  },
+  additionalInformation: 'TEST',
+  isCore: false,
+  affectsAll: false,
+  createdAt: `${fixtureNowISO}`,
+  updatedAt: '2025-08-21T08:53:30.069Z',
+  instanceKeys: [
+    'CEDARPRIVATESPACES-VIRGINIA',
+  ],
+  serviceKeys: [
+    'HerokuData',
+  ],
+  IncidentImpacts: [
+    {
+      id: 20011917,
+      startTime: '2025-08-21T08:52:00.000Z',
+      endTime: null,
+      type: 'herokuDataFeatureDisruption',
+      severity: 'major',
+      createdAt: '2025-08-21T08:53:01.799Z',
+      updatedAt: '2025-08-21T08:53:01.808Z',
+      startTimeCreatedAt: '2025-08-21T08:53:01.800Z',
+      startTimeModifiedAt: null,
+      endTimeCreatedAt: null,
+      endTimeModifiedAt: null,
+    },
+  ],
+  IncidentEvents: [
+    {
+      id: 20008740,
+      type: 'herokuIncident',
+      message: 'Incident update 1',
+      createdAt: `${fixtureNowISO}`,
+      updatedAt: '2025-08-21T08:57:47.859Z',
+    },
+    {
+      id: 20008739,
+      type: 'herokuIncidentMonitoring',
+      message: 'Incident update 2',
+      createdAt: `${fixtureNowISO}`,
+      updatedAt: '2025-08-21T08:53:53.787Z',
+    },
+    {
+      id: 20008738,
+      type: 'herokuIncidentInvestigating',
+      message: 'Incident update 3',
+      createdAt: `${fixtureNowISO}`,
+      updatedAt: '2025-08-21T08:53:30.112Z',
+    },
+  ],
+}
+
+const herokuAppsIncident: TrustIncident = {
+  id: 12345,
+  externalId: '12345',
+  message: {
+    pathToResolution: null,
+    actionPlan: null,
+    rootCause: null,
+  },
+  additionalInformation: 'TEST',
+  isCore: false,
+  affectsAll: false,
+  createdAt: `${fixtureNowISO}`,
+  updatedAt: '2025-08-21T08:53:30.069Z',
+  instanceKeys: [
+    'CEDARPRIVATESPACES-VIRGINIA',
+  ],
+  serviceKeys: [
+    'HerokuApps',
+  ],
+  IncidentImpacts: [
+    {
+      id: 20011917,
+      startTime: '2025-08-21T08:52:00.000Z',
+      endTime: null,
+      type: 'herokuAppsServiceDisruption',
+      severity: 'minor',
+      createdAt: '2025-08-21T08:53:01.799Z',
+      updatedAt: '2025-08-21T08:53:01.808Z',
+      startTimeCreatedAt: '2025-08-21T08:53:01.800Z',
+      startTimeModifiedAt: null,
+      endTimeCreatedAt: null,
+      endTimeModifiedAt: null,
+    },
+  ],
+  IncidentEvents: [
+    {
+      id: 20008740,
+      type: 'herokuIncident',
+      message: 'Incident update 1',
+      createdAt: `${fixtureNowISO}`,
+      updatedAt: '2025-08-21T08:57:47.859Z',
+    },
+    {
+      id: 20008739,
+      type: 'herokuIncidentMonitoring',
+      message: 'Incident update 2',
+      createdAt: `${fixtureNowISO}`,
+      updatedAt: '2025-08-21T08:53:53.787Z',
+    },
+    {
+      id: 20008738,
+      type: 'herokuIncidentInvestigating',
+      message: 'Incident update 3',
+      createdAt: `${fixtureNowISO}`,
+      updatedAt: '2025-08-21T08:53:30.112Z',
+    },
+  ],
+}
+
+const herokuToolsIncident: TrustIncident = {
+  id: 12345,
+  externalId: '12345',
+  message: {
+    pathToResolution: null,
+    actionPlan: null,
+    rootCause: null,
+  },
+  additionalInformation: 'TEST',
+  isCore: false,
+  affectsAll: false,
+  createdAt: `${fixtureNowISO}`,
+  updatedAt: '2025-08-21T08:53:30.069Z',
+  instanceKeys: [
+    'TOOLS',
+  ],
+  serviceKeys: [
+    'Dashboard',
+  ],
+  IncidentImpacts: [
+    {
+      id: 20011917,
+      startTime: '2025-08-21T08:52:00.000Z',
+      endTime: null,
+      type: 'herokuToolsFeatureDisruption',
+      severity: 'minor',
+      createdAt: '2025-08-21T08:53:01.799Z',
+      updatedAt: '2025-08-21T08:53:01.808Z',
+      startTimeCreatedAt: '2025-08-21T08:53:01.800Z',
+      startTimeModifiedAt: null,
+      endTimeCreatedAt: null,
+      endTimeModifiedAt: null,
+    },
+  ],
+  IncidentEvents: [
+    {
+      id: 20008740,
+      type: 'herokuIncident',
+      message: 'Incident update 1',
+      createdAt: `${fixtureNowISO}`,
+      updatedAt: '2025-08-21T08:57:47.859Z',
+    },
+    {
+      id: 20008739,
+      type: 'herokuIncidentMonitoring',
+      message: 'Incident update 2',
+      createdAt: `${fixtureNowISO}`,
+      updatedAt: '2025-08-21T08:53:53.787Z',
+    },
+    {
+      id: 20008738,
+      type: 'herokuIncidentInvestigating',
+      message: 'Incident update 3',
+      createdAt: `${fixtureNowISO}`,
+      updatedAt: '2025-08-21T08:53:30.112Z',
+    },
+  ],
+}
+
+export const nonHerokuIncidentResponse: TrustIncident[] = [
+  nonHerokuIncident,
+  nonHerokuIncident,
+]
+
+export const herokuDataAppsToolsIncidentResponse: TrustIncident[] = [
+  nonHerokuIncident,
+  herokuDataIncident,
+  herokuAppsIncident,
+  herokuToolsIncident,
+]

--- a/packages/cli/test/unit/commands/status.unit.test.ts
+++ b/packages/cli/test/unit/commands/status.unit.test.ts
@@ -1,22 +1,14 @@
 import * as nock from 'nock'
 import * as sinon from 'sinon'
-import {expect, test as base} from '@oclif/test'
+import {expect, test} from '@oclif/test'
 
-const test = base
-
-const api = nock('https://status.heroku.com:443')
-
-beforeEach(function () {
-  return nock.cleanAll()
-})
-afterEach(function () {
-  return api.done()
-})
+const herokuStatusApi = 'https://status.heroku.com:443'
+const trustApi = 'https://api.status.salesforce.com/v1'
 
 describe('when heroku is green', function () {
   test
     .stdout()
-    .nock('https://status.heroku.com', api => {
+    .nock(herokuStatusApi, api => {
       api.get('/api/v4/current-status').reply(200, {
         status: [
           {system: 'Apps', status: 'green'},
@@ -36,7 +28,7 @@ Tools:     No known issues at this time.\n`)
 
   test
     .stdout()
-    .nock('https://status.heroku.com', api => {
+    .nock(herokuStatusApi, api => {
       api.get('/api/v4/current-status').reply(200, {
         status: [
           {system: 'Apps', status: 'green'},
@@ -67,7 +59,7 @@ describe('when heroku has issues', function () {
 
   test
     .stdout()
-    .nock('https://status.heroku.com', api => {
+    .nock(herokuStatusApi, api => {
       api.get('/api/v4/current-status').reply(200, {
         status: [
           {system: 'Apps', status: 'red'},

--- a/packages/cli/test/unit/commands/status.unit.test.ts
+++ b/packages/cli/test/unit/commands/status.unit.test.ts
@@ -32,8 +32,8 @@ describe('status - Heroku Status API', () => {
       .command(['status'])
       .it('shows success message', ctx => {
         expect(ctx.stdout).to.equal(`Apps:      No known issues at this time.
-  Data:      No known issues at this time.
-  Tools:     No known issues at this time.\n`)
+Data:      No known issues at this time.
+Tools:     No known issues at this time.\n`)
       })
 
     test
@@ -90,15 +90,15 @@ describe('status - Heroku Status API', () => {
       .command(['status'])
       .it('shows the issues', ctx => {
         expect(ctx.stdout).to.equal(`Apps:      Red
-  Data:      No known issues at this time.
-  Tools:     No known issues at this time.
-  
-  === incident title ${timeISO} https://status.heroku.com
-  
-  update type ${timeISO} (less than a minute ago)
-  update contents
-  
-  `)
+Data:      No known issues at this time.
+Tools:     No known issues at this time.
+
+=== incident title ${timeISO} https://status.heroku.com
+
+update type ${timeISO} (less than a minute ago)
+update contents
+
+`)
       })
   })
 })
@@ -113,7 +113,11 @@ describe('status - SF Trust API', function () {
       .nock(salesforceTrustApi, api => {
         api.get('/instances?products=Heroku').reply(200, instancesResponse)
         api.get('/incidents/active').reply(200, nonHerokuIncidentResponse)
-        api.get('/maintenances?limit=10&offset=0&product=Heroku&locale=en').reply(200)
+        api.get('/maintenances')
+          .query(params => {
+            return params.limit === '10' && params.offset === '0' && params.product === 'Heroku' && params.locale === 'en'
+          })
+          .reply(200)
         api.get('/localizations?locale=en').reply(200, trustLocalizationsResponse)
       })
       .command(['status'])
@@ -131,7 +135,11 @@ Tools:     No known issues at this time.\n`)
       .nock(salesforceTrustApi, api => {
         api.get('/instances?products=Heroku').reply(200, instancesResponse)
         api.get('/incidents/active').reply(200, nonHerokuIncidentResponse)
-        api.get('/maintenances?limit=10&offset=0&product=Heroku&locale=en').reply(200)
+        api.get('/maintenances')
+          .query(params => {
+            return params.limit === '10' && params.offset === '0' && params.product === 'Heroku' && params.locale === 'en'
+          })
+          .reply(200)
         api.get('/localizations?locale=en').reply(200, trustLocalizationsResponse)
       })
       .command(['status', '--json'])
@@ -147,7 +155,11 @@ Tools:     No known issues at this time.\n`)
       .nock(salesforceTrustApi, api => {
         api.get('/instances?products=Heroku').reply(200, instancesResponse)
         api.get('/incidents/active').reply(200, nonHerokuIncidentResponse)
-        api.get('/maintenances?limit=10&offset=0&product=Heroku&locale=en').reply(200, herokuMaintenanceResponse)
+        api.get('/maintenances')
+          .query(params => {
+            return params.limit === '10' && params.offset === '0' && params.product === 'Heroku' && params.locale === 'en'
+          })
+          .reply(200, herokuMaintenanceResponse)
         api.get('/localizations?locale=en').reply(200, trustLocalizationsResponse)
       })
       .command(['status', '--json'])
@@ -173,7 +185,11 @@ Tools:     No known issues at this time.\n`)
       .nock(salesforceTrustApi, api => {
         api.get('/instances?products=Heroku').reply(200, instancesResponse)
         api.get('/incidents/active').reply(200, herokuDataAppsToolsIncidentResponse)
-        api.get('/maintenances?limit=10&offset=0&product=Heroku&locale=en').reply(200)
+        api.get('/maintenances')
+          .query(params => {
+            return params.limit === '10' && params.offset === '0' && params.product === 'Heroku' && params.locale === 'en'
+          })
+          .reply(200)
         api.get('/localizations?locale=en').reply(200, trustLocalizationsResponse)
       })
       .command(['status'])

--- a/packages/cli/test/unit/commands/status.unit.test.ts
+++ b/packages/cli/test/unit/commands/status.unit.test.ts
@@ -14,7 +14,7 @@ import {
 const herokuStatusApi = 'https://status.heroku.com:443'
 const salesforceTrustApi = 'https://api.status.salesforce.com/v1'
 
-describe('status - Heroku Status API', () => {
+describe('status - Heroku Status API', function () {
   describe('when heroku is green', function () {
     test
       .stdout()

--- a/packages/cli/test/unit/commands/status.unit.test.ts
+++ b/packages/cli/test/unit/commands/status.unit.test.ts
@@ -1,93 +1,223 @@
 import * as nock from 'nock'
 import * as sinon from 'sinon'
 import {expect, test} from '@oclif/test'
+import {
+  herokuDataAppsToolsIncidentResponse,
+  herokuMaintenanceResponse,
+  instancesResponse,
+  nonHerokuIncidentResponse,
+  trustLocalizationsResponse,
+  fixtureNowISO,
+  fixtureNow,
+} from '../../fixtures/status/fixtures'
 
 const herokuStatusApi = 'https://status.heroku.com:443'
-const trustApi = 'https://api.status.salesforce.com/v1'
+const salesforceTrustApi = 'https://api.status.salesforce.com/v1'
 
-describe('when heroku is green', function () {
-  test
-    .stdout()
-    .nock(herokuStatusApi, api => {
-      api.get('/api/v4/current-status').reply(200, {
-        status: [
-          {system: 'Apps', status: 'green'},
-          {system: 'Data', status: 'green'},
-          {system: 'Tools', status: 'green'},
-        ],
-        incidents: [],
-        scheduled: [],
+describe('status - Heroku Status API', () => {
+  describe('when heroku is green', function () {
+    test
+      .stdout()
+      .nock(herokuStatusApi, api => {
+        api.get('/api/v4/current-status').reply(200, {
+          status: [
+            {system: 'Apps', status: 'green'},
+            {system: 'Data', status: 'green'},
+            {system: 'Tools', status: 'green'},
+          ],
+          incidents: [],
+          scheduled: [],
+        })
       })
-    })
-    .command(['status'])
-    .it('shows success message', ctx => {
-      expect(ctx.stdout).to.equal(`Apps:      No known issues at this time.
-Data:      No known issues at this time.
-Tools:     No known issues at this time.\n`)
+      .command(['status'])
+      .it('shows success message', ctx => {
+        expect(ctx.stdout).to.equal(`Apps:      No known issues at this time.
+  Data:      No known issues at this time.
+  Tools:     No known issues at this time.\n`)
+      })
+
+    test
+      .stdout()
+      .nock(herokuStatusApi, api => {
+        api.get('/api/v4/current-status').reply(200, {
+          status: [
+            {system: 'Apps', status: 'green'},
+            {system: 'Data', status: 'green'},
+            {system: 'Tools', status: 'green'},
+          ],
+          incidents: [],
+          scheduled: [],
+        })
+      })
+      .command(['status', '--json'])
+      .it('--json', ctx => {
+        expect(JSON.parse(ctx.stdout).status[0]).to.deep.include({status: 'green'})
+      })
+  })
+
+  describe('when heroku has issues', function () {
+    const now = Date.now()
+    const timeISO = new Date(now).toISOString()
+
+    before(function () {
+      sinon.stub(Date, 'now').returns(now)
     })
 
-  test
-    .stdout()
-    .nock(herokuStatusApi, api => {
-      api.get('/api/v4/current-status').reply(200, {
-        status: [
-          {system: 'Apps', status: 'green'},
-          {system: 'Data', status: 'green'},
-          {system: 'Tools', status: 'green'},
-        ],
-        incidents: [],
-        scheduled: [],
+    after(function () {
+      sinon.restore()
+    })
+
+    test
+      .stdout()
+      .nock(herokuStatusApi, api => {
+        api.get('/api/v4/current-status').reply(200, {
+          status: [
+            {system: 'Apps', status: 'red'},
+            {system: 'Data', status: 'green'},
+            {system: 'Tools', status: 'green'},
+          ],
+          incidents: [
+            {
+              title: 'incident title',
+              created_at: timeISO,
+              full_url: 'https://status.heroku.com',
+              updates: [{update_type: 'update type', updated_at: timeISO, contents: 'update contents'}],
+            },
+          ],
+          scheduled: [],
+        })
       })
-    })
-    .command(['status', '--json'])
-    .it('--json', ctx => {
-      expect(JSON.parse(ctx.stdout).status[0]).to.deep.include({status: 'green'})
-    })
+      .command(['status'])
+      .it('shows the issues', ctx => {
+        expect(ctx.stdout).to.equal(`Apps:      Red
+  Data:      No known issues at this time.
+  Tools:     No known issues at this time.
+  
+  === incident title ${timeISO} https://status.heroku.com
+  
+  update type ${timeISO} (less than a minute ago)
+  update contents
+  
+  `)
+      })
+  })
 })
 
-describe('when heroku has issues', function () {
-  const now = Date.now()
-  const timeISO = new Date(now).toISOString()
-
-  before(function () {
-    sinon.stub(Date, 'now').returns(now)
-  })
-
-  after(function () {
-    sinon.restore()
-  })
-
-  test
-    .stdout()
-    .nock(herokuStatusApi, api => {
-      api.get('/api/v4/current-status').reply(200, {
-        status: [
-          {system: 'Apps', status: 'red'},
-          {system: 'Data', status: 'green'},
-          {system: 'Tools', status: 'green'},
-        ],
-        incidents: [
-          {
-            title: 'incident title',
-            created_at: timeISO,
-            full_url: 'https://status.heroku.com',
-            updates: [{update_type: 'update type', updated_at: timeISO, contents: 'update contents'}],
-          },
-        ],
-        scheduled: [],
+describe('status - SF Trust API', function () {
+  describe('when there are no Heroku incidents', function () {
+    test
+      .stdout()
+      .nock(herokuStatusApi, api => {
+        api.get('/api/v4/current-status').reply(404)
       })
-    })
-    .command(['status'])
-    .it('shows the issues', ctx => {
-      expect(ctx.stdout).to.equal(`Apps:      Red
+      .nock(salesforceTrustApi, api => {
+        api.get('/instances?products=Heroku').reply(200, instancesResponse)
+        api.get('/incidents/active').reply(200, nonHerokuIncidentResponse)
+        api.get('/maintenances?limit=10&offset=0&product=Heroku&locale=en').reply(200)
+        api.get('/localizations?locale=en').reply(200, trustLocalizationsResponse)
+      })
+      .command(['status'])
+      .it('shows success message', ctx => {
+        expect(ctx.stdout).to.equal(`Apps:      No known issues at this time.
 Data:      No known issues at this time.
-Tools:     No known issues at this time.
+Tools:     No known issues at this time.\n`)
+      })
 
-=== incident title ${timeISO} https://status.heroku.com
+    test
+      .stdout()
+      .nock(herokuStatusApi, api => {
+        api.get('/api/v4/current-status').reply(404)
+      })
+      .nock(salesforceTrustApi, api => {
+        api.get('/instances?products=Heroku').reply(200, instancesResponse)
+        api.get('/incidents/active').reply(200, nonHerokuIncidentResponse)
+        api.get('/maintenances?limit=10&offset=0&product=Heroku&locale=en').reply(200)
+        api.get('/localizations?locale=en').reply(200, trustLocalizationsResponse)
+      })
+      .command(['status', '--json'])
+      .it('returns json response with --json flag', ctx => {
+        expect(JSON.parse(ctx.stdout).status[0]).to.deep.include({status: 'green'})
+      })
 
-update type ${timeISO} (less than a minute ago)
-update contents
+    test
+      .stdout()
+      .nock(herokuStatusApi, api => {
+        api.get('/api/v4/current-status').reply(404)
+      })
+      .nock(salesforceTrustApi, api => {
+        api.get('/instances?products=Heroku').reply(200, instancesResponse)
+        api.get('/incidents/active').reply(200, nonHerokuIncidentResponse)
+        api.get('/maintenances?limit=10&offset=0&product=Heroku&locale=en').reply(200, herokuMaintenanceResponse)
+        api.get('/localizations?locale=en').reply(200, trustLocalizationsResponse)
+      })
+      .command(['status', '--json'])
+      .it('includes planned maintenances in the json response with --json flag', ctx => {
+        expect(JSON.parse(ctx.stdout).scheduled).to.deep.equal(herokuMaintenanceResponse)
+      })
+  })
+
+  describe('when there are active Heroku incidents', function () {
+    before(function () {
+      sinon.stub(Date, 'now').returns(fixtureNow)
+    })
+
+    after(function () {
+      sinon.restore()
+    })
+
+    test
+      .stdout()
+      .nock(herokuStatusApi, api => {
+        api.get('/api/v4/current-status').reply(404)
+      })
+      .nock(salesforceTrustApi, api => {
+        api.get('/instances?products=Heroku').reply(200, instancesResponse)
+        api.get('/incidents/active').reply(200, herokuDataAppsToolsIncidentResponse)
+        api.get('/maintenances?limit=10&offset=0&product=Heroku&locale=en').reply(200)
+        api.get('/localizations?locale=en').reply(200, trustLocalizationsResponse)
+      })
+      .command(['status'])
+      .it('shows the issues', ctx => {
+        expect(ctx.stdout).to.equal(`Apps:      Yellow
+Data:      Red
+Tools:     Yellow
+
+=== 12345 ${fixtureNowISO} https://status.salesforce.com/incidents/12345
+
+Heroku - Incident             ${fixtureNowISO} (less than a minute ago)
+Incident update 1
+
+Heroku Incident - Monitoring  ${fixtureNowISO} (less than a minute ago)
+Incident update 2
+
+Heroku Update - Investigating ${fixtureNowISO} (less than a minute ago)
+Incident update 3
+
+
+=== 12345 ${fixtureNowISO} https://status.salesforce.com/incidents/12345
+
+Heroku - Incident             ${fixtureNowISO} (less than a minute ago)
+Incident update 1
+
+Heroku Incident - Monitoring  ${fixtureNowISO} (less than a minute ago)
+Incident update 2
+
+Heroku Update - Investigating ${fixtureNowISO} (less than a minute ago)
+Incident update 3
+
+
+=== 12345 ${fixtureNowISO} https://status.salesforce.com/incidents/12345
+
+Heroku - Incident             ${fixtureNowISO} (less than a minute ago)
+Incident update 1
+
+Heroku Incident - Monitoring  ${fixtureNowISO} (less than a minute ago)
+Incident update 2
+
+Heroku Update - Investigating ${fixtureNowISO} (less than a minute ago)
+Incident update 3
 
 `)
-    })
+      })
+  })
 })


### PR DESCRIPTION
Adds support for SF Trust API to the `heroku status` command.

## Details
- The SF Trust API will only be called if the Heroku Status API call fails
- The responses from the SF Trust API endpoints are formatted to fit the current structure of the command response
- The command will error (with an error message already approved by CX) if calls to both the Heroku Status API and SF Trust API fail

There is a lot of logic in here for formatting the responses from the SF Trust API endpoints. The basic outline of the logic is as follows:
- Retrieve data from the SF Trust API endpoints.
    - Heroku instances, active incidents, upcoming Heroku maintenances, and localizations.
- Filter the array of active incidents by the array of Heroku instances to get an array of Heroku active incidents.
- Filter the array of Heroku active incidents by a given list of service keys in order to separate them into apps incidents, data incidents, and tools incidents.
- Format the data into a structure that matches the basic structure of the Heroku Status API response.

## Testing
- Checkout this branch and run `yarn` and `yarn build`
- Run `./bin/run status` to see responses from the Heroku Status API
- Run `TRUST_ONLY=true ./bin/run status` to see responses from the SF Trust API
- Run `TRUST_ONLY=true SF_TRUST_STAGING=true ./bin/run status` to see responses from the SF Trust staging API

[W-19005486](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002HtjRhYAJ/view)

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
