### PR TITLE
feat: Prepend launcher to `heroku run` commands for fir

### DIFF
--- a/packages/cli/src/commands/run/detached.ts
+++ b/packages/cli/src/commands/run/detached.ts
@@ -3,7 +3,7 @@ import {Command, flags} from '@heroku-cli/command'
 import {DynoSizeCompletion, ProcessTypeCompletion} from '@heroku-cli/command/lib/completions'
 import {ux} from '@oclif/core'
 import Dyno from '../../lib/run/dyno'
-import {buildCommand} from '../../lib/run/helpers'
+import {buildCommandWithLauncher} from '../../lib/run/helpers'
 import logDisplayer from '../../lib/run/log-displayer'
 
 export default class RunDetached extends Command {
@@ -22,6 +22,10 @@ export default class RunDetached extends Command {
     size: flags.string({char: 's', description: 'dyno size', completion: DynoSizeCompletion}),
     tail: flags.boolean({char: 't', description: 'continually stream logs'}),
     type: flags.string({description: 'process type', completion: ProcessTypeCompletion}),
+    'no-launcher': flags.boolean({
+      description: 'don’t prepend ‘launcher’ before a command',
+      default: false,
+    }),
   }
 
   async run() {
@@ -30,7 +34,7 @@ export default class RunDetached extends Command {
     const opts = {
       heroku: this.heroku,
       app: flags.app,
-      command: buildCommand(argv as string[]),
+      command: await buildCommandWithLauncher(this.heroku, flags.app, argv as string[], flags['no-launcher']),
       size: flags.size,
       type: flags.type,
       env: flags.env,

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -4,12 +4,12 @@ import {ux} from '@oclif/core'
 import debugFactory from 'debug'
 import * as Heroku from '@heroku-cli/schema'
 import Dyno from '../../lib/run/dyno'
-import {buildCommand, revertSortedArgs} from '../../lib/run/helpers'
+import {buildCommandWithLauncher, revertSortedArgs} from '../../lib/run/helpers'
 
 const debug = debugFactory('heroku:run')
 
 export default class Run extends Command {
-  static description = 'run a one-off process inside a heroku dyno\nShows a notification if the dyno takes more than 20 seconds to start.'
+  static description = 'run a one-off process inside a heroku dyno\nShows a notification if the dyno takes more than 20 seconds to start.\nHeroku automatically prepends ‘launcher’ to the command on CNB apps (use --no-launcher to disable).'
 
   static examples = [
     '$ heroku run bash',
@@ -29,17 +29,22 @@ export default class Run extends Command {
     'no-tty': flags.boolean({description: 'force the command to not run in a tty'}),
     listen: flags.boolean({description: 'listen on a local port', hidden: true}),
     'no-notify': flags.boolean({description: 'disables notification when dyno is up (alternatively use HEROKU_NOTIFICATIONS=0)'}),
+    'no-launcher': flags.boolean({
+      description: 'don’t prepend ‘launcher’ before a command',
+      default: false,
+    }),
   }
 
   async run() {
     const {argv, flags} = await this.parse(Run)
     const command = revertSortedArgs(process.argv, argv as string[])
+    const builtCommand = await buildCommandWithLauncher(this.heroku, flags.app, command, flags['no-launcher'])
     const opts = {
       'exit-code': flags['exit-code'],
       'no-tty': flags['no-tty'],
       app: flags.app,
       attach: true,
-      command: buildCommand(command),
+      command: builtCommand,
       env: flags.env,
       heroku: this.heroku,
       listen: flags.listen,

--- a/packages/cli/src/commands/run/inside.ts
+++ b/packages/cli/src/commands/run/inside.ts
@@ -3,8 +3,7 @@ import {Args, ux} from '@oclif/core'
 import debugFactory from 'debug'
 import heredoc from 'tsheredoc'
 import Dyno from '../../lib/run/dyno'
-import {buildCommand} from '../../lib/run/helpers'
-import {App} from '../../lib/types/fir'
+import {buildCommandWithLauncher} from '../../lib/run/helpers'
 
 const debug = debugFactory('heroku:run:inside')
 
@@ -57,17 +56,10 @@ export default class RunInside extends Command {
 
     const {dyno_name: dynoName} = args
     const {app: appName, 'exit-code': exitCode, listen, 'no-launcher': noLauncher} = flags
-    const prependLauncher = !noLauncher
-
-    const {body: app} = await this.heroku.get<App>(
-      `/apps/${appName}`, {
-        headers: {Accept: 'application/vnd.heroku+json; version=3.sdk'},
-      })
-    const appStackIsCnb = app.stack.name === 'cnb'
 
     const opts = {
       app: appName,
-      command: buildCommand(argv.slice(1) as string[], appStackIsCnb && prependLauncher),
+      command: await buildCommandWithLauncher(this.heroku, appName, argv.slice(1) as string[], noLauncher),
       dyno: dynoName,
       'exit-code': exitCode,
       heroku: this.heroku,

--- a/packages/cli/src/lib/run/helpers.ts
+++ b/packages/cli/src/lib/run/helpers.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import {ux} from '@oclif/core'
+import type {APIClient} from '@heroku-cli/command'
+import type {App} from '../types/fir'
 
 // this function exists because oclif sorts argv
 // and to capture all non-flag command inputs
@@ -59,4 +61,31 @@ export function buildEnvFromFlag(flag: string) {
   }
 
   return env
+}
+
+/**
+ * Determines whether to prepend `launcher` to the command for a given app.
+ * Behavior: Only prepend on CNB stack apps and when not explicitly disabled.
+ */
+export async function shouldPrependLauncher(heroku: APIClient, appName: string, disableLauncher: boolean): Promise<boolean> {
+  if (disableLauncher) return false
+
+  const {body: app} = await heroku.get<App>(`/apps/${appName}` , {
+    headers: {Accept: 'application/vnd.heroku+json; version=3.sdk'},
+  })
+
+  return (app.stack && app.stack.name) === 'cnb'
+}
+
+/**
+ * Builds the command string, automatically deciding whether to prepend `launcher`.
+ */
+export async function buildCommandWithLauncher(
+  heroku: APIClient,
+  appName: string,
+  args: string[],
+  disableLauncher: boolean,
+): Promise<string> {
+  const prependLauncher = await shouldPrependLauncher(heroku, appName, disableLauncher)
+  return buildCommand(args, prependLauncher)
 }

--- a/packages/cli/test/integration/run.integration.test.ts
+++ b/packages/cli/test/integration/run.integration.test.ts
@@ -21,6 +21,13 @@ describe('run', function () {
     })
 
   testFactory()
+    .stub(runHelper, 'revertSortedArgs', () => ['echo 1 2 3'])
+    .command(['run', '--app=heroku-cli-ci-smoke-test-app', '--no-launcher', 'echo 1 2 3'])
+    .it('respects --no-launcher', async ctx => {
+      expect(ctx.stdout).to.include('1 2 3')
+    })
+
+  testFactory()
     .skip()
     .stub(runHelper, 'revertSortedArgs', () => ['ruby -e "puts ARGV[0]" "{"foo": "bar"} " '])
     .command(['run', '--app=heroku-cli-ci-smoke-test-app', 'ruby -e "puts ARGV[0]" "{"foo": "bar"} " '])

--- a/packages/cli/test/unit/lib/run/helpers.unit.test.ts
+++ b/packages/cli/test/unit/lib/run/helpers.unit.test.ts
@@ -1,6 +1,6 @@
 import {expect, test} from '@oclif/test'
 
-import {buildCommand, buildEnvFromFlag} from '../../../../src/lib/run/helpers'
+import {buildCommand, buildEnvFromFlag, buildCommandWithLauncher} from '../../../../src/lib/run/helpers'
 
 describe('helpers.buildCommand()', function () {
   [
@@ -52,3 +52,30 @@ describe('helpers.buildEnvFromFlag()', function () {
     })
 })
 
+// New tests for buildCommandWithLauncher
+
+describe('helpers.buildCommandWithLauncher()', function () {
+  it('prepends launcher on CNB apps when not disabled', async function () {
+    const heroku: any = {
+      get: async () => ({body: {stack: {name: 'cnb'}}}),
+    }
+    const cmd = await buildCommandWithLauncher(heroku, 'my-app', ['echo', 'foo bar'], false)
+    expect(cmd).to.equal('launcher echo "foo bar"')
+  })
+
+  it('does not prepend launcher on non-CNB apps', async function () {
+    const heroku: any = {
+      get: async () => ({body: {stack: {name: 'heroku-22'}}}),
+    }
+    const cmd = await buildCommandWithLauncher(heroku, 'my-app', ['echo', 'foo'], false)
+    expect(cmd).to.equal('echo foo')
+  })
+
+  it('does not prepend launcher when disabled even on CNB', async function () {
+    const heroku: any = {
+      get: async () => ({body: {stack: {name: 'cnb'}}}),
+    }
+    const cmd = await buildCommandWithLauncher(heroku, 'my-app', ['echo', 'foo'], true)
+    expect(cmd).to.equal('echo foo')
+  })
+})


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

In order to make `heroku run` commands more intuitive by ensuring that common/expected binaries are in the dyno's path, we need to add "-- launcher" to the beginning of every command that users want to run. For example, if the user runs the command `heroku run bash -a MY_APP`, the command should be called as "heroku run -- launcher bash -a MY_APP".

Since there may be cases where user want to run the command without using "launcher", this change includes a param `--no-launcher` which can be used to remove it from the command.

This change was previously introduced to the `heroku run:inside` command in #3116, so I refactored that command to use the shared helper that is used by `heroku run`.

### SOC 2 Compliance

[GUS work item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002M2Ao0YAF/view)
[Slack thread](https://salesforce-internal.slack.com/archives/C048U82QVKQ/p1758139710787289)
