### PR TITLE
fix: separate TERM=dumb run status lines

### DIFF
--- a/src/lib/run/dyno.ts
+++ b/src/lib/run/dyno.ts
@@ -418,7 +418,12 @@ export default class Dyno extends Duplex {
         const pathnameWithSearchParams = this.uri.pathname + this.uri.search
         c.write(pathnameWithSearchParams.slice(1) + '\r\n', () => {
           if (this.opts.showStatus) {
-            ux.action.status = this._status('connecting')
+            if (process.env.TERM === 'dumb') {
+              ux.action.stop(this._status('connecting'))
+              ux.action.start(`Running ${color.code(this.opts.command)} on ${color.app(this.opts.app)}`)
+            } else {
+              ux.action.status = this._status('connecting')
+            }
           }
         })
       })


### PR DESCRIPTION
## Summary
Fixes `TERM=dumb` output formatting for `heroku run` status updates by ensuring the `connecting` and `up` messages render on separate lines instead of being concatenated.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
Validated locally in a real app run session using `TERM=dumb`.

**Steps**:
1. `npm run build`
2. `TERM=dumb node ./bin/run run bash -a <app-name>`
3. Confirm status output renders on separate lines:
   - `starting, run.xxxx`
   - `connecting, run.xxxx`
   - `up, run.xxxx`

## Screenshots (if applicable)

## Related Issues
GitHub issue: #3601  
GUS work item: W-21753415