### PR TITLE
chore: remove destructive copy for pg:upgrade:dryrun

### DIFF
--- a/packages/cli/src/commands/pg/upgrade/dryrun.ts
+++ b/packages/cli/src/commands/pg/upgrade/dryrun.ts
@@ -43,7 +43,6 @@ export default class Upgrade extends Command {
       ux.error(`You can't use ${color.cmd('pg:upgrade:dryrun')} on follower databases. You can only use this command on Standard-tier and higher leader databases.`)
 
     await confirmCommand(app, confirm, heredoc(`
-        Destructive action
         This command starts a test upgrade for ${color.addon(db.name)} to ${versionPhrase}.
     `))
 

--- a/packages/cli/test/unit/commands/pg/upgrade/dryrun.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/upgrade/dryrun.unit.test.ts
@@ -111,7 +111,6 @@ describe('pg:upgrade:dryrun', function () {
       .reply(200, {message: "Started test upgrade. We'll notify you via email when it's complete."})
 
     const message = heredoc(`
-      Destructive action
       This command starts a test upgrade for ${addon.name} to Postgres version 15.
       `)
 
@@ -147,7 +146,6 @@ describe('pg:upgrade:dryrun', function () {
       .reply(200, {message: "Started test upgrade. We'll notify you via email when it's complete."})
 
     const message = heredoc(`
-      Destructive action
       This command starts a test upgrade for ${addon.name} to the latest supported Postgres version.
       `)
 


### PR DESCRIPTION
# Description
[Work Item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002LG2UYYA1/view)

This PR removes the destructive warning copy "Destructive action." This is to reduce confusion for the user when running the dryrun command to clarify that it's not destructive, given the nature of the command.

# Testing
- pull down branch and `yarn && yarn build`
- run `./bin/run pg:upgrade:dryrun <DATABASE> -a <your-app>` and confirm that the destructive copy is no longer there
