### PR TITLE
refactor: apply lint formatting to auth through features commands

### DIFF
--- a/src/commands/auth/2fa/disable.ts
+++ b/src/commands/auth/2fa/disable.ts
@@ -7,9 +7,7 @@ export default class Auth2faGenerate extends Command {
     'twofactor:disable',
     '2fa:disable',
   ]
-
   static description = 'disables 2fa on account'
-
   static example = `${color.command('heroku auth:2fa:disable')}`
 
   async run() {

--- a/src/commands/auth/2fa/index.ts
+++ b/src/commands/auth/2fa/index.ts
@@ -5,7 +5,6 @@ import {ux} from '@oclif/core/ux'
 
 export default class TwoFactor extends Command {
   static aliases = ['2fa', 'twofactor']
-
   static description = 'check 2fa status'
 
   async run() {

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -4,9 +4,7 @@ import * as color from '@heroku/heroku-cli-util/color'
 
 export default class Login extends Command {
   static aliases = ['login']
-
   static description = 'login with your Heroku credentials'
-
   static flags = {
     browser: flags.string({description: 'browser to open SSO with (example: "firefox", "safari")'}),
     'expires-in': flags.integer({char: 'e', description: 'duration of token in seconds (default 30 days)'}),

--- a/src/commands/auth/whoami.ts
+++ b/src/commands/auth/whoami.ts
@@ -23,4 +23,3 @@ export default class AuthWhoami extends Command {
     }
   }
 }
-

--- a/src/commands/authorizations/create.ts
+++ b/src/commands/authorizations/create.ts
@@ -9,11 +9,9 @@ import {display} from '../../lib/authorizations/authorizations.js'
 
 export default class AuthorizationsCreate extends Command {
   static description = 'create a new OAuth authorization'
-
   static examples = [
     color.command('heroku authorizations:create --description "For use with Anvil"'),
   ]
-
   static flags = {
     description: flags.string({char: 'd', description: 'set a custom authorization'}),
     'expires-in': flags.string({char: 'e', description: 'set expiration in seconds (default no expiration)'}),

--- a/src/commands/authorizations/index.ts
+++ b/src/commands/authorizations/index.ts
@@ -5,11 +5,9 @@ import {ux} from '@oclif/core/ux'
 
 export default class AuthorizationsIndex extends Command {
   static description = 'list OAuth authorizations'
-
   static examples = [
     color.command('heroku authorizations'),
   ]
-
   static flags = {
     json: flags.boolean({char: 'j', description: 'output in json format'}),
   }

--- a/src/commands/authorizations/info.ts
+++ b/src/commands/authorizations/info.ts
@@ -1,27 +1,23 @@
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
-import {Args} from '@oclif/core'
 import {hux} from '@heroku/heroku-cli-util'
+import {Args} from '@oclif/core'
 
 import {display} from '../../lib/authorizations/authorizations.js'
 
 export default class AuthorizationsInfo extends Command {
+  static args = {
+    id: Args.string({description: 'ID of the authorization', required: true}),
+  }
   static description = 'show an existing OAuth authorization'
-
   static flags = {
     json: flags.boolean({char: 'j', description: 'output in json format'}),
-  }
-
-  static args = {
-    id: Args.string({required: true, description: 'ID of the authorization'}),
   }
 
   async run() {
     const {args, flags} = await this.parse(AuthorizationsInfo)
 
-    const {body: authentication} = await this.heroku.get<Heroku.OAuthAuthorization>(
-      `/oauth/authorizations/${args.id}`,
-    )
+    const {body: authentication} = await this.heroku.get<Heroku.OAuthAuthorization>(`/oauth/authorizations/${args.id}`)
 
     if (flags.json) {
       hux.styledJSON(authentication)

--- a/src/commands/authorizations/revoke.ts
+++ b/src/commands/authorizations/revoke.ts
@@ -5,13 +5,10 @@ import {Args, ux} from '@oclif/core'
 
 export default class AuthorizationsRevoke extends Command {
   static aliases = ['authorizations:destroy']
-
   static args = {
     id: Args.string({description: 'ID of the authorization', required: true}),
   }
-
   static description = 'revoke OAuth authorization'
-
   static examples = [
     color.command('heroku authorizations:revoke 105a7bfa-34c3-476e-873a-b1ac3fdc12fb'),
   ]
@@ -20,9 +17,7 @@ export default class AuthorizationsRevoke extends Command {
     const {args} = await this.parse(AuthorizationsRevoke)
 
     ux.action.start('Revoking OAuth Authorization')
-    const {body: auth} = await this.heroku.delete<Heroku.OAuthAuthorization>(
-      `/oauth/authorizations/${encodeURIComponent(args.id)}`,
-    )
+    const {body: auth} = await this.heroku.delete<Heroku.OAuthAuthorization>(`/oauth/authorizations/${encodeURIComponent(args.id)}`)
     ux.action.stop(`done, revoked authorization from ${color.cyan(auth.description)}`)
   }
 }

--- a/src/commands/authorizations/rotate.ts
+++ b/src/commands/authorizations/rotate.ts
@@ -5,19 +5,16 @@ import {Args, ux} from '@oclif/core'
 import {display} from '../../lib/authorizations/authorizations.js'
 
 export default class AuthorizationsRotate extends Command {
-  static description = 'updates an OAuth authorization token'
-
   static args = {
-    id: Args.string({required: true, description: 'ID of the authorization'}),
+    id: Args.string({description: 'ID of the authorization', required: true}),
   }
+  static description = 'updates an OAuth authorization token'
 
   async run() {
     const {args} = await this.parse(AuthorizationsRotate)
 
     ux.action.start('Rotating OAuth Authorization')
-    const {body: authorization} = await this.heroku.post<Heroku.OAuthAuthorization>(
-      `/oauth/authorizations/${encodeURIComponent(args.id)}/actions/regenerate-tokens`,
-    )
+    const {body: authorization} = await this.heroku.post<Heroku.OAuthAuthorization>(`/oauth/authorizations/${encodeURIComponent(args.id)}/actions/regenerate-tokens`)
     ux.action.stop()
 
     display(authorization)

--- a/src/commands/authorizations/update.ts
+++ b/src/commands/authorizations/update.ts
@@ -5,16 +5,14 @@ import {Args, ux} from '@oclif/core'
 import {display} from '../../lib/authorizations/authorizations.js'
 
 export default class AuthorizationsUpdate extends Command {
-  static description = 'updates an OAuth authorization'
-
-  static flags = {
-    description: flags.string({char: 'd', description: 'set a custom authorization description'}),
-    'client-id': flags.string({description: 'identifier of OAuth client to set', dependsOn: ['client-secret']}),
-    'client-secret': flags.string({description: 'secret of OAuth client to set', dependsOn: ['client-id']}),
-  }
-
   static args = {
-    id: Args.string({required: true, description: 'ID of the authorization'}),
+    id: Args.string({description: 'ID of the authorization', required: true}),
+  }
+  static description = 'updates an OAuth authorization'
+  static flags = {
+    'client-id': flags.string({dependsOn: ['client-secret'], description: 'identifier of OAuth client to set'}),
+    'client-secret': flags.string({dependsOn: ['client-id'], description: 'secret of OAuth client to set'}),
+    description: flags.string({char: 'd', description: 'set a custom authorization description'}),
   }
 
   async run() {
@@ -34,8 +32,8 @@ export default class AuthorizationsUpdate extends Command {
       `/oauth/authorizations/${args.id}`,
       {
         body: {
-          description: flags.description,
           client,
+          description: flags.description,
         },
       },
     )

--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -1,8 +1,8 @@
 import {Command} from '@oclif/core'
 import debug from 'debug'
 import fs from 'fs-extra'
+import path from 'node:path'
 import {fileURLToPath} from 'node:url'
-import * as path from 'path'
 
 import {AutocompleteBase} from '../../lib/autocomplete/base.js'
 
@@ -14,82 +14,9 @@ const debugLog = debug('autocomplete:create')
 const AC_LIB_PATH = path.resolve(__dirname, '..', '..', '..', 'autocomplete-scripts')
 
 export default class Create extends AutocompleteBase {
-  static hidden = true
-
   static description = 'create autocomplete setup scripts and completion functions'
-
+  static hidden = true
   private _commands?: Command.Loadable[]
-
-  async run() {
-    this.errorIfWindows()
-    // 1. ensure needed dirs
-    await this.ensureDirs()
-    // 2. save (generated) autocomplete files
-    await this.createFiles()
-  }
-
-  private async ensureDirs() {
-    // ensure autocomplete cache dir
-    await fs.ensureDir(this.autocompleteCacheDir)
-    // ensure autocomplete completions dir
-    await fs.ensureDir(this.completionsCacheDir)
-  }
-
-  private async createFiles() {
-    await fs.writeFile(this.bashSetupScriptPath, this.bashSetupScript)
-    await fs.writeFile(this.zshSetupScriptPath, this.zshSetupScript)
-    await fs.writeFile(this.bashCommandsListPath, this.bashCommandsList)
-    await fs.writeFile(this.zshCompletionSettersPath, this.zshCompletionSetters)
-  }
-
-  private get bashSetupScriptPath(): string {
-    // <cacheDir>/autocomplete/bash_setup
-    return path.join(this.autocompleteCacheDir, 'bash_setup')
-  }
-
-  private get bashCommandsListPath(): string {
-    // <cacheDir>/autocomplete/commands
-    return path.join(this.autocompleteCacheDir, 'commands')
-  }
-
-  private get zshSetupScriptPath(): string {
-    // <cacheDir>/autocomplete/zsh_setup
-    return path.join(this.autocompleteCacheDir, 'zsh_setup')
-  }
-
-  private get zshCompletionSettersPath(): string {
-    // <cacheDir>/autocomplete/commands_setters
-    return path.join(this.autocompleteCacheDir, 'commands_setters')
-  }
-
-  private get skipEllipsis(): boolean {
-    return process.env.HEROKU_AC_ZSH_SKIP_ELLIPSIS === '1'
-  }
-
-  private get commands(): Command.Loadable[] {
-    if (this._commands) return this._commands
-
-    const {plugins} = this.config
-    const commands: Command.Loadable[] = []
-
-    plugins.forEach(p => {
-      p.commands.forEach(c => {
-        if (c.hidden) return
-        try {
-          commands.push(c)
-        } catch (error: any) {
-          debugLog(`Error creating completions for command ${c.id}`)
-          debugLog(error.message)
-          this.writeLogFile(error.message).catch(error => {
-            debugLog(`Failed to write log file: ${error.message}`)
-          })
-        }
-      })
-    })
-
-    this._commands = commands
-    return this._commands
-  }
 
   private get bashCommandsList(): string {
     return this.commands.map(c => {
@@ -107,10 +34,84 @@ export default class Create extends AutocompleteBase {
     }).join('\n')
   }
 
-  private get zshCompletionSetters(): string {
-    const cmdsSetter = this.zshCommandsSetter
-    const flagSetters = this.zshCommandsFlagsSetters
-    return `${cmdsSetter}\n${flagSetters}`
+  private get bashCommandsListPath(): string {
+    // <cacheDir>/autocomplete/commands
+    return path.join(this.autocompleteCacheDir, 'commands')
+  }
+
+  private get bashSetupScript(): string {
+    return `${this.envAnalyticsDir}
+${this.envCommandsPath}
+HEROKU_AC_BASH_COMPFUNC_PATH=${AC_LIB_PATH}/bash/heroku.bash && test -f $HEROKU_AC_BASH_COMPFUNC_PATH && source $HEROKU_AC_BASH_COMPFUNC_PATH;
+`
+  }
+
+  private get bashSetupScriptPath(): string {
+    // <cacheDir>/autocomplete/bash_setup
+    return path.join(this.autocompleteCacheDir, 'bash_setup')
+  }
+
+  private get commands(): Command.Loadable[] {
+    if (this._commands) return this._commands
+
+    const {plugins} = this.config
+    const commands: Command.Loadable[] = []
+
+    const pluginList = Array.isArray(plugins) ? plugins : [...plugins.values()]
+    for (const p of pluginList) {
+      for (const c of p.commands) {
+        if (c.hidden) continue
+        try {
+          commands.push(c)
+        } catch (error: any) {
+          debugLog(`Error creating completions for command ${c.id}`)
+          debugLog(error.message)
+          this.writeLogFile(error.message).catch(error => {
+            debugLog(`Failed to write log file: ${error.message}`)
+          })
+        }
+      }
+    }
+
+    this._commands = commands
+    return this._commands
+  }
+
+  private get completionDotsFunc(): string {
+    return `expand-or-complete-with-dots() {
+  echo -n "..."
+  zle expand-or-complete
+  zle redisplay
+}
+zle -N expand-or-complete-with-dots
+bindkey "^I" expand-or-complete-with-dots`
+  }
+
+  private get envAnalyticsDir(): string {
+    return `HEROKU_AC_ANALYTICS_DIR=${path.join(this.autocompleteCacheDir, 'completion_analytics')};`
+  }
+
+  private get envCommandsPath(): string {
+    return `HEROKU_AC_COMMANDS_PATH=${path.join(this.autocompleteCacheDir, 'commands')};`
+  }
+
+  private get skipEllipsis(): boolean {
+    return process.env.HEROKU_AC_ZSH_SKIP_ELLIPSIS === '1'
+  }
+
+  private get zshCommandsFlagsSetters(): string {
+    return this.commands.map(c => {
+      try {
+        return this.genZshCmdFlagsSetter(c)
+      } catch (error: any) {
+        debugLog(`Error creating zsh autocomplete for command ${c.id}, moving on...`)
+        debugLog(error.message)
+        this.writeLogFile(error.message).catch(error => {
+          debugLog(`Failed to write log file: ${error.message}`)
+        })
+        return ''
+      }
+    }).join('\n')
   }
 
   private get zshCommandsSetter(): string {
@@ -130,19 +131,56 @@ export default class Create extends AutocompleteBase {
     return this.genZshAllCmdsListSetter(cmdsWithDescriptions)
   }
 
-  private get zshCommandsFlagsSetters(): string {
-    return this.commands.map(c => {
-      try {
-        return this.genZshCmdFlagsSetter(c)
-      } catch (error: any) {
-        debugLog(`Error creating zsh autocomplete for command ${c.id}, moving on...`)
-        debugLog(error.message)
-        this.writeLogFile(error.message).catch(error => {
-          debugLog(`Failed to write log file: ${error.message}`)
-        })
-        return ''
-      }
-    }).join('\n')
+  private get zshCompletionSetters(): string {
+    const cmdsSetter = this.zshCommandsSetter
+    const flagSetters = this.zshCommandsFlagsSetters
+    return `${cmdsSetter}\n${flagSetters}`
+  }
+
+  private get zshCompletionSettersPath(): string {
+    // <cacheDir>/autocomplete/commands_setters
+    return path.join(this.autocompleteCacheDir, 'commands_setters')
+  }
+
+  private get zshSetupScript(): string {
+    return `${this.skipEllipsis ? '' : this.completionDotsFunc}
+${this.envAnalyticsDir}
+${this.envCommandsPath}
+HEROKU_AC_ZSH_SETTERS_PATH=\${HEROKU_AC_COMMANDS_PATH}_setters && test -f $HEROKU_AC_ZSH_SETTERS_PATH && source $HEROKU_AC_ZSH_SETTERS_PATH;
+fpath=(
+${AC_LIB_PATH}/zsh
+$fpath
+);
+autoload -Uz compinit;
+compinit;
+`
+  }
+
+  private get zshSetupScriptPath(): string {
+    // <cacheDir>/autocomplete/zsh_setup
+    return path.join(this.autocompleteCacheDir, 'zsh_setup')
+  }
+
+  async run() {
+    this.errorIfWindows()
+    // 1. ensure needed dirs
+    await this.ensureDirs()
+    // 2. save (generated) autocomplete files
+    await this.createFiles()
+  }
+
+  private async createFiles() {
+    await fs.writeFile(this.bashSetupScriptPath, this.bashSetupScript)
+    await fs.writeFile(this.zshSetupScriptPath, this.zshSetupScript)
+    await fs.writeFile(this.bashCommandsListPath, this.bashCommandsList)
+    await fs.writeFile(this.zshCompletionSettersPath, this.zshCompletionSetters)
+  }
+
+  private async ensureDirs() {
+    // ensure autocomplete cache dir
+    await fs.ensureDir(this.autocompleteCacheDir)
+    // ensure autocomplete completions dir
+    await fs.ensureDir(this.completionsCacheDir)
   }
 
   private genCmdPublicFlags(command: Command.Loadable): string {
@@ -160,11 +198,21 @@ export default class Create extends AutocompleteBase {
       description = `:"${text}"`
     }
 
-    return `"${command.id.replace(/:/g, '\\:')}"${description}`
+    return `"${command.id.replaceAll(':', String.raw`\:`)}"${description}`
+  }
+
+  private genZshAllCmdsListSetter(cmdsWithDesc: Array<string>): string {
+    return `
+_set_all_commands_list () {
+_all_commands_list=(
+${cmdsWithDesc.join('\n')}
+)
+}
+`
   }
 
   private genZshCmdFlagsSetter(command: Command.Loadable): string {
-    const {id, flags: commandFlags = {}} = command
+    const {flags: commandFlags = {}, id} = command
     const flagscompletions = Object.keys(commandFlags)
       .filter(flag => !commandFlags[flag].hidden)
       .map(flag => {
@@ -188,7 +236,7 @@ export default class Create extends AutocompleteBase {
       .join('\n')
 
     if (flagscompletions) {
-      return `_set_${id.replace(/:/g, '_')}_flags () {
+      return `_set_${id.replaceAll(':', '_')}_flags () {
 _flags=(
 ${flagscompletions}
 )
@@ -197,55 +245,6 @@ ${flagscompletions}
     }
 
     return `# no flags for ${id}`
-  }
-
-  private genZshAllCmdsListSetter(cmdsWithDesc: Array<string>): string {
-    return `
-_set_all_commands_list () {
-_all_commands_list=(
-${cmdsWithDesc.join('\n')}
-)
-}
-`
-  }
-
-  private get envAnalyticsDir(): string {
-    return `HEROKU_AC_ANALYTICS_DIR=${path.join(this.autocompleteCacheDir, 'completion_analytics')};`
-  }
-
-  private get envCommandsPath(): string {
-    return `HEROKU_AC_COMMANDS_PATH=${path.join(this.autocompleteCacheDir, 'commands')};`
-  }
-
-  private get bashSetupScript(): string {
-    return `${this.envAnalyticsDir}
-${this.envCommandsPath}
-HEROKU_AC_BASH_COMPFUNC_PATH=${AC_LIB_PATH}/bash/heroku.bash && test -f $HEROKU_AC_BASH_COMPFUNC_PATH && source $HEROKU_AC_BASH_COMPFUNC_PATH;
-`
-  }
-
-  private get zshSetupScript(): string {
-    return `${this.skipEllipsis ? '' : this.completionDotsFunc}
-${this.envAnalyticsDir}
-${this.envCommandsPath}
-HEROKU_AC_ZSH_SETTERS_PATH=\${HEROKU_AC_COMMANDS_PATH}_setters && test -f $HEROKU_AC_ZSH_SETTERS_PATH && source $HEROKU_AC_ZSH_SETTERS_PATH;
-fpath=(
-${AC_LIB_PATH}/zsh
-$fpath
-);
-autoload -Uz compinit;
-compinit;
-`
-  }
-
-  private get completionDotsFunc(): string {
-    return `expand-or-complete-with-dots() {
-  echo -n "..."
-  zle expand-or-complete
-  zle redisplay
-}
-zle -N expand-or-complete-with-dots
-bindkey "^I" expand-or-complete-with-dots`
   }
 
   private wantsLocalFiles(flag: string): boolean {

--- a/src/commands/autocomplete/doctor.ts
+++ b/src/commands/autocomplete/doctor.ts
@@ -1,8 +1,8 @@
 import {flags} from '@heroku-cli/command'
-import {Args, Interfaces} from '@oclif/core'
 import {hux} from '@heroku/heroku-cli-util'
+import {Args, Interfaces} from '@oclif/core'
 import fs from 'fs-extra'
-import * as path from 'path'
+import path from 'node:path'
 import {fileURLToPath} from 'node:url'
 
 import {AutocompleteBase} from '../../lib/autocomplete/base.js'
@@ -11,17 +11,14 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 export default class Doctor extends AutocompleteBase {
-  static hidden = true
-
-  static description = 'autocomplete diagnostic'
-
   static args = {
     shell: Args.string({description: 'shell type', required: false}),
   }
-
+  static description = 'autocomplete diagnostic'
   static flags: Interfaces.FlagInput = {
     verbose: flags.boolean({description: 'list completable commands'}),
   }
+  static hidden = true
 
   async run() {
     const {args, flags} = await this.parse(Doctor)
@@ -46,7 +43,7 @@ export default class Doctor extends AutocompleteBase {
     try {
       const shellProfile = await fs.readFile(shellProfilePath)
       const regex = /AC_\w+_SETUP_PATH/
-      shimValue = regex.exec(shellProfile.toString()) ? 'present' : 'missing'
+      shimValue = regex.test(shellProfile.toString()) ? 'present' : 'missing'
     } catch {
       // File doesn't exist or can't be read
       shimValue = 'missing'
@@ -94,8 +91,9 @@ export default class Doctor extends AutocompleteBase {
     const header = 'Completable Commands'
     this.log(header)
     this.log('='.repeat(header.length))
-    this.config.plugins.forEach(p => {
-      p.commands.forEach(c => {
+    const pluginList = Array.isArray(this.config.plugins) ? this.config.plugins : Array.from(this.config.plugins.values())
+    for (const p of pluginList) {
+      for (const c of p.commands) {
         try {
           if (c.hidden) {
             this.log(`${c.id} (hidden)`)
@@ -117,7 +115,7 @@ export default class Doctor extends AutocompleteBase {
         } catch {
           this.log(`Error creating autocomplete for command ${c.id}`)
         }
-      })
-    })
+      }
+    }
   }
 }

--- a/src/commands/autocomplete/index.ts
+++ b/src/commands/autocomplete/index.ts
@@ -7,7 +7,7 @@ import {
 } from '@heroku-cli/command/lib/completions.js'
 import * as color from '@heroku/heroku-cli-util/color'
 import {Args, Interfaces, ux} from '@oclif/core'
-import * as path from 'path'
+import path from 'node:path'
 
 import {AutocompleteBase} from '../../lib/autocomplete/base.js'
 import {updateCache} from '../../lib/autocomplete/cache.js'
@@ -17,16 +17,13 @@ export default class Index extends AutocompleteBase {
   static args = {
     shell: Args.string({description: 'shell type', required: false}),
   }
-
   static description = 'display autocomplete installation instructions'
-
   static examples = [
     color.command('heroku autocomplete'),
     color.command('heroku autocomplete bash'),
     color.command('heroku autocomplete zsh'),
     color.command('heroku autocomplete --refresh-cache'),
   ]
-
   static flags: Interfaces.FlagInput = {
     'refresh-cache': flags.boolean({char: 'r', description: 'refresh cache only (ignores displaying instructions)'}),
   }

--- a/src/commands/autocomplete/options.ts
+++ b/src/commands/autocomplete/options.ts
@@ -1,26 +1,21 @@
 import {flags} from '@heroku-cli/command'
 import {Args, Command} from '@oclif/core'
-import * as path from 'path'
+import path from 'node:path'
 
 import {AutocompleteBase} from '../../lib/autocomplete/base.js'
 import {fetchCache} from '../../lib/autocomplete/cache.js'
 
 export default class Options extends AutocompleteBase {
-  static hidden = true
-
-  static description = 'display arg or flag completion options (used internally by completion functions)'
-
-  static flags = {
-    app: flags.app({required: false, hidden: true}),
-  }
-
   static args = {
     completion: Args.string({strict: false}),
   }
-
-  parsedArgs: { [name: string]: string } = {}
-
-  parsedFlags: { [name: string]: string } = {}
+  static description = 'display arg or flag completion options (used internally by completion functions)'
+  static flags = {
+    app: flags.app({hidden: true, required: false}),
+  }
+  static hidden = true
+  parsedArgs: {[name: string]: string} = {}
+  parsedFlags: {[name: string]: string} = {}
 
   // helpful dictionary
   //
@@ -46,121 +41,6 @@ export default class Options extends AutocompleteBase {
     }
   }
 
-  private async processCommandLine() {
-    // find command id
-    const commandLineToComplete = this.argv[0].split(' ')
-    const id = commandLineToComplete[1]
-    // find Command
-    const C = this.config.findCommand(id)
-    let Klass
-    if (C) {
-      Klass = await C.load()
-      // process Command state from command line data
-      const slicedArgv = commandLineToComplete.slice(2)
-      const [argsIndex, curPositionIsFlag, curPositionIsFlagValue] = this.determineCmdState(slicedArgv, Klass)
-      return {id, Klass, argsIndex, curPositionIsFlag, curPositionIsFlagValue, slicedArgv}
-    }
-
-    this.throwError(`Command ${id} not found`)
-  }
-
-  private determineCompletion(commandStateVars: any) {
-    const {id, Klass, argsIndex, curPositionIsFlag, curPositionIsFlagValue, slicedArgv} = commandStateVars
-    // setup empty cache completion vars to assign
-    let cacheKey: any
-    let cacheCompletion: any
-
-    // completing a flag/value? else completing an arg
-    if (curPositionIsFlag || curPositionIsFlagValue) {
-      const slicedArgvCount = slicedArgv.length
-      const lastArgvArg = slicedArgv[slicedArgvCount - 1]
-      const previousArgvArg = slicedArgv[slicedArgvCount - 2]
-      const argvFlag = curPositionIsFlagValue ? previousArgvArg : lastArgvArg
-      const {name, flag} = this.findFlagFromWildArg(argvFlag, Klass)
-      if (!flag) this.throwError(`${argvFlag} is not a valid flag for ${id}`)
-      cacheKey = name || flag.name
-      cacheCompletion = flag.completion
-    } else {
-      const cmdArgs = Klass.args || []
-      // variable arg (strict: false)
-      if (!Klass.strict) {
-        cacheKey = cmdArgs[0] && cmdArgs[0].name.toLowerCase()
-        cacheCompletion = this.findCompletion(cacheKey, id)
-        if (!cacheCompletion) this.throwError(`Cannot complete variable arg position for ${id}`)
-      } else if (argsIndex > cmdArgs.length - 1) {
-        this.throwError(`Cannot complete arg position ${argsIndex} for ${id}`)
-      } else {
-        const arg = cmdArgs[argsIndex]
-        cacheKey = arg.name.toLowerCase()
-      }
-    }
-
-    // try to auto-populate the completion object
-    if (!cacheCompletion) {
-      cacheCompletion = this.findCompletion(cacheKey, id)
-    }
-
-    return {cacheKey, cacheCompletion}
-  }
-
-  private async fetchOptions(cache: any) {
-    const {cacheCompletion, cacheKey} = cache
-    const flags = await this.parsedFlagsWithEnvVars()
-
-    // build/retrieve & return options cache
-    if (cacheCompletion && cacheCompletion.options) {
-      const ctx = {
-        args: this.parsedArgs,
-        // special case for app & team env vars
-        flags,
-        argv: this.argv,
-        config: this.config,
-      }
-      // use cacheKey function or fallback to arg/flag name
-      const ckey = cacheCompletion.cacheKey ? await cacheCompletion.cacheKey(ctx) : null
-      const key: string = ckey || cacheKey || 'unknown_key_error'
-      const flagCachePath = path.join(this.completionsCacheDir, key)
-
-      // build/retrieve cache
-      const duration = cacheCompletion.cacheDuration || 60 * 60 * 24 // 1 day
-      const opts = {cacheFn: () => cacheCompletion.options(ctx)}
-      const options = await fetchCache(flagCachePath, duration, opts)
-
-      // return options cache
-      return (options || []).join('\n')
-    }
-  }
-
-  private async parsedFlagsWithEnvVars() {
-    const {flags} = await this.parse(Options)
-    return {
-      app: process.env.HEROKU_APP || flags.app,
-      team: process.env.HEROKU_TEAM || process.env.HEROKU_ORG,
-      ...this.parsedFlags,
-    }
-  }
-
-  private throwError(msg: string) {
-    throw new Error(msg)
-  }
-
-  private findFlagFromWildArg(wild: string, Klass: Command.Class): { flag: any; name: any } {
-    let name = wild.replace(/^-+/, '')
-    name = name.replace(/[=](.+)?$/, '')
-
-    const unknown = {flag: undefined, name: undefined}
-    if (!Klass.flags) return unknown
-    const CFlags = Klass.flags
-
-    let flag = CFlags[name]
-    if (flag) return {name, flag}
-
-    name = Object.keys(CFlags).find((k: string) => CFlags[k].char === name) || 'undefinedcommand'
-    flag = CFlags && CFlags[name]
-    if (flag) return {name, flag}
-    return unknown
-  }
-
   private determineCmdState(argv: string[], Klass: Command.Class): [number, boolean, boolean] {
     const argNames = Object.keys(Klass.args || {})
     let needFlagValueSatisfied = false
@@ -170,26 +50,24 @@ export default class Options extends AutocompleteBase {
     let flagName: string
 
     argv.filter(wild => {
-      if (wild.match(/^-(-)?/)) {
+      if (/^-(-)?/.test(wild)) {
         // we're a flag
         argIsFlag = true
 
         // ignore me
         const wildSplit = wild.split('=')
         const key = wildSplit.length === 1 ? wild : wildSplit[0]
-        const {name, flag} = this.findFlagFromWildArg(key, Klass)
+        const {flag, name} = this.findFlagFromWildArg(key, Klass)
         flagName = name
         // end ignore me
 
-        if (wildSplit.length === 1) {
-          // we're a flag w/o a '=value'
+        if (wildSplit.length === 1 // we're a flag w/o a '=value'
           // (find flag & see if flag needs a value)
-          if (flag && flag.type !== 'boolean') {
-            // we're a flag who needs our value to be next
-            argIsFlagValue = false
-            needFlagValueSatisfied = true
-            return false
-          }
+          && flag && flag.type !== 'boolean') {
+          // we're a flag who needs our value to be next
+          argIsFlagValue = false
+          needFlagValueSatisfied = true
+          return false
         }
 
         // --app=my-app is considered a flag & not a flag value
@@ -233,5 +111,122 @@ export default class Options extends AutocompleteBase {
     })
 
     return [argsIndex, argIsFlag, argIsFlagValue]
+  }
+
+  private determineCompletion(commandStateVars: any) {
+    const {argsIndex, curPositionIsFlag, curPositionIsFlagValue, id, Klass, slicedArgv} = commandStateVars
+    // setup empty cache completion vars to assign
+    let cacheKey: any
+    let cacheCompletion: any
+
+    // completing a flag/value? else completing an arg
+    if (curPositionIsFlag || curPositionIsFlagValue) {
+      const slicedArgvCount = slicedArgv.length
+      const lastArgvArg = slicedArgv[slicedArgvCount - 1]
+      const previousArgvArg = slicedArgv[slicedArgvCount - 2]
+      const argvFlag = curPositionIsFlagValue ? previousArgvArg : lastArgvArg
+      const {flag, name} = this.findFlagFromWildArg(argvFlag, Klass)
+      if (!flag) this.throwError(`${argvFlag} is not a valid flag for ${id}`)
+      cacheKey = name || flag.name
+      cacheCompletion = flag.completion
+    } else {
+      const cmdArgs = Klass.args || []
+      // variable arg (strict: false)
+      if (!Klass.strict) {
+        cacheKey = cmdArgs[0] && cmdArgs[0].name.toLowerCase()
+        cacheCompletion = this.findCompletion(cacheKey, id)
+        if (!cacheCompletion) this.throwError(`Cannot complete variable arg position for ${id}`)
+      } else if (argsIndex > cmdArgs.length - 1) {
+        this.throwError(`Cannot complete arg position ${argsIndex} for ${id}`)
+      } else {
+        const arg = cmdArgs[argsIndex]
+        cacheKey = arg.name.toLowerCase()
+      }
+    }
+
+    // try to auto-populate the completion object
+    if (!cacheCompletion) {
+      cacheCompletion = this.findCompletion(cacheKey, id)
+    }
+
+    return {cacheCompletion, cacheKey}
+  }
+
+  private async fetchOptions(cache: any) {
+    const {cacheCompletion, cacheKey} = cache
+    const flags = await this.parsedFlagsWithEnvVars()
+
+    // build/retrieve & return options cache
+    if (cacheCompletion && cacheCompletion.options) {
+      const ctx = {
+        args: this.parsedArgs,
+        argv: this.argv,
+        config: this.config,
+        // special case for app & team env vars
+        flags,
+      }
+      // use cacheKey function or fallback to arg/flag name
+      const ckey = cacheCompletion.cacheKey ? await cacheCompletion.cacheKey(ctx) : null
+      const key: string = ckey || cacheKey || 'unknown_key_error'
+      const flagCachePath = path.join(this.completionsCacheDir, key)
+
+      // build/retrieve cache
+      const duration = cacheCompletion.cacheDuration || 60 * 60 * 24 // 1 day
+      const opts = {cacheFn: () => cacheCompletion.options(ctx)}
+      const options = await fetchCache(flagCachePath, duration, opts)
+
+      // return options cache
+      return (options || []).join('\n')
+    }
+  }
+
+  private findFlagFromWildArg(wild: string, Klass: Command.Class): {flag: any; name: any} {
+    let name = wild.replace(/^-+/, '')
+    name = name.replace(/[=](.+)?$/, '')
+
+    const unknown = {flag: undefined, name: undefined}
+    if (!Klass.flags) return unknown
+    const CFlags = Klass.flags
+
+    let flag = CFlags[name]
+    if (flag) return {flag, name}
+
+    name = Object.keys(CFlags).find((k: string) => CFlags[k].char === name) || 'undefinedcommand'
+    flag = CFlags && CFlags[name]
+    if (flag) return {flag, name}
+    return unknown
+  }
+
+  private async parsedFlagsWithEnvVars() {
+    const {flags} = await this.parse(Options)
+    return {
+      app: process.env.HEROKU_APP || flags.app,
+      team: process.env.HEROKU_TEAM || process.env.HEROKU_ORG,
+      ...this.parsedFlags,
+    }
+  }
+
+  private async processCommandLine() {
+    // find command id
+    const commandLineToComplete = this.argv[0].split(' ')
+    const id = commandLineToComplete[1]
+    // find Command
+    const C = this.config.findCommand(id)
+    let Klass
+    if (C) {
+      Klass = await C.load()
+      // process Command state from command line data
+      const slicedArgv = commandLineToComplete.slice(2)
+      const [argsIndex, curPositionIsFlag, curPositionIsFlagValue] = this.determineCmdState(slicedArgv, Klass)
+      return {
+        argsIndex, curPositionIsFlag, curPositionIsFlagValue, id, Klass, slicedArgv,
+      }
+    }
+
+    this.throwError(`Command ${id} not found`)
+  }
+
+  private throwError(msg: string) {
+    throw new Error(msg)
   }
 }

--- a/src/commands/autocomplete/script.ts
+++ b/src/commands/autocomplete/script.ts
@@ -1,15 +1,17 @@
 import {Args} from '@oclif/core'
-import * as path from 'path'
+import path from 'node:path'
 
 import {AutocompleteBase} from '../../lib/autocomplete/base.js'
 
 export default class Script extends AutocompleteBase {
-  static description = 'display autocomplete setup script for shell'
-
-  static hidden = true
-
   static args = {
     shell: Args.string({description: 'shell type', required: false}),
+  }
+  static description = 'display autocomplete setup script for shell'
+  static hidden = true
+
+  private get prefix(): string {
+    return `\n# ${this.config.bin} autocomplete setup\n`
   }
 
   async run() {
@@ -18,16 +20,9 @@ export default class Script extends AutocompleteBase {
     this.errorIfNotSupportedShell(shell)
 
     const shellUpcase = shell.toUpperCase()
-    this.log(
-      `${this.prefix}HEROKU_AC_${shellUpcase}_SETUP_PATH=${path.join(
-        this.autocompleteCacheDir,
-        `${shell}_setup`,
-      )} && test -f $HEROKU_AC_${shellUpcase}_SETUP_PATH && source $HEROKU_AC_${shellUpcase}_SETUP_PATH;`,
-    )
-  }
-
-  private get prefix(): string {
-    return `\n# ${this.config.bin} autocomplete setup\n`
+    this.log(`${this.prefix}HEROKU_AC_${shellUpcase}_SETUP_PATH=${path.join(
+      this.autocompleteCacheDir,
+      `${shell}_setup`,
+    )} && test -f $HEROKU_AC_${shellUpcase}_SETUP_PATH && source $HEROKU_AC_${shellUpcase}_SETUP_PATH;`)
   }
 }
-

--- a/src/commands/buildpacks/add.ts
+++ b/src/commands/buildpacks/add.ts
@@ -4,22 +4,20 @@ import {Args} from '@oclif/core'
 import {BuildpackCommand} from '../../lib/buildpacks/buildpacks.js'
 
 export default class Add extends Command {
-  static description = 'add new app buildpack, inserting into list of buildpacks if necessary'
-
-  static flags = {
-    app: Flags.app({required: true}),
-    remote: Flags.remote(),
-    index: Flags.integer({
-      description: 'the 1-based index of the URL in the list of URLs',
-      char: 'i',
-    }),
-  }
-
   static args = {
     buildpack: Args.string({
-      required: true,
       description: 'namespace/name of the buildpack',
+      required: true,
     }),
+  }
+  static description = 'add new app buildpack, inserting into list of buildpacks if necessary'
+  static flags = {
+    app: Flags.app({required: true}),
+    index: Flags.integer({
+      char: 'i',
+      description: 'the 1-based index of the URL in the list of URLs',
+    }),
+    remote: Flags.remote(),
   }
 
   async run() {

--- a/src/commands/buildpacks/clear.ts
+++ b/src/commands/buildpacks/clear.ts
@@ -4,7 +4,6 @@ import {BuildpackCommand} from '../../lib/buildpacks/buildpacks.js'
 
 export default class Clear extends Command {
   static description = 'clear all buildpacks set on the app'
-
   static flags = {
     app: Flags.app({required: true}),
     remote: Flags.remote(),

--- a/src/commands/buildpacks/index.ts
+++ b/src/commands/buildpacks/index.ts
@@ -1,5 +1,5 @@
-import {color, hux} from '@heroku/heroku-cli-util'
 import {Command, flags as Flags} from '@heroku-cli/command'
+import {color, hux} from '@heroku/heroku-cli-util'
 
 import {getGeneration} from '../../lib/apps/generation.js'
 import {BuildpackCommand} from '../../lib/buildpacks/buildpacks.js'
@@ -7,7 +7,6 @@ import {App} from '../../lib/types/fir.js'
 
 export default class Index extends Command {
   static description = 'list the buildpacks on an app'
-
   static flags = {
     app: Flags.app({required: true}),
     remote: Flags.remote(),
@@ -28,11 +27,9 @@ export default class Index extends Command {
     } else {
       const pluralizedBuildpacks = buildpacks.length > 1 ? 'Buildpacks' : 'Buildpack'
       let header = `${color.app(flags.app)}`
-      if (isFirApp) {
-        header += ` Cloud Native ${pluralizedBuildpacks} (from the latest release's OCI image)`
-      } else {
-        header += ` Classic ${pluralizedBuildpacks} (from the Heroku Buildpack Registry)`
-      }
+      header += isFirApp
+        ? ` Cloud Native ${pluralizedBuildpacks} (from the latest release's OCI image)`
+        : ` Classic ${pluralizedBuildpacks} (from the Heroku Buildpack Registry)`
 
       hux.styledHeader(header)
       buildpacksCommand.display(buildpacks, '')

--- a/src/commands/buildpacks/info.ts
+++ b/src/commands/buildpacks/info.ts
@@ -1,19 +1,17 @@
 import {Command} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
+import {BuildpackRegistry} from '@heroku/buildpack-registry'
 import {hux} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
 import {Result} from 'true-myth'
 
-import {BuildpackRegistry} from '@heroku/buildpack-registry'
-
 export default class Info extends Command {
-  static description = 'fetch info about a buildpack'
-
   static args = {
     buildpack: Args.string({
-      required: true,
       description: 'namespace/name of the buildpack',
+      required: true,
     }),
   }
+  static description = 'fetch info about a buildpack'
 
   async run() {
     const {args} = await this.parse(Info)
@@ -26,16 +24,16 @@ export default class Info extends Command {
 
     const result = await registry.info(args.buildpack)
     Result.match({
-      Ok(buildpack: unknown) {
-        hux.styledHeader(args.buildpack)
-        hux.styledObject(buildpack, ['description', 'category', 'license', 'support', 'source', 'readme'])
-      },
       Err(err: any) {
         if (err.status === 404) {
           ux.error(`Could not find the buildpack '${args.buildpack}'`)
         } else {
           ux.error(`Problems finding buildpack info: ${err.description}`)
         }
+      },
+      Ok(buildpack: unknown) {
+        hux.styledHeader(args.buildpack)
+        hux.styledObject(buildpack, ['description', 'category', 'license', 'support', 'source', 'readme'])
       },
     }, result as any)
   }

--- a/src/commands/buildpacks/remove.ts
+++ b/src/commands/buildpacks/remove.ts
@@ -10,9 +10,7 @@ export default class Remove extends Command {
       description: 'namespace/name of the buildpack',
     }),
   }
-
   static description = 'remove a buildpack set on the app'
-
   static flags = {
     app: Flags.app({required: true}),
     index: Flags.integer({

--- a/src/commands/buildpacks/search.ts
+++ b/src/commands/buildpacks/search.ts
@@ -1,22 +1,19 @@
 import {Command, flags as Flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
-import {hux} from '@heroku/heroku-cli-util'
-
 import {BuildpackBody, BuildpackRegistry, Category} from '@heroku/buildpack-registry'
+import {hux} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
 
 export default class Search extends Command {
-  static description = 'search for buildpacks'
-
-  static flags = {
-    namespace: Flags.string({description: 'buildpack namespaces to filter on using a comma separated list'}),
-    name: Flags.string({description: 'buildpack names to filter on using a comma separated list '}),
-    description: Flags.string({description: 'buildpack description to filter on'}),
-  }
-
   static args = {
     term: Args.string({
       description: 'search term that searches across name, namespace, and description',
     }),
+  }
+  static description = 'search for buildpacks'
+  static flags = {
+    description: Flags.string({description: 'buildpack description to filter on'}),
+    name: Flags.string({description: 'buildpack names to filter on using a comma separated list '}),
+    namespace: Flags.string({description: 'buildpack namespaces to filter on using a comma separated list'}),
   }
 
   async run() {

--- a/src/commands/buildpacks/set.ts
+++ b/src/commands/buildpacks/set.ts
@@ -4,22 +4,20 @@ import {Args} from '@oclif/core'
 import {BuildpackCommand} from '../../lib/buildpacks/buildpacks.js'
 
 export default class Set extends Command {
-  static description: 'set new app buildpack, overwriting into list of buildpacks if necessary'
-
-  static flags = {
-    app: Flags.app({required: true}),
-    remote: Flags.remote(),
-    index: Flags.integer({
-      description: 'the 1-based index of the URL in the list of URLs',
-      char: 'i',
-    }),
-  }
-
   static args = {
     buildpack: Args.string({
-      required: true,
       description: 'namespace/name of the buildpack',
+      required: true,
     }),
+  }
+  static description: 'set new app buildpack, overwriting into list of buildpacks if necessary'
+  static flags = {
+    app: Flags.app({required: true}),
+    index: Flags.integer({
+      char: 'i',
+      description: 'the 1-based index of the URL in the list of URLs',
+    }),
+    remote: Flags.remote(),
   }
 
   async run() {

--- a/src/commands/buildpacks/versions.ts
+++ b/src/commands/buildpacks/versions.ts
@@ -1,21 +1,18 @@
 import {Command} from '@heroku-cli/command'
-import {Args} from '@oclif/core'
+import {BuildpackRegistry, RevisionBody} from '@heroku/buildpack-registry'
 import {hux} from '@heroku/heroku-cli-util'
+import {Args} from '@oclif/core'
 import {ux} from '@oclif/core/ux'
-
 import {Result} from 'true-myth'
 
-import {BuildpackRegistry, RevisionBody} from '@heroku/buildpack-registry'
-
 export default class Versions extends Command {
-  static description = 'list versions of a buildpack'
-
   static args = {
     buildpack: Args.string({
-      required: true,
       description: 'namespace/name of the buildpack',
+      required: true,
     }),
   }
+  static description = 'list versions of a buildpack'
 
   async run() {
     const {args} = await this.parse(Versions)
@@ -33,7 +30,15 @@ export default class Versions extends Command {
 
     const result = await registry.listVersions(args.buildpack)
     Result.match({
+      Err(err: any) {
+        if (err.status === 404) {
+          ux.error(`Could not find '${args.buildpack}'`)
+        } else {
+          ux.error(`Problem fetching versions, ${err.status}: ${err.description}`)
+        }
+      },
       Ok(versions: RevisionBody[]) {
+        /* eslint-disable perfectionist/sort-objects */
         hux.table(versions.sort((a: RevisionBody, b: RevisionBody) => a.release > b.release ? -1 : 1), {
           release: {
             header: 'Version',
@@ -45,13 +50,7 @@ export default class Versions extends Command {
             header: 'Status',
           },
         })
-      },
-      Err(err: any) {
-        if (err.status === 404) {
-          ux.error(`Could not find '${args.buildpack}'`)
-        } else {
-          ux.error(`Problem fetching versions, ${err.status}: ${err.description}`)
-        }
+        /* eslint-enable perfectionist/sort-objects */
       },
     }, result as any)
   }

--- a/src/commands/certs/add.ts
+++ b/src/commands/certs/add.ts
@@ -1,6 +1,6 @@
-import {hux, color} from '@heroku/heroku-cli-util'
 import {APIClient, Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {color, hux} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -17,7 +17,6 @@ export default class Add extends Command {
     CRT: Args.string({description: 'absolute path of the certificate file on disk', required: true}),
     KEY: Args.string({description: 'absolute path of the key file on disk', required: true}),
   }
-
   static description = `Add an SSL certificate to an app.
 
   Note: certificates with PEM encoding are also valid.
@@ -25,16 +24,12 @@ export default class Add extends Command {
   static examples = [heredoc(`
     ${color.command('heroku certs:add example.com.crt example.com.key')}
     If you require intermediate certificates, refer to this article on merging certificates to get a complete chain:
-    ${color.info('https://help.salesforce.com/s/articleView?id=000333504&type=1')}`,
-  )]
-
+    ${color.info('https://help.salesforce.com/s/articleView?id=000333504&type=1')}`)]
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
   static strict = true
-
   static topic = 'certs'
 
   async configureDomains(app: string, heroku: APIClient, cert: SniEndpoint, inquirer: any) {
@@ -97,12 +92,12 @@ function splitDomains(domains: string[]): [string, string][] {
 function createMatcherFromSplitDomain([firstChar, rest]: [string, string]) {
   const matcherContents = []
   if (firstChar === '*') {
-    matcherContents.push('^[\\w\\-]+')
+    matcherContents.push(String.raw`^[\w\-]+`)
   } else {
     matcherContents.push(firstChar)
   }
 
-  const escapedRest = rest.replaceAll('.', '\\.')
+  const escapedRest = rest.replaceAll('.', String.raw`\.`)
 
   matcherContents.push(escapedRest)
 
@@ -115,11 +110,11 @@ function matchDomains(certDomains: string[], appDomains: string[]) {
 
   if (splitCertDomains.some(domain => (domain[0] === '*'))) {
     const matchedDomains: string[] = []
-    appDomains.forEach(appDomain => {
+    for (const appDomain of appDomains) {
       if (matchers.some(matcher => matcher.test(appDomain))) {
         matchedDomains.push(appDomain)
       }
-    })
+    }
 
     return matchedDomains
   }

--- a/src/commands/certs/auto/disable.ts
+++ b/src/commands/certs/auto/disable.ts
@@ -14,7 +14,6 @@ export default class Disable extends Command {
     confirm: flags.string({char: 'c', hidden: true}),
     remote: flags.remote(),
   }
-
   static topic = 'certs'
 
   public async run(): Promise<void> {

--- a/src/commands/certs/auto/enable.ts
+++ b/src/commands/certs/auto/enable.ts
@@ -17,9 +17,7 @@ export default class Enable extends Command {
     remote: flags.remote(),
     wait: flags.boolean({description: 'watch ACM status and exit when complete'}),
   }
-
   public static notifier: (subtitle: string, message: string, success?: boolean) => void = notify
-
   static topic = 'certs'
 
   public async run(): Promise<void> {

--- a/src/commands/certs/auto/index.ts
+++ b/src/commands/certs/auto/index.ts
@@ -1,6 +1,6 @@
-import {color, hux} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {color, hux} from '@heroku/heroku-cli-util'
 import {ux} from '@oclif/core/ux'
 import tsheredoc from 'tsheredoc'
 
@@ -46,7 +46,6 @@ export default class Index extends Command {
     remote: flags.remote(),
     wait: flags.boolean({description: 'watch ACM status and display the status when complete'}),
   }
-
   static topic = 'certs'
 
   public async run(): Promise<void> {
@@ -101,11 +100,13 @@ export default class Index extends Command {
           Status: {
             get: (domain: Domain) => humanize(domain.acm_status),
           },
-          ...(domains.some(d => d.acm_status_reason) ? {
-            Reason: {
-              get: (domain: Domain) => domain.acm_status_reason ?? '',
-            },
-          } : {}),
+          ...(domains.some(d => d.acm_status_reason)
+            ? {
+              Reason: {
+                get: (domain: Domain) => domain.acm_status_reason ?? '',
+              },
+            }
+            : {}),
           lastUpdated: {
             get: (domain: Domain) => formatDistanceToNow(new Date(domain.updated_at)),
             header: 'Last Updated',

--- a/src/commands/certs/auto/refresh.ts
+++ b/src/commands/certs/auto/refresh.ts
@@ -7,7 +7,6 @@ export default class Refresh extends Command {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
   static topic = 'certs'
 
   public async run(): Promise<void> {

--- a/src/commands/certs/generate.ts
+++ b/src/commands/certs/generate.ts
@@ -5,7 +5,7 @@ import {spawn} from 'node:child_process'
 import {lazyModuleLoader} from '../../lib/lazy-module-loader.js'
 import {SniEndpoint} from '../../lib/types/sni-endpoint.js'
 
-function getCommand(certs: SniEndpoint[], domain: string): 'update' | 'add' {
+function getCommand(certs: SniEndpoint[], domain: string): 'add' | 'update' {
   const shouldUpdate = certs
     .map(cert => cert?.ssl_cert?.cert_domains)
     .filter(certDomains => certDomains?.length)
@@ -16,87 +16,28 @@ function getCommand(certs: SniEndpoint[], domain: string): 'update' | 'add' {
 }
 
 export default class Generate extends Command {
-  static topic = 'certs'
-  static description = 'generate a key and a CSR or self-signed certificate'
-  static help = 'Generate a key and certificate signing request (or self-signed certificate)\nfor an app. Prompts for information to put in the certificate unless --now\nis used, or at least one of the --subject, --owner, --country, --area, or\n--city options is specified.'
-  static flags = {
-    selfsigned: flags.boolean({required: false, description: 'generate a self-signed certificate instead of a CSR'}),
-    keysize: flags.string({optional: true, description: 'RSA key size in bits (default: 2048)'}),
-    owner: flags.string({optional: true, description: 'name of organization certificate belongs to'}),
-    country: flags.string({optional: true, description: 'country of owner, as a two-letter ISO country code'}),
-    area: flags.string({optional: true, description: 'sub-country area (state, province, etc.) of owner'}),
-    city: flags.string({optional: true, description: 'city of owner'}),
-    subject: flags.string({optional: true, description: 'specify entire certificate subject'}),
-    now: flags.boolean({required: false, description: 'do not prompt for any owner information'}),
-    app: flags.app({required: true}),
-    remote: flags.remote(),
-  }
-
   static args = {
-    domain: Args.string({required: true, description: 'domain name to generate'}),
+    domain: Args.string({description: 'domain name to generate', required: true}),
   }
-
-  async promptForOwnerInfo(inquirer: any) {
-    return inquirer.prompt([
-      {type: 'input', message: 'Owner of this certificate', name: 'owner'},
-      {type: 'input', message: 'Country of owner (two-letter ISO code)', name: 'country'},
-      {type: 'input', message: 'State/province/etc. of owner', name: 'area'},
-      {type: 'input', message: 'City of owner', name: 'city'},
-    ])
+  static description = 'generate a key and a CSR or self-signed certificate'
+  static flags = {
+    app: flags.app({required: true}),
+    area: flags.string({description: 'sub-country area (state, province, etc.) of owner', optional: true}),
+    city: flags.string({description: 'city of owner', optional: true}),
+    country: flags.string({description: 'country of owner, as a two-letter ISO country code', optional: true}),
+    keysize: flags.string({description: 'RSA key size in bits (default: 2048)', optional: true}),
+    now: flags.boolean({description: 'do not prompt for any owner information', required: false}),
+    owner: flags.string({description: 'name of organization certificate belongs to', optional: true}),
+    remote: flags.remote(),
+    selfsigned: flags.boolean({description: 'generate a self-signed certificate instead of a CSR', required: false}),
+    subject: flags.string({description: 'specify entire certificate subject', optional: true}),
   }
-
-  public async run(): Promise<void> {
-    const inquirer = await lazyModuleLoader.loadInquirer()
-
-    const {flags, args} = await this.parse(Generate)
-    const {app, selfsigned} = flags
-    if (this.requiresPrompt(flags)) {
-      const {owner, country, area, city} = await this.promptForOwnerInfo(inquirer)
-      Object.assign(flags, {owner, country, area, city})
-    }
-
-    const subject = this.getSubject(args, flags)
-    const {domain} = args
-    const keysize = flags.keysize || 2048
-    const keyfile = `${domain}.key`
-    const {body: certs} = await this.heroku.get<SniEndpoint[]>(`/apps/${app}/sni-endpoints`)
-    const command = getCommand(certs, domain)
-    if (selfsigned) {
-      const crtfile = `${domain}.crt`
-      await this.spawnOpenSSL(['req', '-new', '-newkey', `rsa:${keysize}`, '-nodes', '-keyout', keyfile, '-out', crtfile, '-subj', subject, '-x509'])
-      console.error('Your key and self-signed certificate have been generated.')
-      console.error('Next, run:')
-      console.error(`$ heroku certs:${command} ${crtfile} ${keyfile}`)
-    } else {
-      const csrfile = `${domain}.csr`
-      await this.spawnOpenSSL(['req', '-new', '-newkey', `rsa:${keysize}`, '-nodes', '-keyout', keyfile, '-out', csrfile, '-subj', subject])
-      console.error('Your key and certificate signing request have been generated.')
-      console.error(`Submit the CSR in '${csrfile}' to your preferred certificate authority.`)
-      console.error('When you\'ve received your certificate, run:')
-      console.error(`$ heroku certs:${command} CERTFILE ${keyfile}`)
-    }
-  }
-
-  protected requiresPrompt(flags: any) {
-    if (flags.subject) {
-      return false
-    }
-
-    if (flags.now) {
-      return false
-    }
-
-    const args = [flags.owner, flags.country, flags.area, flags.city]
-    if (args.every((arg: string | undefined) => !arg)) {
-      return true
-    }
-
-    return false
-  }
+  static help = 'Generate a key and certificate signing request (or self-signed certificate)\nfor an app. Prompts for information to put in the certificate unless --now\nis used, or at least one of the --subject, --owner, --country, --area, or\n--city options is specified.'
+  static topic = 'certs'
 
   protected getSubject(args: any, flags: any) {
     const {domain} = args
-    const {owner, country, area, city, subject} = flags
+    const {area, city, country, owner, subject} = flags
     if (subject) {
       return subject
     }
@@ -121,6 +62,66 @@ export default class Generate extends Command {
     constructedSubject += `/CN=${domain}`
 
     return constructedSubject
+  }
+
+  async promptForOwnerInfo(inquirer: any) {
+    return inquirer.prompt([
+      {message: 'Owner of this certificate', name: 'owner', type: 'input'},
+      {message: 'Country of owner (two-letter ISO code)', name: 'country', type: 'input'},
+      {message: 'State/province/etc. of owner', name: 'area', type: 'input'},
+      {message: 'City of owner', name: 'city', type: 'input'},
+    ])
+  }
+
+  protected requiresPrompt(flags: any) {
+    if (flags.subject) {
+      return false
+    }
+
+    if (flags.now) {
+      return false
+    }
+
+    const args = [flags.owner, flags.country, flags.area, flags.city]
+    if (args.every((arg: string | undefined) => !arg)) {
+      return true
+    }
+
+    return false
+  }
+
+  public async run(): Promise<void> {
+    const inquirer = await lazyModuleLoader.loadInquirer()
+
+    const {args, flags} = await this.parse(Generate)
+    const {app, selfsigned} = flags
+    if (this.requiresPrompt(flags)) {
+      const {area, city, country, owner} = await this.promptForOwnerInfo(inquirer)
+      Object.assign(flags, {
+        area, city, country, owner,
+      })
+    }
+
+    const subject = this.getSubject(args, flags)
+    const {domain} = args
+    const keysize = flags.keysize || 2048
+    const keyfile = `${domain}.key`
+    const {body: certs} = await this.heroku.get<SniEndpoint[]>(`/apps/${app}/sni-endpoints`)
+    const command = getCommand(certs, domain)
+    if (selfsigned) {
+      const crtfile = `${domain}.crt`
+      await this.spawnOpenSSL(['req', '-new', '-newkey', `rsa:${keysize}`, '-nodes', '-keyout', keyfile, '-out', crtfile, '-subj', subject, '-x509'])
+      console.error('Your key and self-signed certificate have been generated.')
+      console.error('Next, run:')
+      console.error(`$ heroku certs:${command} ${crtfile} ${keyfile}`)
+    } else {
+      const csrfile = `${domain}.csr`
+      await this.spawnOpenSSL(['req', '-new', '-newkey', `rsa:${keysize}`, '-nodes', '-keyout', keyfile, '-out', csrfile, '-subj', subject])
+      console.error('Your key and certificate signing request have been generated.')
+      console.error(`Submit the CSR in '${csrfile}' to your preferred certificate authority.`)
+      console.error('When you\'ve received your certificate, run:')
+      console.error(`$ heroku certs:${command} CERTFILE ${keyfile}`)
+    }
   }
 
   protected async spawnOpenSSL(args: ReadonlyArray<string>) {

--- a/src/commands/certs/index.ts
+++ b/src/commands/certs/index.ts
@@ -11,7 +11,6 @@ export default class Index extends Command {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
   static topic = 'certs'
 
   public async run(): Promise<void> {

--- a/src/commands/certs/info.ts
+++ b/src/commands/certs/info.ts
@@ -16,7 +16,6 @@ export default class Info extends Command {
     remote: flags.remote(),
     'show-domains': flags.boolean({description: 'show associated domains'}),
   }
-
   static topic = 'certs'
 
   public async run(): Promise<void> {

--- a/src/commands/certs/remove.ts
+++ b/src/commands/certs/remove.ts
@@ -17,7 +17,6 @@ export default class Remove extends Command {
     name: flags.string({description: 'name to remove'}),
     remote: flags.remote(),
   }
-
   static topic = 'certs'
 
   public async run(): Promise<void> {

--- a/src/commands/certs/update.ts
+++ b/src/commands/certs/update.ts
@@ -16,7 +16,6 @@ export default class Update extends Command {
     CRT: Args.string({description: 'absolute path of the certificate file on disk', required: true}),
     KEY: Args.string({description: 'absolute path of the key file on disk', required: true}),
   }
-
   static description = heredoc`
     update an SSL certificate on an app
     Note: certificates with PEM encoding are also valid
@@ -27,7 +26,6 @@ export default class Update extends Command {
         If you require intermediate certificates, refer to this article on merging certificates to get a complete chain:
         https://help.salesforce.com/s/articleView?id=000333504&type=1
   `]
-
   static flags = {
     app: flags.app({required: true}),
     confirm: flags.string({hidden: true}),
@@ -35,7 +33,6 @@ export default class Update extends Command {
     name: flags.string({description: 'name to update'}),
     remote: flags.remote(),
   }
-
   static topic = 'certs'
 
   public async run(): Promise<void> {

--- a/src/commands/ci/config/get.ts
+++ b/src/commands/ci/config/get.ts
@@ -10,19 +10,16 @@ export default class CiConfigGet extends Command {
   static args = {
     key: Args.string({description: 'name of the config var key', required: true}),
   }
-
   static description = 'get a CI config var'
   static examples = [
     color.command('heroku ci:config:get --pipeline=PIPELINE RAILS_ENV test'),
   ]
-
   static flags = {
     app: flags.app(),
     pipeline: flags.pipeline({exactlyOne: ['pipeline', 'app']}),
     remote: flags.remote(),
     shell: flags.boolean({char: 's', description: 'output config var in shell format'}),
   }
-
   static topic = 'ci'
 
   async run() {

--- a/src/commands/ci/config/index.ts
+++ b/src/commands/ci/config/index.ts
@@ -9,12 +9,10 @@ import {quote} from '../../../lib/config/quote.js'
 
 export default class CiConfig extends Command {
   static description = 'display CI config vars'
-
   static examples = [
     color.command(`heroku ci:config --app murmuring-headland-14719 --json
 `),
   ]
-
   static flags = {
     app: cmdFlags.app(),
     json: cmdFlags.boolean({description: 'output config vars in json format'}),
@@ -29,17 +27,18 @@ export default class CiConfig extends Command {
     const {body: config} = await getPipelineConfigVars(this.heroku, pipeline.id)
 
     if (flags.shell) {
-      Object.keys(config).forEach(key => {
+      for (const key of Object.keys(config)) {
         ux.stdout(`${key}=${quote(config[key])}`)
-      })
+      }
     } else if (flags.json) {
       hux.styledJSON(config)
     } else {
       hux.styledHeader(`${color.pipeline(pipeline.name)} test config vars`)
       const formattedConfig: Heroku.Pipeline = {}
-      Object.keys(config).forEach(key => {
+      for (const key of Object.keys(config)) {
         formattedConfig[color.green(key)] = config[key]
-      })
+      }
+
       hux.styledObject(formattedConfig)
     }
   }

--- a/src/commands/ci/config/set.ts
+++ b/src/commands/ci/config/set.ts
@@ -12,20 +12,16 @@ const heredoc = tsheredoc.default
 
 export default class CiConfigSet extends Command {
   static description = 'set CI config vars'
-
   static examples = [heredoc(`
     ${color.command('heroku ci:config:set --pipeline PIPELINE RAILS_ENV=test')}
     Setting test config vars... done
     RAILS_ENV: test`)]
-
   static flags = {
     app: flags.app(),
     pipeline: flags.pipeline({exactlyOne: ['pipeline', 'app']}),
     remote: flags.remote(),
   }
-
   static strict = false
-
   static topic = 'ci'
 
   async run() {
@@ -47,12 +43,10 @@ export default class CiConfigSet extends Command {
     await setPipelineConfigVars(this.heroku, pipeline.id, vars)
     ux.action.stop()
 
-    hux.styledObject(
-      Object.keys(vars).reduce((memo: Record<string, string>, key: string) => {
-        memo[color.green(key)] = vars[key]
-        return memo
-      }, {}),
-    )
+    hux.styledObject(Object.keys(vars).reduce((memo: Record<string, string>, key: string) => {
+      memo[color.green(key)] = vars[key]
+      return memo
+    }, {}))
   }
 }
 

--- a/src/commands/ci/config/unset.ts
+++ b/src/commands/ci/config/unset.ts
@@ -11,15 +11,12 @@ export default class CiConfigUnset extends Command {
   static examples = [
     color.command('heroku ci:config:unset RAILS_ENV'),
   ]
-
   static flags = {
     app: flags.app(),
     pipeline: flags.pipeline({exactlyOne: ['pipeline', 'app']}),
     remote: flags.remote(),
   }
-
   static strict = false
-
   static topic = 'ci'
 
   async run() {

--- a/src/commands/ci/debug.ts
+++ b/src/commands/ci/debug.ts
@@ -1,21 +1,28 @@
+import {flags as cmdFlags, Command} from '@heroku-cli/command'
+import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core/ux'
 
-import {Command, flags as cmdFlags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
-import {createTestRun, getAppSetup, getTestNodes, updateTestRun} from '../../lib/api.js'
+import {
+  createTestRun, getAppSetup, getTestNodes, updateTestRun,
+} from '../../lib/api.js'
 import {getPipeline} from '../../lib/ci/pipelines.js'
-import KolkrabbiAPI from '../../lib/pipelines/kolkrabbi-api.js'
-import Dyno from '../../lib/run/dyno.js'
-import Git from '../../lib/git/git.js'
 import {createSourceBlob} from '../../lib/ci/source.js'
 import {waitForStates} from '../../lib/ci/test-run.js'
+import Git from '../../lib/git/git.js'
+import KolkrabbiAPI from '../../lib/pipelines/kolkrabbi-api.js'
+import Dyno from '../../lib/run/dyno.js'
 
 // Default command. Run setup, source profile.d scripts and open a bash session
 const SETUP_COMMAND = 'ci setup && eval $(ci env)'
 
 export default class Debug extends Command {
   static description = 'opens an interactive test debugging session with the contents of the current directory'
-
+  static flags = {
+    app: cmdFlags.app(),
+    'no-cache': cmdFlags.boolean({description: 'start test run with an empty cache'}),
+    'no-setup': cmdFlags.boolean({description: 'start test dyno without running test-setup'}),
+    pipeline: cmdFlags.pipeline(),
+  }
   static help = `Example:
 
     $ heroku ci:debug --pipeline PIPELINE
@@ -25,13 +32,6 @@ export default class Debug extends Command {
 
 ~ $
 `
-  static flags = {
-    app: cmdFlags.app(),
-    'no-cache': cmdFlags.boolean({description: 'start test run with an empty cache'}),
-    'no-setup': cmdFlags.boolean({description: 'start test dyno without running test-setup'}),
-    pipeline: cmdFlags.pipeline(),
-  }
-
   static topic = 'ci'
 
   public async run(): Promise<void> {
@@ -53,11 +53,11 @@ export default class Debug extends Command {
     ux.action.start('Creating test run')
 
     const {body: run}: {body: Heroku.TestRun} = await createTestRun(this.heroku, {
+      clear_cache: Boolean(flags['no-cache']),
       commit_branch: commit.branch,
       commit_message: commit.message,
       commit_sha: commit.ref,
       debug: true,
-      clear_cache: Boolean(flags['no-cache']),
       organization,
       pipeline: pipeline.id,
       source_blob_url: sourceBlobUrl,
@@ -83,10 +83,10 @@ export default class Debug extends Command {
     const {body: testNodes} = await getTestNodes(this.heroku, testRun.id!)
 
     const dyno = new Dyno({
-      heroku: this.heroku,
       app: appSetup?.app?.id || '', // this should exist by here. ` || ''` is TS nudging
-      showStatus: false,
       command: '', // command is required, but is not used.
+      heroku: this.heroku,
+      showStatus: false,
     })
 
     dyno.dyno = {attach_url: testNodes?.[0]?.dyno?.attach_url}
@@ -111,8 +111,8 @@ export default class Debug extends Command {
 
     await ux.action.start('Cleaning up')
     await updateTestRun(this.heroku, testRun.id!, {
-      status: 'cancelled',
       message: 'debug run cancelled by Heroku CLI',
+      status: 'cancelled',
     })
     await ux.action.stop()
   }

--- a/src/commands/ci/index.ts
+++ b/src/commands/ci/index.ts
@@ -7,12 +7,10 @@ import {renderList} from '../../lib/ci/test-run.js'
 
 export default class CiIndex extends Command {
   static description = 'display the most recent CI runs for the given pipeline'
-
   static examples = [
     color.command(`heroku ci --app murmuring-headland-14719
 `),
   ]
-
   static flags = {
     app: flags.app(),
     json: flags.boolean({description: 'output in json format', required: false}),

--- a/src/commands/ci/info.ts
+++ b/src/commands/ci/info.ts
@@ -10,14 +10,11 @@ export default class CiInfo extends Command {
   static args = {
     'test-run': Args.string({description: 'auto-incremented test run number', required: true}),
   }
-
   static description = 'show the status of a specific test run'
-
   static examples = [
     color.command(`heroku ci:info 1288 --app murmuring-headland-14719
 `),
   ]
-
   static flags = {
     app: flags.app(),
     node: flags.string({description: 'the node number to show its setup and output', required: false}),

--- a/src/commands/ci/last.ts
+++ b/src/commands/ci/last.ts
@@ -8,12 +8,10 @@ import {displayTestRunInfo} from '../../lib/ci/test-run.js'
 
 export default class CiLast extends Command {
   static description = 'looks for the most recent run and returns the output of that run'
-
   static examples = [
     color.command(`heroku ci:last --pipeline=my-pipeline --node 100
 `),
   ]
-
   static flags = {
     app: flags.app(),
     node: flags.string({description: 'the node number to show its setup and output', required: false}),

--- a/src/commands/ci/migrate-manifest.ts
+++ b/src/commands/ci/migrate-manifest.ts
@@ -10,13 +10,10 @@ const {readFile} = fs
 export default class CiMigrateManifest extends Command {
   static baseFlags = Command.baseFlagsWithoutPrompt()
   static description = 'app-ci.json is deprecated. Run this command to migrate to app.json with an environments key.'
-
   static examples = [
     color.command('heroku ci:migrate-manifest'),
   ]
-
   static promptFlagActive = true
-
   static topic = 'ci'
 
   async run() {

--- a/src/commands/ci/open.ts
+++ b/src/commands/ci/open.ts
@@ -1,6 +1,5 @@
-import * as color from '@heroku/heroku-cli-util/color'
-
 import {Command, flags} from '@heroku-cli/command'
+import * as color from '@heroku/heroku-cli-util/color'
 import open from 'open'
 
 import {getPipeline} from '../../lib/ci/pipelines.js'
@@ -10,13 +9,11 @@ export default class CiOpen extends Command {
   static examples = [
     color.command('heroku ci:open --app murmuring-headland-14719'),
   ]
-
   static flags = {
     app: flags.app(),
     pipeline: flags.pipeline({required: false}),
     remote: flags.remote(),
   }
-
   static topic = 'ci'
 
   async run() {

--- a/src/commands/ci/rerun.ts
+++ b/src/commands/ci/rerun.ts
@@ -12,14 +12,11 @@ export default class CiReRun extends Command {
   static args = {
     number: Args.string({description: 'auto-incremented test run number', required: false}),
   }
-
   static description = 'rerun tests against current directory'
-
   static examples = [
     color.command(`heroku ci:rerun 985 --app murmuring-headland-14719
 `),
   ]
-
   static flags = {
     app: flags.app(),
     pipeline: flags.pipeline({required: false}),

--- a/src/commands/ci/run.ts
+++ b/src/commands/ci/run.ts
@@ -11,12 +11,10 @@ import {displayAndExit} from '../../lib/ci/test-run.js'
 
 export default class CiRun extends Command {
   static description = 'run tests against current directory'
-
   static examples = [
     color.command(`heroku ci:run --app murmuring-headland-14719
 `),
   ]
-
   static flags = {
     app: flags.app(),
     pipeline: flags.pipeline({required: false}),

--- a/src/commands/clients/create.ts
+++ b/src/commands/clients/create.ts
@@ -11,13 +11,10 @@ export default class ClientsCreate extends Command {
     name: Args.string({description: 'name of the OAuth client', required: true}),
     redirect_uri: Args.string({description: 'redirect URL of the OAuth client', required: true}),
   }
-
   static description = 'create a new OAuth client'
-
   static examples = [
     color.command('heroku clients:create "Amazing" https://amazing-client.herokuapp.com/auth/heroku/callback'),
   ]
-
   static flags = {
     json: flags.boolean({char: 'j', description: 'output in json format'}),
     shell: flags.boolean({char: 's', description: 'output in shell format'}),

--- a/src/commands/clients/destroy.ts
+++ b/src/commands/clients/destroy.ts
@@ -7,7 +7,6 @@ export default class ClientsDestroy extends Command {
   static args = {
     id: Args.string({description: 'ID of the OAuth client', required: true}),
   }
-
   static description = 'delete client by ID'
 
   async run() {
@@ -15,9 +14,7 @@ export default class ClientsDestroy extends Command {
 
     ux.action.start(`Destroying ${color.name(args.id)}`)
 
-    await this.heroku.delete<Heroku.OAuthClient>(
-      `/oauth/clients/${args.id}`,
-    )
+    await this.heroku.delete<Heroku.OAuthClient>(`/oauth/clients/${args.id}`)
 
     ux.action.stop()
   }

--- a/src/commands/clients/index.ts
+++ b/src/commands/clients/index.ts
@@ -5,7 +5,6 @@ import {ux} from '@oclif/core/ux'
 
 export default class ClientsIndex extends Command {
   static description = 'list your OAuth clients'
-
   static flags = {
     json: flags.boolean({char: 'j', description: 'output in json format', name: 'json'}),
   }

--- a/src/commands/clients/info.ts
+++ b/src/commands/clients/info.ts
@@ -1,19 +1,16 @@
-import {color, hux} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {color, hux} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 export default class ClientsInfo extends Command {
   static args = {
-    id: Args.string({required: true, description: 'ID of the OAuth client'}),
+    id: Args.string({description: 'ID of the OAuth client', required: true}),
   }
-
   static description = 'show details of an oauth client'
-
   static examples = [
     color.command('heroku clients:info 36120128-fee7-455e-8b7f-807aee130946'),
   ]
-
   static flags = {
     json: flags.boolean({char: 'j', description: 'output in json format'}),
     shell: flags.boolean({char: 's', description: 'output in shell format'}),

--- a/src/commands/clients/rotate.ts
+++ b/src/commands/clients/rotate.ts
@@ -1,15 +1,13 @@
-import {color, hux} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {color, hux} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 export default class ClientsRotate extends Command {
   static args = {
     id: Args.string({description: 'ID of the OAuth client', required: true}),
   }
-
   static description = 'rotate OAuth client secret'
-
   static flags = {
     json: flags.boolean({char: 'j', description: 'output in json format'}),
     shell: flags.boolean({char: 's', description: 'output in shell format'}),
@@ -20,9 +18,7 @@ export default class ClientsRotate extends Command {
 
     ux.action.start(`Updating ${color.name(args.id)}`)
 
-    const {body: client} = await this.heroku.post<Heroku.OAuthClient>(
-      `/oauth/clients/${encodeURIComponent(args.id)}/actions/rotate-credentials`,
-    )
+    const {body: client} = await this.heroku.post<Heroku.OAuthClient>(`/oauth/clients/${encodeURIComponent(args.id)}/actions/rotate-credentials`)
 
     ux.action.stop()
 

--- a/src/commands/clients/update.ts
+++ b/src/commands/clients/update.ts
@@ -25,13 +25,10 @@ export default class ClientsUpdate extends Command {
   static args = {
     id: Args.string({description: 'ID of the OAuth client', required: true}),
   }
-
   static description = 'update OAuth client'
-
   static examples = [
     color.command('heroku clients:update 3e304bda-d376-4278-bdea-6d6c08aa1359 --url https://amazing-client.herokuapp.com/auth/heroku/callback'),
   ]
-
   static flags = {
     name: flags.string({char: 'n', description: 'change the client name'}),
     url: flags.string({description: 'change the client redirect URL'}),

--- a/src/commands/config/edit.ts
+++ b/src/commands/config/edit.ts
@@ -18,11 +18,9 @@ export default class ConfigEdit extends Command {
   static args = {
     key: Args.string({description: 'edit a single key', optional: true}),
   }
-
   static description = `interactively edit config vars
 This command opens the app config in a text editor set by $VISUAL or $EDITOR.
 Any variables added/removed/changed will be updated on the app after saving and closing the file.`
-
   static examples = [
     `# edit with vim
 ${color.command('EDITOR="vim" heroku config:edit')}`,
@@ -33,12 +31,10 @@ ${color.command('EDITOR="pico" heroku config:edit')}`,
     `# edit with atom editor
 ${color.command('VISUAL="atom --wait" heroku config:edit')}`,
   ]
-
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
   app!: string
 
   async run() {

--- a/src/commands/config/get.ts
+++ b/src/commands/config/get.ts
@@ -1,9 +1,8 @@
-import * as color from '@heroku/heroku-cli-util/color'
-
-import {hux} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
-import {Args, ux} from '@oclif/core'
+import {hux} from '@heroku/heroku-cli-util'
+import * as color from '@heroku/heroku-cli-util/color'
+import {Args} from '@oclif/core'
 
 import {quote} from '../../lib/config/quote.js'
 
@@ -11,21 +10,16 @@ export class ConfigGet extends Command {
   static args = {
     KEY: Args.string({description: 'key name of the config var value', required: true}),
   }
-
   static description = 'display a single config value for an app'
-
   static example = `${color.command(`heroku config:get RAILS_ENV
 production`)}`
-
   static flags = {
     app: flags.app({required: true}),
     json: flags.boolean({char: 'j', description: 'output in json format'}),
     remote: flags.remote(),
     shell: flags.boolean({char: 's', description: 'output config vars in shell format'}),
   }
-
   static strict = false
-
   static usage = 'config:get KEY...'
 
   async run() {

--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -7,7 +7,6 @@ import {quote} from '../../lib/config/quote.js'
 
 export class ConfigIndex extends Command {
   static description = 'display the config vars for an app'
-
   static flags = {
     app: flags.app({required: true}),
     json: flags.boolean({char: 'j', description: 'output config vars in json format'}),
@@ -19,15 +18,12 @@ export class ConfigIndex extends Command {
     const {flags} = await this.parse(ConfigIndex)
     const {body: config} = await this.heroku.get<Heroku.ConfigVars>(`/apps/${flags.app}/config-vars`)
     if (flags.shell) {
-      Object.entries(config)
-        .forEach(([k, v]) => ux.stdout(`${k}=${quote(v)}`))
+      for (const [k, v] of Object.entries(config)) ux.stdout(`${k}=${quote(v)}`)
     } else if (flags.json) {
       hux.styledJSON(config)
     } else {
       hux.styledHeader(`${color.app(flags.app)} Config Vars`)
-      const coloredConfig = Object.fromEntries(
-        Object.entries(config).map(([key, value]) => [color.name(key), value]),
-      )
+      const coloredConfig = Object.fromEntries(Object.entries(config).map(([key, value]) => [color.name(key), value]))
       hux.styledObject(coloredConfig)
     }
   }

--- a/src/commands/config/set.ts
+++ b/src/commands/config/set.ts
@@ -25,14 +25,11 @@ ${color.command('heroku config:set RAILS_ENV=staging RACK_ENV=staging')}
 Setting config vars and restarting example... done, v11
 RAILS_ENV: staging
 RACK_ENV:  staging`)]
-
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
   static hiddenAliases = ['config:add']
-
   static strict = false
 
   async run() {
@@ -62,11 +59,9 @@ RACK_ENV:  staging`)]
     const release = await lastRelease(this.heroku, flags.app)
     ux.action.stop(`done, ${color.name('v' + release.version)}`)
 
-    config = Object.fromEntries(
-      Object.entries(config)
-        .filter(([k]) => vars[k])
-        .map(([k, v]) => [color.name(k), v]),
-    )
+    config = Object.fromEntries(Object.entries(config)
+      .filter(([k]) => vars[k])
+      .map(([k, v]) => [color.name(k), v]))
     hux.styledObject(config)
     await this.config.runHook('recache', {app: flags.app, type: 'config'})
   }

--- a/src/commands/config/unset.ts
+++ b/src/commands/config/unset.ts
@@ -10,20 +10,16 @@ export class ConfigUnset extends Command {
   static aliases = [
     'config:remove',
   ]
-
   static description = 'unset one or more config vars'
-
   static examples = [heredoc(`
     ${color.command('heroku config:unset RAILS_ENV')}
 Unsetting RAILS_ENV and restarting example... done, v10`), heredoc(`
     ${color.command('heroku config:unset RAILS_ENV RACK_ENV')}
 Unsetting RAILS_ENV, RACK_ENV and restarting example... done, v10`)]
-
   static flags = {
     app: flags.app({char: 'a', required: true}),
     remote: flags.remote({char: 'r'}),
   }
-
   static strict = false
 
   async run() {

--- a/src/commands/console.ts
+++ b/src/commands/console.ts
@@ -1,30 +1,29 @@
 
-// tslint:disable:file-name-casing
 import {Command, flags} from '@heroku-cli/command'
 import {DynoSizeCompletion} from '@heroku-cli/command/lib/completions.js'
+
 import Dyno from '../lib/run/dyno.js'
 import {buildCommand} from '../lib/run/helpers.js'
 
 export default class RunConsole extends Command {
-  static hidden = true
-
   static flags = {
     app: flags.app({required: true}),
-    remote: flags.remote(),
-    size: flags.string({char: 's', description: 'dyno size', completion: DynoSizeCompletion}),
     env: flags.string({char: 'e', description: 'environment variables to set (use \';\' to split multiple vars)'}),
+    remote: flags.remote(),
+    size: flags.string({char: 's', completion: DynoSizeCompletion, description: 'dyno size'}),
   }
+  static hidden = true
 
   async run() {
     const {flags} = await this.parse(RunConsole)
 
     const opts = {
-      heroku: this.heroku,
       app: flags.app,
-      command: buildCommand(['console']),
-      size: flags.size,
-      env: flags.env,
       attach: true,
+      command: buildCommand(['console']),
+      env: flags.env,
+      heroku: this.heroku,
+      size: flags.size,
     }
 
     const dyno = new Dyno(opts)

--- a/src/commands/container/login.ts
+++ b/src/commands/container/login.ts
@@ -1,17 +1,46 @@
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core/ux'
 
-import {DockerHelper} from '../../lib/container/docker-helper.js'
 import {debug} from '../../lib/container/debug.js'
+import {DockerHelper} from '../../lib/container/docker-helper.js'
 
 export default class Login extends Command {
-  static topic = 'container'
   static description = 'log in to Heroku Container Registry'
   static flags = {
     verbose: flags.boolean({char: 'v'}),
   }
-
+  static topic = 'container'
   dockerHelper = new DockerHelper()
+
+  async dockerLogin(registry: string, password: string) {
+    const [major, minor] = await new DockerHelper().version()
+
+    if (major > 17 || (major === 17 && minor >= 7)) {
+      return this.dockerLoginStdin(registry, password)
+    }
+
+    return this.dockerLoginArgv(registry, password)
+  }
+
+  dockerLoginArgv(registry: string, password: string) {
+    const args = [
+      'login',
+      '--username=_',
+      `--password=${password}`,
+      registry,
+    ]
+    return this.dockerHelper.cmd('docker', args)
+  }
+
+  dockerLoginStdin(registry: string, password: string) {
+    const args = [
+      'login',
+      '--username=_',
+      '--password-stdin',
+      registry,
+    ]
+    return this.dockerHelper.cmd('docker', args, {input: password})
+  }
 
   async run() {
     const {flags} = await this.parse(Login)
@@ -31,35 +60,5 @@ export default class Login extends Command {
     } catch (error: any) {
       ux.error(`Login failed${error.message ? ` with: ${error.message}` : ''}.`, {exit: 1})
     }
-  }
-
-  async dockerLogin(registry: string, password: string) {
-    const [major, minor] = await new DockerHelper().version()
-
-    if (major > 17 || (major === 17 && minor >= 7)) {
-      return this.dockerLoginStdin(registry, password)
-    }
-
-    return this.dockerLoginArgv(registry, password)
-  }
-
-  dockerLoginStdin(registry: string, password: string) {
-    const args = [
-      'login',
-      '--username=_',
-      '--password-stdin',
-      registry,
-    ]
-    return this.dockerHelper.cmd('docker', args, {input: password})
-  }
-
-  dockerLoginArgv(registry: string, password: string) {
-    const args = [
-      'login',
-      '--username=_',
-      `--password=${password}`,
-      registry,
-    ]
-    return this.dockerHelper.cmd('docker', args)
   }
 }

--- a/src/commands/container/logout.ts
+++ b/src/commands/container/logout.ts
@@ -1,17 +1,25 @@
 import {Command, flags} from '@heroku-cli/command'
 import {ux} from '@oclif/core/ux'
 
-import {DockerHelper} from '../../lib/container/docker-helper.js'
 import {debug} from '../../lib/container/debug.js'
+import {DockerHelper} from '../../lib/container/docker-helper.js'
 
 export default class Logout extends Command {
-  static topic = 'container'
   static description = 'log out from Heroku Container Registry'
   static flags = {
     verbose: flags.boolean({char: 'v'}),
   }
-
+  static topic = 'container'
   dockerHelper = new DockerHelper()
+
+  dockerLogout(registry: string) {
+    const args = [
+      'logout',
+      registry,
+    ]
+
+    return this.dockerHelper.cmd('docker', args)
+  }
 
   async run() {
     const {flags} = await this.parse(Logout)
@@ -29,14 +37,5 @@ export default class Logout extends Command {
       const {message} = error as {message: string}
       ux.error(`Error: docker logout exited${message ? ` with: ${message}` : ''}.`)
     }
-  }
-
-  dockerLogout(registry: string) {
-    const args = [
-      'logout',
-      registry,
-    ]
-
-    return this.dockerHelper.cmd('docker', args)
   }
 }

--- a/src/commands/container/pull.ts
+++ b/src/commands/container/pull.ts
@@ -1,6 +1,6 @@
-import {color, hux} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {color, hux} from '@heroku/heroku-cli-util'
 
 import {debug} from '../../lib/container/debug.js'
 import {DockerHelper} from '../../lib/container/docker-helper.js'
@@ -13,19 +13,14 @@ export default class Pull extends Command {
     `${color.command('heroku container:pull web worker')} # Pulls both the web and worker images from the app`,
     `${color.command('heroku container:pull web:latest')} # Pulls the latest tag from the web image`,
   ]
-
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
     verbose: flags.boolean({char: 'v'}),
   }
-
   static strict = false
-
   static topic = 'container'
-
   static usage = 'container:pull -a APP [-v] PROCESS_TYPE...'
-
   dockerHelper = new DockerHelper()
 
   async run() {

--- a/src/commands/container/push.ts
+++ b/src/commands/container/push.ts
@@ -107,7 +107,9 @@ export default class Push extends Command {
     }
 
     if (recursive) {
-      filteredJobs = processTypes.length > 0 ? this.dockerHelper.filterByProcessType(jobs, processTypes) : jobs
+      filteredJobs = processTypes.length > 0
+        ? this.dockerHelper.filterByProcessType(jobs, processTypes)
+        : jobs
 
       selectedJobs = await this.dockerHelper.chooseJobs(filteredJobs)
     } else if (jobs.standard) {

--- a/src/commands/container/push.ts
+++ b/src/commands/container/push.ts
@@ -17,7 +17,6 @@ export default class Push extends Command {
     `${color.command('heroku container:push web --arg ENV=live,HTTPS=on')}  # Build-time variables`,
     `${color.command('heroku container:push --recursive --context-path .')} # Pushes Dockerfile.* using current dir as build context`,
   ]
-
   static flags = {
     app: flags.app({required: true}),
     arg: flags.string({description: 'set build-time variables'}),
@@ -26,11 +25,8 @@ export default class Push extends Command {
     remote: flags.remote({char: 'r'}),
     verbose: flags.boolean({char: 'v'}),
   }
-
   static strict = false
-
   static topic = 'container'
-
   dockerHelper = new DockerHelper()
 
   async run(): Promise<void> {
@@ -111,17 +107,14 @@ export default class Push extends Command {
     }
 
     if (recursive) {
-      if (processTypes.length > 0) {
-        filteredJobs = this.dockerHelper.filterByProcessType(jobs, processTypes)
-      } else {
-        filteredJobs = jobs
-      }
+      filteredJobs = processTypes.length > 0 ? this.dockerHelper.filterByProcessType(jobs, processTypes) : jobs
 
       selectedJobs = await this.dockerHelper.chooseJobs(filteredJobs)
     } else if (jobs.standard) {
-      jobs.standard.forEach(pj => {
+      for (const pj of jobs.standard) {
         pj.resource = pj.resource.replace(/standard$/, processTypes[0])
-      })
+      }
+
       selectedJobs = jobs.standard || []
     }
 

--- a/src/commands/container/release.ts
+++ b/src/commands/container/release.ts
@@ -13,7 +13,7 @@ type ImageResponse = {
   }
   history: [{
     v1Compatibility: string,
-    }
+  },
   ],
   schemaVersion: number,
 }
@@ -24,17 +24,13 @@ export default class ContainerRelease extends Command {
     `${color.command('heroku container:release web')}        # Releases the previously pushed web process type`,
     `${color.command('heroku container:release web worker')} # Releases the previously pushed web and worker process types`,
   ]
-
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
     verbose: flags.boolean({char: 'v'}),
   }
-
   static strict = false
-
   static topic = 'container'
-
   static usage = 'container:release'
 
   async run() {
@@ -70,16 +66,16 @@ export default class ContainerRelease extends Command {
       let imageID
       let v1Comp
       switch (imageResp.schemaVersion) {
-      case 1: {
-        v1Comp = JSON.parse(imageResp.history[0].v1Compatibility)
-        imageID = v1Comp.id
-        break
-      }
+        case 1: {
+          v1Comp = JSON.parse(imageResp.history[0].v1Compatibility)
+          imageID = v1Comp.id
+          break
+        }
 
-      case 2: {
-        imageID = imageResp.config.digest
-        break
-      }
+        case 2: {
+          imageID = imageResp.config.digest
+          break
+        }
       }
 
       updateData.push({

--- a/src/commands/container/release.ts
+++ b/src/commands/container/release.ts
@@ -8,13 +8,8 @@ import {ensureContainerStack} from '../../lib/container/helpers.js'
 import {streamer} from '../../lib/container/streamer.js'
 
 type ImageResponse = {
-  config: {
-    digest: string
-  }
-  history: [{
-    v1Compatibility: string,
-  },
-  ],
+  config: {digest: string}
+  history: [{v1Compatibility: string}],
   schemaVersion: number,
 }
 

--- a/src/commands/container/rm.ts
+++ b/src/commands/container/rm.ts
@@ -11,16 +11,12 @@ export default class Rm extends Command {
     `${color.command('heroku container:rm web')}        # Destroys the web container`,
     `${color.command('heroku container:rm web worker')} # Destroys the web and worker containers`,
   ]
-
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
   static strict = false
-
   static topic = 'container'
-
   static usage = 'container:rm -a APP [-v] PROCESS_TYPE...'
 
   async run() {

--- a/src/commands/container/run.ts
+++ b/src/commands/container/run.ts
@@ -14,20 +14,15 @@ export default class Run extends Command {
     `${color.command('heroku container:pull web worker')} # Pulls both the web and worker images from the app`,
     `${color.command('heroku container:pull web:latest')} # Pulls the latest tag from the web image`,
   ]
-
   static flags = {
     app: flags.app({required: true}),
     port: flags.integer({char: 'p', default: 5000, description: 'port the app will run on'}),
     remote: flags.remote(),
     verbose: flags.boolean({char: 'v'}),
   }
-
   static strict = false
-
   static topic = 'container'
-
   static usage = 'container:run -a APP [-v] PROCESS_TYPE...'
-
   dockerHelper = new DockerHelper()
 
   async run() {
@@ -56,7 +51,7 @@ export default class Run extends Command {
     let jobs: DockerJob[] = []
 
     if (possibleJobs.standard) {
-      possibleJobs.standard.forEach((pj: { resource: string }) => {
+      possibleJobs.standard.forEach((pj: {resource: string}) => {
         pj.resource = pj.resource.replace(/standard$/, processType)
       })
       jobs = possibleJobs.standard || []

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -2,11 +2,11 @@ import {APIClient, Command} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {color, hux} from '@heroku/heroku-cli-util'
 import {ux} from '@oclif/core/ux'
-import {execSync} from 'child_process'
-import * as path from 'path'
-import * as process from 'process'
+import {execSync} from 'node:child_process'
+import path from 'node:path'
+import * as process from 'node:process'
+import {fileURLToPath} from 'node:url'
 import img from 'term-img'
-import {fileURLToPath} from 'url'
 
 import {lazyModuleLoader} from '../lib/lazy-module-loader.js'
 import {ago} from '../lib/time.js'
@@ -39,11 +39,10 @@ function displayErrors(metrics: FetchMetricsResponse[0], _: any) {
   }
 
   if (metrics.dynoErrors) {
-    metrics.dynoErrors.filter(Boolean)
-      .forEach(dynoErrors => {
-        errors = errors.concat(Object.entries(dynoErrors?.data || {})
-          .map(e => color.failure(`${_.sum(e[1])} ${e[0]}`)))
-      })
+    for (const dynoErrors of metrics.dynoErrors.filter(Boolean)) {
+      errors = errors.concat(Object.entries(dynoErrors?.data || {})
+        .map(e => color.failure(`${_.sum(e[1])} ${e[0]}`)))
+    }
   }
 
   if (errors.length > 0)
@@ -61,13 +60,13 @@ function displayMetrics(metrics: FetchMetricsResponse[0], _: any) {
     if (['win32', 'windows'].includes(process.platform))
       return ''
     const points: number[] = []
-    Object.values(metrics.routerStatus?.data || {})
-      .forEach(cur => {
-        for (const [i, element] of cur.entries()) {
-          const j = Math.floor(i / 3)
-          points[j] = (points[j] || 0) + element
-        }
-      })
+    for (const cur of Object.values(metrics.routerStatus?.data || {})) {
+      for (const [i, element] of cur.entries()) {
+        const j = Math.floor(i / 3)
+        points[j] = (points[j] || 0) + element
+      }
+    }
+
     points.pop()
     return dim(sparkline(points)) + ' last 24 hours rpm'
   }
@@ -108,13 +107,10 @@ const fetchMetrics = async (apps: Heroku.App[], heroku: APIClient): Promise<Fetc
 
   const metricsData = await Promise.all(apps.map(app => {
     const types = app.formation.map((p: Heroku.Formation) => p.type)
-    const dynoErrorsPromise: Promise<(AppErrors | undefined)[]> = Promise.all(
-      types.map((type: string) => heroku.get<AppErrors>(
-        `/apps/${app.app.name}/formation/${type}/metrics/errors?${date}`,
-        {hostname: 'api.metrics.herokai.com'},
-      ).catch(() => {}),
-      ),
-    )
+    const dynoErrorsPromise: Promise<(AppErrors | undefined)[]> = Promise.all(types.map((type: string) => heroku.get<AppErrors>(
+      `/apps/${app.app.name}/formation/${type}/metrics/errors?${date}`,
+      {hostname: 'api.metrics.herokai.com'},
+    ).catch(() => {})))
     return Promise.all([
       dynoErrorsPromise,
       heroku.get<AppErrors>(`/apps/${app.app.name}/router-metrics/latency?${date}&process_type=${types[0]}`, {hostname: 'api.metrics.herokai.com'}).catch(() => {}),
@@ -170,7 +166,7 @@ export default class Dashboard extends Command {
     const apps = await favoriteApps()
     const [{body: teams}, notificationsResponse, appsWithMoreInfo] = await Promise.all([
       this.heroku.get<Heroku.Team[]>('/teams'),
-      this.heroku.get<{ read: boolean }[]>('/user/notifications', {hostname: 'telex.heroku.com'})
+      this.heroku.get<{read: boolean}[]>('/user/notifications', {hostname: 'telex.heroku.com'})
         .catch(() => null),
       Promise.all(apps.map(async appID => {
         const [{body: app}, {body: formation}, pipelineResponse] = await Promise.all([

--- a/src/commands/domains/add.ts
+++ b/src/commands/domains/add.ts
@@ -1,11 +1,11 @@
-import {color, hux} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {color, hux} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 import {quote} from '../../lib/config/quote.js'
-import {lazyModuleLoader} from '../../lib/lazy-module-loader.js'
 import waitForDomain from '../../lib/domains/wait-for-domain.js'
+import {lazyModuleLoader} from '../../lib/lazy-module-loader.js'
 
 interface DomainCreatePayload {
   hostname: string;
@@ -21,11 +21,8 @@ export default class DomainsAdd extends Command {
   static args = {
     hostname: Args.string({description: 'unique identifier of the domain or full hostname', required: true}),
   }
-
   static description = 'add a domain to an app'
-
   static examples = [`${color.command('heroku domains:add www.example.com')}`]
-
   static flags = {
     app: flags.app({required: true}),
     cert: flags.string({char: 'c', description: 'the name of the SSL cert you want to use for this domain'}),
@@ -33,7 +30,6 @@ export default class DomainsAdd extends Command {
     remote: flags.remote(),
     wait: flags.boolean(),
   }
-
   certSelect = async (certs: Array<Heroku.SniEndpoint>, inquirer: any) => {
     const nullCertChoice = {
       name: 'No SNI Endpoint',

--- a/src/commands/domains/clear.ts
+++ b/src/commands/domains/clear.ts
@@ -5,9 +5,7 @@ import {ux} from '@oclif/core/ux'
 
 export default class DomainsClear extends Command {
   static description = 'remove all domains from an app'
-
   static examples = [`${color.command('heroku domains:clear')}`]
-
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),

--- a/src/commands/domains/index.ts
+++ b/src/commands/domains/index.ts
@@ -11,7 +11,6 @@ import {huxTableNoWrapOptions} from '../../lib/utils/table-utils.js'
 
 export default class DomainsIndex extends Command {
   static description = 'list domains for an app'
-
   static examples = [`${color.command('heroku domains')}
 === example Heroku Domain
 example-xxxxxxxxxxxx.herokuapp.com
@@ -23,7 +22,6 @@ www.example.com  CNAME            www.example.herokudns.com
 === example Custom Domains
 Domain Name      DNS Record Type  DNS Target
 www.example.com  CNAME            www.example.herokudns.com`]
-
   static flags = {
     app: flags.app({required: true}),
     columns: flags.string({description: 'only show provided columns (comma-separated)'}),
@@ -35,7 +33,6 @@ www.example.com  CNAME            www.example.herokudns.com`]
     remote: flags.remote(),
     sort: flags.string({description: 'sort by property'}),
   }
-
   getFilteredDomains = (filterKeyValue: string, domains: Array<Heroku.Domain>) => {
     const filteredInfo = {filteredDomains: domains, size: 0}
     const {key: filterName, value} = parseKeyValue(filterKeyValue)
@@ -69,7 +66,6 @@ www.example.com  CNAME            www.example.herokudns.com`]
     filteredInfo.size = filteredInfo.filteredDomains.length
     return filteredInfo
   }
-
   mapColumnHeadersToKeys = (columnHeaders: string[]): string[] => {
     const headerToKeyMap: Record<string, string> = {
       'ACM Status': 'acm_status',
@@ -81,7 +77,6 @@ www.example.com  CNAME            www.example.herokudns.com`]
 
     return columnHeaders.map(header => headerToKeyMap[header.trim()] || header.trim())
   }
-
   mapSortFieldToProperty = (sortField: string): string => {
     const headerToPropertyMap: Record<string, string> = {
       'ACM Status': 'acm_status',
@@ -93,7 +88,6 @@ www.example.com  CNAME            www.example.herokudns.com`]
 
     return headerToPropertyMap[sortField] || sortField
   }
-
   outputCSV = (customDomains: Heroku.Domain[], tableConfig: Record<string, any>, sortProperty?: string) => {
     const getValue = (domain: Heroku.Domain, key: string, config?: Record<string, any>) => {
       const columnConfig = config ?? tableConfig[key]
@@ -119,7 +113,6 @@ www.example.com  CNAME            www.example.herokudns.com`]
       ux.stdout(row.join(','))
     }
   }
-
   tableConfig = (needsEndpoints: boolean, extended: boolean, requestedColumns?: string[]) => {
     const tableConfig: Record<string, any> = {
       hostname: {
@@ -164,11 +157,12 @@ www.example.com  CNAME            www.example.herokudns.com`]
     // If specific columns are requested, filter the configuration
     if (requestedColumns && requestedColumns.length > 0) {
       const filteredConfig: Record<string, any> = {}
-      requestedColumns.forEach(columnKey => {
+      for (const columnKey of requestedColumns) {
         if (fullConfig[columnKey]) {
           filteredConfig[columnKey] = fullConfig[columnKey]
         }
-      })
+      }
+
       return filteredConfig
     }
 

--- a/src/commands/domains/info.ts
+++ b/src/commands/domains/info.ts
@@ -8,13 +8,10 @@ export default class DomainsInfo extends Command {
   static args = {
     hostname: Args.string({description: 'unique identifier of the domain or full hostname', required: true}),
   }
-
   static description = 'show detailed information for a domain on an app'
-
   static examples = [
     color.command('heroku domains:info www.example.com'),
   ]
-
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),

--- a/src/commands/domains/remove.ts
+++ b/src/commands/domains/remove.ts
@@ -6,11 +6,8 @@ export default class DomainsRemove extends Command {
   static args = {
     hostname: Args.string({description: 'unique identifier of the domain or full hostname', required: true}),
   }
-
   static description = 'remove a domain from an app'
-
   static examples = [`${color.command('heroku domains:remove www.example.com')}`]
-
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),

--- a/src/commands/domains/update.ts
+++ b/src/commands/domains/update.ts
@@ -6,11 +6,8 @@ export default class DomainsUpdate extends Command {
   static args = {
     hostname: Args.string({description: 'unique identifier of the domain or full hostname', required: true}),
   }
-
   static description = 'update a domain to use a different SSL certificate on an app'
-
   static examples = [`${color.command('heroku domains:update www.example.com --cert mycert')}`]
-
   static flags = {
     app: flags.app({required: true}),
     cert: flags.string({

--- a/src/commands/domains/wait.ts
+++ b/src/commands/domains/wait.ts
@@ -5,15 +5,13 @@ import {Args} from '@oclif/core'
 import waitForDomain from '../../lib/domains/wait-for-domain.js'
 
 export default class DomainsWait extends Command {
+  static args = {
+    hostname: Args.string({description: 'unique identifier of the domain or full hostname'}),
+  }
   static description = 'wait for domain to be active for an app'
-
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
-  }
-
-  static args = {
-    hostname: Args.string({description: 'unique identifier of the domain or full hostname'}),
   }
 
   async run() {

--- a/src/commands/drains/add.ts
+++ b/src/commands/drains/add.ts
@@ -7,9 +7,7 @@ export default class Add extends Command {
   static args = {
     url: Args.string({description: 'URL of the log drain', required: true}),
   }
-
   static description = 'adds a log drain to an app'
-
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),

--- a/src/commands/drains/index.ts
+++ b/src/commands/drains/index.ts
@@ -5,7 +5,6 @@ import {ux} from '@oclif/core/ux'
 
 export default class Drains extends Command {
   static description = 'display the log drains of an app'
-
   static flags = {
     app: flags.app({required: true}),
     extended: flags.boolean({char: 'x', hidden: true}),
@@ -26,17 +25,15 @@ export default class Drains extends Command {
     if (flags.json) {
       hux.styledJSON(drains)
     } else {
-      const [drainsWithAddons, drainsWithoutAddons] = drains.reduce<Heroku.LogDrain[]>(
-        (acc, drain) => {
-          if (drain.addon) {
-            acc[0].push(drain)
-          } else {
-            acc[1].push(drain)
-          }
+      const [drainsWithAddons, drainsWithoutAddons] = drains.reduce<Heroku.LogDrain[]>((acc, drain) => {
+        if (drain.addon) {
+          acc[0].push(drain)
+        } else {
+          acc[1].push(drain)
+        }
 
-          return acc
-        }, [[], []],
-      )
+        return acc
+      }, [[], []])
 
       if (drainsWithoutAddons.length > 0) {
         hux.styledHeader('Drains')
@@ -46,13 +43,11 @@ export default class Drains extends Command {
       }
 
       if (drainsWithAddons.length > 0) {
-        const addons = await Promise.all(
-          drainsWithAddons.map((d: Heroku.LogDrain) => this.heroku.get<Heroku.AddOn>(`/apps/${flags.app}/addons/${d.addon?.name}`)),
-        )
+        const addons = await Promise.all(drainsWithAddons.map((d: Heroku.LogDrain) => this.heroku.get<Heroku.AddOn>(`/apps/${flags.app}/addons/${d.addon?.name}`)))
         hux.styledHeader('Add-on Drains')
-        addons.forEach(({body: addon}, i) => {
+        for (const [i, {body: addon}] of addons.entries()) {
           styledDrain(color.addon(addon.plan?.name || ''), color.addon(addon.name || ''), drainsWithAddons[i])
-        })
+        }
       }
     }
   }

--- a/src/commands/drains/remove.ts
+++ b/src/commands/drains/remove.ts
@@ -7,11 +7,8 @@ export default class Remove extends Command {
   static args = {
     url: Args.string({description: 'URL of the log drain', required: true}),
   }
-
   static description = 'removes a log drain from an app'
-
   static example = `${color.command('drains:remove [URL|TOKEN]')}`
-
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),

--- a/src/commands/features/disable.ts
+++ b/src/commands/features/disable.ts
@@ -7,9 +7,7 @@ export default class Disable extends Command {
   static args = {
     feature: Args.string({description: 'unique identifier or name of the app feature', required: true}),
   }
-
   static description = 'disables an app feature'
-
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),

--- a/src/commands/features/enable.ts
+++ b/src/commands/features/enable.ts
@@ -7,9 +7,7 @@ export default class Enable extends Command {
   static args = {
     feature: Args.string({description: 'unique identifier or name of the app feature', required: true}),
   }
-
   static description = 'enables an app feature'
-
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),

--- a/src/commands/features/index.ts
+++ b/src/commands/features/index.ts
@@ -1,15 +1,14 @@
+import {Command, flags} from '@heroku-cli/command'
+import * as Heroku from '@heroku-cli/schema'
 import {color, hux} from '@heroku/heroku-cli-util'
 import {ux} from '@oclif/core/ux'
-
-import * as Heroku from '@heroku-cli/schema'
-import {flags, Command} from '@heroku-cli/command'
 
 export default class Features extends Command {
   static description = 'list available app features'
   static flags = {
     app: flags.app({required: true}),
-    remote: flags.remote(),
     json: flags.boolean({description: 'output in json format'}),
+    remote: flags.remote(),
   }
 
   async run() {

--- a/src/commands/features/info.ts
+++ b/src/commands/features/info.ts
@@ -1,15 +1,13 @@
-import {color, hux} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {color, hux} from '@heroku/heroku-cli-util'
 import {Args} from '@oclif/core'
 
 export default class Info extends Command {
   static args = {
     feature: Args.string({description: 'unique identifier or name of the app feature', required: true}),
   }
-
   static description = 'display information about a feature'
-
   static flags = {
     app: flags.app({required: true}),
     json: flags.boolean({description: 'output in json format'}),


### PR DESCRIPTION
## Summary
This PR applies automated lint formatting to command files in preparation for migration to ESLint 9. Changes include import ordering, class property ordering, object property ordering, and whitespace cleanup.

Affected command groups: auth, authorizations, autocomplete, buildpacks, certs, ci, clients, config, console, container, dashboard, domains, drains, features.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
These are purely formatting changes with no behavioral modifications. Part of a series of PRs to break up linting changes in preparation for ESLint 9 migration.

**Steps**:
1. Passing CI suffices.

## Related Issues
Part of a series of PRs to reduce what is implemented in https://github.com/heroku/cli/pull/3661