### PR TITLE
fix(W-20270674): bump heroku-cli-util and fix resulting errors

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "@heroku-cli/schema": "^1.0.25",
     "@heroku/buildpack-registry": "^1.0.1",
     "@heroku/eventsource": "^1.0.7",
-    "@heroku/heroku-cli-util": "^9.1.3",
+    "@heroku/heroku-cli-util": "^9.2.0",
     "@heroku/http-call": "^5.5.0",
     "@heroku/mcp-server": "1.0.7-alpha.1",
     "@heroku/plugin-ai": "^1.0.1",

--- a/packages/cli/src/commands/pg/psql.ts
+++ b/packages/cli/src/commands/pg/psql.ts
@@ -39,7 +39,7 @@ export default class Psql extends Command {
 
       const psqlService = new utils.pg.PsqlService(db)
 
-      console.error(`--> Connecting to ${color.yellow(db.attachment.addon.name)}`)
+      console.error(`--> Connecting to ${color.yellow(db.attachment!.addon.name)}`)
       if (command) {
         const output = await psqlService.execQuery(command)
         process.stdout.write(output)

--- a/packages/cli/src/commands/pg/pull.ts
+++ b/packages/cli/src/commands/pg/pull.ts
@@ -58,7 +58,7 @@ export default class Pull extends Command {
     const source = await dbResolver.getDatabase(app, args.source)
     const target = utils.pg.DatabaseResolver.parsePostgresConnectionString(args.target)
 
-    ux.log(`Pulling ${color.cyan(source.attachment.addon.name)} to ${color.addon(args.target)}`)
+    ux.log(`Pulling ${color.cyan(source.attachment!.addon.name)} to ${color.addon(args.target)}`)
     await this.pull(source, target, exclusions)
     ux.log('Pulling complete.')
   }

--- a/packages/cli/src/commands/pg/push.ts
+++ b/packages/cli/src/commands/pg/push.ts
@@ -55,7 +55,7 @@ export default class Push extends Command {
     const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
     const target = await dbResolver.getDatabase(app, args.target)
 
-    ux.log(`Pushing ${color.cyan(args.source)} to ${color.addon(target.attachment.addon.name)}`)
+    ux.log(`Pushing ${color.cyan(args.source)} to ${color.addon(target.attachment!.addon.name)}`)
     await this.push(source, target, exclusions)
     ux.log('Pushing complete.')
   }

--- a/packages/cli/src/lib/pg/psql.ts
+++ b/packages/cli/src/lib/pg/psql.ts
@@ -3,9 +3,9 @@ import {SpawnOptions} from 'child_process'
 import debug from 'debug'
 import * as fs from 'fs'
 import * as path from 'node:path'
-import {ConnectionDetailsWithAttachment, utils} from '@heroku/heroku-cli-util'
+import {ConnectionDetails, utils} from '@heroku/heroku-cli-util'
 
-export async function fetchVersion(db: ConnectionDetailsWithAttachment) {
+export async function fetchVersion(db: ConnectionDetails) {
   const psqlService = new utils.pg.PsqlService(db)
   const output = await psqlService.execQuery('SHOW server_version', ['-X', '-q'])
   return output.match(/[0-9]{1,}\.[0-9]{1,}/)?.[0]
@@ -58,7 +58,7 @@ export function psqlInteractiveOptions(prompt: string, dbEnv: NodeJS.ProcessEnv)
   }
 }
 
-export async function execFile(db: ConnectionDetailsWithAttachment, file: string) {
+export async function execFile(db: ConnectionDetails, file: string) {
   const psqlService = new utils.pg.PsqlService(db)
   const configs = utils.pg.psql.getPsqlConfigs(db)
   const options = psqlFileOptions(file, configs.dbEnv)
@@ -66,10 +66,10 @@ export async function execFile(db: ConnectionDetailsWithAttachment, file: string
   return psqlService.runWithTunnel(configs.dbTunnelConfig, options)
 }
 
-export async function interactive(db: ConnectionDetailsWithAttachment) {
+export async function interactive(db: ConnectionDetails) {
   const psqlService = new utils.pg.PsqlService(db)
-  const attachmentName = db.attachment.name
-  const prompt = `${db.attachment.app.name}::${attachmentName}%R%# `
+  const attachmentName = db.attachment!.name
+  const prompt = `${db.attachment!.app.name}::${attachmentName}%R%# `
   const configs = utils.pg.psql.getPsqlConfigs(db)
   configs.dbEnv.PGAPPNAME = 'psql interactive' // default was 'psql non-interactive`
   const options = psqlInteractiveOptions(prompt, configs.dbEnv)

--- a/packages/cli/test/unit/commands/pg/pull.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/pull.unit.test.ts
@@ -3,7 +3,7 @@ import runCommand, {GenericCmd} from '../../../helpers/runCommand'
 import {expect} from 'chai'
 import * as proxyquire from 'proxyquire'
 import heredoc from 'tsheredoc'
-import {ConnectionDetailsWithAttachment, utils} from '@heroku/heroku-cli-util'
+import {ConnectionDetails, utils} from '@heroku/heroku-cli-util'
 import sinon = require('sinon')
 import * as childProcess from 'node:child_process'
 
@@ -11,7 +11,7 @@ describe('pg:pull', function () {
   const skipOnWindows = process.platform === 'win32' ? it.skip : it
   const dumpFlags = ['--verbose', '-F', 'c', '-Z', '0', '-N', '_heroku', '-U', 'jeff', '-h', 'herokai.com', '-p', '5432', 'mydb']
   const restoreFlags = ['--verbose', '-F', 'c', '--no-acl', '--no-owner', '-d', 'localdb']
-  let db: ConnectionDetailsWithAttachment
+  let db: ConnectionDetails
   let push_pull: unknown
   let Cmd: GenericCmd
   let createDbStub: sinon.SinonStub
@@ -39,7 +39,7 @@ describe('pg:pull', function () {
         config_vars: ['DATABASE_URL'],
         app: {name: 'myapp'},
       },
-    } as ConnectionDetailsWithAttachment
+    } as ConnectionDetails
     sshTunnelStub = sinon.stub().resolves()
     const mockUtils = {
       pg: {
@@ -53,7 +53,7 @@ describe('pg:pull', function () {
           execQuery = sinon.stub().resolves('')
         },
         psql: {
-          getPsqlConfigs: sinon.stub().callsFake((db: ConnectionDetailsWithAttachment) => {
+          getPsqlConfigs: sinon.stub().callsFake((db: ConnectionDetails) => {
             return utils.pg.psql.getPsqlConfigs(db)
           }),
           sshTunnel: sshTunnelStub,

--- a/packages/cli/test/unit/commands/pg/push.unit.test.ts
+++ b/packages/cli/test/unit/commands/pg/push.unit.test.ts
@@ -3,13 +3,13 @@ import runCommand, {GenericCmd} from '../../../helpers/runCommand'
 import {expect} from 'chai'
 import * as proxyquire from 'proxyquire'
 import heredoc from 'tsheredoc'
-import {ConnectionDetailsWithAttachment, utils} from '@heroku/heroku-cli-util'
+import {ConnectionDetails, utils} from '@heroku/heroku-cli-util'
 import sinon = require('sinon')
 import * as childProcess from 'node:child_process'
 
 describe('pg:push', function () {
   const skipOnWindows = process.platform === 'win32' ? it.skip : it
-  let db: ConnectionDetailsWithAttachment
+  let db: ConnectionDetails
   let push_pull: unknown
   const emptyResponse = '00'
   let Cmd: GenericCmd
@@ -37,7 +37,7 @@ describe('pg:push', function () {
         config_vars: ['DATABASE_URL'],
         app: {name: 'myapp'},
       },
-    } as ConnectionDetailsWithAttachment
+    } as ConnectionDetails
     sshTunnelStub = sinon.stub().resolves()
     const mockUtils = {
       pg: {
@@ -51,7 +51,7 @@ describe('pg:push', function () {
           execQuery = sinon.stub().resolves(emptyResponse)
         },
         psql: {
-          getPsqlConfigs: sinon.stub().callsFake((db: ConnectionDetailsWithAttachment) => {
+          getPsqlConfigs: sinon.stub().callsFake((db: ConnectionDetails) => {
             return utils.pg.psql.getPsqlConfigs(db)
           }),
           sshTunnel: sshTunnelStub,

--- a/packages/cli/test/unit/lib/pg/psql.unit.test.ts
+++ b/packages/cli/test/unit/lib/pg/psql.unit.test.ts
@@ -4,15 +4,15 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import * as proxyquire from 'proxyquire'
 import {stderr} from 'stdout-stderr'
-import {ConnectionDetailsWithAttachment, utils} from '@heroku/heroku-cli-util'
+import {ConnectionDetails, utils} from '@heroku/heroku-cli-util'
 import {unwrap} from '../../../helpers/utils/unwrap'
 import sinon = require('sinon')
 import * as tmp from 'tmp'
 import type * as Pgsql from '../../../../src/lib/pg/psql'
 
 describe('psql', function () {
-  const db: ConnectionDetailsWithAttachment = {
-    attachment: {} as ConnectionDetailsWithAttachment['attachment'],
+  const db: ConnectionDetails = {
+    attachment: {} as ConnectionDetails['attachment'],
     user: 'jeff',
     password: 'pass',
     database: 'mydb',
@@ -24,8 +24,8 @@ describe('psql', function () {
     url: '',
   }
 
-  const bastionDb: ConnectionDetailsWithAttachment = {
-    attachment: {} as  ConnectionDetailsWithAttachment['attachment'],
+  const bastionDb: ConnectionDetails = {
+    attachment: {} as  ConnectionDetails['attachment'],
     user: 'jeff',
     password: 'pass',
     database: 'mydb',
@@ -68,7 +68,7 @@ describe('psql', function () {
           runWithTunnel = psqlServiceRunWithTunnelSpy
         },
         psql: {
-          getPsqlConfigs: sinon.stub().callsFake((db: ConnectionDetailsWithAttachment) => {
+          getPsqlConfigs: sinon.stub().callsFake((db: ConnectionDetails) => {
             return utils.pg.psql.getPsqlConfigs(db)
           }),
         },
@@ -76,7 +76,7 @@ describe('psql', function () {
     }
     psql = proxyquire('../../../../src/lib/pg/psql', {
       '@heroku/heroku-cli-util': {
-        ConnectionDetailsWithAttachment: {} as ConnectionDetailsWithAttachment,
+        ConnectionDetailsWithAttachment: {} as ConnectionDetails,
         utils: mockUtils,
       },
     })
@@ -175,7 +175,7 @@ describe('psql', function () {
         },
         name: 'DATABASE',
       },
-    } as ConnectionDetailsWithAttachment
+    } as ConnectionDetails
 
     context('when HEROKU_PSQL_HISTORY is set', function () {
       let historyPath: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -1801,9 +1801,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@heroku/heroku-cli-util@npm:^9.1.3":
-  version: 9.1.3
-  resolution: "@heroku/heroku-cli-util@npm:9.1.3"
+"@heroku/heroku-cli-util@npm:^9.2.0":
+  version: 9.2.0
+  resolution: "@heroku/heroku-cli-util@npm:9.2.0"
   dependencies:
     "@heroku-cli/color": ^2.0.4
     "@heroku-cli/command": ^11.8.0
@@ -1811,7 +1811,7 @@ __metadata:
     "@oclif/core": ^2.16.0
     debug: ^4.4.0
     tunnel-ssh: 5.2.0
-  checksum: d23a3894f2e69cdc9552696e648afa44133f95b807658310562a2cad3e9a6581785fdceea60bb1efb51a7a1481c6ac243cb5aa249e01636c1693238bc7d8040f
+  checksum: 95fdc285d3d095bc8a04e6d0ae61c5260e5e5a5aa4e555505fdc134cc5b7f6f99825acfeaa4ff401fbb66aff7e88b4d1b60f5d0c1bf1c6e9f3e75a90b8acd16e
   languageName: node
   linkType: hard
 
@@ -10922,7 +10922,7 @@ __metadata:
     "@heroku-cli/schema": ^1.0.25
     "@heroku/buildpack-registry": ^1.0.1
     "@heroku/eventsource": ^1.0.7
-    "@heroku/heroku-cli-util": ^9.1.3
+    "@heroku/heroku-cli-util": ^9.2.0
     "@heroku/http-call": ^5.5.0
     "@heroku/mcp-server": 1.0.7-alpha.1
     "@heroku/plugin-ai": ^1.0.1


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

Bumps the version of @heroku/heroku-cli-util in order to fix a bug with several `pg` commands. Also fixes resulting errors.

## Testing
1. Check out this branch
2. Run `yarn && yarn build`
3. Run HEROKU_POSTGRESQL_ADDON_NAME='heroku-postgresql-ekozil' ./bin/run pg:psql HEROKU_POSTGRESQL_EKOZIL --app k80-test-pg (the k80-test-pg app is already set up with a database for testing).
4. Run `HEROKU_POSTGRESQL_ADDON_NAME='heroku-postgresql-ekozil' ./bin/run pg:psql --app k80-test-pg`. Confirm that you get an error message that tells you that `HEROKU_POSTGRESQL_EKOZIL` is a valid option (and not `HEROKU_POSTGRESQL_EKOZIL_URL`).

## Relevant links
GUS work item: [W-20270674](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002PlJTJYA3/view)
