### PR TITLE
feat: migrate to color.user from @heroku/heroku-cli-util

### DIFF
--- a/packages/cli/src/commands/access/add.ts
+++ b/packages/cli/src/commands/access/add.ts
@@ -1,4 +1,4 @@
-import {color} from '@heroku-cli/color'
+import {color} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {Args, ux} from '@oclif/core'
@@ -28,7 +28,7 @@ export default class AccessAdd extends Command {
     const {email} = args
     const {app: appName, permissions} = flags
     const {body: appInfo} = await this.heroku.get<Heroku.App>(`/apps/${appName}`)
-    let output = `Adding ${color.cyan(email)} access to the app ${color.app(appName)}`
+    let output = `Adding ${color.user(email)} access to the app ${color.app(appName)}`
     let teamFeatures: Heroku.TeamFeature[] = []
     if (isTeamApp(appInfo?.owner?.email)) {
       const teamName = getOwner(appInfo?.owner?.email)

--- a/packages/cli/src/commands/access/remove.ts
+++ b/packages/cli/src/commands/access/remove.ts
@@ -1,5 +1,4 @@
-
-import {color} from '@heroku-cli/color'
+import {color} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
@@ -21,7 +20,7 @@ export default class AccessRemove extends Command {
     const {app} = flags
     const email = argv[0] as string
     const appName = app
-    ux.action.start(`Removing ${color.cyan(email)} access from the app ${color.app(appName)}`)
+    ux.action.start(`Removing ${color.user(email)} access from the app ${color.app(appName)}`)
     await this.heroku.delete<Heroku.Collaborator>(`/apps/${appName}/collaborators/${email}`)
     ux.action.stop()
   }

--- a/packages/cli/src/commands/access/update.ts
+++ b/packages/cli/src/commands/access/update.ts
@@ -1,38 +1,40 @@
-import {color} from '@heroku-cli/color'
+import {color} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
 import * as Heroku from '@heroku-cli/schema'
+import {Args, ux} from '@oclif/core'
+
 import {isTeamApp} from '../../lib/teamUtils.js'
 
 export default class Update extends Command {
-  static topic = 'access'
+  static args = {
+    email: Args.string({description: 'email address of the team member', required: true}),
+  }
+
   static description = 'update existing collaborators on an team app'
   static flags = {
+    app: flags.app({required: true}),
     permissions: flags.string({
       char: 'p',
       description: 'comma-delimited list of permissions to update (deploy,manage,operate)',
       required: true,
     }),
-    app: flags.app({required: true}),
     remote: flags.remote(),
   }
 
-  static args = {
-    email: Args.string({required: true, description: 'email address of the team member'}),
-  }
+  static topic = 'access'
 
   public async run(): Promise<void> {
-    const {flags, args} = await this.parse(Update)
+    const {args, flags} = await this.parse(Update)
     const appName = flags.app
     let permissions = flags.permissions.split(',')
 
     const {body: appInfo} = await this.heroku.get<Heroku.App>(`/apps/${appName}`)
     if (!isTeamApp(appInfo?.owner?.email))
-      this.error(`Error: cannot update permissions. The app ${color.cyan(appName)} is not owned by a team`)
+      this.error(`Error: cannot update permissions. The app ${color.app(appName)} is not owned by a team`)
     permissions.push('view')
     permissions = Array.from(new Set(permissions.sort()))
 
-    ux.action.start(`Updating ${args.email} in application ${color.cyan(appName)} with ${permissions} permissions`)
+    ux.action.start(`Updating ${color.user(args.email)} in application ${color.app(appName)} with ${permissions} permissions`)
     await this.heroku.patch(`/teams/apps/${appName}/collaborators/${args.email}`, {
       body: {permissions},
     })

--- a/packages/cli/src/commands/apps/index.ts
+++ b/packages/cli/src/commands/apps/index.ts
@@ -36,25 +36,25 @@ function listApps(apps: Heroku.App) {
 function print(apps: Heroku.App, user: Heroku.Account, space?: string, team?: null | string) {
   if (apps.length === 0) {
     if (space) ux.stdout(`There are no apps in space ${color.space(space)}.`)
-    else if (team) ux.stdout(`There are no apps in team ${color.magenta(team)}.`)
+    else if (team) ux.stdout(`There are no apps in team ${color.team(team)}.`)
     else ux.stdout('You have no apps.')
   } else if (space) {
     hux.styledHeader(`Apps in space ${color.space(space)}`)
     listApps(apps)
   } else if (team) {
-    hux.styledHeader(`Apps in team ${color.magenta(team)}`)
+    hux.styledHeader(`Apps in team ${color.team(team)}`)
     listApps(apps)
   } else {
     apps = _.partition(apps, (app: App) => app.owner.email === user.email)
     if (apps[0].length > 0) {
-      hux.styledHeader(`${color.cyan(user.email!)} Apps`)
+      hux.styledHeader(`${color.user(user.email!)} Apps`)
       listApps(apps[0])
     }
 
     const columns = {
       Name: {get: regionizeAppName},
       // eslint-disable-next-line perfectionist/sort-objects
-      Email: {get: ({owner}: any) => owner.email},
+      Email: {get: ({owner}: any) => color.user(owner.email)},
     }
 
     if (apps[1].length > 0) {

--- a/packages/cli/src/commands/apps/info.ts
+++ b/packages/cli/src/commands/apps/info.ts
@@ -76,7 +76,7 @@ function print(info: Heroku.App, addons: Heroku.AddOn[], collaborators: Heroku.C
   data['Web URL'] = info.app.web_url
   data['Repo Size'] = filesize(info.app.repo_size, {round: 0, standard: 'jedec'})
   if (getGeneration(info.app) !== 'fir') data['Slug Size'] = filesize(info.app.slug_size, {round: 0, standard: 'jedec'})
-  data.Owner = info.app.owner.email
+  data.Owner = color.user(info.app.owner.email)
   data.Region = info.app.region.name
   data.Dynos = countBy(info.dynos, 'type')
   data.Stack = (function (app) {

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -1,26 +1,26 @@
-import {color} from '@heroku-cli/color'
+import {color} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 
 export default class Login extends Command {
-  static description = 'login with your Heroku credentials'
-
   static aliases = ['login']
+
+  static description = 'login with your Heroku credentials'
 
   static flags = {
     browser: flags.string({description: 'browser to open SSO with (example: "firefox", "safari")'}),
-    sso: flags.boolean({hidden: true, char: 's', description: 'login for enterprise users under SSO'}),
-    interactive: flags.boolean({char: 'i', description: 'login with username/password'}),
     'expires-in': flags.integer({char: 'e', description: 'duration of token in seconds (default 30 days)'}),
+    interactive: flags.boolean({char: 'i', description: 'login with username/password'}),
+    sso: flags.boolean({char: 's', description: 'login for enterprise users under SSO', hidden: true}),
   }
 
   async run() {
     const {flags} = await this.parse(Login)
     let method: 'interactive' | undefined
     if (flags.interactive) method = 'interactive'
-    await this.heroku.login({method, expiresIn: flags['expires-in'], browser: flags.browser})
+    await this.heroku.login({browser: flags.browser, expiresIn: flags['expires-in'], method})
     const {body: account} = await this.heroku.get<Heroku.Account>('/account', {retryAuth: false})
-    this.log(`Logged in as ${color.green(account.email!)}`)
+    this.log(`Logged in as ${color.user(account.email!)}`)
     await this.config.runHook('recache', {type: 'login'})
   }
 }

--- a/packages/cli/src/commands/keys/index.ts
+++ b/packages/cli/src/commands/keys/index.ts
@@ -1,8 +1,7 @@
-import {ux} from '@oclif/core'
-import {hux} from '@heroku/heroku-cli-util'
-import {color} from '@heroku-cli/color'
+import {color, hux} from '@heroku/heroku-cli-util'
+import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
-import {flags, Command} from '@heroku-cli/command'
+import {ux} from '@oclif/core'
 
 function formatKey(key: string) {
   const [name, pub, email] = key.trim().split(/\s/)
@@ -24,7 +23,7 @@ export default class Keys extends Command {
     } else if (keys.length === 0) {
       ux.warn('You have no SSH keys.')
     } else {
-      hux.styledHeader(`${color.cyan(keys[0].email || '')} keys`)
+      hux.styledHeader(`${color.user(keys[0].email || '')} keys`)
       if (flags.long) {
         keys.forEach(k => ux.stdout(k.public_key))
       } else {

--- a/packages/cli/src/commands/labs/index.ts
+++ b/packages/cli/src/commands/labs/index.ts
@@ -1,13 +1,12 @@
-import {color} from '@heroku-cli/color'
+import {color, hux} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
-import {hux} from '@heroku/heroku-cli-util'
 
 interface Features {
+  app?: Heroku.AppFeature | null,
   currentUser: Heroku.Account,
   user: Heroku.AccountFeature,
-  app?: Heroku.AppFeature | null,
 }
 
 function printJSON(features: Heroku.Account | Heroku.AccountFeature | Heroku.AppFeature) {
@@ -15,7 +14,7 @@ function printJSON(features: Heroku.Account | Heroku.AccountFeature | Heroku.App
 }
 
 function printFeatures(features: Heroku.AccountFeature | Heroku.AppFeature) {
-  const groupedFeatures = features.sort((a: Heroku.AccountFeature | Heroku.AppFeature, b: Heroku.AppFeature | Heroku.AccountFeature) =>
+  const groupedFeatures = features.sort((a: Heroku.AccountFeature | Heroku.AppFeature, b: Heroku.AccountFeature | Heroku.AppFeature) =>
     (a.name || '').localeCompare(b.name || ''))
   const longest = Math.max(...groupedFeatures.map((f: Heroku.AccountFeature | Heroku.AppFeature) => (f.name || '').length))
   for (const f of groupedFeatures) {
@@ -28,13 +27,13 @@ function printFeatures(features: Heroku.AccountFeature | Heroku.AppFeature) {
 
 export default class LabsIndex extends Command {
   static description = 'list experimental features'
-  static topic = 'labs'
-
   static flags = {
     app: flags.app({required: false}),
-    remote: flags.remote(),
     json: flags.boolean({description: 'display as json', required: false}),
+    remote: flags.remote(),
   }
+
+  static topic = 'labs'
 
   async run() {
     const {flags} = await this.parse(LabsIndex)
@@ -54,7 +53,7 @@ export default class LabsIndex extends Command {
     }
 
     // makes sure app isn't added to json object if null
-    // eslint-disable-next-line unicorn/no-negated-condition
+    // eslint-disable-next-line unicorn/no-negated-condition, no-negated-condition
     if (appResponse !== null) {
       app = appResponse?.body
       features.app = app
@@ -68,7 +67,7 @@ export default class LabsIndex extends Command {
     if (flags.json) {
       printJSON({app, user})
     } else {
-      hux.styledHeader(`User Features ${color.cyan(features.currentUser.email!)}`)
+      hux.styledHeader(`User Features ${color.user(features.currentUser.email!)}`)
       printFeatures(features.user)
       if (features.app) {
         ux.stdout()

--- a/packages/cli/src/commands/members/index.ts
+++ b/packages/cli/src/commands/members/index.ts
@@ -1,16 +1,17 @@
 import {color, hux} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {RoleCompletion} from '@heroku-cli/command/lib/completions.js'
-import {ux} from '@oclif/core'
 import * as Heroku from '@heroku-cli/schema'
-import {isTeamInviteFeatureEnabled, getTeamInvites} from '../../lib/members/team-invite-utils.js'
+import {ux} from '@oclif/core'
 
-type MemberWithStatus = Heroku.TeamMember & { status?: string }
+import {getTeamInvites, isTeamInviteFeatureEnabled} from '../../lib/members/team-invite-utils.js'
+
+type MemberWithStatus = { status?: string } & Heroku.TeamMember
 
 const buildTableColumns = (teamInvites: MemberWithStatus[]) => {
   const baseColumns = {
     email: {
-      get: ({email}: any): string => color.cyan(email),
+      get: ({email}: any): string => color.user(email),
     },
     role: {
       get: ({role}: any): string => color.green(role),
@@ -30,27 +31,28 @@ const buildTableColumns = (teamInvites: MemberWithStatus[]) => {
 }
 
 export default class MembersIndex extends Command {
-  static topic = 'members'
   static description = 'list members of a team'
-
   static flags = {
+    json: flags.boolean({description: 'output in json format'}),
+    pending: flags.boolean({description: 'filter by pending team invitations'}),
     role: flags.string({
       char: 'r',
-      description: 'filter by role',
       completion: RoleCompletion,
+      description: 'filter by role',
     }),
-    pending: flags.boolean({description: 'filter by pending team invitations'}),
-    json: flags.boolean({description: 'output in json format'}),
     team: flags.team({required: true}),
   }
 
+  static topic = 'members'
+
   public async run(): Promise<void> {
     const {flags} = await this.parse(MembersIndex)
-    const {role, pending, json, team} = flags
+    const {json, pending, role, team} = flags
     let teamInvites: MemberWithStatus[] = []
 
     if (await isTeamInviteFeatureEnabled(team, this.heroku)) {
       const invites = await getTeamInvites(team, this.heroku)
+      /* eslint-disable perfectionist/sort-objects */
       teamInvites = invites.map((invite: Heroku.TeamInvitation): MemberWithStatus => ({
         email: invite.user?.email || '',
         role: invite.role,
@@ -61,6 +63,7 @@ export default class MembersIndex extends Command {
         created_at: invite.created_at || '',
         updated_at: invite.updated_at || '',
       }))
+      /* eslint-enable perfectionist/sort-objects */
     }
 
     let {body: members} = await this.heroku.get<MemberWithStatus[]>(`/teams/${team}/members`)

--- a/packages/cli/src/commands/members/remove.ts
+++ b/packages/cli/src/commands/members/remove.ts
@@ -1,8 +1,9 @@
 import {color} from '@heroku/heroku-cli-util'
 import {APIClient, Command, flags} from '@heroku-cli/command'
-import {ux} from '@oclif/core'
 import * as Heroku from '@heroku-cli/schema'
-import {isTeamInviteFeatureEnabled, getTeamInvites} from '../../lib/members/team-invite-utils.js'
+import {ux} from '@oclif/core'
+
+import {getTeamInvites, isTeamInviteFeatureEnabled} from '../../lib/members/team-invite-utils.js'
 
 const revokeInvite = async (email: string, team: string, heroku: APIClient) => {
   ux.action.start(`Revoking invite for ${color.user(email)} in ${color.team(team)}`)
@@ -23,17 +24,17 @@ const removeUserMembership = async (email: string, team: string, heroku: APIClie
 }
 
 export default class MembersRemove extends Command {
-  static topic = 'members'
   static description = 'removes a user from a team'
-
   static flags = {
     team: flags.team({required: true}),
   }
 
   static strict = false
 
+  static topic = 'members'
+
   public async run(): Promise<void> {
-    const {flags, argv} = await this.parse(MembersRemove)
+    const {argv, flags} = await this.parse(MembersRemove)
     const {team} = flags
     const email = argv[0] as string
     const teamInviteFeatureEnabled = await isTeamInviteFeatureEnabled(team, this.heroku)

--- a/packages/cli/src/commands/releases/index.ts
+++ b/packages/cli/src/commands/releases/index.ts
@@ -1,4 +1,4 @@
-import {color as newColor, hux} from '@heroku/heroku-cli-util'
+import {hux, color as newColor} from '@heroku/heroku-cli-util'
 import {color} from '@heroku-cli/color'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
@@ -157,15 +157,17 @@ export default class Index extends Command {
       return color.cyan('v' + release.version)
     }
 
+    /* eslint-disable perfectionist/sort-objects */
     const columns: Record<string, ColumnConfig> = {
       // column name "v" as ux.table will make it's width at least "version" even though 'no-header': true
       v: {get: getVersionColor},
       description: {get: descriptionWithStatus},
-      user: {get: ({user}) => color.magenta(user?.email || '')},
+      user: {get: ({user}) => newColor.user(user?.email || '')},
       created_at: {get: ({created_at}) => time.ago(new Date(created_at || ''))},
       slug_id: {extended: true, get: ({extended}) => extended?.slug_id},
       slug_uuid: {extended: true, get: ({extended}) => extended?.slug_uuid},
     }
+    /* eslint-enable perfectionist/sort-objects */
 
     // `getDescriptionTruncation` is dependent on `columns` being defined and thus `descriptionWithStatus`.
     // `descriptionWithStatus` requires `optimizationWidth` to be defined. Redefine here before `descriptionWithStatus` is actually called.

--- a/packages/cli/src/lib/pipelines/ownership.ts
+++ b/packages/cli/src/lib/pipelines/ownership.ts
@@ -1,4 +1,4 @@
-import {color} from '@heroku-cli/color'
+import {color} from '@heroku/heroku-cli-util'
 import {APIClient} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
@@ -10,10 +10,10 @@ export function warnMixedOwnership(pipelineApps: Array<AppWithPipelineCoupling>,
 
   if (hasMixedOwnership) {
     ux.stdout()
-    let message = `Some apps in this pipeline do not belong to ${color.cmd(owner)}.`
+    let message = `Some apps in this pipeline do not belong to ${color.team(owner)}.`
     message += '\n\nAll apps in a pipeline must have the same owner as the pipeline owner.'
     message += '\nTransfer these apps or change the pipeline owner in pipeline settings.'
-    message += `\nSee ${color.cyan('https://devcenter.heroku.com/articles/pipeline-ownership-transition')} for more info.`
+    message += `\nSee ${color.info('https://devcenter.heroku.com/articles/pipeline-ownership-transition')} for more info.`
     ux.warn(message)
   }
 }
@@ -33,5 +33,5 @@ export function getOwner(heroku: APIClient, apps: Array<AppWithPipelineCoupling>
     ownerPromise = Promise.resolve(owner)
   }
 
-  return ownerPromise.then(owner => (owner.name ? `${owner.name} (team)` : owner))
+  return ownerPromise.then(owner => (owner.name ? `${color.team(owner.name)} (team)` : color.user(owner)))
 }

--- a/packages/cli/src/lib/pipelines/render-pipeline.ts
+++ b/packages/cli/src/lib/pipelines/render-pipeline.ts
@@ -44,7 +44,7 @@ export default async function renderPipeline(
         const email = row.owner && row.owner.email
 
         if (email) {
-          return email.endsWith('@herokumanager.com') ? `${email.split('@')[0]} (team)` : email
+          return email.endsWith('@herokumanager.com') ? `${color.team(email.split('@')[0])} (team)` : color.user(email)
         }
       },
       header: 'owner',
@@ -74,7 +74,7 @@ export default async function renderPipeline(
 
   hux.table(apps, columns)
 
-  if (showOwnerWarning && pipeline.owner) {
+  if (showOwnerWarning && pipeline.owner && owner) {
     warnMixedOwnership(pipelineApps, pipeline, owner)
   }
 }

--- a/packages/cli/test/unit/commands/access/update.unit.test.ts
+++ b/packages/cli/test/unit/commands/access/update.unit.test.ts
@@ -1,11 +1,12 @@
-import {stdout, stderr} from 'stdout-stderr'
+import ansis from 'ansis'
+import {expect} from 'chai'
+import nock from 'nock'
+import {stderr, stdout} from 'stdout-stderr'
+
 import Cmd from '../../../../src/commands/access/update.js'
 import runCommand from '../../../helpers/runCommand.js'
-import nock from 'nock'
-import {expect} from 'chai'
 import {personalApp, teamApp} from '../../../helpers/stubs/get.js'
 import {appCollaboratorWithPermissions} from '../../../helpers/stubs/patch.js'
-import stripAnsi from 'strip-ansi'
 
 describe('heroku access:update', function () {
   context('with a team app with permissions', function () {
@@ -24,7 +25,7 @@ describe('heroku access:update', function () {
         'gandalf@heroku.com',
       ])
       expect('').to.eq(stdout.output)
-      expect(stderr.output).to.equal('Updating gandalf@heroku.com in application myapp with deploy,view permissions... done\n')
+      expect(stderr.output).to.equal('Updating gandalf@heroku.com in application ⬢ myapp with deploy,view permissions... done\n')
     })
 
     it('updates the app permissions, even specifying view as a permission', async function () {
@@ -38,7 +39,7 @@ describe('heroku access:update', function () {
         'gandalf@heroku.com',
       ])
       expect('').to.eq(stdout.output)
-      expect(stderr.output).to.equal('Updating gandalf@heroku.com in application myapp with deploy,view permissions... done\n')
+      expect(stderr.output).to.equal('Updating gandalf@heroku.com in application ⬢ myapp with deploy,view permissions... done\n')
     })
   })
 
@@ -56,7 +57,7 @@ describe('heroku access:update', function () {
         'gandalf@heroku.com',
       ]).catch(error => {
         const {message} = error as {message: string}
-        expect(stripAnsi(message)).to.contain('Error: cannot update permissions. The app myapp is not owned by a team')
+        expect(ansis.strip(message)).to.contain('Error: cannot update permissions. The app ⬢ myapp is not owned by a team')
       })
     })
   })


### PR DESCRIPTION
## Summary
This PR migrates user email coloring from generic `color.cyan()` to the semantic `color.user()` function from `@heroku/heroku-cli-util`. This is part 8 of 17 of the color system migration plan.

**Changes:**
- Updated imports from `@heroku-cli/color` to `@heroku/heroku-cli-util` in 5 files
- Replaced `color.cyan()` with `color.user()` for user emails throughout the codebase
- Also updated `color.magenta()` to `color.team()` for team names (forward compatibility from PR 7)

The `color.user()` function displays user emails in cyan, providing semantic meaning to the coloring.

## Type of Change

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

## Testing
**Notes**: 
This change updates visual output coloring for user emails. The semantic `color.user()` function displays emails in cyan, providing consistent and meaningful coloring across the CLI.

**Steps**:
1. Passing CI suffices for build validation
2. Manual testing can be done by running commands like `heroku access`, `heroku members`, `heroku apps`, or `heroku keys` to verify user emails display with the new semantic coloring

## Related Issues
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002T2hvTYAR/view
Part of the color system migration plan (8 of 17).