### PR TITLE
fix: Remove Advanced beta (pilot test) plans (W-21340270)

### DIFF
--- a/src/commands/data/pg/create.ts
+++ b/src/commands/data/pg/create.ts
@@ -73,9 +73,7 @@ export default class DataPgCreate extends BaseCommand {
     const {followers, 'high-availability': highAvailability, level} = flags
     const service = utils.pg.addonService()
 
-    const useProd = process.env.HEROKU_PROD_NGPG === 'true'
-    const planSuffix = useProd ? '' : '-beta'
-    const plan = `advanced${network ? `-${network}` : ''}${planSuffix}`
+    const plan = `advanced${network ? `-${network}` : ''}`
     const servicePlan = `${service}:${plan}`
 
     // Parse provision options

--- a/test/fixtures/data/pg/fixtures.ts
+++ b/test/fixtures/data/pg/fixtures.ts
@@ -54,7 +54,7 @@ export const addon: DeepRequired<Heroku.AddOn> = {
     id: 'ab0490b3-b7cd-4bf6-b840-9db509f3d075',
     installable_inside_private_network: false,
     installable_outside_private_network: true,
-    name: 'heroku-postgresql:advanced-beta',
+    name: 'heroku-postgresql:advanced',
     price: {
       cents: 0,
       contract: false,
@@ -135,27 +135,6 @@ export const pricingResponse: PricingInfoResponse = {
       rate: 20,
     },
   },
-  'advanced-beta': {
-    'instance-4G': {
-      billing_period: 'month',
-      billing_unit: 'compute',
-      product_description: '4G-Performance',
-      rate: 6000,
-    },
-    'instance-8G': {
-      billing_period: 'month',
-      billing_unit: 'compute',
-      product_description: '8G-Performance',
-      rate: 20000,
-    },
-    'storage-optimized': {
-      billing_period: 'month',
-      billing_unit: 'gigabyte',
-      included_units: 100,
-      product_description: 'Optimized Storage',
-      rate: 20,
-    },
-  },
   'advanced-private': {
     'instance-4G': {
       billing_period: 'month',
@@ -177,49 +156,7 @@ export const pricingResponse: PricingInfoResponse = {
       rate: 24,
     },
   },
-  'advanced-private-beta': {
-    'instance-4G': {
-      billing_period: 'month',
-      billing_unit: 'compute',
-      product_description: '4G-Performance',
-      rate: 7200,
-    },
-    'instance-8G': {
-      billing_period: 'month',
-      billing_unit: 'compute',
-      product_description: '8G-Performance',
-      rate: 24000,
-    },
-    'storage-optimized': {
-      billing_period: 'month',
-      billing_unit: 'gigabyte',
-      included_units: 100,
-      product_description: 'Optimized Storage',
-      rate: 24,
-    },
-  },
   'advanced-shield': {
-    'instance-4G': {
-      billing_period: 'month',
-      billing_unit: 'compute',
-      product_description: '4G-Performance',
-      rate: 8400,
-    },
-    'instance-8G': {
-      billing_period: 'month',
-      billing_unit: 'compute',
-      product_description: '8G-Performance',
-      rate: 28000,
-    },
-    'storage-optimized': {
-      billing_period: 'month',
-      billing_unit: 'gigabyte',
-      included_units: 100,
-      product_description: 'Optimized Storage',
-      rate: 28,
-    },
-  },
-  'advanced-shield-beta': {
     'instance-4G': {
       billing_period: 'month',
       billing_unit: 'compute',

--- a/test/unit/commands/data/pg/create.unit.test.ts
+++ b/test/unit/commands/data/pg/create.unit.test.ts
@@ -73,7 +73,7 @@ describe('data:pg:create', function () {
         .post('/apps/myapp/addons', {
           attachment: {},
           config: {level: '4G-Performance'},
-          plan: {name: 'heroku-postgresql:advanced-beta'},
+          plan: {name: 'heroku-postgresql:advanced'},
         })
         .reply(200, createAddonResponse)
       const dataApi = nock('https://api.data.heroku.com')
@@ -107,7 +107,7 @@ describe('data:pg:create', function () {
         .post('/apps/myapp/addons', {
           attachment: {},
           config: {level: '4G-Performance'},
-          plan: {name: 'heroku-postgresql:advanced-private-beta'},
+          plan: {name: 'heroku-postgresql:advanced-private'},
         })
         .reply(200, createAddonResponse)
 
@@ -135,7 +135,7 @@ describe('data:pg:create', function () {
         .post('/apps/myapp/addons', {
           attachment: {},
           config: {level: '4G-Performance'},
-          plan: {name: 'heroku-postgresql:advanced-shield-beta'},
+          plan: {name: 'heroku-postgresql:advanced-shield'},
         })
         .reply(200, createAddonResponse)
 
@@ -156,99 +156,6 @@ describe('data:pg:create', function () {
       expect(ansis.strip(stderr.output)).to.equal(heredoc`
         Creating a 4G-Performance database on ⬢ myapp... done
       `)
-    })
-
-    describe('with HEROKU_PROD_NGPG env var set', function () {
-      let originalEnv: NodeJS.ProcessEnv
-
-      beforeEach(function () {
-        originalEnv = {...process.env}
-        process.env.HEROKU_PROD_NGPG = 'true'
-      })
-
-      afterEach(function () {
-        process.env = originalEnv
-      })
-
-      it('creates database with non-beta plan', async function () {
-        const herokuApi = nock('https://api.heroku.com')
-          .post('/apps/myapp/addons', {
-            attachment: {},
-            config: {level: '4G-Performance'},
-            plan: {name: 'heroku-postgresql:advanced'},
-          })
-          .reply(200, createAddonResponse)
-
-        await runCommand(DataPgCreate, ['--app=myapp', '--level=4G-Performance'])
-
-        herokuApi.done()
-      })
-
-      it('creates database in private network with non-beta plan', async function () {
-        const herokuApi = nock('https://api.heroku.com')
-          .post('/apps/myapp/addons', {
-            attachment: {},
-            config: {level: '4G-Performance'},
-            plan: {name: 'heroku-postgresql:advanced-private'},
-          })
-          .reply(200, createAddonResponse)
-
-        await runCommand(DataPgCreate, [
-          '--app=myapp',
-          '--network=private',
-          '--level=4G-Performance',
-        ])
-
-        herokuApi.done()
-      })
-
-      it('creates database in shield network with non-beta plan', async function () {
-        const herokuApi = nock('https://api.heroku.com')
-          .post('/apps/myapp/addons', {
-            attachment: {},
-            config: {level: '4G-Performance'},
-            plan: {name: 'heroku-postgresql:advanced-shield'},
-          })
-          .reply(200, createAddonResponse)
-
-        await runCommand(DataPgCreate, [
-          '--app=myapp',
-          '--network=shield',
-          '--level=4G-Performance',
-        ])
-
-        herokuApi.done()
-      })
-
-      it('uses non-beta pricing in interactive mode', async function () {
-        const herokuApi = nock('https://api.heroku.com')
-          .post('/apps/myapp/addons', {
-            attachment: {},
-            config: {
-              'high-availability': true,
-              level: levelsResponse.items[0].name,
-            },
-            plan: {name: 'heroku-postgresql:advanced'},
-          })
-          .reply(200, createAddonResponse)
-
-        const dataApi = nock('https://api.data.heroku.com')
-          .get('/data/postgres/v1/levels/advanced')
-          .reply(200, levelsResponse)
-          .get('/data/postgres/v1/pricing')
-          .reply(200, pricingResponse)
-
-        poolConfigStubs.levelStep.resolves(levelsResponse.items[0].name) // Level selection
-        promptStub
-          .onCall(0).resolves({action: 'keep'}) // High availability selection
-          .onCall(1).resolves({action: 'confirm'}) // Confirmation
-          .onCall(2).resolves({action: 'exit'}) // Exit at follower pool configuration
-
-        await runCommand(DataPgCreate, ['--app=myapp'])
-
-        herokuApi.done()
-        dataApi.done()
-      })
     })
 
     it('creates database with provision options', async function () {
@@ -286,7 +193,7 @@ describe('data:pg:create', function () {
             level: '4G-Performance',
           },
           confirm: 'myapp',
-          plan: {name: 'heroku-postgresql:advanced-beta'},
+          plan: {name: 'heroku-postgresql:advanced'},
         })
         .reply(200, createAddonResponse)
 
@@ -313,7 +220,7 @@ describe('data:pg:create', function () {
             'high-availability': true,
             level: levelsResponse.items[0].name,
           },
-          plan: {name: 'heroku-postgresql:advanced-beta'},
+          plan: {name: 'heroku-postgresql:advanced'},
         })
         .reply(200, createAddonResponse)
 
@@ -387,7 +294,7 @@ describe('data:pg:create', function () {
             'high-availability': false,
             level: levelsResponse.items[0].name,
           },
-          plan: {name: 'heroku-postgresql:advanced-beta'},
+          plan: {name: 'heroku-postgresql:advanced'},
         })
         .reply(200, createAddonResponse)
 
@@ -428,7 +335,7 @@ describe('data:pg:create', function () {
             'high-availability': true,
             level: levelsResponse.items[1].name,
           },
-          plan: {name: 'heroku-postgresql:advanced-beta'},
+          plan: {name: 'heroku-postgresql:advanced'},
         })
         .reply(200, createAddonResponse)
 
@@ -472,7 +379,7 @@ describe('data:pg:create', function () {
             'high-availability': false,
             level: levelsResponse.items[0].name,
           },
-          plan: {name: 'heroku-postgresql:advanced-beta'},
+          plan: {name: 'heroku-postgresql:advanced'},
         })
         .reply(200, createAddonResponse)
 
@@ -515,7 +422,7 @@ describe('data:pg:create', function () {
             'high-availability': true,
             level: levelsResponse.items[0].name,
           },
-          plan: {name: 'heroku-postgresql:advanced-beta'},
+          plan: {name: 'heroku-postgresql:advanced'},
         })
         .reply(200, createAddonResponse)
 
@@ -571,7 +478,7 @@ describe('data:pg:create', function () {
             'high-availability': true,
             level: levelsResponse.items[0].name,
           },
-          plan: {name: 'heroku-postgresql:advanced-beta'},
+          plan: {name: 'heroku-postgresql:advanced'},
         })
         .reply(200, createAddonResponse)
 
@@ -649,7 +556,7 @@ describe('data:pg:create', function () {
             'high-availability': true,
             level: levelsResponse.items[0].name,
           },
-          plan: {name: 'heroku-postgresql:advanced-beta'},
+          plan: {name: 'heroku-postgresql:advanced'},
         })
         .reply(200, createAddonResponse)
 

--- a/test/unit/commands/data/pg/fork.unit.test.ts
+++ b/test/unit/commands/data/pg/fork.unit.test.ts
@@ -45,7 +45,7 @@ describe('data:pg:fork', function () {
             fork: 'advanced-horizontal-01234',
             level: '4G-Performance',
           },
-          plan: {name: 'heroku-postgresql:advanced-beta'},
+          plan: {name: 'heroku-postgresql:advanced'},
         })
         .reply(200, createForkResponse)
 
@@ -83,7 +83,7 @@ describe('data:pg:fork', function () {
             level: '4G-Performance',
           },
           name: 'my-forked-db',
-          plan: {name: 'heroku-postgresql:advanced-beta'},
+          plan: {name: 'heroku-postgresql:advanced'},
         })
         .reply(200, createForkResponse)
 
@@ -122,7 +122,7 @@ describe('data:pg:fork', function () {
             fork: 'advanced-horizontal-01234',
             level: '8G-Performance',
           },
-          plan: {name: 'heroku-postgresql:advanced-beta'},
+          plan: {name: 'heroku-postgresql:advanced'},
         })
         .reply(200, createForkResponse)
 
@@ -189,7 +189,7 @@ describe('data:pg:fork', function () {
             'recovery-time': '2025-01-11T12:35:00',
             rollback: 'advanced-horizontal-01234',
           },
-          plan: {name: 'heroku-postgresql:advanced-beta'},
+          plan: {name: 'heroku-postgresql:advanced'},
         })
         .reply(200, createForkResponse)
 
@@ -234,7 +234,7 @@ describe('data:pg:fork', function () {
             'recovery-time': '2025-01-30T00:00:00',
             rollback: 'advanced-horizontal-01234',
           },
-          plan: {name: 'heroku-postgresql:advanced-beta'},
+          plan: {name: 'heroku-postgresql:advanced'},
         })
         .reply(200, createForkResponse)
 


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary

Here we change the default plans provisioned for `data:pg:create` from the beta test plans to the production ones, removing the dependency on the `HEROKU_PROD_NGPG` environment variable used in pilot tests to force production plan provisioning.

For the Core CLI v11 release, the `heroku data:pg:create` is expected to provision always the production plans, not the beta test plans.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [X] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing

**Steps**:
1. Checkout this branch: `git checkout sbosio/ngpg-production-plans`.
2. Build it: `npm install && npm run build`.
3. Run `./bin/run data:pg:create -a <test-app-name>` and follow the interactive process to create a 4G-Performance with no HA standby.
4. Run `./bin/run addons -a <test-app-name>` and verify the plan associated with the add-on is `Advanced` (no Beta mention).
5. Destroy the database after testing: `./bin/run data:pg:destroy <add-on-name> -a <test-app-name> --confirm <test-app-name>`.


## Related Issues
GUS work item: [W-21340270](https://gus.lightning.force.com/a07EE00002VFwffYAD)
