### PR TITLE
fix(W-17704930): set ignoreStdin to true for redis:cli database arg

### DIFF
--- a/packages/cli/src/commands/redis/cli.ts
+++ b/packages/cli/src/commands/redis/cli.ts
@@ -180,7 +180,7 @@ export default class Cli extends Command {
   }
 
   static args = {
-    database: Args.string({description: 'name of the Key-Value Store database. If omitted, it defaults to the primary database associated with the app.'}),
+    database: Args.string({description: 'name of the Key-Value Store database. If omitted, it defaults to the primary database associated with the app.', ignoreStdin: true}),
   }
 
   static examples = [


### PR DESCRIPTION
[W-17704930](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000028kWdrYAE/view)

Resolves #3186 

Sets the database arg to ignore stdin in order to allow a user to pipe commands through to their redis instance.

## Testing
1. Check out this branch and run `yarn && yarn build`
2. Run `heroku addons:create heroku-redis:mini -a TEST_APP` to install a redis instance. Wait for the addon to be provisioned.
3. Run `echo "test" | ./bin/run redis:cli -a TEST_APP` and verify that you see a message that the CLI is connecting to your redis instance, the word "test" is printed, and then you get an error about the "unknown command 'test'", and then the connection closes. You should not see an "Unexpected argument" error or a "No Redis instances found error and the connection should close and not remain open.

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
