### PR TITLE
feat: adding json flag to config:get command

### DIFF
--- a/packages/cli/src/commands/config/get.ts
+++ b/packages/cli/src/commands/config/get.ts
@@ -1,3 +1,4 @@
+import {hux} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {Args} from '@oclif/core'
@@ -5,33 +6,52 @@ import {Args} from '@oclif/core'
 import {quote} from '../../lib/config/quote'
 
 export class ConfigGet extends Command {
-  static usage = 'config:get KEY...'
+  static args = {
+    KEY: Args.string({description: 'key name of the config var value', required: true}),
+  }
 
   static description = 'display a single config value for an app'
 
   static example = `$ heroku config:get RAILS_ENV
 production`
 
-  static strict = false
-
-  static args = {
-    KEY: Args.string({required: true, description: 'key name of the config var value'}),
-  }
-
   static flags = {
     app: flags.app({required: true}),
+    json: flags.boolean({char: 'j', description: 'output in json format'}),
     remote: flags.remote(),
     shell: flags.boolean({char: 's', description: 'output config vars in shell format'}),
   }
 
+  static strict = false
+
+  static usage = 'config:get KEY...'
+
   async run() {
-    const {flags, argv} = await this.parse(ConfigGet)
+    const {argv, flags} = await this.parse(ConfigGet)
     const {body: config} = await this.heroku.get<Heroku.ConfigVars>(`/apps/${flags.app}/config-vars`)
-    for (const key of (argv as string[])) {
-      const v = config[key]
-      if (flags.shell) {
-        this.log(`${key}=${quote(v || '')}`)
+
+    if (flags.json) {
+      const results = (argv as string[]).map(key => {
+        const exists = key in config
+        return {
+          key,
+          value: exists ? config[key] : null,
+        }
+      })
+
+      if (results.length === 1) {
+        hux.styledJSON(results[0])
       } else {
+        hux.styledJSON(results)
+      }
+    } else if (flags.shell) {
+      for (const key of (argv as string[])) {
+        const v = config[key]
+        this.log(`${key}=${quote(v || '')}`)
+      }
+    } else {
+      for (const key of (argv as string[])) {
+        const v = config[key]
         this.log(v || '')
       }
     }

--- a/packages/cli/test/unit/commands/config/get.unit.test.ts
+++ b/packages/cli/test/unit/commands/config/get.unit.test.ts
@@ -33,4 +33,52 @@ describe('config', function () {
     .it('missing', ({stdout}) => {
       expect(stdout).to.equal('\n')
     })
+
+  test
+    .nock('https://api.heroku.com', api => api
+      .get('/apps/myapp/config-vars')
+      .reply(200, {EMPTY_VAR: '', RACK_ENV: 'production'}),
+    )
+    .stdout()
+    .command(['config:get', '--app=myapp', '--json', 'MISSING'])
+    .it('--json with unset var', ({stdout}) => {
+      expect(JSON.parse(stdout)).to.deep.equal({key: 'MISSING', value: null})
+    })
+
+  test
+    .nock('https://api.heroku.com', api => api
+      .get('/apps/myapp/config-vars')
+      .reply(200, {EMPTY_VAR: '', RACK_ENV: 'production'}),
+    )
+    .stdout()
+    .command(['config:get', '--app=myapp', '--json', 'EMPTY_VAR'])
+    .it('--json with empty string var', ({stdout}) => {
+      expect(JSON.parse(stdout)).to.deep.equal({key: 'EMPTY_VAR', value: ''})
+    })
+
+  test
+    .nock('https://api.heroku.com', api => api
+      .get('/apps/myapp/config-vars')
+      .reply(200, {LANG: 'en_US.UTF-8', RACK_ENV: 'production'}),
+    )
+    .stdout()
+    .command(['config:get', '--app=myapp', '--json', 'RACK_ENV'])
+    .it('--json with normal var', ({stdout}) => {
+      expect(JSON.parse(stdout)).to.deep.equal({key: 'RACK_ENV', value: 'production'})
+    })
+
+  test
+    .nock('https://api.heroku.com', api => api
+      .get('/apps/myapp/config-vars')
+      .reply(200, {EMPTY_VAR: '', RACK_ENV: 'production'}),
+    )
+    .stdout()
+    .command(['config:get', '--app=myapp', '--json', 'MISSING', 'EMPTY_VAR', 'RACK_ENV'])
+    .it('--json with multiple vars', ({stdout}) => {
+      expect(JSON.parse(stdout)).to.deep.equal([
+        {key: 'MISSING', value: null},
+        {key: 'EMPTY_VAR', value: ''},
+        {key: 'RACK_ENV', value: 'production'},
+      ])
+    })
 })


### PR DESCRIPTION
## Summary

Adds a `--json` flag to the `config:get` command that outputs structured JSON, allowing users to distinguish between unset config vars (outputs `null`) and empty string config vars (outputs `""`). This addresses the issue where both cases previously returned empty output, making them indistinguishable. The implementation follows existing patterns in the codebase and maintains full backward compatibility.

## Type of Change

- [x] **feat**: Introduces a new feature to the codebase (minor semvar update)
- [ ] **fix**: Bug fix or issue (patch semvar update)
- [ ] **perf**: Performance improvement
- [ ] **docs**: Documentation only changes
- [ ] **tests**: Adding missing tests or correcting existing tests
- [ ] **chore**: Code cleanup tasks, dependency updates, or other changes

Note: Add a `!` after your change type to denote a breaking change.

## Testing
Add 2 variables to a new app. One to unset and one as an empty string 

```
# first unset this var
heroku config:unset UNSET_VAR --app safe-dusk-66960

# then run the test commands
./bin/run config:get UNSET_VAR --app safe-dusk-66960 --json
./bin/run config:get EMPTY_STRING_VAR --app safe-dusk-66960 --json
```

Expected output:
<img width="797" height="213" alt="image" src="https://github.com/user-attachments/assets/26b52ab2-5314-4876-acb3-d50ee12771e6" />

## Additional Context

Previously, `heroku config:get KEY` could not distinguish between:
1. A config var that doesn't exist (unset/removed)
2. A config var that exists but has an empty string value

Both scenarios returned empty output, making it impossible to determine the actual state. The new `--json` flag provides structured output:
- Unset vars: `{"key": "KEY", "value": null}`
- Empty string vars: `{"key": "KEY", "value": ""}`
- Normal vars: `{"key": "KEY", "value": "value"}`

For multiple keys, the output is an array of objects. The implementation follows the same pattern as `config --json` and uses `hux.styledJSON()` for consistent formatting. Default behavior remains unchanged for backward compatibility.

## Related Issue

Closes #3450 
[W-20875855](https://gus.lightning.force.com/a07EE00002SmT8iYAF)
