### PR TITLE
fix: stabilize apps:diff 404 tests by mocking both apps

### DIFF
--- a/test/unit/commands/apps/diff.unit.test.ts
+++ b/test/unit/commands/apps/diff.unit.test.ts
@@ -132,6 +132,8 @@ describe('apps:diff', function () {
   it('throws App not found when one app returns 404 on releases', async function () {
     api
       .get(`/apps/${app1Name}/releases`).matchHeader('range', /version/).reply(404, {id: 'not_found', message: 'Couldn\'t find that app.'})
+      .get(`/apps/${app2Name}/releases`).matchHeader('range', /version/).reply(200, releasesWithSlug(slugId2))
+      .get(`/apps/${app2Name}/slugs/${slugId2}`).reply(200, slugBody(sameChecksum))
 
     const {error} = await runCommand(AppsDiff, [app1Name, app2Name])
 
@@ -144,6 +146,8 @@ describe('apps:diff', function () {
     api
       .get(`/apps/${app1Name}/releases`).matchHeader('range', /version/).reply(200, releasesWithSlug(slugId1))
       .get(`/apps/${app1Name}/slugs/${slugId1}`).reply(404, {id: 'not_found', message: 'Not found'})
+      .get(`/apps/${app2Name}/releases`).matchHeader('range', /version/).reply(200, releasesWithSlug(slugId2))
+      .get(`/apps/${app2Name}/slugs/${slugId2}`).reply(200, slugBody(sameChecksum))
 
     const {error} = await runCommand(AppsDiff, [app1Name, app2Name])
 


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
This fixes flakiness in two tests that only mocked app1 where app2 was unmocked and could fail first. 

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
<!-- Add any context/setup necessary for testing. -->

CI passes 

## Related Issues
GitHub issue: #[GitHub issue number]
GUS work item: [W-17818328](https://gus.lightning.force.com/a07EE000029leoeYAA)
