### PR TITLE
fix: CPU ISA detection logic in standalone install script

### DIFF
--- a/install-standalone.sh
+++ b/install-standalone.sh
@@ -29,10 +29,10 @@
   ARCH="\$(uname -m)"
   if [ "\$ARCH" == "x86_64" ]; then
     ARCH=x64
+  elif [[ "\$ARCH" == "aarch64" || "\$ARCH" == "arm64" ]]; then
+	  ARCH=arm64
   elif [[ "\$ARCH" == aarch* ]]; then
     ARCH=arm
-  elif [[ "\$ARCH" == "arm64" ]]; then
-    ARCH=arm64
   else
     echoerr "unsupported arch: \$ARCH"
     exit 1


### PR DESCRIPTION
On Linux, `uname -m` will report `aarch64` on 64-bit ARM CPUs. The previous logic in this script matched that against the expression `aarch*`, causing the script to wrongly select the 32-bit ARM architecture identifier, which gives a runtime error when launching the CLI due to the lack of 32-bit dynamic linker on the system (specifically, the error indicates that `ld-linux-armhf.so.3` is missing).

<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
