### PR TITLE
fix: update '@heroku/heroku-cli-util' dependency version (W-21546520)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@heroku-cli/notifications": "^1.2.6",
         "@heroku-cli/schema": "^1.0.25",
         "@heroku/buildpack-registry": "^1.0.1",
-        "@heroku/heroku-cli-util": "^10.6.0",
+        "@heroku/heroku-cli-util": "^10.6.1",
         "@heroku/http-call": "^5.5.1",
         "@heroku/mcp-server": "^1.2.0",
         "@heroku/socksv5": "^0.0.9",
@@ -2170,12 +2170,12 @@
       "license": "MIT"
     },
     "node_modules/@heroku/heroku-cli-util": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/@heroku/heroku-cli-util/-/heroku-cli-util-10.6.0.tgz",
-      "integrity": "sha512-vrycJn9XnRMJmyJidBca6ftZbR49pGkb4iiRLvvw3AL9LQC5qIuAKst3i9Se4J7RdnAESwPJh/1ElSCmF/Zq+A==",
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/@heroku/heroku-cli-util/-/heroku-cli-util-10.6.1.tgz",
+      "integrity": "sha512-40atOo7ty4Fg6Igefif6biFw4m54dHN5KDiGXYRYgFNvSf5gRU9K8SmUQasMqjj9kLUSNa7ac4NR9wLjyxJvkw==",
       "license": "ISC",
       "dependencies": {
-        "@heroku-cli/command": "^12.0.0",
+        "@heroku-cli/command": "^12.2.0",
         "@heroku/http-call": "^5.5.0",
         "@oclif/core": "^4.3.0",
         "@oclif/table": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@heroku-cli/notifications": "^1.2.6",
     "@heroku-cli/schema": "^1.0.25",
     "@heroku/buildpack-registry": "^1.0.1",
-    "@heroku/heroku-cli-util": "^10.6.0",
+    "@heroku/heroku-cli-util": "^10.6.1",
     "@heroku/http-call": "^5.5.1",
     "@heroku/mcp-server": "^1.2.0",
     "@heroku/socksv5": "^0.0.9",

--- a/src/commands/data/pg/destroy.ts
+++ b/src/commands/data/pg/destroy.ts
@@ -32,10 +32,6 @@ export default class DataPgDestroy extends BaseCommand {
     const addonResolver = new utils.AddonResolver(this.heroku)
     const addon = await addonResolver.resolve(databaseName, app, utils.pg.addonService())
 
-    if (!utils.pg.isPostgresAddon(addon)) {
-      ux.error(`You can only use this command to delete Heroku Postgres databases. Run ${color.code(`heroku addons:destroy ${addon.name}`)} instead.`)
-    }
-
     // prevent deletion of add-on when context.app is set but the addon is
     // attached to a different app
     const addonApp = addon.app!.name!

--- a/test/unit/commands/data/pg/destroy.unit.test.ts
+++ b/test/unit/commands/data/pg/destroy.unit.test.ts
@@ -45,17 +45,17 @@ describe('data:pg:destroy', function () {
     }
   })
 
-  it('prevents destruction of add-ons other than Heroku Postgres', async function () {
+  it('doesn\'t destroy non-Postgres addons', async function () {
     const resolveApi = nock('https://api.heroku.com')
       .post('/actions/addons/resolve')
       .reply(200, [nonPostgresAddon])
 
     try {
-      await runCommand(DataPgDestroy, [addon.name!, '--app=myapp', '--confirm=myapp'])
+      await runCommand(DataPgDestroy, [nonPostgresAddon.name!, '--app=myapp', '--confirm=myapp'])
     } catch (error: unknown) {
       resolveApi.done()
       expect(ansis.strip((error as Error).message)).to.equal(
-        'You can only use this command to delete Heroku Postgres databases. Run heroku addons:destroy redis-database instead.',
+        'Couldn\'t find that addon.',
       )
     }
   })

--- a/test/unit/commands/pg/backups/capture.unit.test.ts
+++ b/test/unit/commands/pg/backups/capture.unit.test.ts
@@ -34,7 +34,7 @@ describe('pg:backups:capture', function () {
     }
     api
       .post('/actions/addon-attachments/resolve', {
-        addon_attachment: 'DATABASE_URL', addon_service: 'heroku-postgresql', app: 'myapp',
+        addon_attachment: 'DATABASE_URL', app: 'myapp',
       })
       .reply(200, [{addon}])
     pgApi
@@ -76,7 +76,7 @@ describe('pg:backups:capture', function () {
     }
     api
       .post('/actions/addon-attachments/resolve', {
-        addon_attachment: 'DATABASE_URL', addon_service: 'heroku-postgresql', app: 'myapp',
+        addon_attachment: 'DATABASE_URL', app: 'myapp',
       })
       .reply(200, [{addon}])
     pgApi
@@ -122,7 +122,7 @@ describe('pg:backups:capture', function () {
     }
     api
       .post('/actions/addon-attachments/resolve', {
-        addon_attachment: 'DATABASE_URL', addon_service: 'heroku-postgresql', app: 'myapp',
+        addon_attachment: 'DATABASE_URL', app: 'myapp',
       })
       .reply(200, [{addon}])
     pgApi

--- a/test/unit/commands/pg/backups/restore.unit.test.ts
+++ b/test/unit/commands/pg/backups/restore.unit.test.ts
@@ -20,7 +20,7 @@ describe('pg:backups:restore', function () {
   beforeEach(async function () {
     api = nock('https://api.heroku.com')
     api.post('/actions/addon-attachments/resolve', {
-      addon_attachment: 'DATABASE_URL', addon_service: 'heroku-postgresql', app: 'myapp',
+      addon_attachment: 'DATABASE_URL', app: 'myapp',
     }).reply(200, [{addon}])
     pg = nock('https://api.data.heroku.com')
   })

--- a/test/unit/commands/pg/backups/schedule.unit.test.ts
+++ b/test/unit/commands/pg/backups/schedule.unit.test.ts
@@ -29,7 +29,6 @@ describe('pg:backups:schedule', function () {
       api
         .post('/actions/addon-attachments/resolve', {
           addon_attachment: 'DATABASE_URL',
-          addon_service: 'heroku-postgresql',
           app: 'myapp',
         })
         .reply(200, [
@@ -136,7 +135,6 @@ describe('pg:backups:schedule', function () {
     api
       .post('/actions/addon-attachments/resolve', {
         addon_attachment: 'DATABASE_URL',
-        addon_service: 'heroku-postgresql',
         app: 'myapp',
       })
       .reply(200, [

--- a/test/unit/commands/pg/backups/unschedule.unit.test.ts
+++ b/test/unit/commands/pg/backups/unschedule.unit.test.ts
@@ -24,7 +24,6 @@ describe('pg:backups:unschedule', function () {
         .reply(200, [addon])
         .post('/actions/addon-attachments/resolve', {
           addon_attachment: 'DATABASE_URL',
-          addon_service: 'heroku-postgresql',
           app: appName,
         })
         .reply(200, [attachment])
@@ -66,7 +65,6 @@ describe('pg:backups:unschedule error state', function () {
       .reply(200, [addon])
       .post('/actions/addon-attachments/resolve', {
         addon_attachment: 'DATABASE_URL',
-        addon_service: 'heroku-postgresql',
         app: appName,
       })
       .reply(200, [attachment])

--- a/test/unit/commands/pg/connection-pooling/attach.unit.test.ts
+++ b/test/unit/commands/pg/connection-pooling/attach.unit.test.ts
@@ -17,7 +17,7 @@ describe('pg:connection-pooling:attach', function () {
 
   beforeEach(function () {
     api = nock('https://api.heroku.com')
-      .post('/actions/addon-attachments/resolve', {addon_attachment: 'postgres-1', addon_service: 'heroku-postgresql', app: 'myapp'})
+      .post('/actions/addon-attachments/resolve', {addon_attachment: 'postgres-1', app: 'myapp'})
       .reply(200, [resolvedAttachments['myapp::postgres-1']])
       .get('/addons/postgres-1')
       .reply(200, addon)

--- a/test/unit/commands/pg/copy.unit.test.ts
+++ b/test/unit/commands/pg/copy.unit.test.ts
@@ -58,7 +58,7 @@ describe('pg:copy', function () {
       api.get('/addons/postgres-1')
         .reply(200, addon)
       api.post('/actions/addon-attachments/resolve', {
-        app: 'myapp', addon_attachment: 'HEROKU_POSTGRESQL_RED_URL', addon_service: 'heroku-postgresql',
+        app: 'myapp', addon_attachment: 'HEROKU_POSTGRESQL_RED_URL',
       })
         .reply(200, [attachment])
       api.get('/apps/myapp/config-vars')
@@ -108,11 +108,11 @@ describe('pg:copy', function () {
       api.get('/addons/postgres-2')
         .reply(200, otherAddon)
       api.post('/actions/addon-attachments/resolve', {
-        app: 'myapp', addon_attachment: 'HEROKU_POSTGRESQL_RED_URL', addon_service: 'heroku-postgresql',
+        app: 'myapp', addon_attachment: 'HEROKU_POSTGRESQL_RED_URL',
       })
         .reply(200, [attachment])
       api.post('/actions/addon-attachments/resolve', {
-        app: 'myotherapp', addon_attachment: 'DATABASE_URL', addon_service: 'heroku-postgresql',
+        app: 'myotherapp', addon_attachment: 'DATABASE_URL',
       })
         .reply(200, [otherAttachment])
       api.get('/apps/myapp/config-vars')
@@ -152,11 +152,11 @@ describe('pg:copy', function () {
       api.get('/addons/postgres-2')
         .reply(200, otherAddon)
       api.post('/actions/addon-attachments/resolve', {
-        app: 'myapp', addon_attachment: 'HEROKU_POSTGRESQL_RED_URL', addon_service: 'heroku-postgresql',
+        app: 'myapp', addon_attachment: 'HEROKU_POSTGRESQL_RED_URL',
       })
         .reply(200, [attachment])
       api.post('/actions/addon-attachments/resolve', {
-        app: 'myapp', addon_attachment: 'ATTACHED_BLUE', addon_service: 'heroku-postgresql',
+        app: 'myapp', addon_attachment: 'ATTACHED_BLUE',
       })
         .reply(200, [attachedBlueAttachment])
       api.get('/apps/myapp/config-vars')
@@ -192,11 +192,11 @@ describe('pg:copy', function () {
       api.get('/addons/postgres-2')
         .reply(200, otherAddon)
       api.post('/actions/addon-attachments/resolve', {
-        app: 'mylowercaseapp', addon_attachment: 'lowercase_database_URL', addon_service: 'heroku-postgresql',
+        app: 'mylowercaseapp', addon_attachment: 'lowercase_database_URL',
       })
         .reply(200, [lowercaseAttachment])
       api.post('/actions/addon-attachments/resolve', {
-        app: 'myotherapp', addon_attachment: 'DATABASE_URL', addon_service: 'heroku-postgresql',
+        app: 'myotherapp', addon_attachment: 'DATABASE_URL',
       })
         .reply(200, [otherAttachment])
       api.get('/apps/mylowercaseapp/config-vars')
@@ -231,7 +231,7 @@ describe('pg:copy', function () {
       api.get('/addons/postgres-1')
         .reply(200, addon)
       api.post('/actions/addon-attachments/resolve', {
-        app: 'myapp', addon_attachment: 'HEROKU_POSTGRESQL_RED_URL', addon_service: 'heroku-postgresql',
+        app: 'myapp', addon_attachment: 'HEROKU_POSTGRESQL_RED_URL',
       })
         .reply(200, [attachment])
       api.get('/apps/myapp/config-vars')

--- a/test/unit/commands/pg/credentials.unit.test.ts
+++ b/test/unit/commands/pg/credentials.unit.test.ts
@@ -91,7 +91,7 @@ describe('pg:credentials', function () {
       },
     ]
 
-    api.post('/actions/addon-attachments/resolve', {addon_attachment: 'DATABASE_URL', addon_service: 'heroku-postgresql', app: 'myapp'})
+    api.post('/actions/addon-attachments/resolve', {addon_attachment: 'DATABASE_URL', app: 'myapp'})
       .reply(200, [{addon}])
       .get('/addons/1/addon-attachments')
       .reply(200, attachments)
@@ -175,7 +175,7 @@ describe('pg:credentials', function () {
       },
     ]
 
-    api.post('/actions/addon-attachments/resolve', {addon_attachment: 'DATABASE_URL', addon_service: 'heroku-postgresql', app: 'myapp'})
+    api.post('/actions/addon-attachments/resolve', {addon_attachment: 'DATABASE_URL', app: 'myapp'})
       .reply(200, [{addon}])
       .get('/addons/1/addon-attachments')
       .reply(200, attachments)

--- a/test/unit/commands/pg/credentials/create.unit.test.ts
+++ b/test/unit/commands/pg/credentials/create.unit.test.ts
@@ -26,7 +26,6 @@ describe('pg:credentials:create', function () {
     api.post('/actions/addon-attachments/resolve', {
       app: 'myapp',
       addon_attachment: 'DATABASE_URL',
-      addon_service: 'heroku-postgresql',
     }).reply(200, [{addon}])
 
     pg.post('/postgres/v0/databases/postgres-1/credentials')
@@ -50,7 +49,6 @@ describe('pg:credentials:create', function () {
     api.post('/actions/addon-attachments/resolve', {
       app: 'myapp',
       addon_attachment: 'DATABASE_URL',
-      addon_service: 'heroku-postgresql',
     }).reply(200, [{addon: essentialAddon}])
 
     const err = "You can't create a custom credential on Essential-tier databases."
@@ -69,7 +67,6 @@ describe('pg:credentials:create', function () {
     api.post('/actions/addon-attachments/resolve', {
       app: 'myapp',
       addon_attachment: 'DATABASE_URL',
-      addon_service: 'heroku-postgresql',
     }).reply(200, [{addon: hobbyAddon}])
 
     const err = "You can't create a custom credential on Essential-tier databases."

--- a/test/unit/commands/pg/credentials/rotate.unit.test.ts
+++ b/test/unit/commands/pg/credentials/rotate.unit.test.ts
@@ -60,7 +60,6 @@ describe('pg:credentials:rotate', function () {
       api.post('/actions/addon-attachments/resolve', {
         app: 'myapp',
         addon_attachment: 'DATABASE_URL',
-        addon_service: 'heroku-postgresql',
       }).reply(200, [{addon}])
     })
 
@@ -215,7 +214,6 @@ describe('pg:credentials:rotate', function () {
     api.post('/actions/addon-attachments/resolve', {
       app: 'myapp',
       addon_attachment: 'DATABASE_URL',
-      addon_service: 'heroku-postgresql',
     }).reply(200, [{addon: hobbyAddon}])
 
     const err = 'Legacy Essential-tier databases do not support named credentials.'
@@ -235,7 +233,6 @@ describe('pg:credentials:rotate', function () {
     api.post('/actions/addon-attachments/resolve', {
       app: 'myapp',
       addon_attachment: 'DATABASE_URL',
-      addon_service: 'heroku-postgresql',
     }).reply(200, [{addon: essentialAddon}])
 
     pg.post('/postgres/v0/databases/postgres-1/credentials/lucy/credentials_rotation')
@@ -263,7 +260,6 @@ describe('pg:credentials:rotate', function () {
     api.post('/actions/addon-attachments/resolve', {
       app: 'myapp',
       addon_attachment: 'DATABASE_URL',
-      addon_service: 'heroku-postgresql',
     }).reply(200, [{addon: hobbyAddon}])
 
     pg.post('/postgres/v0/databases/postgres-1/credentials/default/credentials_rotation')
@@ -288,7 +284,6 @@ describe('pg:credentials:rotate', function () {
     api.post('/actions/addon-attachments/resolve', {
       app: 'myapp',
       addon_attachment: 'DATABASE_URL',
-      addon_service: 'heroku-postgresql',
     }).reply(200, [{addon: hobbyAddon}])
 
     pg.post('/postgres/v0/databases/postgres-1/credentials_rotation')

--- a/test/unit/commands/pg/info.unit.test.ts
+++ b/test/unit/commands/pg/info.unit.test.ts
@@ -98,7 +98,7 @@ describe('pg:info', function () {
       const addon = addons[1]
       api.get('/apps/myapp/config-vars')
         .reply(200, config)
-        .post('/actions/addon-attachments/resolve', {addon_attachment: 'postgres-2', addon_service: 'heroku-postgresql', app: 'myapp'})
+        .post('/actions/addon-attachments/resolve', {addon_attachment: 'postgres-2', app: 'myapp'})
         .reply(200, [{addon}])
       pg.get('/client/v11/databases/2')
         .reply(200, dbB)

--- a/test/unit/commands/pg/killall.unit.test.ts
+++ b/test/unit/commands/pg/killall.unit.test.ts
@@ -23,7 +23,7 @@ describe('pg:killall', function () {
   })
 
   it('waits for all databases to be available', async function () {
-    api.post('/actions/addon-attachments/resolve', {addon_attachment: 'DATABASE_URL', addon_service: 'heroku-postgresql', app: 'myapp'})
+    api.post('/actions/addon-attachments/resolve', {addon_attachment: 'DATABASE_URL', app: 'myapp'})
       .reply(200, [{addon: db}])
     pg.post('/client/v11/databases/1/connection_reset')
       .reply(200)

--- a/test/unit/commands/pg/links/create.unit.test.ts
+++ b/test/unit/commands/pg/links/create.unit.test.ts
@@ -29,7 +29,7 @@ describe('pg:links:create', function () {
 
     it('errors when attempting to create a link', async function () {
       api.post('/actions/addon-attachments/resolve', {
-        addon_attachment: 'heroku-postgres', addon_service: 'heroku-postgresql', app: 'myapp',
+        addon_attachment: 'heroku-postgres', app: 'myapp',
       }).reply(200, [{addon}])
 
       api.post('/actions/addons/resolve', {
@@ -61,7 +61,6 @@ describe('pg:links:create', function () {
     it('errors when attempting to create a link', async function () {
       api.post('/actions/addon-attachments/resolve', {
         addon_attachment: 'heroku-postgres',
-        addon_service: 'heroku-postgresql',
         app: 'myapp',
       }).reply(200, [{addon}])
 

--- a/test/unit/commands/pg/promote.unit.test.ts
+++ b/test/unit/commands/pg/promote.unit.test.ts
@@ -295,7 +295,6 @@ describe('pg:promote when argument is a credential attachment', function () {
       .post('/actions/addon-attachments/resolve', {
         app: 'myapp',
         addon_attachment: 'DATABASE',
-        addon_service: 'heroku-postgresql',
       })
       .reply(200, [{addon, name: 'PURPLE', namespace: 'credential:hello'}])
       .get('/apps/myapp/formation')
@@ -565,10 +564,10 @@ describe('pg:promote when release phase is present', function () {
       })
       .reply(201)
       .post('/actions/addon-attachments/resolve', {
-        app: 'myapp', addon_attachment: 'DATABASE', addon_service: 'heroku-postgresql',
+        app: 'myapp', addon_attachment: 'DATABASE',
       })
       .reply(201, [{
-        name: 'PURPLE', addon: {name: addon.name, id: addon.id}, namespace: 'credential:hello',
+        name: 'PURPLE', addon: {name: addon.name, id: addon.id, plan: {id: addon.plan!.id, name: addon.plan!.name}}, namespace: 'credential:hello',
       }])
     nock('https://api.data.heroku.com')
       .get(`/client/v11/databases/${addon.id}/wait_status`)

--- a/test/unit/commands/pg/settings/auto-explain.unit.test.ts
+++ b/test/unit/commands/pg/settings/auto-explain.unit.test.ts
@@ -23,7 +23,6 @@ describe('pg:settings:auto-explain', function () {
     api.post('/actions/addon-attachments/resolve', {
       app: 'myapp',
       addon_attachment: 'test-database',
-      addon_service: 'heroku-postgresql',
     }).reply(200, [{addon}])
 
     pg = nock('https://api.data.heroku.com')

--- a/test/unit/commands/pg/settings/auto-explain/log-analyze.unit.test.ts
+++ b/test/unit/commands/pg/settings/auto-explain/log-analyze.unit.test.ts
@@ -16,7 +16,6 @@ describe('pg:settings:auto-explain:log-analyze', function () {
       .post('/actions/addon-attachments/resolve', {
         app: 'myapp',
         addon_attachment: 'test-database',
-        addon_service: 'heroku-postgresql',
       }).reply(200, [{addon}])
   })
 

--- a/test/unit/commands/pg/settings/auto-explain/log-buffers.unit.test.ts
+++ b/test/unit/commands/pg/settings/auto-explain/log-buffers.unit.test.ts
@@ -15,7 +15,6 @@ describe('pg:settings:auto-explain:log-buffers', function () {
       .post('/actions/addon-attachments/resolve', {
         app: 'myapp',
         addon_attachment: 'test-database',
-        addon_service: 'heroku-postgresql',
       }).reply(200, [{addon}])
   })
 

--- a/test/unit/commands/pg/settings/auto-explain/log-format.unit.test.ts
+++ b/test/unit/commands/pg/settings/auto-explain/log-format.unit.test.ts
@@ -16,7 +16,6 @@ describe('pg:settings:auto-explain:log-format', function () {
       .post('/actions/addon-attachments/resolve', {
         app: 'myapp',
         addon_attachment: 'test-database',
-        addon_service: 'heroku-postgresql',
       }).reply(200, [{addon}])
   })
 

--- a/test/unit/commands/pg/settings/auto-explain/log-min-duration.unit.test.ts
+++ b/test/unit/commands/pg/settings/auto-explain/log-min-duration.unit.test.ts
@@ -15,7 +15,6 @@ describe('pg:settings:auto-explain:log-min-duration', function () {
       .post('/actions/addon-attachments/resolve', {
         app: 'myapp',
         addon_attachment: 'test-database',
-        addon_service: 'heroku-postgresql',
       }).reply(200, [{addon}])
   })
 

--- a/test/unit/commands/pg/settings/auto-explain/log-nested-statements.unit.test.ts
+++ b/test/unit/commands/pg/settings/auto-explain/log-nested-statements.unit.test.ts
@@ -15,7 +15,6 @@ describe('pg:settings:auto-explain:log-nested-statements', function () {
       .post('/actions/addon-attachments/resolve', {
         app: 'myapp',
         addon_attachment: 'test-database',
-        addon_service: 'heroku-postgresql',
       }).reply(200, [{addon}])
   })
 

--- a/test/unit/commands/pg/settings/auto-explain/log-triggers.unit.test.ts
+++ b/test/unit/commands/pg/settings/auto-explain/log-triggers.unit.test.ts
@@ -16,7 +16,6 @@ describe('pg:settings:auto-explain:log-triggers', function () {
       .post('/actions/addon-attachments/resolve', {
         app: 'myapp',
         addon_attachment: 'test-database',
-        addon_service: 'heroku-postgresql',
       }).reply(200, [{addon}])
   })
 

--- a/test/unit/commands/pg/settings/auto-explain/log-verbose.unit.test.ts
+++ b/test/unit/commands/pg/settings/auto-explain/log-verbose.unit.test.ts
@@ -17,7 +17,6 @@ describe('pg:settings:auto-explain:log-verbose', function () {
     api.post('/actions/addon-attachments/resolve', {
       app: 'myapp',
       addon_attachment: 'test-database',
-      addon_service: 'heroku-postgresql',
     }).reply(200, [{addon}])
 
     pg = nock('https://api.data.heroku.com')

--- a/test/unit/commands/pg/settings/data-connector-details-logs.unit.test.ts
+++ b/test/unit/commands/pg/settings/data-connector-details-logs.unit.test.ts
@@ -15,7 +15,6 @@ describe('pg:data-connector-details-logs', function () {
       .post('/actions/addon-attachments/resolve', {
         app: 'myapp',
         addon_attachment: 'test-database',
-        addon_service: 'heroku-postgresql',
       }).reply(200, [{addon}])
   })
 

--- a/test/unit/commands/pg/settings/index.unit.test.ts
+++ b/test/unit/commands/pg/settings/index.unit.test.ts
@@ -22,7 +22,6 @@ describe('pg:settings', function () {
       .post('/actions/addon-attachments/resolve', {
         app: 'myapp',
         addon_attachment: 'postgres-1',
-        addon_service: 'heroku-postgresql',
       }).reply(200, [{addon}])
 
     pg = nock('https://api.data.heroku.com')

--- a/test/unit/commands/pg/settings/log-connections.unit.test.ts
+++ b/test/unit/commands/pg/settings/log-connections.unit.test.ts
@@ -23,7 +23,6 @@ describe('pg:settings:log-connections', function () {
     api.post('/actions/addon-attachments/resolve', {
       app: 'myapp',
       addon_attachment: 'test-database',
-      addon_service: 'heroku-postgresql',
     }).reply(200, [{addon}])
 
     pg = nock('https://api.data.heroku.com')

--- a/test/unit/commands/pg/settings/log-lock-waits.unit.test.ts
+++ b/test/unit/commands/pg/settings/log-lock-waits.unit.test.ts
@@ -15,7 +15,6 @@ describe('pg:settings:log-lock-waits', function () {
       .post('/actions/addon-attachments/resolve', {
         app: 'myapp',
         addon_attachment: 'test-database',
-        addon_service: 'heroku-postgresql',
       }).reply(200, [{addon}])
   })
 

--- a/test/unit/commands/pg/settings/log-min-duration-statement.unit.test.ts
+++ b/test/unit/commands/pg/settings/log-min-duration-statement.unit.test.ts
@@ -17,7 +17,6 @@ describe('pg:settings:log-min-duration-statement', function () {
       .post('/actions/addon-attachments/resolve', {
         app: 'myapp',
         addon_attachment: 'test-database',
-        addon_service: 'heroku-postgresql',
       })
       .reply(200, [{addon}])
   })

--- a/test/unit/commands/pg/settings/log-min-error-statement.unit.test.ts
+++ b/test/unit/commands/pg/settings/log-min-error-statement.unit.test.ts
@@ -17,7 +17,6 @@ describe('pg:settings:log-min-error-statement', function () {
       .post('/actions/addon-attachments/resolve', {
         app: 'myapp',
         addon_attachment: 'test-database',
-        addon_service: 'heroku-postgresql',
       })
       .reply(200, [{addon}])
   })

--- a/test/unit/commands/pg/settings/log-statement.unit.test.ts
+++ b/test/unit/commands/pg/settings/log-statement.unit.test.ts
@@ -17,7 +17,6 @@ describe('pg:settings:log-statement', function () {
       .post('/actions/addon-attachments/resolve', {
         app: 'myapp',
         addon_attachment: 'test-database',
-        addon_service: 'heroku-postgresql',
       })
       .reply(200, [{addon}])
   })

--- a/test/unit/commands/pg/settings/track-functions.unit.test.ts
+++ b/test/unit/commands/pg/settings/track-functions.unit.test.ts
@@ -17,7 +17,6 @@ describe('pg:settings:track-functions', function () {
       .post('/actions/addon-attachments/resolve', {
         app: 'myapp',
         addon_attachment: 'test-database',
-        addon_service: 'heroku-postgresql',
       })
       .reply(200, [{addon}])
   })


### PR DESCRIPTION
## Summary

Here we update the version for the `@heroku/heroku-cli-util` dependency to the latest patch release, which includes a fix for the resolver methods. The fix consists in reverting the change where we passed the add-on service slug on the call to Platform API resolvers to avoid filtering out provisioned add-ons for development services used by Data engineers for testing. Reverting this change affects a lot of tests here that mocked API calls with Nock using the exact contents of the POST payload to the API resolver endpoint. We needed to remove the `addon_service` parameter from all those calls, because it isn't passed any longer by the resolver method in `@heroku/heroku-cli-util`.

We should improve all these tests by mocking directly at the resolver method level, instead of mocking the Platform API call, because that API call is external to this code base and creates this messy situation where a change to an external dependency forces us to update a lot of tests. The resolver methods are extensively tested on the external package and don't need us to reassure here the correct payload on the API calls.

We're not doing the proposed refactor here, to keep a low number of changes for the upcoming v11.0.0 release.

Updating the version for `@heroku/heroku-cli-util` also fixes a [reported issue with `data:pg:psql`](https://salesforce-internal.slack.com/archives/C04S5SL8319/p1773079730348259) when targeting Heroku Advanced databases provisioned on non-Shield Private Space apps.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [X] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing

**Notes**:
Testing requires some complex preparation. We're providing screenshots for each one of the fixes, but if you want to perform further testing, we can meet and go over the prerequisites for testing, or I can share or request access for you to test assets required.

**Steps**:
1. Passing CI suffices.

## Screenshots (if applicable)

### Testing that the PR updates fix the problem with dev add-on resolution:
<img width="1326" height="993" alt="Captura de pantalla 2026-03-16 a la(s) 19 06 28" src="https://github.com/user-attachments/assets/224aa9cf-f4a3-412a-87d3-b51e194441c4" />

### Testing that the PR updates fix the issue with `data:pg:psql` for Private Space apps:
<img width="1049" height="508" alt="Captura de pantalla 2026-03-16 a la(s) 18 42 53" src="https://github.com/user-attachments/assets/638d0fc0-c545-436e-b7db-165e6cc4eb8d" />

## Related Issues
GUS work item: [W-21546520](https://gus.lightning.force.com/a07EE00002W6PLrYAN)
