### PR TITLE
fix: CPU ISA detection logic in standalone install script

### DIFF
--- a/install-standalone.sh
+++ b/install-standalone.sh
@@ -29,10 +29,10 @@
   ARCH="\$(uname -m)"
   if [ "\$ARCH" == "x86_64" ]; then
     ARCH=x64
+  elif [[ "\$ARCH" == "aarch64" || "\$ARCH" == "arm64" ]]; then
+    ARCH=arm64
   elif [[ "\$ARCH" == aarch* ]]; then
     ARCH=arm
-  elif [[ "\$ARCH" == "arm64" ]]; then
-    ARCH=arm64
   else
     echoerr "unsupported arch: \$ARCH"
     exit 1


### PR DESCRIPTION
Based on #3393 from @zachmullen. Opened in a separate PR so that our CI will run.

Description copied from his PR:

> On Linux, uname -m will report aarch64 on 64-bit ARM CPUs. The previous logic in this script matched that against the expression aarch*, causing the script to wrongly select the 32-bit ARM architecture identifier, which gives a runtime error when launching the CLI due to the lack of 32-bit dynamic linker on the system (specifically, the error indicates that ld-linux-armhf.so.3 is missing).

## Test
I was able to validate this fix using an Ubuntu environment in a Docker container. I've included a screenshot below, but if you'd like to test for yourself you can do the following:
1. Start Docker if it isn't already running
2. Checkout this branch
3. Run `docker run -dit ubuntu:latest` to pull down the `ubuntu:latest` docker image and start a container running in the background
4. Run `docker ps` to verify that your container is running and to get its name
5. Run `docker cp ~/location/of/cli/repo/install-standalone.sh docker_container_name` to copy the updated `install-standalone.sh` file into your docker container
6. Run `docker exec -it docker_container_name sh` to open a bash terminal inside your container. The rest of these instructions will be run inside the bash terminal.
7. Run `uname -m` to verify that the architecture is reported as `aarch64`
8. Run `apt update && apt install curl` to install curl inside your container
9. Run `apt install nodejs npm` to install nodejs and npm inside your container. You will be prompted to set your country and timezone.
10. Run `curl https://cli-assets.heroku.com/install.sh | sh` to install the Heroku CLI using the existing distributed standalone install script. You should see an error that says "Could not open '/lib/ld-linux-armhf.so.3': No such file or directory"
11. Run `./install-standalone.sh` to install the Heroku CLI using the updated `install-standalone.sh` script from this PR. The CLI should install and you should not see an error message.
12. Run `exit` to close out of the bash terminal
13. Run `docker stop docker_container_name` to stop your container.

## Screenshots
<img width="699" height="331" alt="image" src="https://github.com/user-attachments/assets/ed8eaee9-9bb1-476b-8839-bea4facf1c74" />


<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`).

Examples:

`feat: add growl notification to spaces:wait`

`fix: handle special characters in app names`

`chore: refactor tests`

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->
