### PR TITLE
fix: point bin to run.js instead of symlink for npm compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "yargs-parser": "18.1.3"
       },
       "bin": {
-        "heroku": "bin/run"
+        "heroku": "bin/run.js"
       },
       "devDependencies": {
         "@actions/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "CLI to interact with Heroku",
   "version": "11.0.1",
   "author": "Heroku",
-  "bin": "./bin/run",
+  "bin": "./bin/run.js",
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
     "@heroku-cli/command": "^12.2.2",


### PR DESCRIPTION
## Summary
This PR fixes an issue where the `heroku` command doesn't work for users installing from npm. The problem was that `package.json` pointed to `bin/run`, which is a symlink to `run.js`. Since symlinks are not preserved in npm tarballs, the published package was broken for npm users.

The fix changes the bin entry from `./bin/run` to `./bin/run.js`, pointing directly to the actual executable file instead of the symlink. This ensures the package works correctly when installed from npm while keeping the symlink in the repo for local development convenience.

## Type of Change
### Patch Updates (patch semver update)
- [x] **fix**: Bug fix

## Testing
**Notes**:
This issue only affects users installing from npm (not from git), and CI wouldn't catch it since CI runs from the git repository where the symlink exists.

**Steps**:
1. Verify the package builds correctly: `npm run build`
2. Create a test tarball: `npm pack`
3. Extract and inspect the tarball to confirm `bin/run.js` is present
4. Install from the tarball and verify the `heroku` command works
5. Passing CI suffices for general functionality

## Related Issues
https://github.com/heroku/cli/issues/3622