### PR TITLE
fix: add-on resolution for 'data:pg:attachments:destroy' (W-21411154)

### DIFF
--- a/src/commands/data/pg/attachments/destroy.ts
+++ b/src/commands/data/pg/attachments/destroy.ts
@@ -29,7 +29,7 @@ export default class DataPgAttachmentsDestroy extends BaseCommand {
       `/apps/${app}/addon-attachments/${attachmentName}`,
     )
     const addonResolver = new utils.AddonResolver(this.heroku)
-    const addon = await addonResolver.resolve(attachment.addon.name, app, utils.pg.addonService())
+    const addon = await addonResolver.resolve(attachment.addon.name, undefined, utils.pg.addonService())
 
     if (!utils.pg.isAdvancedDatabase(addon)) {
       ux.error(

--- a/test/unit/commands/data/pg/attachments/destroy.unit.test.ts
+++ b/test/unit/commands/data/pg/attachments/destroy.unit.test.ts
@@ -1,6 +1,8 @@
+import {utils} from '@heroku/heroku-cli-util'
 import ansis from 'ansis'
 import {expect} from 'chai'
 import nock from 'nock'
+import sinon from 'sinon'
 import {stderr, stdout} from 'stdout-stderr'
 import tsheredoc from 'tsheredoc'
 
@@ -16,6 +18,16 @@ import runCommand from '../../../../../helpers/runCommand.js'
 const heredoc = tsheredoc.default
 
 describe('data:pg:attachments:destroy', function () {
+  let resolveStub: sinon.SinonStub
+
+  beforeEach(function () {
+    resolveStub = sinon.stub(utils.AddonResolver.prototype, 'resolve')
+  })
+
+  afterEach(function () {
+    sinon.restore()
+  })
+
   it('shows error for non-advanced databases', async function () {
     const herokuApi = nock('https://api.heroku.com')
       .get('/apps/myapp/addon-attachments/DATABASE_ANALYST')
@@ -30,8 +42,8 @@ describe('data:pg:attachments:destroy', function () {
           name: nonAdvancedAddon.name,
         },
       })
-      .post('/actions/addons/resolve')
-      .reply(200, [nonAdvancedAddon])
+    resolveStub.withArgs(nonAdvancedAddon.name, undefined, utils.pg.addonService())
+      .resolves(nonAdvancedAddon)
 
     try {
       await runCommand(DataPgAttachmentsDestroy, [
@@ -55,12 +67,12 @@ describe('data:pg:attachments:destroy', function () {
       const herokuApi = nock('https://api.heroku.com')
         .get('/apps/myapp/addon-attachments/DATABASE_ANALYST')
         .reply(200, multipleAttachmentsResponse[1])
-        .post('/actions/addons/resolve')
-        .reply(200, [addon])
         .delete('/addon-attachments/9a301cce-e1f7-4f1e-a955-5a0ab1d62cb4')
         .reply(200, multipleAttachmentsResponse[1])
         .get('/apps/myapp/releases')
         .reply(200, releasesResponse)
+      resolveStub.withArgs(addon.name, undefined, utils.pg.addonService())
+        .resolves(addon)
 
       await runCommand(DataPgAttachmentsDestroy, [
         'DATABASE_ANALYST',
@@ -110,13 +122,13 @@ describe('data:pg:attachments:destroy', function () {
       const herokuApi = nock('https://api.heroku.com')
         .get('/apps/myapp/addon-attachments/DATABASE_ANALYST')
         .reply(200, multipleAttachmentsResponse[1])
-        .post('/actions/addons/resolve')
-        .reply(200, [addon])
         .delete('/addon-attachments/9a301cce-e1f7-4f1e-a955-5a0ab1d62cb4')
         .reply(500, {
           id: 'internal_server_error',
           message: 'Internal server error.',
         })
+      resolveStub.withArgs(addon.name, undefined, utils.pg.addonService())
+        .resolves(addon)
 
       try {
         await runCommand(DataPgAttachmentsDestroy, [
@@ -143,8 +155,6 @@ describe('data:pg:attachments:destroy', function () {
       const herokuApi = nock('https://api.heroku.com')
         .get('/apps/myapp/addon-attachments/DATABASE_ANALYST')
         .reply(200, multipleAttachmentsResponse[1])
-        .post('/actions/addons/resolve')
-        .reply(200, [addon])
         .delete('/addon-attachments/9a301cce-e1f7-4f1e-a955-5a0ab1d62cb4')
         .reply(200, multipleAttachmentsResponse[1])
         .get('/apps/myapp/releases')
@@ -152,6 +162,8 @@ describe('data:pg:attachments:destroy', function () {
           id: 'internal_server_error',
           message: 'Internal server error.',
         })
+      resolveStub.withArgs(addon.name, undefined, utils.pg.addonService())
+        .resolves(addon)
 
       try {
         await runCommand(DataPgAttachmentsDestroy, [


### PR DESCRIPTION
## Summary

This fixes an issue with add-on resolution for foreign attachment destructions in `data:pg:attachments:destroy`. The problem was caused because we were trying to resolve the add-on by name while still passing the app name where the attachment is located as if it was the app owning the add-on, which is not the case for foreign attachments.

Now we remove the app name in the call to the add-on resolver and that fixes the issue. A small refactor included on tests to align with other attachments' commands tests.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [X] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
You'll need to have two test apps and an Advanced database provisioned in one of them and attached to the other one. You can create one database with `./bin/run data:pg:create -a <test-app-name>` and attach it to the other one with `./bin/run data:pg:attachments:create <addon-name> -a <other-test-app-name> --as FOREIGN_ATT`. Keep in mind that provisioning a database may take up to 30 mins and you need to wait for it to be available before creating the foreign attachment.

**Steps**:
1. Checkout this branch and run ```npm install && npm run build```
2. Destroy the foreign attachment using the add-on name:
    ```./bin/run data:pg:attachments:destroy FOREIGN_ATT -a <other-test-app-name>```

The command should ask for confirmation and succeed after confirming it.

## Screenshots (if applicable)

<img width="1594" height="681" alt="Captura de pantalla 2026-03-09 a la(s) 19 21 43" src="https://github.com/user-attachments/assets/c576f512-e8b8-40c9-9d75-a7559ba3a2ba" />

## Related Issues
GUS work item: [W-21411154](https://gus.lightning.force.com/a07EE00002Vc8hhYAB)
