### PR TITLE
refactor: reimplement csv option for domains

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2536,6 +2536,7 @@
     },
     "node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -5649,6 +5650,7 @@
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clean-stack": "^2.0.0",
@@ -5660,6 +5662,7 @@
     },
     "node_modules/aggregate-error/node_modules/clean-stack": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5741,6 +5744,7 @@
     },
     "node_modules/aproba": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/are-we-there-yet": {
@@ -8397,6 +8401,7 @@
     },
     "node_modules/chownr": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -8696,6 +8701,7 @@
     },
     "node_modules/common-ancestor-path": {
       "version": "1.0.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/compare-func": {
@@ -9865,6 +9871,7 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9895,6 +9902,7 @@
     },
     "node_modules/err-code": {
       "version": "2.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/error-ex": {
@@ -13422,6 +13430,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -14412,6 +14421,7 @@
     },
     "node_modules/json-stringify-nice": {
       "version": "1.1.4",
+      "dev": true,
       "license": "ISC",
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -14456,6 +14466,7 @@
     },
     "node_modules/jsonparse": {
       "version": "1.3.1",
+      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
@@ -14497,6 +14508,7 @@
     },
     "node_modules/just-diff-apply": {
       "version": "5.5.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/keyv": {
@@ -15015,6 +15027,7 @@
     },
     "node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -15052,6 +15065,7 @@
     },
     "node_modules/minipass-flush": {
       "version": "1.0.5",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -15071,6 +15085,7 @@
     },
     "node_modules/minipass-pipeline": {
       "version": "1.2.4",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -15081,6 +15096,7 @@
     },
     "node_modules/minipass-sized": {
       "version": "1.0.3",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -15091,6 +15107,7 @@
     },
     "node_modules/minizlib": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^3.0.0",
@@ -16382,6 +16399,7 @@
     },
     "node_modules/p-map": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "aggregate-error": "^3.0.0"
@@ -16847,6 +16865,7 @@
     },
     "node_modules/promise-all-reject-late": {
       "version": "1.0.1",
+      "dev": true,
       "license": "ISC",
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -16867,6 +16886,7 @@
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "err-code": "^2.0.2",
@@ -18232,6 +18252,7 @@
     },
     "node_modules/retry": {
       "version": "0.12.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -18830,6 +18851,7 @@
     },
     "node_modules/spdx-correct": {
       "version": "3.1.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
@@ -18838,10 +18860,12 @@
     },
     "node_modules/spdx-exceptions": {
       "version": "2.2.0",
+      "dev": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
@@ -18850,6 +18874,7 @@
     },
     "node_modules/spdx-license-ids": {
       "version": "3.0.5",
+      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/split": {
@@ -20040,6 +20065,7 @@
     },
     "node_modules/tar": {
       "version": "6.2.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
@@ -20083,6 +20109,7 @@
     },
     "node_modules/tar/node_modules/fs-minipass": {
       "version": "2.1.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -20093,6 +20120,7 @@
     },
     "node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -20103,6 +20131,7 @@
     },
     "node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=8"
@@ -20110,6 +20139,7 @@
     },
     "node_modules/tar/node_modules/mkdirp": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -20136,6 +20166,7 @@
     },
     "node_modules/text-table": {
       "version": "0.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/through": {
@@ -20741,6 +20772,7 @@
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "spdx-correct": "^3.0.0",
@@ -21282,6 +21314,7 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {
@@ -21451,6 +21484,7 @@
         "https-proxy-agent": "^7.0.6",
         "inquirer": "^8.2.6",
         "lodash": "^4.17.21",
+        "natural-orderby": "^5.0.0",
         "netrc-parser": "3.1.6",
         "node-fetch": "^2.6.7",
         "open": "^10.1.2",
@@ -23434,6 +23468,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/cli/node_modules/@heroku/plugin-ai/node_modules/natural-orderby": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-2.0.3.tgz",
+      "integrity": "sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "packages/cli/node_modules/@heroku/plugin-ai/node_modules/open": {
       "version": "8.4.2",
       "license": "MIT",
@@ -24075,6 +24118,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/cli/node_modules/@oclif/plugin-legacy/node_modules/natural-orderby": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-2.0.3.tgz",
+      "integrity": "sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "packages/cli/node_modules/@oclif/plugin-legacy/node_modules/password-prompt": {
       "version": "1.1.3",
       "license": "0BSD",
@@ -24490,6 +24542,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/@oclif/test/node_modules/natural-orderby": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-2.0.3.tgz",
+      "integrity": "sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "packages/cli/node_modules/@oclif/test/node_modules/tslib": {
@@ -25473,6 +25535,7 @@
     },
     "packages/cli/node_modules/archy": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "packages/cli/node_modules/argparse": {
@@ -25545,6 +25608,7 @@
     },
     "packages/cli/node_modules/binary-extensions": {
       "version": "2.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -25674,17 +25738,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "packages/cli/node_modules/caching-transform/node_modules/write-file-atomic": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
       }
     },
     "packages/cli/node_modules/caniuse-lite": {
@@ -25954,6 +26007,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/cli-ux/node_modules/natural-orderby": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-2.0.3.tgz",
+      "integrity": "sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "packages/cli/node_modules/cli-ux/node_modules/semver": {
@@ -27509,10 +27571,12 @@
       "optional": true
     },
     "packages/cli/node_modules/natural-orderby": {
-      "version": "2.0.3",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-5.0.0.tgz",
+      "integrity": "sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==",
       "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">=18"
       }
     },
     "packages/cli/node_modules/negotiator": {
@@ -27597,19 +27661,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "packages/cli/node_modules/node-notifier/node_modules/which": {
-      "version": "2.0.2",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "packages/cli/node_modules/node-preload": {
@@ -31871,20 +31922,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/cli/node_modules/spawn-wrap/node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "packages/cli/node_modules/sprintf-js": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,6 +53,7 @@
     "https-proxy-agent": "^7.0.6",
     "inquirer": "^8.2.6",
     "lodash": "^4.17.21",
+    "natural-orderby": "^5.0.0",
     "netrc-parser": "3.1.6",
     "node-fetch": "^2.6.7",
     "open": "^10.1.2",

--- a/packages/cli/src/commands/domains/index.ts
+++ b/packages/cli/src/commands/domains/index.ts
@@ -5,6 +5,7 @@ import {ux} from '@oclif/core'
 import {hux} from '@heroku/heroku-cli-util'
 import Uri from 'urijs'
 import {confirm} from '@inquirer/prompts'
+import {orderBy} from 'natural-orderby'
 import {paginateRequest} from '../../lib/utils/paginator.js'
 import parseKeyValue from '../../lib/utils/keyValueParser.js'
 
@@ -153,12 +154,12 @@ www.example.com  CNAME            www.example.herokudns.com
 
   outputCSV = (customDomains: Heroku.Domain[], tableConfig: Record<string, any>, sortProperty?: string) => {
     const getValue = (domain: Heroku.Domain, key: string, config?: Record<string, any>) => {
-      const cfg = config ?? tableConfig[key]
-      return cfg?.get?.(domain) ?? domain[key] ?? ''
+      const columnConfig = config ?? tableConfig[key]
+      return columnConfig?.get?.(domain) ?? domain[key] ?? ''
     }
 
     const escapeCSV = (value: string) => {
-      const needsEscaping = value.includes('"') || value.includes('\n') || value.includes('\r') || value.includes(',')
+      const needsEscaping = /["\n\r,]/.test(value)
       return needsEscaping ? `"${value.replaceAll('"', '""')}"` : value
     }
 
@@ -168,7 +169,7 @@ www.example.com  CNAME            www.example.herokudns.com
     ux.stdout(columnHeaders.join(','))
 
     if (sortProperty) {
-      customDomains.sort((a, b) => getValue(a, sortProperty).localeCompare(getValue(b, sortProperty), undefined, {numeric: true}))
+      customDomains = orderBy(customDomains, [domain => getValue(domain, sortProperty)], ['asc'])
     }
 
     for (const domain of customDomains) {


### PR DESCRIPTION
## Description
[W-19830244](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002MzpbAYAR/view)

This PR reimplements `--csv` for `heroku domains`, since it was removed from oclif during the migration to v4. It allows users to output domain data in CSV format and export to a `.csv` file.

### Type of change:
Refactor

## Testing
**NOTE:** You will need an app with multiple domains (at least 3-4 to test sorting).

**Test CSV output:**
1. checkout this branch and run `npm install && npm run build`
2. Run `./bin/run domains -a <your-app> --csv`, confirm CSV output with headers
3. Run `./bin/run domains -a <your-app> --csv > test-output.csv`, confirm file was created successfully and opens with proper CSV format

**Test CSV sorting:**

4. Run `./bin/run domains -a <your-app> --csv --sort "Domain Name"`, confirm CSV output was sorted by the Domain Name column (direct property)
5. Run `./bin/run domains -a <your-app> --csv --sort "DNS Record Type"`, confirm CSV output was sorted by the DNS Record Type column (not a direct property)

**Test CSV with other flags:**

6. Run `./bin/run domains -a <your-app> --csv --extended`, confirm output includes additional columns (ACM Status, ACM Status Reason)
7. Run `./bin/run domains -a <your-app> --csv --columns "Domain Name,DNS Target"`, confirm output only shows specified columns
8. Run `./bin/run domains -a <your-app> --csv --filter "Domain Name=example"`, confirm output only shows domains matching the filter criteria

**Verify no regressions:**

9. Run `./bin/run domains -a <your-app>`, confirm table output still works
10. Run `./bin/run domains -a <your-app> --sort "Domain Name"`, confirm table sorting still works