### PR TITLE
fix: address UI issues with confirmation prompts on multiple commands (W-21649376)

### DIFF
--- a/src/commands/addons/attach.ts
+++ b/src/commands/addons/attach.ts
@@ -1,6 +1,6 @@
-import {color} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {color} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 import {trapConfirmationRequired} from '../../lib/addons/util.js'
@@ -36,10 +36,16 @@ export default class Attach extends Command {
         addon: {name: addon.name}, app: {name: app}, confirm: confirmed, name: as, namespace,
       }
 
-      ux.action.start(`Attaching ${credential ? color.name(credential) + ' of ' : ''}${color.datastore(addon.name || '')}${as ? ' as ' + color.attachment(as) : ''} to ${color.app(app)}`)
-      const {body: attachments} = await this.heroku.post<Heroku.AddOnAttachment>('/addon-attachments', {body})
-      ux.action.stop()
-      return attachments
+      try {
+        ux.action.start(`Attaching ${credential ? color.name(credential) + ' of ' : ''}${color.datastore(addon.name || '')}${as ? ' as ' + color.attachment(as) : ''} to ${color.app(app)}`)
+        const {body: attachment} = await this.heroku.post<Heroku.AddOnAttachment>('/addon-attachments', {body})
+        ux.action.stop()
+
+        return attachment
+      } catch (error: unknown) {
+        ux.action.stop(color.red('!'))
+        throw error
+      }
     }
 
     if (credential && credential !== 'default') {

--- a/src/lib/addons/create_addon.ts
+++ b/src/lib/addons/create_addon.ts
@@ -1,6 +1,6 @@
-import {color, utils} from '@heroku/heroku-cli-util'
 import {APIClient} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {ux} from '@oclif/core'
 
 import {waitForAddonProvisioning} from './addons_wait.js'
@@ -40,18 +40,22 @@ export default async function (
       plan: {name: plan},
     }
 
-    ux.action.start(options.actionStartMessage || `Creating ${plan} on ${color.app(app)}`)
-    const {body: addon} = await heroku.post<Heroku.AddOn>(`/apps/${app}/addons`, {
-      body,
-      headers: {
-        'accept-expansion': 'plan',
-        'x-heroku-legacy-provider-messages': 'true',
-      },
-    })
+    try {
+      ux.action.start(options.actionStartMessage || `Creating ${plan} on ${color.app(app)}`)
+      const {body: addon} = await heroku.post<Heroku.AddOn>(`/apps/${app}/addons`, {
+        body,
+        headers: {
+          'accept-expansion': 'plan',
+          'x-heroku-legacy-provider-messages': 'true',
+        },
+      })
+      ux.action.stop(options.actionStopMessage || color.green(util.formatPriceText(addon.plan?.price || '')))
 
-    ux.action.stop(options.actionStopMessage || color.green(util.formatPriceText(addon.plan?.price || '')))
-
-    return addon
+      return addon
+    } catch (error: unknown) {
+      ux.action.stop(color.red('!'))
+      throw error
+    }
   }
 
   let addon = await util.trapConfirmationRequired<Heroku.AddOn>(app, confirm, confirm => (createAddonRequest(confirm)))


### PR DESCRIPTION
## Summary

There's a UI issue when creating a Heroku Postgres Advanced database with `data:pg:create` and confirmation is required to overwrite existing config vars in the application. The problem was being caused by a bad interaction between the `ux.action.start()...ux.action.stop()` block and `trapConfirmationRequired` usage.

Here we're applying the same logic used for `data:pg:attachments:create` that also uses `trapConfirmationRequired` and didn't show this problem.

We detected that this same problem was affecting also `addons:attach`, for the very same reasons, so we're applying the same fix there.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [X] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
For testing you will be required to have at least one Heroku Postgres Advanced test database with two attachments like in the screenshots below.

**Steps**:
1. Checkout this branch, and build the CLI with ```npm install && npm run build```.
2. Attempt to create a new Advanced database re-using one of the attachment names assigned to the existing database:
    ```./bin/run data:pg:create --level 4G-Performance --no-high-availability -a test-app-name --as EXISTING_ATTACHMENT_NAME```
    You shouldn't observe the error described in the referenced GUS work item.
3. Same can be repeated for the `data:pg:fork` error reports on the ticket and `addons:attach` command. See the examples on the screenshots below.

## Screenshots (if applicable)

### Fix for `data:pg:create`

<img width="1728" height="939" alt="Captura de pantalla 2026-03-19 a la(s) 14 26 02" src="https://github.com/user-attachments/assets/5c852598-3d5d-467c-a07e-117914bd60a6" />

### The fix also addresses `data:pg:fork` action error showing "done" instead of the red exclamation mark

<img width="1728" height="674" alt="Captura de pantalla 2026-03-19 a la(s) 14 18 24" src="https://github.com/user-attachments/assets/1423c24b-57bd-4d27-9dfe-a46c51935e8b" />

### ...and also the `data:pg:fork` problem with the confirmation prompt

<img width="1728" height="873" alt="Captura de pantalla 2026-03-19 a la(s) 14 21 20" src="https://github.com/user-attachments/assets/b91caab8-f6c4-462b-9e6f-e99304508a7e" />

## Related Issues
GUS work item: [W-21649376](https://gus.lightning.force.com/a07EE00002WXgLDYA1)
