### PR TITLE
fix: resolve addons across data maintenances commands

### DIFF
--- a/src/commands/data/maintenances/info.ts
+++ b/src/commands/data/maintenances/info.ts
@@ -85,7 +85,7 @@ export default class DataMaintenancesInfo extends BaseCommand {
     const {args, flags} = await this.parse(DataMaintenancesInfo)
     const addonResolver = new utils.AddonResolver(this.heroku)
     const {app, json} = flags
-    const addon = await addonResolver.resolve(args.addon, app, utils.pg.addonService())
+    const addon = await addonResolver.resolve(args.addon, app)
 
     ux.action.start(`Fetching maintenance for ${color.addon(addon.name!)}`)
     const {body: maintenance} = await this.dataApi.get<Maintenance>(

--- a/src/commands/data/maintenances/run.ts
+++ b/src/commands/data/maintenances/run.ts
@@ -56,7 +56,7 @@ export default class DataMaintenancesRun extends BaseCommand {
     const {args, flags} = await this.parse(DataMaintenancesRun)
     const addonResolver = new utils.AddonResolver(this.heroku)
     const {app, confirm, force, wait} = flags
-    const addon = await addonResolver.resolve(args.addon, app, utils.pg.addonService())
+    const addon = await addonResolver.resolve(args.addon, app)
 
     const isEssentialTier = utils.pg.isEssentialDatabase(addon) || utils.pg.isLegacyEssentialDatabase(addon)
     if (isEssentialTier) {

--- a/src/commands/data/maintenances/schedule.ts
+++ b/src/commands/data/maintenances/schedule.ts
@@ -62,7 +62,7 @@ export default class DataMaintenancesSchedule extends BaseCommand {
     const addonResolver = new utils.AddonResolver(this.heroku)
     const {app, week, weeks} = flags
 
-    const addon = await addonResolver.resolve(args.addon, app, utils.pg.addonService())
+    const addon = await addonResolver.resolve(args.addon, app)
 
     const delayWeeks = week === undefined
       ? weeks

--- a/src/commands/data/maintenances/wait.ts
+++ b/src/commands/data/maintenances/wait.ts
@@ -26,7 +26,7 @@ export default class DataMaintenancesWait extends BaseCommand {
   async run() {
     const {args, flags} = await this.parse(DataMaintenancesWait)
     const addonResolver = new utils.AddonResolver(this.heroku)
-    const addon = await addonResolver.resolve(args.addon, flags.app, utils.pg.addonService())
+    const addon = await addonResolver.resolve(args.addon, flags.app)
 
     const isEssentialTier = utils.pg.isEssentialDatabase(addon) || utils.pg.isLegacyEssentialDatabase(addon)
     if (isEssentialTier) {

--- a/src/commands/data/maintenances/window/index.ts
+++ b/src/commands/data/maintenances/window/index.ts
@@ -29,7 +29,7 @@ export default class DataMaintenancesWindow extends BaseCommand {
   async run() {
     const {args, flags} = await this.parse(DataMaintenancesWindow)
     const addonResolver = new utils.AddonResolver(this.heroku)
-    const addon = await addonResolver.resolve(args.addon, flags.app, utils.pg.addonService())
+    const addon = await addonResolver.resolve(args.addon, flags.app)
 
     ux.action.start(`Fetching maintenance window for ${color.addon(addon.name!)}`)
     const {body: window} = await this.dataApi.get<Window>(

--- a/src/commands/data/maintenances/window/update.ts
+++ b/src/commands/data/maintenances/window/update.ts
@@ -38,7 +38,7 @@ export default class DataMaintenancesWindowUpdate extends BaseCommand {
   async run() {
     const {args, flags} = await this.parse(DataMaintenancesWindowUpdate)
     const addonResolver = new utils.AddonResolver(this.heroku)
-    const addon = await addonResolver.resolve(args.addon, flags.app, utils.pg.addonService())
+    const addon = await addonResolver.resolve(args.addon, flags.app)
 
     const combinedWindowLabel = `${args.day_of_week} ${args.time_of_day}`
     ux.action.start(

--- a/test/unit/commands/data/maintenances/info.unit.test.ts
+++ b/test/unit/commands/data/maintenances/info.unit.test.ts
@@ -3,7 +3,7 @@ import nock from 'nock'
 import {stderr, stdout} from 'stdout-stderr'
 
 import DataMaintenancesInfo from '../../../../../src/commands/data/maintenances/info.js'
-import {addon} from '../../../../fixtures/data/pg/fixtures.js'
+import {addon, nonPostgresAddon} from '../../../../fixtures/data/pg/fixtures.js'
 import runCommand from '../../../../helpers/runCommand.js'
 import {unwrap} from '../../../../helpers/utils/unwrap.js'
 
@@ -157,5 +157,19 @@ window:                   Thursdays 22:00 to Fridays 02:00 UTC
       const {message} = error as {message: string}
       expect(message).to.equal('not found')
     }
+  })
+
+  it('shows maintenance for non-postgres add-ons', async function () {
+    herokuApi
+      .post('/actions/addons/resolve', body => body.addon_service === undefined)
+      .reply(200, [nonPostgresAddon])
+    dataApi
+      .get(`/data/maintenances/v1/${nonPostgresAddon.id}`)
+      .reply(200, maintenance)
+
+    await runCommand(DataMaintenancesInfo, [nonPostgresAddon.name, '--json'])
+
+    expect(unwrap(stderr.output)).to.contain(`Fetching maintenance for ${nonPostgresAddon.name}... done\n`)
+    expect(JSON.parse(stdout.output)).to.deep.equal(maintenance)
   })
 })

--- a/test/unit/commands/data/maintenances/run.unit.test.ts
+++ b/test/unit/commands/data/maintenances/run.unit.test.ts
@@ -7,7 +7,7 @@ import DataMaintenancesRun from '../../../../../src/commands/data/maintenances/r
 import {Maintenance, MaintenanceStatus} from '../../../../../src/lib/data/types.js'
 import {cedarApp} from '../../../../fixtures/apps/fixtures.js'
 import {maintenance, maintenancesResponse} from '../../../../fixtures/data/maintenances/fixtures.js'
-import {addon, legacyEssentialAddon} from '../../../../fixtures/data/pg/fixtures.js'
+import {addon, legacyEssentialAddon, nonPostgresAddon} from '../../../../fixtures/data/pg/fixtures.js'
 import runCommand from '../../../../helpers/runCommand.js'
 
 const appInMaintenance = {
@@ -63,6 +63,25 @@ describe('data:maintenances:run', function () {
       .reply(200, maintenancesResponse)
 
     await runCommand(DataMaintenancesRun, [addon.name])
+
+    expect(stderr.output).to.contain('maintenance triggered')
+    expect(stdout.output).to.contain('')
+  })
+
+  it('runs maintenance for non-postgres add-ons', async function () {
+    herokuApi
+      .post('/actions/addons/resolve', body => body.addon_service === undefined)
+      .reply(200, [nonPostgresAddon])
+
+    herokuApi
+      .get(`/apps/${nonPostgresAddon.app.id}`)
+      .reply(200, appInMaintenance)
+
+    dataApi
+      .post(`/data/maintenances/v1/${nonPostgresAddon.id}/run`)
+      .reply(200, maintenancesResponse)
+
+    await runCommand(DataMaintenancesRun, [nonPostgresAddon.name])
 
     expect(stderr.output).to.contain('maintenance triggered')
     expect(stdout.output).to.contain('')

--- a/test/unit/commands/data/maintenances/schedule.unit.test.ts
+++ b/test/unit/commands/data/maintenances/schedule.unit.test.ts
@@ -4,7 +4,7 @@ import {stderr, stdout} from 'stdout-stderr'
 
 import DataMaintenancesSchedule from '../../../../../src/commands/data/maintenances/schedule.js'
 import {maintenance, maintenancesResponse} from '../../../../fixtures/data/maintenances/fixtures.js'
-import {addon} from '../../../../fixtures/data/pg/fixtures.js'
+import {addon, nonPostgresAddon} from '../../../../fixtures/data/pg/fixtures.js'
 import runCommand from '../../../../helpers/runCommand.js'
 
 const unscheduledScheduleResponse = {
@@ -83,6 +83,19 @@ describe('data:maintenances:schedule', function () {
     await runCommand(DataMaintenancesSchedule, [addon.name, '--weeks=4'])
 
     expect(stderr.output).to.contain(`Scheduling maintenance for ${addon.name}... maintenance scheduled`)
+  })
+
+  it('schedules maintenance for non-postgres add-ons', async function () {
+    herokuApi
+      .post('/actions/addons/resolve', body => body.addon_service === undefined)
+      .reply(200, [nonPostgresAddon])
+    dataApi
+      .post(`/data/maintenances/v1/${nonPostgresAddon.id}/schedule`)
+      .reply(200, unscheduledScheduleResponse)
+
+    await runCommand(DataMaintenancesSchedule, [nonPostgresAddon.name])
+
+    expect(stderr.output).to.contain(`Scheduling maintenance for ${nonPostgresAddon.name}... maintenance scheduled`)
   })
 
   it('schedules a maintenance for a specific week', async function () {

--- a/test/unit/commands/data/maintenances/wait.unit.test.ts
+++ b/test/unit/commands/data/maintenances/wait.unit.test.ts
@@ -6,7 +6,7 @@ import {stderr} from 'stdout-stderr'
 import DataMaintenancesWait from '../../../../../src/commands/data/maintenances/wait.js'
 import {Maintenance, MaintenanceStatus} from '../../../../../src/lib/data/types.js'
 import {maintenance} from '../../../../fixtures/data/maintenances/fixtures.js'
-import {addon} from '../../../../fixtures/data/pg/fixtures.js'
+import {addon, nonPostgresAddon} from '../../../../fixtures/data/pg/fixtures.js'
 import runCommand from '../../../../helpers/runCommand.js'
 
 const completedMaintenance: Maintenance = {
@@ -101,5 +101,31 @@ describe('data:maintenances:wait', function () {
       const {message} = error as {message: string}
       expect(ansis.strip(message)).to.equal(`There currently isn't any maintenance in progress for ${addon.name}`)
     }
+  })
+
+  it('waits for non-postgres add-ons', async function () {
+    herokuApi
+      .post('/actions/addons/resolve', body => body.addon_service === undefined)
+      .reply(200, [nonPostgresAddon])
+
+    let pollingCalls = 0
+    dataApi
+      .get(`/data/maintenances/v1/${nonPostgresAddon.id}`)
+      .reply(200, runningMaintenance)
+    dataApi
+      .get(`/data/maintenances/v1/${nonPostgresAddon.id}`)
+      .thrice()
+      .reply(() => {
+        pollingCalls++
+
+        return pollingCalls === 3
+          ? [200, completedMaintenance]
+          : [200, runningMaintenance]
+      })
+
+    await runCommand(DataMaintenancesWait, [nonPostgresAddon.name])
+
+    expect(stderr.output).to.contain(`Waiting for maintenance on ${nonPostgresAddon.name} to complete`)
+    expect(stderr.output).to.contain('maintenance completed')
   })
 })

--- a/test/unit/commands/data/maintenances/window/index.unit.test.ts
+++ b/test/unit/commands/data/maintenances/window/index.unit.test.ts
@@ -4,7 +4,7 @@ import {stderr, stdout} from 'stdout-stderr'
 
 import DataMaintenancesWindow from '../../../../../../src/commands/data/maintenances/window/index.js'
 import {maintenanceWindow} from '../../../../../fixtures/data/maintenances/fixtures.js'
-import {addon} from '../../../../../fixtures/data/pg/fixtures.js'
+import {addon, nonPostgresAddon} from '../../../../../fixtures/data/pg/fixtures.js'
 import runCommand from '../../../../../helpers/runCommand.js'
 
 describe('data:maintenances:window', function () {
@@ -51,6 +51,20 @@ describe('data:maintenances:window', function () {
     await runCommand(DataMaintenancesWindow, [addon.name, `--app=${app.name}`])
 
     expect(stderr.output).to.contain(`Fetching maintenance window for ${addon.name}... done\n`)
+    expect(stdout.output).to.contain('window:          Tuesdays 17:30 to 21:30 UTC\n')
+  })
+
+  it('can fetch a window for a non-postgres addon', async function () {
+    herokuApi
+      .post('/actions/addons/resolve', body => body.addon_service === undefined)
+      .reply(200, [nonPostgresAddon])
+    dataApi
+      .get(`/data/maintenances/v1/${nonPostgresAddon.id}/window`)
+      .reply(200, maintenanceWindow)
+
+    await runCommand(DataMaintenancesWindow, [nonPostgresAddon.name])
+
+    expect(stderr.output).to.contain(`Fetching maintenance window for ${nonPostgresAddon.name}... done\n`)
     expect(stdout.output).to.contain('window:          Tuesdays 17:30 to 21:30 UTC\n')
   })
 })

--- a/test/unit/commands/data/maintenances/window/update.unit.test.ts
+++ b/test/unit/commands/data/maintenances/window/update.unit.test.ts
@@ -4,7 +4,7 @@ import {stderr, stdout} from 'stdout-stderr'
 
 import DataMaintenancesWindowUpdate from '../../../../../../src/commands/data/maintenances/window/update.js'
 import {maintenanceWindow} from '../../../../../fixtures/data/maintenances/fixtures.js'
-import {addon} from '../../../../../fixtures/data/pg/fixtures.js'
+import {addon, nonPostgresAddon} from '../../../../../fixtures/data/pg/fixtures.js'
 import runCommand from '../../../../../helpers/runCommand.js'
 
 describe('data:maintenances:window:update', function () {
@@ -58,6 +58,24 @@ describe('data:maintenances:window:update', function () {
     await runCommand(DataMaintenancesWindowUpdate, [addon.name, 'tuesday', '5:30PM', `--app=${app.name}`])
 
     expect(stderr.output).to.contain(`Setting maintenance window for ${addon.name} to tuesday 5:30PM... done`)
+    expect(stdout.output).to.contain('previous_window: Fridays 17:30 to 21:30 UTC\n')
+    expect(stdout.output).to.contain('window:          Tuesdays 17:30 to 21:30 UTC\n')
+  })
+
+  it('can change a window for a non-postgres addon', async function () {
+    herokuApi
+      .post('/actions/addons/resolve', body => body.addon_service === undefined)
+      .reply(200, [nonPostgresAddon])
+    dataApi
+      .post(`/data/maintenances/v1/${nonPostgresAddon.id}/window`, {
+        day_of_week: 'tuesday',
+        time_of_day: '5:30PM',
+      })
+      .reply(200, maintenanceWindow)
+
+    await runCommand(DataMaintenancesWindowUpdate, [nonPostgresAddon.name, 'tuesday', '5:30PM'])
+
+    expect(stderr.output).to.contain(`Setting maintenance window for ${nonPostgresAddon.name} to tuesday 5:30PM... done`)
     expect(stdout.output).to.contain('previous_window: Fridays 17:30 to 21:30 UTC\n')
     expect(stdout.output).to.contain('window:          Tuesdays 17:30 to 21:30 UTC\n')
   })


### PR DESCRIPTION
## Summary
Fixes a v11 regression where maintenance commands were resolving add-ons as Postgres-only, causing valid Redis/Kafka add-ons to fail with `Couldn't find that addon.`  
Updates all `data:maintenances*` subcommands to resolve supported add-ons consistently and adds regression tests for non-Postgres add-ons.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [x] **test**: Add/update/remove tests

## Testing
**Notes**:
Validated locally against the reported Redis repro case using local CLI code.

**Steps**:
1. `npm ci`
2. `npm run build`
3. `node ./bin/run data:maintenances --app [APP NAME]`
4. `node ./bin/run data:maintenances:schedule DATABASE --app [APP NAME]`
5. `npm run test:file -- test/unit/commands/data/maintenances/schedule.unit.test.ts`

## Screenshots (if applicable)

## Related Issues
GitHub issue: #3608  
GUS work item: W-21715781