### PR TITLE
fix: resolution for 'data:pg:attachments:create' (W-21411346)

### DIFF
--- a/src/commands/data/pg/attachments/create.ts
+++ b/src/commands/data/pg/attachments/create.ts
@@ -1,10 +1,8 @@
-import {color, utils} from '@heroku/heroku-cli-util'
-import {flags as Flags} from '@heroku-cli/command'
+import {color, pg, utils} from '@heroku/heroku-cli-util'
+import {flags as Flags, HerokuAPIError} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
-
-import type {DeepRequired} from '../../../../lib/data/types.js'
 
 import {trapConfirmationRequired} from '../../../../lib/addons/util.js'
 import BaseCommand from '../../../../lib/data/baseCommand.js'
@@ -37,8 +35,23 @@ export default class DataPgAttachmentsCreate extends BaseCommand {
     const {args, flags} = await this.parse(DataPgAttachmentsCreate)
     const {database: databaseArg} = args
     const {app, as, confirm, credential, pool} = flags
+    const addonResolver = new utils.AddonResolver(this.heroku)
 
-    const {body: addon} = await this.heroku.get<DeepRequired<Heroku.AddOn>>(`/addons/${databaseArg}`)
+    // For attachment creation, app is always the target app where the attachment will be created.
+    // When attaching to the same app, both add-on name and attachment name will resolve without issues
+    // by passing the app name for resolution, but when attaching to a different app using the add-on name
+    // to specify the source add-on, we have to remove the app name from the resolution for the resolver to
+    // find the correct add-on.
+    let addon: pg.ExtendedAddon
+    try {
+      addon = await addonResolver.resolve(databaseArg, app, utils.pg.addonService())
+    } catch (error: unknown) {
+      if (error instanceof HerokuAPIError && error.http.statusCode === 404) {
+        addon = await addonResolver.resolve(databaseArg, undefined, utils.pg.addonService())
+      } else {
+        throw error
+      }
+    }
 
     if (!utils.pg.isAdvancedDatabase(addon)) {
       const cmd = `heroku addons:attach ${addon.name} -a ${app}${as ? ` --as ${as}` : ''}`

--- a/test/unit/commands/data/pg/attachments/create.unit.test.ts
+++ b/test/unit/commands/data/pg/attachments/create.unit.test.ts
@@ -1,6 +1,10 @@
+import {utils} from '@heroku/heroku-cli-util'
+import {HTTPError} from '@heroku/http-call'
+import {HerokuAPIError} from '@heroku-cli/command'
 import ansis from 'ansis'
 import {expect} from 'chai'
 import nock from 'nock'
+import sinon from 'sinon'
 import {stderr} from 'stdout-stderr'
 import tsheredoc from 'tsheredoc'
 
@@ -21,10 +25,19 @@ import runCommand from '../../../../../helpers/runCommand.js'
 const heredoc = tsheredoc.default
 
 describe('data:pg:attachments:create', function () {
+  let resolveStub: sinon.SinonStub
+
+  beforeEach(function () {
+    resolveStub = sinon.stub(utils.AddonResolver.prototype, 'resolve')
+  })
+
+  afterEach(function () {
+    sinon.restore()
+  })
+
   it('shows error for non-advanced databases', async function () {
-    const herokuApi = nock('https://api.heroku.com')
-      .get('/addons/advanced-horizontal-01234')
-      .reply(200, nonAdvancedAddon)
+    resolveStub.withArgs('advanced-horizontal-01234', 'myapp', utils.pg.addonService())
+      .resolves(nonAdvancedAddon)
 
     try {
       await runCommand(DataPgAttachmentsCreate, [
@@ -35,7 +48,6 @@ describe('data:pg:attachments:create', function () {
     } catch (error: unknown) {
       const err = error as Error
 
-      herokuApi.done()
       expect(ansis.strip(err.message)).to.equal(
         'You can only use this command on Advanced-tier databases.\n'
          + 'Use heroku addons:attach standard-database -a myapp --as TEST instead.',
@@ -46,8 +58,6 @@ describe('data:pg:attachments:create', function () {
   describe('basic attachment creation', function () {
     it('creates a basic attachment to the same app', async function () {
       const herokuApi = nock('https://api.heroku.com')
-        .get('/addons/advanced-horizontal-01234')
-        .reply(200, addon)
         .post('/addon-attachments', {
           addon: {name: addon.name},
           app: {name: addon.app.name},
@@ -56,6 +66,8 @@ describe('data:pg:attachments:create', function () {
         .reply(200, createAttachmentResponse)
         .get('/apps/myapp/releases')
         .reply(200, releasesResponse)
+      resolveStub.withArgs('advanced-horizontal-01234', 'myapp', utils.pg.addonService())
+        .resolves(addon)
 
       await runCommand(DataPgAttachmentsCreate, [
         'advanced-horizontal-01234',
@@ -72,8 +84,6 @@ describe('data:pg:attachments:create', function () {
 
     it('creates a basic (foreign) attachment to a different app using the database name', async function () {
       const herokuApi = nock('https://api.heroku.com')
-        .get('/addons/advanced-horizontal-01234')
-        .reply(200, addon)
         .post('/addon-attachments', {
           addon: {name: addon.name},
           app: {name: 'myapp2'},
@@ -82,6 +92,11 @@ describe('data:pg:attachments:create', function () {
         .reply(200, createForeignAttachmentResponse)
         .get('/apps/myapp2/releases')
         .reply(200, releasesResponse)
+      resolveStub.withArgs('advanced-horizontal-01234', 'myapp2', utils.pg.addonService()).rejects(new HerokuAPIError({
+        body: {id: 'not_found', message: 'Couldn\'t find that add on.', resource: 'add_on'},
+        statusCode: 404,
+      } as unknown as HTTPError))
+      resolveStub.withArgs('advanced-horizontal-01234', undefined, utils.pg.addonService()).resolves(addon)
 
       await runCommand(DataPgAttachmentsCreate, [
         'advanced-horizontal-01234',
@@ -98,8 +113,6 @@ describe('data:pg:attachments:create', function () {
 
     it('creates a basic (foreign) attachment to a different app using an app namespaced attachment name', async function () {
       const herokuApi = nock('https://api.heroku.com')
-        .get('/addons/myapp::DATABASE')
-        .reply(200, addon)
         .post('/addon-attachments', {
           addon: {name: addon.name},
           app: {name: 'myapp2'},
@@ -108,6 +121,8 @@ describe('data:pg:attachments:create', function () {
         .reply(200, createForeignAttachmentResponse)
         .get('/apps/myapp2/releases')
         .reply(200, releasesResponse)
+      resolveStub.withArgs('myapp::DATABASE', 'myapp2', utils.pg.addonService())
+        .resolves(addon)
 
       await runCommand(DataPgAttachmentsCreate, [
         'myapp::DATABASE',
@@ -124,8 +139,6 @@ describe('data:pg:attachments:create', function () {
 
     it('creates a basic attachment without a custom attachment name', async function () {
       const herokuApi = nock('https://api.heroku.com')
-        .get('/addons/advanced-horizontal-01234')
-        .reply(200, addon)
         .post('/addon-attachments', {
           addon: {name: addon.name},
           app: {name: addon.app.name},
@@ -136,6 +149,8 @@ describe('data:pg:attachments:create', function () {
         })
         .get('/apps/myapp/releases')
         .reply(200, releasesResponse)
+      resolveStub.withArgs('advanced-horizontal-01234', 'myapp', utils.pg.addonService())
+        .resolves(addon)
 
       await runCommand(DataPgAttachmentsCreate, [
         'advanced-horizontal-01234',
@@ -149,10 +164,57 @@ describe('data:pg:attachments:create', function () {
       `)
     })
 
+    it('handles API errors gracefully on the add-on resolution', async function () {
+      resolveStub.withArgs('advanced-horizontal-01234', 'myapp', utils.pg.addonService())
+        .rejects(new HerokuAPIError({
+          body: {id: 'internal_server_error', message: 'Internal server error.', resource: 'add_on'},
+          http: {statusCode: 500},
+        } as unknown as HTTPError))
+
+      try {
+        await runCommand(DataPgAttachmentsCreate, [
+          'advanced-horizontal-01234',
+          '--app=myapp',
+        ])
+      } catch (error: unknown) {
+        const err = error as Error
+        expect(resolveStub.callCount).to.equal(1)
+        expect(ansis.strip(err.message)).to.equal(heredoc`
+          Internal server error.
+
+          Error ID: internal_server_error`,
+        )
+      }
+    })
+
+    it('handles API errors gracefully if the add-on doesn\'t exist', async function () {
+      resolveStub.withArgs('advanced-horizontal-01234', 'myapp', utils.pg.addonService()).rejects(new HerokuAPIError({
+        body: {id: 'not_found', message: 'Couldn\'t find that add on.', resource: 'add_on'},
+        statusCode: 404,
+      } as unknown as HTTPError))
+      resolveStub.withArgs('advanced-horizontal-01234', undefined, utils.pg.addonService()).rejects(new HerokuAPIError({
+        body: {id: 'not_found', message: 'Couldn\'t find that add on.', resource: 'add_on'},
+        statusCode: 404,
+      } as unknown as HTTPError))
+
+      try {
+        await runCommand(DataPgAttachmentsCreate, [
+          'advanced-horizontal-01234',
+          '--app=myapp',
+        ])
+      } catch (error: unknown) {
+        const err = error as Error
+        expect(resolveStub.callCount).to.equal(2)
+        expect(ansis.strip(err.message)).to.equal(heredoc`
+          Couldn't find that add on.
+
+          Error ID: not_found`,
+        )
+      }
+    })
+
     it('handles API errors gracefully on the attachment creation', async function () {
       const herokuApi = nock('https://api.heroku.com')
-        .get('/addons/advanced-horizontal-01234')
-        .reply(200, addon)
         .post('/addon-attachments', {
           addon: {name: addon.name},
           app: {name: addon.app.name},
@@ -162,6 +224,8 @@ describe('data:pg:attachments:create', function () {
           id: 'internal_server_error',
           message: 'Internal server error.',
         })
+      resolveStub.withArgs('advanced-horizontal-01234', 'myapp', utils.pg.addonService())
+        .resolves(addon)
 
       try {
         await runCommand(DataPgAttachmentsCreate, [
@@ -171,6 +235,7 @@ describe('data:pg:attachments:create', function () {
         ])
       } catch (error: unknown) {
         const err = error as Error
+        expect(resolveStub.callCount).to.equal(1)
         expect(ansis.strip(err.message)).to.equal(heredoc`
           Internal server error.
 
@@ -186,8 +251,6 @@ describe('data:pg:attachments:create', function () {
 
     it('handles API errors gracefully on the release retrieval', async function () {
       const herokuApi = nock('https://api.heroku.com')
-        .get('/addons/advanced-horizontal-01234')
-        .reply(200, addon)
         .post('/addon-attachments', {
           addon: {name: addon.name},
           app: {name: addon.app.name},
@@ -199,6 +262,8 @@ describe('data:pg:attachments:create', function () {
           id: 'internal_server_error',
           message: 'Internal server error.',
         })
+      resolveStub.withArgs('advanced-horizontal-01234', 'myapp', utils.pg.addonService())
+        .resolves(addon)
 
       try {
         await runCommand(DataPgAttachmentsCreate, [
@@ -208,6 +273,7 @@ describe('data:pg:attachments:create', function () {
         ])
       } catch (error: unknown) {
         const err = error as Error
+        expect(resolveStub.callCount).to.equal(1)
         expect(ansis.strip(err.message)).to.equal(heredoc`
           Internal server error.
 
@@ -226,8 +292,6 @@ describe('data:pg:attachments:create', function () {
   describe('credential-based attachment', function () {
     it('creates attachment with credential', async function () {
       const herokuApi = nock('https://api.heroku.com')
-        .get('/addons/advanced-horizontal-01234')
-        .reply(200, addon)
         .get(`/addons/${addon.name}/config/role:mycredential`)
         .reply(200, credentialConfigResponse)
         .post('/addon-attachments', {
@@ -239,6 +303,8 @@ describe('data:pg:attachments:create', function () {
         .reply(200, createCredentialAttachmentResponse)
         .get('/apps/myapp/releases')
         .reply(200, releasesResponse)
+      resolveStub.withArgs('advanced-horizontal-01234', 'myapp', utils.pg.addonService())
+        .resolves(addon)
 
       await runCommand(DataPgAttachmentsCreate, [
         'advanced-horizontal-01234',
@@ -256,10 +322,10 @@ describe('data:pg:attachments:create', function () {
 
     it('throws error when credential does not exist', async function () {
       const herokuApi = nock('https://api.heroku.com')
-        .get('/addons/advanced-horizontal-01234')
-        .reply(200, addon)
         .get(`/addons/${addon.name}/config/role:nonexistent`)
         .reply(200, [])
+      resolveStub.withArgs('advanced-horizontal-01234', 'myapp', utils.pg.addonService())
+        .resolves(addon)
 
       try {
         await runCommand(DataPgAttachmentsCreate, [
@@ -270,6 +336,7 @@ describe('data:pg:attachments:create', function () {
       } catch (error: unknown) {
         const err = error as Error
 
+        expect(resolveStub.callCount).to.equal(1)
         expect(ansis.strip(err.message)).to.equal(
           'The credential nonexistent doesn\'t exist on the database ⛁ advanced-horizontal-01234.\n'
           + 'Use heroku data:pg:credentials advanced-horizontal-01234 -a myapp '
@@ -284,8 +351,6 @@ describe('data:pg:attachments:create', function () {
   describe('pool-based attachment', function () {
     it('creates attachment with pool', async function () {
       const herokuApi = nock('https://api.heroku.com')
-        .get('/addons/advanced-horizontal-01234')
-        .reply(200, addon)
         .get(`/addons/${addon.name}/config/pool:mypool`)
         .reply(200, poolConfigResponse)
         .post('/addon-attachments', {
@@ -297,6 +362,8 @@ describe('data:pg:attachments:create', function () {
         .reply(200, createPoolAttachmentResponse)
         .get('/apps/myapp/releases')
         .reply(200, releasesResponse)
+      resolveStub.withArgs('advanced-horizontal-01234', 'myapp', utils.pg.addonService())
+        .resolves(addon)
 
       await runCommand(DataPgAttachmentsCreate, [
         'advanced-horizontal-01234',
@@ -316,10 +383,10 @@ describe('data:pg:attachments:create', function () {
 
     it('throws error when pool does not exist', async function () {
       const herokuApi = nock('https://api.heroku.com')
-        .get('/addons/advanced-horizontal-01234')
-        .reply(200, addon)
         .get(`/addons/${addon.name}/config/pool:nonexistent`)
         .reply(200, [])
+      resolveStub.withArgs('advanced-horizontal-01234', 'myapp', utils.pg.addonService())
+        .resolves(addon)
 
       try {
         await runCommand(DataPgAttachmentsCreate, [
@@ -330,6 +397,7 @@ describe('data:pg:attachments:create', function () {
       } catch (error: unknown) {
         const err = error as Error
 
+        expect(resolveStub.callCount).to.equal(1)
         expect(ansis.strip(err.message)).to.equal(
           'The pool nonexistent doesn\'t exist on the database ⛁ advanced-horizontal-01234.\n'
           + 'Use heroku data:pg:info advanced-horizontal-01234 -a myapp '


### PR DESCRIPTION
## Summary

This fixes an issue with add-on resolution for attachment creation in `data:pg:attachments:create`. Resolving the correct add-on is problematic in this case because of foreign attachments.

In the original implementation (the same for `addons:attach`), we were using Platform API Add-on Info endpoint directly, but that caused issues with foreign attachment creation, because the `--app` flag in this case refers to the target app where the attachment will be created and not the origin app where the add-on is to be found. For same app attachments there was no issues, but when the apps were different it would cause to fail resolution by attachment name.

Now we use the add-on resolver class from `heroku-cli-util` but it comes with similar limitations. When the source and target apps differ it will fail to resolve by add-on name. The only way to fix this was to catch a 404 error on the first call and then retry without passing the app name to the resolver, in case the user was specifying the add-on by name.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [X] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
You'll need to have two test apps and an Advanced database provisioned in one of them to run these tests. You can create one with `./bin/run data:pg:create -a <test-app-name>`, but keep in mind that provisioning such a database may take up to 30 mins.

**Steps**:
1. Checkout this branch and run ```npm install && npm run build```
2. Create a foreign attachment using a fully qualified attachment name:
    ```./bin/run data:pg:attachments:create <test-app1>::<ATTACHMENT_NAME> -a test-app-2 --as TEST_ATT_1```
3. Create a foreign attachment using the add-on name:
    ```./bin/run data:pg:attachments:create <addon-name> -a test-app-1 --as TEST_ATT_2```

Both commands should succeed.

## Screenshots (if applicable)

<img width="1277" height="969" alt="Captura de pantalla 2026-03-09 a la(s) 18 42 48" src="https://github.com/user-attachments/assets/e03561f7-3b3a-4676-b291-18da880b7076" />

## Related Issues
GUS work item: [W-21411346](https://gus.lightning.force.com/a07EE00002VcCKBYA3)
