### PR TITLE
fix: updating node version for the dev center doc update workflow

### DIFF
--- a/.github/workflows/devcenter-doc-update.yml
+++ b/.github/workflows/devcenter-doc-update.yml
@@ -23,10 +23,10 @@ jobs:
     if: ${{ fromJSON(inputs.isStableRelease) }}
     steps:
       - uses: actions/checkout@v6
-      - name: Use Node.js 16.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v6
         with:
-          node-version: 16.x
+          node-version: 22.x
           cache: yarn
       - name: Use Ruby 3.2.x
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Summary
<!-- Brief description of the changes in this PR. -->
This updates the dev center update workflow to node 22 from 16 to enable the workflow.
This is more of a test case since v11.0.0 already uses node 22. 
https://github.com/heroku/cli/blob/v11.0.0/.github/workflows/devcenter-doc-update.yml

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Screenshots (if applicable)

## Related Issues
GitHub issue: #[GitHub issue number]
GUS work item: [W-19690160](https://gus.lightning.force.com/a07EE00002M3HdRYAV)
