### PR TITLE
chore: remove default team from docs

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -34,7 +34,7 @@ FLAGS
   -j, --json           output in json format
   -p, --personal       list apps in personal account when a default team is set
   -s, --space=<value>  filter by space
-  -t, --team=<value>   [default: terraform-ci-test-team] team to use
+  -t, --team=<value>   team to use
 
 DESCRIPTION
   list your apps
@@ -62,7 +62,7 @@ FLAGS
   -n, --no-remote          do not create a git remote
   -r, --remote=<value>     [default: heroku] the git remote to create, default "heroku"
   -s, --stack=<value>      the stack to create the app on
-  -t, --team=<value>       [default: terraform-ci-test-team] team to use
+  -t, --team=<value>       team to use
       --addons=<value>     comma-delimited list of addons to install
       --json               output in json format
       --region=<value>     specify region for the app to run in

--- a/docs/members.md
+++ b/docs/members.md
@@ -18,7 +18,7 @@ USAGE
 
 FLAGS
   -r, --role=<value>  filter by role
-  -t, --team=<value>  (required) [default: terraform-ci-test-team] team to use
+  -t, --team=<value>  (required) team to use
       --json          output in json format
       --pending       filter by pending team invitations
 
@@ -41,7 +41,7 @@ ARGUMENTS
 
 FLAGS
   -r, --role=<value>  (required) member role (admin, collaborator, member, owner)
-  -t, --team=<value>  (required) [default: terraform-ci-test-team] team to use
+  -t, --team=<value>  (required) team to use
 
 DESCRIPTION
   adds a user to a team
@@ -58,7 +58,7 @@ USAGE
   $ heroku members:remove -t <value>
 
 FLAGS
-  -t, --team=<value>  (required) [default: terraform-ci-test-team] team to use
+  -t, --team=<value>  (required) team to use
 
 DESCRIPTION
   removes a user from a team
@@ -76,7 +76,7 @@ USAGE
 
 FLAGS
   -r, --role=<value>  (required) member role (admin, collaborator, member, owner)
-  -t, --team=<value>  (required) [default: terraform-ci-test-team] team to use
+  -t, --team=<value>  (required) team to use
 
 DESCRIPTION
   sets a members role in a team

--- a/docs/orgs.md
+++ b/docs/orgs.md
@@ -33,7 +33,7 @@ USAGE
   $ heroku orgs:open -t <value>
 
 FLAGS
-  -t, --team=<value>  (required) [default: terraform-ci-test-team] team to use
+  -t, --team=<value>  (required) team to use
 
 DESCRIPTION
   open the team interface in a browser window

--- a/docs/spaces.md
+++ b/docs/spaces.md
@@ -36,7 +36,7 @@ USAGE
   $ heroku spaces [--json] [-t <value>]
 
 FLAGS
-  -t, --team=<value>  [default: terraform-ci-test-team] team to use
+  -t, --team=<value>  team to use
       --json          output in json format
 
 DESCRIPTION
@@ -56,7 +56,7 @@ USAGE
 
 FLAGS
   -s, --space=<value>        name of space to create
-  -t, --team=<value>         (required) [default: terraform-ci-test-team] team to use
+  -t, --team=<value>         (required) team to use
       --cidr=<value>         RFC-1918 CIDR the space will use
       --data-cidr=<value>    RFC-1918 CIDR used by Heroku Data resources for the space
       --generation=<option>  [default: cedar] generation for space


### PR DESCRIPTION
This PR just updates the docs and removes the mention of a team default.