### PR TITLE
feat(W-19386384): add domain name validation for Heroku API requests

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,7 @@
     "@heroku/buildpack-registry": "^1.0.1",
     "@heroku/eventsource": "^1.0.7",
     "@heroku/heroku-cli-util": "^9.0.2",
-    "@heroku/http-call": "^5.4.0",
+    "@heroku/http-call": "^5.5.0",
     "@heroku/mcp-server": "1.0.7-alpha.1",
     "@heroku/plugin-ai": "^1.0.1",
     "@inquirer/prompts": "^5.0.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,7 @@
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/color": "2.0.1",
-    "@heroku-cli/command": "^11.5.0",
+    "@heroku-cli/command": "^11.7.0",
     "@heroku-cli/notifications": "^1.2.4",
     "@heroku-cli/plugin-ps-exec": "2.6.2",
     "@heroku-cli/schema": "^1.0.25",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1639,6 +1639,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@heroku-cli/command@npm:^11.7.0":
+  version: 11.7.0
+  resolution: "@heroku-cli/command@npm:11.7.0"
+  dependencies:
+    "@heroku-cli/color": ^2.0.1
+    "@heroku/http-call": ^5.5.0
+    "@oclif/core": ^2.16.0
+    cli-ux: ^6.0.9
+    debug: ^4.4.0
+    fs-extra: ^9.1.0
+    heroku-client: ^3.1.0
+    netrc-parser: ^3.1.6
+    open: ^8.4.2
+    uuid: ^8.3.0
+    yargs-parser: ^18.1.3
+    yargs-unparser: ^2.0.0
+  checksum: 2a3415ad379d95d97ca059ede5fdd1fdbcd89214bffdcdaa21e827fa6898ff1c2fadbfd529f66c4386cc6165290f2cc3dcc5aaf25537fe25862e2371e7dbe199
+  languageName: node
+  linkType: hard
+
 "@heroku-cli/command@npm:^8.5.0":
   version: 8.5.0
   resolution: "@heroku-cli/command@npm:8.5.0"
@@ -1787,6 +1807,21 @@ __metadata:
     is-stream: ^2.0.0
     tunnel-agent: ^0.6.0
   checksum: 46e522a6f1d1ae44d857db202862aa0ca800804af7ba04b13a46a99f7bb1233adaf47d7d22dbf4fcd7443e78603e3793b3d6662486e8eb1c9ab6e3569e116f25
+  languageName: node
+  linkType: hard
+
+"@heroku/http-call@npm:^5.5.0":
+  version: 5.5.0
+  resolution: "@heroku/http-call@npm:5.5.0"
+  dependencies:
+    chalk: ^4.1.2
+    content-type: ^1.0.5
+    debug: ^4.4.0
+    is-retry-allowed: ^2.2.0
+    is-stream: ^2.0.0
+    sinon: ^20.0.0
+    tunnel-agent: ^0.6.0
+  checksum: 78b4d178b41c1f2dd2babc3e7eb08594e911a194940f4a19ff596623ef3bc8ec6d5acfe0eaa3a2fc21469b91fa0c35a7228671e57f840d27389151864b5c607d
   languageName: node
   linkType: hard
 
@@ -4308,7 +4343,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/fake-timers@npm:^13.0.1, @sinonjs/fake-timers@npm:^13.0.2":
+"@sinonjs/fake-timers@npm:^13.0.1, @sinonjs/fake-timers@npm:^13.0.2, @sinonjs/fake-timers@npm:^13.0.5":
   version: 13.0.5
   resolution: "@sinonjs/fake-timers@npm:13.0.5"
   dependencies:
@@ -10734,7 +10769,7 @@ __metadata:
   resolution: "heroku@workspace:packages/cli"
   dependencies:
     "@heroku-cli/color": 2.0.1
-    "@heroku-cli/command": ^11.5.0
+    "@heroku-cli/command": ^11.7.0
     "@heroku-cli/notifications": ^1.2.4
     "@heroku-cli/plugin-ps-exec": 2.6.2
     "@heroku-cli/schema": ^1.0.25
@@ -15914,6 +15949,19 @@ __metadata:
     nise: ^6.1.1
     supports-color: ^7.2.0
   checksum: 7eccc0505b73f8465ac42bd984eb75b6cdae5428282316856a98ac1b3aa2bccffc8f62f27142fbf49006032cd416a91a4fdd5d159d84515e1ccab70d93962bf5
+  languageName: node
+  linkType: hard
+
+"sinon@npm:^20.0.0":
+  version: 20.0.0
+  resolution: "sinon@npm:20.0.0"
+  dependencies:
+    "@sinonjs/commons": ^3.0.1
+    "@sinonjs/fake-timers": ^13.0.5
+    "@sinonjs/samsam": ^8.0.1
+    diff: ^7.0.0
+    supports-color: ^7.2.0
+  checksum: c6dcd3bc60aa360fede157fbed30c3984eb222990ff28f3014a5e31834cec74e5203c0575332a99c3f7976425167f70e0777507c0c58867473ad0a0c4c1a759c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10776,7 +10776,7 @@ __metadata:
     "@heroku/buildpack-registry": ^1.0.1
     "@heroku/eventsource": ^1.0.7
     "@heroku/heroku-cli-util": ^9.0.2
-    "@heroku/http-call": ^5.4.0
+    "@heroku/http-call": ^5.5.0
     "@heroku/mcp-server": 1.0.7-alpha.1
     "@heroku/plugin-ai": ^1.0.1
     "@inquirer/prompts": ^5.0.5


### PR DESCRIPTION
Bumps the version of `@heroku-cli/command` in order to apply domain name validation for Heroku API requests. Also bumps the version of `@heroku/http-call`.

## Testing
- Check out this branch and run `yarn` and `yarn build`
- Run `HEROKU_HOST=bogus-domain.com ./bin/run whoami`
    - You should see a string of warning messages indicating that you have provided an invalid domain and that the default domain is being used instead. We are aware that there are a lot of warning messages that are currently being printed. We will be improving that as part of some follow-up work.

[W-19386384](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002KS9klYAD/view)

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
