### PR TITLE
fix: prevent spinner from interfering with 2FA prompt in heroku run and heroku console

### DIFF
--- a/src/lib/run/dyno.ts
+++ b/src/lib/run/dyno.ts
@@ -103,10 +103,6 @@ export default class Dyno extends Duplex {
   // Starts the dyno
   async start() {
     this._startedAt = Date.now()
-    if (this.opts.showStatus) {
-      ux.action.start(`Running ${color.code(this.opts.command)} on ${color.app(this.opts.app)}`)
-    }
-
     await this._doStart()
   }
 
@@ -178,6 +174,12 @@ export default class Dyno extends Duplex {
       })
       // @ts-ignore
       this.dyno = dyno.body
+
+      // Show status after dyno is created (after any 2FA prompt)
+      if (this.opts.showStatus) {
+        ux.action.start(`Running ${color.code(this.opts.command)} on ${color.app(this.opts.app)}`)
+      }
+
       if (this.opts.attach || this.opts.dyno) {
         // @ts-ignore
         if (this.dyno.name && this.opts.dyno === undefined) {


### PR DESCRIPTION
## Summary
Fixes an issue where the 2FA prompt repeats itself on every keystroke when running `heroku run` commands that require two-factor authentication.

The root cause was that the "Running <command> on <app>" spinner was started before the dyno creation API call. When the API returned a 403 requiring 2FA, inquirer would attempt to prompt for the code while the oclif action spinner was still running. The spinner's cursor manipulation interfered with inquirer's readline interface, causing the prompt text to be reprinted with each keystroke.

This fix moves the status message to display after the dyno is successfully created, ensuring any 2FA prompts appear without active spinner interference.

## Type of Change
### Patch Updates (patch semver update)
- [x] **fix**: Bug fix

## Testing
**Notes**:
This issue only occurs with the `heroku run` command when 2FA is required.

**Steps**:
1. Enable 2FA on a Heroku account
2. Run `heroku run bash` on an app requiring 2FA
3. Verify the "? Two-factor code" prompt displays cleanly without repeating on each keystroke
4. Verify the "Running bash on <app>" status appears after successful authentication

## Related Issues
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002VUyU7YAL/view