### PR TITLE
fix: skip check-npm-auth hook during autoupdate

### DIFF
--- a/src/hooks/preupdate/check-npm-auth.ts
+++ b/src/hooks/preupdate/check-npm-auth.ts
@@ -15,9 +15,14 @@ const tsheredoc = tsheredocLib.default
  */
 const checkNpmAuth: Hook<'preupdate'> = async function (opts) {
   try {
-    // Check if npm is available on the system
-    const npmAvailable = await NpmAuth.isNpmAvailable()
-    if (!npmAvailable) {
+    // Skip during autoupdate (stdin not available for prompts) or if npm not available
+    if (process.argv.includes('--autoupdate')) {
+      this.debug('Skipping npm auth check during autoupdate (stdin not available for prompts)')
+      return
+    }
+
+    if (!await NpmAuth.isNpmAvailable()) {
+      this.debug('Skipping npm auth check: npm not available')
       return
     }
 


### PR DESCRIPTION
## Summary

The `check-npm-auth` preupdate hook prompts users for npm authentication when they have private plugins installed but are not logged into npm. During autoupdate, stdin is redirected to a log file, making interactive prompts impossible and potentially causing the hook to hang.

This PR fixes the issue by detecting when the update is running in autoupdate mode and skipping the authentication check.

**Changes:**
- Detect `--autoupdate` flag via `process.argv.includes('--autoupdate')`
- Skip the npm auth check when autoupdate is detected
- Add debug logging for both skip conditions (autoupdate and npm unavailable)
- Debug messages will appear in `~/.local/share/heroku/cache/autoupdate.log` for troubleshooting

**Why this approach?**

The `--autoupdate` flag is not passed through the hook's options parameter (only `channel` and `version` are included per the oclif type definitions). Checking `process.argv` is the standard way to detect command-line flags in this context.

When autoupdate runs, it spawns the update process with `stdio: ['ignore', stream, stream]` which means stdin is ignored and stdout/stderr are redirected to the log file.

**Behavior:**
- Manual update: Hook runs normally, prompts user if needed
- Autoupdate: Hook is skipped silently, logged to autoupdate.log
- No npm: Hook is skipped (both manual and auto), logged in debug mode

## Type of Change
### Patch Updates (patch semver update)
- [x] **fix**: Bug fix

## Testing
**Notes**:
This fix prevents the check-npm-auth hook from attempting interactive prompts during background autoupdate when stdin is unavailable.

**Steps**:
1. Verify the hook runs normally during manual `heroku update` commands
2. Verify the hook is skipped during autoupdate (check autoupdate.log for debug message)
3. Verify users with private plugins are still prompted during manual updates
4. Passing CI suffices for build and linting checks

## Related Issues
GitHub issue: #3512