### PR TITLE
feat: Copy NGPG 'data:pg:info' command (W-21189547)

### DIFF
--- a/src/commands/data/pg/info.ts
+++ b/src/commands/data/pg/info.ts
@@ -1,0 +1,205 @@
+import {color, hux, utils} from '@heroku/heroku-cli-util'
+import {flags as Flags} from '@heroku-cli/command'
+import * as Heroku from '@heroku-cli/schema'
+import {Args, ux} from '@oclif/core'
+import tsheredoc from 'tsheredoc'
+
+import BaseCommand from '../../../lib/data/baseCommand.js'
+import {formatQuotaStatus} from '../../../lib/data/displayQuota.js'
+import {InfoResponse, PoolInfoResponse, Quota} from '../../../lib/data/types.js'
+
+const heredoc = tsheredoc.default
+
+const poolStatusRenderMap: Record<PoolInfoResponse['status'], string> = {
+  available: color.success('✓ Available'),
+  modifying: color.warning('⚡ Modifying'),
+  provisioning: color.warning('⚡ Provisioning'),
+  unknown: color.failure('? Unknown'),
+}
+
+function renderPoolSummary(pool: PoolInfoResponse, attachments: Required<Heroku.AddOnAttachment>[]) {
+  const poolAttachmentNames = attachments
+    .filter(a => {
+      if (pool.name === 'leader') {
+        return !a.namespace && a.addon.app.id === a.app.id
+      }
+
+      return a.namespace === `pool:${pool.name}` && a.addon.app.id === a.app.id
+    })
+    .map(a => color.attachment(a.name))
+    .join(', ')
+
+  const poolStatus = poolStatusRenderMap[pool.status]
+  const connections = `Connections: ${pool.connections_used ?? color.dim('?')} / ${pool.expected_connection_limit} used`
+  const {expected_count: expectedCount, expected_level: expectedLevel} = pool
+  const poolSize = color.bold(`${expectedCount} instance${expectedCount === 1 ? '' : 's'} of ${expectedLevel}${expectedCount > 1 ? ' (HA)' : ''}:`)
+
+  const instances: string[] = []
+  const {compute_instances: computeInstances, name: poolName} = pool
+  computeInstances.forEach(({id, role, status}) => {
+    let instanceName: string
+
+    if (role === 'standby') {
+      instanceName = color.dim(`${role}.${id}`)
+    } else {
+      instanceName = `${role}.${id}`
+    }
+
+    const instanceStatus = status === 'up' ? color.success(status) : color.warning(status)
+    instances.push(`  ${instanceName}: ${instanceStatus}`)
+  })
+
+  if (poolName === 'leader') {
+    hux.styledHeader(`Leader pool${poolAttachmentNames ? color.dim(` (attached as ${poolAttachmentNames})`) : ''}`)
+  } else {
+    hux.styledHeader(`Follower pool ${color.name(poolName)}${poolAttachmentNames ? color.dim(` (attached as ${poolAttachmentNames})`) : ''}`)
+  }
+
+  ux.stdout(
+    `  ${poolStatus}\n`
+    + `  ${connections}\n`
+    + `  ${poolSize}\n`
+    + `  ${instances.join('\n  ')}\n`,
+  )
+}
+
+export default class DataPgInfo extends BaseCommand {
+  static args = {
+    database: Args.string({
+      description: 'database name, database attachment name, or related config var on an app',
+      required: true,
+    }),
+  }
+
+  static description = 'get details on a Postgres Advanced database'
+
+  static examples = ['<%= config.bin %> <%= command.id %> database_name']
+
+  static flags = {
+    app: Flags.app({required: true}),
+    remote: Flags.remote(),
+  }
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(DataPgInfo)
+    const {database} = args
+    const {app} = flags
+
+    const addonResolver = new utils.AddonResolver(this.heroku)
+    const addon = await addonResolver.resolve(database, app, utils.pg.addonService())
+
+    if (!utils.pg.isAdvancedDatabase(addon)) {
+      ux.error(heredoc`
+        You can only use this command on Advanced-tier databases.
+        Run ${color.code(`heroku pg:info ${addon.name} -a ${app}`)} instead.`,
+      )
+    }
+
+    const [{body: info}, {body: attachments}] = await Promise.all([
+      this.dataApi.get<InfoResponse>(`/data/postgres/v1/${addon.id}/info`),
+      this.heroku.get<Required<Heroku.AddOnAttachment>[]>(`/addons/${addon.id}/addon-attachments`),
+    ])
+    const {
+      created_at: createdAt,
+      features,
+      forked_from: forkedFrom,
+      pools,
+      quotas,
+      region,
+      status,
+      tier,
+      version,
+    } = info
+
+    hux.styledHeader(`${color.datastore(info.addon.name)} on ${color.app(info.app.name!)}`)
+
+    const statusInfo = status === 'available'
+      ? color.success(hux.toTitleCase(status)!)
+      : color.warning(hux.toTitleCase(status)!)
+
+    const rollbackInfo = features.rollback.enabled
+      ? (features.rollback.earliest_time
+        ? `earliest from ${this.renderDateInfo(features.rollback.earliest_time!)}`
+        : 'Unavailable')
+      : 'Unsupported'
+
+    /* eslint-disable perfectionist/sort-objects */
+    const infoObject: Record<string, string> = {
+      Plan: hux.toTitleCase(tier)!,
+      Status: statusInfo,
+      'Data Size': this.renderDataSizeInfo(info),
+      Tables: this.renderTableInfo(info),
+      'PG Version': version,
+      Rollback: rollbackInfo,
+      Region: region,
+    }
+    /* eslint-enable perfectionist/sort-objects */
+
+    if (forkedFrom) {
+      infoObject['Forked From'] = color.datastore(forkedFrom.name)
+    }
+
+    Object.assign(infoObject, {
+      ...infoObject,
+      Created: this.renderDateInfo(createdAt),
+      Quotas: ' ',
+    })
+
+    const quotasInfo = this.renderQuotasInfo(quotas)
+    hux.styledObject({...infoObject, ...quotasInfo}, [...Object.keys(infoObject), ...Object.keys(quotasInfo)])
+    ux.stdout('')
+
+    if (pools.length > 0) {
+      const leaderPool = pools.find(pool => pool.name === 'leader')
+      const otherPools = pools.filter(pool => pool.name !== 'leader').sort((a, b) => a.name.localeCompare(b.name))
+
+      if (leaderPool) {
+        renderPoolSummary(leaderPool, attachments)
+      }
+
+      if (otherPools.length > 0) {
+        otherPools.forEach(pool => {
+          renderPoolSummary(pool, attachments)
+        })
+      }
+    }
+  }
+
+  private renderDataSizeInfo(info: InfoResponse) {
+    const storageLimit = info.plan_limits.find(limit => limit.name === 'storage-limit-in-gb')
+
+    if (!storageLimit || !storageLimit.current) {
+      return 'N/A'
+    }
+
+    return `${hux.toHumanReadableDataSize(storageLimit.current)} / ${hux.toHumanReadableDataSize(storageLimit.limit)}`
+  }
+
+  private renderDateInfo(dateStr: string): string {
+    const date = new Date(dateStr)
+    const year = date.getUTCFullYear()
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0')
+    const day = String(date.getUTCDate()).padStart(2, '0')
+    const hours = String(date.getUTCHours()).padStart(2, '0')
+    const minutes = String(date.getUTCMinutes()).padStart(2, '0')
+
+    return `${year}-${month}-${day} ${hours}:${minutes} UTC`
+  }
+
+  private renderQuotasInfo(quotas: Quota[]): Record<string, string> {
+    const quotaInfo: Record<string, string> = {}
+    quotas.forEach(quota => {
+      const usageMessage = formatQuotaStatus(quota)
+      quotaInfo[`  ${hux.toTitleCase(quota.type)}`] = `${usageMessage}`
+    })
+    return quotaInfo
+  }
+
+  private renderTableInfo(info: InfoResponse) {
+    const tableLimit = info.plan_limits.find(limit => limit.name === 'table-limit')
+    const tableLimitCompliance = tableLimit && tableLimit.current <= tableLimit.limit
+      ? 'In compliance'
+      : 'Not in compliance'
+    return tableLimit ? `${tableLimit.current} / ${tableLimit.limit} (${tableLimitCompliance})` : color.dim('N/A')
+  }
+}

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -49,7 +49,7 @@ export type InfoResponse = {
   pools: Array<PoolInfoResponse>
   quotas: Array<Quota>
   region: CommonRuntimeRegion | PrivateSpaceRegion
-  status: 'available' | 'modifying' | 'provisioning' | 'unavailable'
+  status: 'available' | 'migrating' | 'modifying' | 'provisioning' | 'unavailable'
   tier: 'advanced'
   version: string
 }
@@ -146,12 +146,23 @@ export type ConnectionEndpoint = {
 
 export type PoolInfoResponse = {
   compute_instances: Array<ComputeInstance>
+  connections_used: null | number
   endpoints: Array<ConnectionEndpoint>
+  expected_connection_limit: number
   expected_count: number
   expected_level: string
   id: string
+  metrics_sources: {
+    cluster: null | string
+    database: null | string
+    leader: null | string
+  }
   name: string
-  status: 'available' | 'modifying'
+  status: 'available' | 'modifying' | 'provisioning' | 'unknown'
+  wait_status: {
+    message: null | string
+    waiting: boolean
+  }
 }
 
 export type CredentialsInfo = { items: Array<AdvancedCredentialInfo> }

--- a/test/fixtures/data/pg/fixtures.ts
+++ b/test/fixtures/data/pg/fixtures.ts
@@ -316,7 +316,7 @@ export const pgInfo: InfoResponse = {
           level: '4G-Performance',
           name: 'i3r507gt6dbscn',
           role: 'leader',
-          status: 'available',
+          status: 'up',
           updated_at: '2025-01-01T12:00:00+00:00',
         },
         {
@@ -324,10 +324,11 @@ export const pgInfo: InfoResponse = {
           level: '4G-Performance',
           name: 'i7fquhvs4efu74',
           role: 'standby',
-          status: 'available',
+          status: 'up',
           updated_at: '2025-01-01T06:00:00+00:00',
         },
       ],
+      connections_used: 10,
       endpoints: [
         {
           host: 'cc3hipc68aca1l.cluster-caqt9jk3hth8.us-east-1.rds.amazonaws.com',
@@ -335,11 +336,21 @@ export const pgInfo: InfoResponse = {
           status: 'available',
         },
       ],
+      expected_connection_limit: 400,
       expected_count: 2,
       expected_level: '4G-Performance',
       id: '199cc055-ad6b-48dd-8344-ef1a7688659e',
+      metrics_sources: {
+        cluster: null,
+        database: null,
+        leader: null,
+      },
       name: 'leader',
       status: 'available',
+      wait_status: {
+        message: null,
+        waiting: false,
+      },
     },
     {
       compute_instances: [
@@ -348,7 +359,7 @@ export const pgInfo: InfoResponse = {
           level: '4G-Performance',
           name: 'ic7mb4lq0rkurk',
           role: 'follower',
-          status: 'available',
+          status: 'up',
           updated_at: '2025-01-01T12:00:00+00:00',
         },
         {
@@ -356,10 +367,11 @@ export const pgInfo: InfoResponse = {
           level: '4G-Performance',
           name: 'i7q78mp2fg4v15',
           role: 'follower',
-          status: 'available',
+          status: 'up',
           updated_at: '2025-01-01T06:00:00+00:00',
         },
       ],
+      connections_used: 50,
       endpoints: [
         {
           host: 'cc3hipc68aca1l.cluster-caqt9jk3hth8.us-east-1.rds.amazonaws.com',
@@ -367,11 +379,21 @@ export const pgInfo: InfoResponse = {
           status: 'available',
         },
       ],
+      expected_connection_limit: 800,
       expected_count: 2,
       expected_level: '4G-Performance',
       id: 'b2492c07-c2d4-4956-b739-c15e9a6d6485',
+      metrics_sources: {
+        cluster: null,
+        database: null,
+        leader: null,
+      },
       name: 'analytics',
       status: 'available',
+      wait_status: {
+        message: null,
+        waiting: false,
+      },
     },
   ],
   quotas: [
@@ -423,10 +445,11 @@ export const pgInfoWithDisabledFeatures: InfoResponse = {
           level: '4G-Performance',
           name: 'i3r507gt6dbscn',
           role: 'leader',
-          status: 'available',
+          status: 'up',
           updated_at: '2025-01-01T12:00:00+00:00',
         },
       ],
+      connections_used: 10,
       endpoints: [
         {
           host: 'cc3hipc68aca1l.cluster-caqt9jk3hth8.us-east-1.rds.amazonaws.com',
@@ -434,13 +457,31 @@ export const pgInfoWithDisabledFeatures: InfoResponse = {
           status: 'available',
         },
       ],
+      expected_connection_limit: 400,
       expected_count: 1,
       expected_level: '4G-Performance',
       id: '199cc055-ad6b-48dd-8344-ef1a7688659e',
+      metrics_sources: {
+        cluster: null,
+        database: null,
+        leader: null,
+      },
       name: 'leader',
       status: 'available',
+      wait_status: {
+        message: null,
+        waiting: false,
+      },
     },
   ],
+}
+
+export const pgInfoWithForkedDatabase: InfoResponse = {
+  ...pgInfo,
+  forked_from: {
+    id: '6ddd0626-e8b0-463c-a405-4df431c89fa7',
+    name: 'advanced-oblique-01234',
+  },
 }
 
 export const pgInfoWithUncompliantPlanLimits: InfoResponse = {
@@ -686,12 +727,23 @@ export const releasesResponse = [
 
 export const createPoolResponse: PoolInfoResponse = {
   compute_instances: [],
+  connections_used: 0,
   endpoints: [],
+  expected_connection_limit: 800,
   expected_count: 2,
   expected_level: '4G-Performance',
   id: '12345678-90ab-cdef-0123-456789abcdef',
+  metrics_sources: {
+    cluster: null,
+    database: null,
+    leader: null,
+  },
   name: 'readers',
   status: 'modifying',
+  wait_status: {
+    message: 'Waiting for instances to become available',
+    waiting: true,
+  },
 }
 
 export const advancedCredentialsResponse: CredentialsInfo = {

--- a/test/unit/commands/data/pg/info.unit.test.ts
+++ b/test/unit/commands/data/pg/info.unit.test.ts
@@ -1,0 +1,518 @@
+import ansis from 'ansis'
+import {expect} from 'chai'
+import nock from 'nock'
+import sinon from 'sinon'
+import {stderr, stdout} from 'stdout-stderr'
+import tsheredoc from 'tsheredoc'
+
+import DataPgInfo from '../../../../../src/commands/data/pg/info.js'
+import {
+  addon,
+  multipleAttachmentsResponse,
+  nonAdvancedAddon,
+  pgInfo,
+  pgInfoWithDisabledFeatures,
+  pgInfoWithForkedDatabase,
+  pgInfoWithUncompliantPlanLimits,
+} from '../../../../fixtures/data/pg/fixtures.js'
+import runCommand from '../../../../helpers/runCommand.js'
+
+const heredoc = tsheredoc.default
+
+describe('data:pg:info', function () {
+  let dataApi: nock.Scope
+  let herokuApi: nock.Scope
+
+  beforeEach(function () {
+    dataApi = nock('https://api.data.heroku.com')
+    herokuApi = nock('https://api.heroku.com')
+  })
+
+  afterEach(function () {
+    sinon.restore()
+    dataApi.done()
+    herokuApi.done()
+  })
+
+  it('returns info with pool information', async function () {
+    dataApi
+      .get(`/data/postgres/v1/${addon.id}/info`)
+      .reply(200, pgInfo)
+    herokuApi
+      .post('/actions/addons/resolve')
+      .reply(200, [addon])
+      .get(`/addons/${addon.id}/addon-attachments`)
+      .reply(200, multipleAttachmentsResponse)
+
+    await runCommand(DataPgInfo, [
+      'advanced-horizontal-01234',
+      '--app=myapp',
+    ])
+
+    expect(stderr.output).to.equal('')
+    expect(ansis.strip(stdout.output)).to.equal(
+      // cspell:disable
+      heredoc(`
+        === ⛁ advanced-horizontal-01234 on ⬢ myapp
+
+        Plan:       Advanced
+        Status:     Available
+        Data Size:  1.10 GB / 128.00 TB
+        Tables:     10 / 4000 (In compliance)
+        PG Version: 17.5
+        Rollback:   earliest from 2025-01-02 00:00 UTC
+        Region:     us
+        Created:    2025-01-01 00:00 UTC
+        Quotas:      
+          Storage:  1.10 GB (No quotas set)
+
+        === Leader pool (attached as DATABASE)
+
+          ✓ Available
+          Connections: 10 / 400 used
+          2 instances of 4G-Performance (HA):
+            leader.i3r507gt6dbscn: up
+            standby.i7fquhvs4efu74: up
+
+        === Follower pool analytics (attached as DATABASE_ANALYTICS)
+
+          ✓ Available
+          Connections: 50 / 800 used
+          2 instances of 4G-Performance (HA):
+            follower.ic7mb4lq0rkurk: up
+            follower.i7q78mp2fg4v15: up
+
+      `),
+      // cspell:enable
+    )
+  })
+
+  it('returns info with forked database information', async function () {
+    dataApi
+      .get(`/data/postgres/v1/${addon.id}/info`)
+      .reply(200, pgInfoWithForkedDatabase)
+    herokuApi
+      .post('/actions/addons/resolve')
+      .reply(200, [addon])
+      .get(`/addons/${addon.id}/addon-attachments`)
+      .reply(200, multipleAttachmentsResponse)
+
+    await runCommand(DataPgInfo, [
+      'advanced-horizontal-01234',
+      '--app=myapp',
+    ])
+
+    expect(stderr.output).to.equal('')
+    expect(ansis.strip(stdout.output)).to.equal(
+      // cspell:disable
+      heredoc(`
+        === ⛁ advanced-horizontal-01234 on ⬢ myapp
+
+        Plan:        Advanced
+        Status:      Available
+        Data Size:   1.10 GB / 128.00 TB
+        Tables:      10 / 4000 (In compliance)
+        PG Version:  17.5
+        Rollback:    earliest from 2025-01-02 00:00 UTC
+        Region:      us
+        Forked From: ⛁ advanced-oblique-01234
+        Created:     2025-01-01 00:00 UTC
+        Quotas:       
+          Storage:   1.10 GB (No quotas set)
+
+        === Leader pool (attached as DATABASE)
+
+          ✓ Available
+          Connections: 10 / 400 used
+          2 instances of 4G-Performance (HA):
+            leader.i3r507gt6dbscn: up
+            standby.i7fquhvs4efu74: up
+
+        === Follower pool analytics (attached as DATABASE_ANALYTICS)
+
+          ✓ Available
+          Connections: 50 / 800 used
+          2 instances of 4G-Performance (HA):
+            follower.ic7mb4lq0rkurk: up
+            follower.i7q78mp2fg4v15: up
+
+      `),
+      // cspell:enable
+    )
+  })
+
+  it('returns info correctly when features are disabled', async function () {
+    dataApi
+      .get(`/data/postgres/v1/${addon.id}/info`)
+      .reply(200, pgInfoWithDisabledFeatures)
+    herokuApi
+      .post('/actions/addons/resolve')
+      .reply(200, [addon])
+      .get(`/addons/${addon.id}/addon-attachments`)
+      .reply(200, multipleAttachmentsResponse)
+
+    await runCommand(DataPgInfo, [
+      'advanced-horizontal-01234',
+      '--app=myapp',
+    ])
+
+    expect(stderr.output).to.equal('')
+    expect(ansis.strip(stdout.output)).to.equal(
+      // cspell:disable
+      heredoc(`
+        === ⛁ advanced-horizontal-01234 on ⬢ myapp
+
+        Plan:       Advanced
+        Status:     Available
+        Data Size:  1.10 GB / 128.00 TB
+        Tables:     10 / 4000 (In compliance)
+        PG Version: 17.5
+        Rollback:   Unsupported
+        Region:     us
+        Created:    2025-01-01 00:00 UTC
+        Quotas:      
+          Storage:  1.10 GB (No quotas set)
+
+        === Leader pool (attached as DATABASE)
+
+          ✓ Available
+          Connections: 10 / 400 used
+          1 instance of 4G-Performance:
+            leader.i3r507gt6dbscn: up
+
+      `),
+      // cspell:enable
+    )
+  })
+
+  it('returns info correctly when rollback is enabled but no earliest_time is available', async function () {
+    const info = {
+      ...pgInfo,
+      features: {
+        ...pgInfo.features,
+        rollback: {
+          earliest_time: null,
+          enabled: true,
+          latest_time: null,
+        },
+      },
+    }
+
+    dataApi
+      .get(`/data/postgres/v1/${addon.id}/info`)
+      .reply(200, info)
+    herokuApi
+      .post('/actions/addons/resolve')
+      .reply(200, [addon])
+      .get(`/addons/${addon.id}/addon-attachments`)
+      .reply(200, multipleAttachmentsResponse)
+
+    await runCommand(DataPgInfo, [
+      'advanced-horizontal-01234',
+      '--app=myapp',
+    ])
+
+    expect(stderr.output).to.equal('')
+    expect(ansis.strip(stdout.output.replaceAll(/\s+/g, ' '))).to.include('Rollback: Unavailable')
+  })
+
+  it('returns info correctly when the table limits are not in compliance', async function () {
+    dataApi
+      .get(`/data/postgres/v1/${addon.id}/info`)
+      .reply(200, pgInfoWithUncompliantPlanLimits)
+    herokuApi
+      .post('/actions/addons/resolve')
+      .reply(200, [addon])
+      .get(`/addons/${addon.id}/addon-attachments`)
+      .reply(200, multipleAttachmentsResponse)
+
+    await runCommand(DataPgInfo, [
+      'advanced-horizontal-01234',
+      '--app=myapp',
+    ])
+
+    expect(stderr.output).to.equal('')
+    expect(ansis.strip(stdout.output)).to.equal(
+      // cspell:disable
+      heredoc(`
+        === ⛁ advanced-horizontal-01234 on ⬢ myapp
+
+        Plan:       Advanced
+        Status:     Available
+        Data Size:  128.05 TB / 128.00 TB
+        Tables:     4001 / 4000 (Not in compliance)
+        PG Version: 17.5
+        Rollback:   Unsupported
+        Region:     us
+        Created:    2025-01-01 00:00 UTC
+        Quotas:      
+          Storage:  128.05 TB (No quotas set)
+
+        === Leader pool (attached as DATABASE)
+
+          ✓ Available
+          Connections: 10 / 400 used
+          1 instance of 4G-Performance:
+            leader.i3r507gt6dbscn: up
+
+      `),
+      // cspell:enable
+    )
+  })
+
+  describe('data size', function () {
+    it('renders N/A when plan limits info doesn\'t contain a storage limit', async function () {
+      const info = {
+        ...pgInfo,
+        plan_limits: [],
+      }
+
+      dataApi
+        .get(`/data/postgres/v1/${addon.id}/info`)
+        .reply(200, info)
+      herokuApi
+        .post('/actions/addons/resolve')
+        .reply(200, [addon])
+        .get(`/addons/${addon.id}/addon-attachments`)
+        .reply(200, multipleAttachmentsResponse)
+
+      await runCommand(DataPgInfo, [
+        'advanced-horizontal-01234',
+        '--app=myapp',
+      ])
+
+      expect(stderr.output).to.equal('')
+      expect(ansis.strip(stdout.output.replaceAll(/\s+/g, ' '))).to.include('Data Size: N/A')
+    })
+
+    it('renders N/A when storage limit is null', async function () {
+      const info = {
+        ...pgInfo,
+        plan_limits: [{current: null, limit: 128_000, name: 'storage-limit-in-gb'}],
+      }
+
+      dataApi
+        .get(`/data/postgres/v1/${addon.id}/info`)
+        .reply(200, info)
+      herokuApi
+        .post('/actions/addons/resolve')
+        .reply(200, [addon])
+        .get(`/addons/${addon.id}/addon-attachments`)
+        .reply(200, multipleAttachmentsResponse)
+
+      await runCommand(DataPgInfo, [
+        'advanced-horizontal-01234',
+        '--app=myapp',
+      ])
+
+      expect(stderr.output).to.equal('')
+      expect(ansis.strip(stdout.output.replaceAll(/\s+/g, ' '))).to.include('Data Size: N/A')
+    })
+
+    it('renders the data size when storage limit is present', async function () {
+      const info = {
+        ...pgInfo,
+        plan_limits: [{current: 64_000, limit: 128_000, name: 'storage-limit-in-gb'}],
+      }
+
+      dataApi
+        .get(`/data/postgres/v1/${addon.id}/info`)
+        .reply(200, info)
+      herokuApi
+        .post('/actions/addons/resolve')
+        .reply(200, [addon])
+        .get(`/addons/${addon.id}/addon-attachments`)
+        .reply(200, multipleAttachmentsResponse)
+
+      await runCommand(DataPgInfo, [
+        'advanced-horizontal-01234',
+        '--app=myapp',
+      ])
+
+      expect(stderr.output).to.equal('')
+      expect(ansis.strip(stdout.output)).to.include('64.00 TB / 128.00 TB')
+    })
+  })
+
+  describe('quotas display', function () {
+    it('renders the percent of quota used when the critical quota has been set', async function () {
+      const info = {
+        ...pgInfo,
+        quotas: [{critical_gb: 128_000, current_gb: 64_000, type: 'storage'}],
+      }
+
+      dataApi
+        .get(`/data/postgres/v1/${addon.id}/info`)
+        .reply(200, info)
+      herokuApi
+        .post('/actions/addons/resolve')
+        .reply(200, [addon])
+        .get(`/addons/${addon.id}/addon-attachments`)
+        .reply(200, multipleAttachmentsResponse)
+
+      await runCommand(DataPgInfo, [
+        'advanced-horizontal-01234',
+        '--app=myapp',
+      ])
+
+      expect(stderr.output).to.equal('')
+      expect(ansis.strip(stdout.output.replaceAll(/\s+/g, ' '))).to.include(
+        'Storage: 64.00 TB / 128.00 TB (50.00%) (Within configured quotas)',
+      )
+    })
+
+    it('renders the percent of quota used when there is no current usage', async function () {
+      const info = {
+        ...pgInfo,
+        quotas: [{critical_gb: 128_000, current_gb: null, type: 'storage'}],
+      }
+
+      dataApi
+        .get(`/data/postgres/v1/${addon.id}/info`)
+        .reply(200, info)
+      herokuApi
+        .post('/actions/addons/resolve')
+        .reply(200, [addon])
+        .get(`/addons/${addon.id}/addon-attachments`)
+        .reply(200, multipleAttachmentsResponse)
+
+      await runCommand(DataPgInfo, [
+        'advanced-horizontal-01234',
+        '--app=myapp',
+      ])
+
+      expect(stderr.output).to.equal('')
+      expect(ansis.strip(stdout.output.replaceAll(/\s+/g, ' '))).to.include(
+        'Storage: 0.00 MB / 128.00 TB (Within configured quotas)',
+      )
+    })
+
+    it('does not show the percent of quota used when no critical quota has been set', async function () {
+      const info = {
+        ...pgInfo,
+        quotas: [{current_gb: 64_000, type: 'storage', warning_gb: 80_000}],
+      }
+
+      dataApi
+        .get(`/data/postgres/v1/${addon.id}/info`)
+        .reply(200, info)
+      herokuApi
+        .post('/actions/addons/resolve')
+        .reply(200, [addon])
+        .get(`/addons/${addon.id}/addon-attachments`)
+        .reply(200, multipleAttachmentsResponse)
+
+      await runCommand(DataPgInfo, [
+        'advanced-horizontal-01234',
+        '--app=myapp',
+      ])
+
+      expect(stderr.output).to.equal('')
+      expect(ansis.strip(stdout.output.replaceAll(/\s+/g, ' '))).to.include(
+        'Storage: 64.00 TB (Within configured quotas)',
+      )
+    })
+
+    it('shows a compliance message when the quotas have not been exceeded', async function () {
+      const info = {
+        ...pgInfo,
+        quotas: [{
+          critical_gb: 128_000, current_gb: 64_000, type: 'storage', warning_gb: 80_000,
+        }],
+      }
+
+      dataApi
+        .get(`/data/postgres/v1/${addon.id}/info`)
+        .reply(200, info)
+      herokuApi
+        .post('/actions/addons/resolve')
+        .reply(200, [addon])
+        .get(`/addons/${addon.id}/addon-attachments`)
+        .reply(200, multipleAttachmentsResponse)
+
+      await runCommand(DataPgInfo, [
+        'advanced-horizontal-01234',
+        '--app=myapp',
+      ])
+
+      expect(stderr.output).to.equal('')
+      expect(ansis.strip(stdout.output.replaceAll(/\s+/g, ' '))).to.include(
+        'Storage: 64.00 TB / 128.00 TB (50.00%) (Within configured quotas)',
+      )
+    })
+
+    it('shows a compliance message when the warning quota has been exceeded', async function () {
+      const info = {
+        ...pgInfo,
+        quotas: [{
+          critical_gb: 128_000, current_gb: 64_000, type: 'storage', warning_gb: 60_000,
+        }],
+      }
+
+      dataApi
+        .get(`/data/postgres/v1/${addon.id}/info`)
+        .reply(200, info)
+      herokuApi
+        .post('/actions/addons/resolve')
+        .reply(200, [addon])
+        .get(`/addons/${addon.id}/addon-attachments`)
+        .reply(200, multipleAttachmentsResponse)
+
+      await runCommand(DataPgInfo, [
+        'advanced-horizontal-01234',
+        '--app=myapp',
+      ])
+
+      expect(stderr.output).to.equal('')
+      expect(ansis.strip(stdout.output.replaceAll(/\s+/g, ' '))).to.include(
+        'Storage: 64.00 TB / 128.00 TB (50.00%) (Exceeded configured warning quota)',
+      )
+    })
+
+    it('shows a compliance message when the critical quota been exceeded', async function () {
+      const info = {
+        ...pgInfo,
+        quotas: [{
+          critical_gb: 50_000, current_gb: 64_000, type: 'storage', warning_gb: 40_000,
+        }],
+      }
+
+      dataApi
+        .get(`/data/postgres/v1/${addon.id}/info`)
+        .reply(200, info)
+      herokuApi
+        .post('/actions/addons/resolve')
+        .reply(200, [addon])
+        .get(`/addons/${addon.id}/addon-attachments`)
+        .reply(200, multipleAttachmentsResponse)
+
+      await runCommand(DataPgInfo, [
+        'advanced-horizontal-01234',
+        '--app=myapp',
+      ])
+
+      expect(stderr.output).to.equal('')
+      expect(ansis.strip(stdout.output.replaceAll(/\s+/g, ' '))).to.include(
+        'Storage: 64.00 TB / 50.00 TB (128.00%) (Exceeded configured critical quota)',
+      )
+    })
+  })
+
+  describe('error handling', function () {
+    it('errors when used with non-advanced addons', async function () {
+      herokuApi
+        .post('/actions/addons/resolve')
+        .reply(200, [nonAdvancedAddon])
+
+      try {
+        await runCommand(DataPgInfo, ['advanced-horizontal-01234', '--app=myapp'])
+      } catch (error: unknown) {
+        const err = error as Error
+        expect(ansis.strip(err.message)).to.equal(heredoc`
+            You can only use this command on Advanced-tier databases.
+            Run heroku pg:info ${nonAdvancedAddon.name} -a myapp instead.`,
+        )
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Here we bring a copy of NPGP plugin 'data:pg:info' command to Core CLI v11.

Small refactors where required for conversion to ESM and `@oclif/core` v4, but all functionality was kept intact.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [X] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing

All NGPG commands have been extensively tested on the plugin implementations. But it's recommended that at least you download this branch, run `npm install && npm run build` and proceed to minimally test the involved command:

- `./bin/run data:pg:info <DATABASE-NAME> -a <test-app>`. The command should succeed if it's an Advanced-tier database. An error should appear if targeting a non-Advanced database. Use `./bin/run data:pg:create` to create the required database if you don't have one test database readily at hand for testing.

## Screenshots (if applicable)

<img width="818" height="687" alt="Captura de pantalla 2026-02-12 a la(s) 16 44 36" src="https://github.com/user-attachments/assets/14d1802c-840a-4ea5-8ff1-733982ace8ca" />

## Related Issues
GUS work item: [W-21189547](https://gus.lightning.force.com/a07EE00002UIStsYAH)
