### PR TITLE
fix: show correct error message for Essential-tier (W-21653472)

### DIFF
--- a/src/commands/data/pg/credentials/destroy.ts
+++ b/src/commands/data/pg/credentials/destroy.ts
@@ -1,6 +1,10 @@
-import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {flags as Flags} from '@heroku-cli/command'
 import {AddOnAttachment} from '@heroku-cli/schema'
+import * as color from '@heroku/heroku-cli-util/color'
+import {confirmCommand} from '@heroku/heroku-cli-util/hux'
+import {
+  AddonResolver, getAddonService, isAdvancedDatabase, isEssentialDatabase, isLegacyEssentialDatabase,
+} from '@heroku/heroku-cli-util/utils'
 import {Args, ux} from '@oclif/core'
 
 import type {CredentialInfo, CredentialsInfo} from '../../../../lib/data/types.js'
@@ -33,10 +37,11 @@ export default class DataPgCredentialsDestroy extends BaseCommand {
     const {app, confirm, name} = flags
     const {database} = args
 
-    const addonResolver = new utils.AddonResolver(this.heroku)
-    const addon = await addonResolver.resolve(database, app, utils.pg.addonService())
-    const isEssentialTier = utils.pg.isEssentialDatabase(addon) || utils.pg.isLegacyEssentialDatabase(addon)
-    const isAdvancedTier = utils.pg.isAdvancedDatabase(addon)
+    const addonResolver = new AddonResolver(this.heroku)
+    const addon = await addonResolver.resolve(database, app, getAddonService())
+    const isEssentialTier = isEssentialDatabase(addon)
+    const isLegacyEssentialTier = isLegacyEssentialDatabase(addon)
+    const isAdvancedTier = isAdvancedDatabase(addon)
     let credAttachments: Required<AddOnAttachment>[] = []
 
     if (isAdvancedTier) {
@@ -50,7 +55,9 @@ export default class DataPgCredentialsDestroy extends BaseCommand {
       }
 
       credAttachments = attachments.filter(a => a.namespace === `role:${name}`)
-    } else if (isEssentialTier || name === 'default') {
+    } else if (isEssentialTier) {
+      ux.error('You can\'t destroy custom credentials on Essential-tier databases.')
+    } else if (isLegacyEssentialTier || name === 'default') {
       ux.error('You can\'t destroy the default credential.')
     } else {
       const {body: attachments} = await this.heroku.get<Required<AddOnAttachment>[]>(
@@ -68,7 +75,7 @@ export default class DataPgCredentialsDestroy extends BaseCommand {
       )
     }
 
-    await hux.confirmCommand({comparison: app, confirmation: confirm})
+    await confirmCommand({comparison: app, confirmation: confirm})
 
     try {
       ux.action.start(`Destroying credential ${color.name(name)}`)

--- a/test/unit/commands/data/pg/credentials/destroy.unit.test.ts
+++ b/test/unit/commands/data/pg/credentials/destroy.unit.test.ts
@@ -60,7 +60,7 @@ describe('data:pg:credentials:destroy', function () {
 
       herokuApi.done()
       expect(ansis.strip(err.message)).to.equal(
-        'You can\'t destroy the default credential.',
+        'You can\'t destroy custom credentials on Essential-tier databases.',
       )
     }
   })


### PR DESCRIPTION
## Summary

The error message for `data:pg:credentials:destroy` command when dealing with an Essential-tier database (essential-0/1/2) isn't the correct one.

Here we add a new conditional branch that shows the correct error message when dealing with the referred databases.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [X] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
For this you will need to have an Essential-tier database created on your test app. You can create it with
```
heroku addons:create heroku-postgresql:essential-0 -a test-app-name --as ESSENTIAL_DB
heroku addons:wait -a test-app-name
```

**Steps**:
1. List the credentials on your essential database with
    ```heroku pg:credentials ESSENTIAL_DB -a test-app-name```
2. Grab the credential name from the table list (there should be only one active credential) and use it to attempt to destroy it with our current implementation:
    ```heroku data:pg:credentials:destroy ESSENTIAL_DB -a test-app-name --name grabbed-credential-name```
    You should see the error "You can't destroy the default credential." (wrong message).
3. Repeat for the fixed implementation:
    ```./bin/run data:pg:credentials:destroy ESSENTIAL_DB -a test-app-name --name grabbed-credential-name```
    You should see the error "You can't destroy custom credentials on Essential-tier databases." (correct message).

## Screenshots (if applicable)

<img width="1485" height="314" alt="Captura de pantalla 2026-03-25 a la(s) 18 12 37" src="https://github.com/user-attachments/assets/5b6dafb4-e393-42b1-b75a-333d59cd42cd" />

## Related Issues
GUS work item: [W-21653472](https://gus.lightning.force.com/a07EE00002WYP76YAH)
