### PR TITLE
fix: update create-fig-autocomplete-pr job conditional

### DIFF
--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -31,40 +31,40 @@ jobs:
         with:
           path: './packages/cli/package.json'
 
-  # publish-npm:
-  #   needs: [get-version-channel]
-  #   # if NOT isStableCandidate confirm dist tag is in package.json version
-  #   if: fromJSON(needs.get-version-channel.outputs.isStableRelease) || (!fromJSON(inputs.isStableCandidate) && !!needs.get-version-channel.outputs.channel)
-  #   uses: ./.github/workflows/publish-npm.yml
-  #   with:
-  #     isStableRelease: ${{ fromJSON(needs.get-version-channel.outputs.isStableRelease) }}
-  #     channel: ${{ needs.get-version-channel.outputs.channel }}
-  #   secrets: inherit
+  publish-npm:
+    needs: [get-version-channel]
+    # if NOT isStableCandidate confirm dist tag is in package.json version
+    if: fromJSON(needs.get-version-channel.outputs.isStableRelease) || (!fromJSON(inputs.isStableCandidate) && !!needs.get-version-channel.outputs.channel)
+    uses: ./.github/workflows/publish-npm.yml
+    with:
+      isStableRelease: ${{ fromJSON(needs.get-version-channel.outputs.isStableRelease) }}
+      channel: ${{ needs.get-version-channel.outputs.channel }}
+    secrets: inherit
 
-  # pack-upload:
-  #   needs: [publish-npm]
-  #   uses: ./.github/workflows/pack-upload.yml
-  #   secrets: inherit
+  pack-upload:
+    needs: [publish-npm]
+    uses: ./.github/workflows/pack-upload.yml
+    secrets: inherit
 
-  # promote:
-  #   needs: [get-version-channel, pack-upload]
-  #   if: needs.pack-upload.result == 'success'
-  #   uses: ./.github/workflows/promote-release.yml
-  #   with:
-  #     version: ${{ needs.get-version-channel.outputs.version }}
-  #     isStableRelease: ${{ fromJSON(needs.get-version-channel.outputs.isStableRelease) }}
-  #     channel: ${{ needs.get-version-channel.outputs.channel }}
-  #   secrets: inherit
+  promote:
+    needs: [get-version-channel, pack-upload]
+    if: needs.pack-upload.result == 'success'
+    uses: ./.github/workflows/promote-release.yml
+    with:
+      version: ${{ needs.get-version-channel.outputs.version }}
+      isStableRelease: ${{ fromJSON(needs.get-version-channel.outputs.isStableRelease) }}
+      channel: ${{ needs.get-version-channel.outputs.channel }}
+    secrets: inherit
 
   create-fig-autocomplete-pr:
-    needs: [get-version-channel]
+    needs: [get-version-channel, promote]
     if: ${{ fromJSON(needs.get-version-channel.outputs.isStableRelease) }}
     ## Calls publish-to-fig-autocomplete workflow during post release jobs
     uses: ./.github/workflows/publish-to-fig-autocomplete.yml
 
-  # publish-docs:
-  #   needs: [get-version-channel, promote]
-  #   uses: ./.github/workflows/devcenter-doc-update.yml
-  #   with:
-  #     isStableRelease: ${{ fromJSON(inputs.isStableCandidate) }}
-  #   secrets: inherit
+  publish-docs:
+    needs: [get-version-channel, promote]
+    uses: ./.github/workflows/devcenter-doc-update.yml
+    with:
+      isStableRelease: ${{ fromJSON(inputs.isStableCandidate) }}
+    secrets: inherit

--- a/.github/workflows/publish-to-fig-autocomplete.yml
+++ b/.github/workflows/publish-to-fig-autocomplete.yml
@@ -16,21 +16,21 @@ jobs:
           cache: yarn
       - name: Install Fig Oclif Plugin
         run: cd packages/cli && yarn add @fig/complete-oclif && jq '.oclif.plugins += ["@fig/complete-oclif"]' package.json > temp.json && mv temp.json package.json
-      # - run: yarn --immutable --network-timeout 1000000
-      # - name: Build Heroku CLI
-      #   run: yarn build
-      # - name: Get Heroku Version
-      #   id: cli-version
-      #   run: echo "version=$(./bin/run --version | sed -rn 's/^heroku\/([0-9\.]+).*$/\1/p')" >> $GITHUB_OUTPUT
-      # - name: Generate Fig Spec
-      #   run: cd packages/cli && ./bin/run generate-fig-spec > spec.ts
-      # - name: Create Fig Autocomplete PR
-      #   uses: withfig/push-to-fig-autocomplete-action@v2
-      #   with:
-      #     token: ${{ secrets.HEROKU_CLI_BOT_TOKEN }}
-      #     autocomplete-spec-name: 'heroku'
-      #     spec-path: ./packages/cli/spec.ts
-      #     integration: oclif
-      #     diff-based-versioning: true
-      #     new-spec-version: ${{ steps.cli-version.outputs.version }}
-      #     pr-body: Automated PR for latest Heroku CLI release
+      - run: yarn --immutable --network-timeout 1000000
+      - name: Build Heroku CLI
+        run: yarn build
+      - name: Get Heroku Version
+        id: cli-version
+        run: echo "version=$(./bin/run --version | sed -rn 's/^heroku\/([0-9\.]+).*$/\1/p')" >> $GITHUB_OUTPUT
+      - name: Generate Fig Spec
+        run: cd packages/cli && ./bin/run generate-fig-spec > spec.ts
+      - name: Create Fig Autocomplete PR
+        uses: withfig/push-to-fig-autocomplete-action@v2
+        with:
+          token: ${{ secrets.HEROKU_CLI_BOT_TOKEN }}
+          autocomplete-spec-name: 'heroku'
+          spec-path: ./packages/cli/spec.ts
+          integration: oclif
+          diff-based-versioning: true
+          new-spec-version: ${{ steps.cli-version.outputs.version }}
+          pr-body: Automated PR for latest Heroku CLI release


### PR DESCRIPTION
# Description
[Work Item](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002GSicdYAD/view)

This PR updates the conditional in the `create-fig-autocomplete-pr` job to use the `isStableRelease` value from the `get-version-channel` job. The previous value was returning empty because the job didn't have access to the value via the `needs` property.

# Testing
- Successfully ran conditional in [triggered workflow](https://github.com/heroku/cli/actions/runs/17957848714)