### PR TITLE
chore: remove check-plugin-health hook from update hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,8 +204,7 @@
         "./dist/hooks/update/completions",
         "./dist/hooks/update/tidy",
         "./dist/hooks/recache",
-        "./dist/hooks/update/show-version-info",
-        "./dist/hooks/update/check-plugin-health"
+        "./dist/hooks/update/show-version-info"
       ]
     },
     "macos": {


### PR DESCRIPTION
## Summary
Remove the `check-plugin-health` hook from the update hooks configuration as this hook's has already been removed.

## Type of Change
### Patch Updates (patch semver update)
- [x] **chore**: Change that does not affect production code

## Testing
**Notes**:
This removes an unused hook from the configuration.

**Steps**:
1. Passing CI suffices

## Related Issues
N/A