### PR TITLE
fix: address bug on level selection for 'data:pg:update' (W-21513335)

### DIFF
--- a/src/lib/data/utils.ts
+++ b/src/lib/data/utils.ts
@@ -2,7 +2,7 @@ import type {DistinctChoice, ListChoiceMap} from 'inquirer'
 
 import {color, hux} from '@heroku/heroku-cli-util'
 import {APIClient} from '@heroku-cli/command'
-import * as inquirer from 'inquirer'
+import inquirer from 'inquirer'
 import printf from 'printf'
 
 import {
@@ -13,6 +13,7 @@ import {
   PricingInfoResponse,
 } from './types.js'
 
+// eslint-disable-next-line import/no-named-as-default-member
 const {Separator} = inquirer
 
 /**


### PR DESCRIPTION
## Summary

Here we fix a bug reported recently and involving `data:pg:update`. The issue is caused by the conversion to ESM and the way the package `inquirer` was imported on a utility library. The fix is straightforward by using the same import declaration present on all other `data:pg` interactive commands that use the `inquirer` package.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [X] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
You'll need to have an Advanced database at hand to run this test. You can create one with `./bin/run data:pg:create -a <test-app-name>`, but keep in mind that provisioning such a database may take up to 30 mins.

**Steps**:
1. Checkout this branch and run ```npm install && npm run build```
2. Try to update the leader pool level on your test database with ```./bin/run data:pg:update -a <test-app-name>```, following the interactive menus. You should be able to update the pool level without issues.

## Screenshots (if applicable)

<img width="1422" height="489" alt="Captura de pantalla 2026-03-09 a la(s) 15 40 14" src="https://github.com/user-attachments/assets/63c9c85f-f1a8-40be-b028-1fac7793d2fb" />


## Related Issues
GUS work item: [W-21513335](https://gus.lightning.force.com/a07EE00002VzQGwYAN)
