### PR TITLE
refactor: apply lint formatting to git through pg commands

### DIFF
--- a/src/commands/data/maintenances/history.ts
+++ b/src/commands/data/maintenances/history.ts
@@ -1,5 +1,5 @@
-import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {flags as Flags} from '@heroku-cli/command'
+import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 import BaseCommand from '../../../lib/data/base-command.js'
@@ -10,16 +10,13 @@ export default class DataMaintenancesHistory extends BaseCommand {
   static args = {
     addon: Args.string({description: 'data addon', required: true}),
   }
-
   static description = 'show details of the most recent maintenances for an addon'
-
   static examples = [
     '$ heroku data:maintenances:history postgresql-sinuous-92834',
     '$ heroku data:maintenances:history postgresql-sinuous-92834 --num 10',
     '$ heroku data:maintenances:history postgresql-sinuous-92834 --json',
     '$ heroku data:maintenances:history DATABASE --app production-app',
   ]
-
   static flags = {
     app: Flags.app(),
     columns: Flags.string({description: 'only show provided columns (comma-separated)'}),
@@ -57,6 +54,7 @@ export default class DataMaintenancesHistory extends BaseCommand {
       return
     }
 
+    /* eslint-disable perfectionist/sort-objects */
     const allTableColumns = {
       scheduled_for: {
         get: (row: Maintenance) => row && row.scheduled_for ? row.scheduled_for : '-',
@@ -85,7 +83,7 @@ export default class DataMaintenancesHistory extends BaseCommand {
         header: 'Window',
       },
     }
-
+    /* eslint-enable perfectionist/sort-objects */
     const tableColumns = constructTableColumns(allTableColumns, Object.keys(allTableColumns), false, flags.columns)
 
     if (flags.json) {

--- a/src/commands/data/maintenances/index.ts
+++ b/src/commands/data/maintenances/index.ts
@@ -9,12 +9,10 @@ import {constructSortFilterTableOptions, constructTableColumns, outputCSV} from 
 
 export default class DataMaintenancesIndex extends BaseCommand {
   static description = 'list maintenances for an app\'s data addons'
-
   static examples = [
     '$ heroku data:maintenances --app production-app',
     '$ heroku data:maintenances --app production-app --json',
   ]
-
   static flags = {
     app: Flags.app({
       description: 'app to list addon maintenances for',

--- a/src/commands/data/maintenances/info.ts
+++ b/src/commands/data/maintenances/info.ts
@@ -1,10 +1,10 @@
-import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {flags} from '@heroku-cli/command'
+import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 import BaseCommand from '../../../lib/data/base-command.js'
-import {lazyModuleLoader} from '../../../lib/lazy-module-loader.js'
 import {Maintenance} from '../../../lib/data/types.js'
+import {lazyModuleLoader} from '../../../lib/lazy-module-loader.js'
 
 interface StyledMaintenance extends Maintenance {
   [key: string]: any;
@@ -18,15 +18,12 @@ export default class DataMaintenancesInfo extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'display details of the most recent maintenance for an addon'
-
   static examples = [
     '$ heroku data:maintenances:info postgresql-sinuous-83720',
     '$ heroku data:maintenances:info postgresql-sinuous-83720 --json',
     '$ heroku data:maintenances:info DATABASE --app test-app',
   ]
-
   static flags = {
     app: flags.app({description: 'app to list addon maintenances for'}),
     json: flags.boolean({char: 'j', description: 'output result in json'}),
@@ -57,14 +54,14 @@ export default class DataMaintenancesInfo extends BaseCommand {
     }
 
     ['app',  'addon'].forEach((key: string) => {
-      Object.keys(styledMaintenance[key]).forEach(childKey => {
+      for (const childKey of Object.keys(styledMaintenance[key])) {
         const composedKey = `${key}_${childKey}`
         const childValue = styledMaintenance[key][childKey]
 
         if (childValue !== undefined) {
           styledMaintenance[composedKey] = childValue
         }
-      })
+      }
 
       // after flattening the child keys from `key`, we can remove `key`
       // off the of object so that it isn't shown

--- a/src/commands/data/maintenances/run.ts
+++ b/src/commands/data/maintenances/run.ts
@@ -13,16 +13,13 @@ export default class DataMaintenancesRun extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'triggers a scheduled maintenance for a data add-on'
-
   static examples = [
     '$ heroku data:maintenances:run postgresql-sinuous-92834',
     '$ heroku data:maintenances:run postgresql-sinuous-92834 --confirm production-app',
     '$ heroku data:maintenances:run postgresql-sinuous-92834 --wait',
     '$ heroku data:maintenances:run DATABASE --app production-app',
   ]
-
   static flags = {
     app: Flags.app({description: 'app to run addon maintenance for'}),
     confirm: Flags.string({

--- a/src/commands/data/maintenances/schedule.ts
+++ b/src/commands/data/maintenances/schedule.ts
@@ -1,11 +1,11 @@
-import {color, utils} from '@heroku/heroku-cli-util'
 import {flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 import BaseCommand from '../../../lib/data/base-command.js'
-import {lazyModuleLoader} from '../../../lib/lazy-module-loader.js'
 import {Maintenance} from '../../../lib/data/types.js'
+import {lazyModuleLoader} from '../../../lib/lazy-module-loader.js'
 
 export default class DataMaintenancesSchedule extends BaseCommand {
   static args = {
@@ -14,9 +14,7 @@ export default class DataMaintenancesSchedule extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'schedule or re-schedule maintenance for an add-on'
-
   static examples = [
     '$ heroku data:maintenances:schedule postgresql-sinuous-83910',
     '$ heroku data:maintenances:schedule postgresql-sinuous-83910 --weeks 3',
@@ -24,7 +22,6 @@ export default class DataMaintenancesSchedule extends BaseCommand {
     '$ heroku data:maintenances:schedule postgresql-sinuous-83910 --week 2020-02-23',
     '$ heroku data:maintenances:schedule HEROKU_POSTGRESQL_RED --app test-app',
   ]
-
   static flags = {
     app: flags.app(),
     remote: flags.remote(),

--- a/src/commands/data/maintenances/wait.ts
+++ b/src/commands/data/maintenances/wait.ts
@@ -1,5 +1,5 @@
-import {color, utils} from '@heroku/heroku-cli-util'
 import {flags as Flags} from '@heroku-cli/command'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 import BaseCommand from '../../../lib/data/base-command.js'
@@ -10,14 +10,11 @@ export default class DataMaintenancesWait extends BaseCommand {
   static args = {
     addon: Args.string({description: 'data addon', required: true}),
   }
-
   static description = 'blocks until the maintenance process has completed'
-
   static examples = [
     '$ heroku data:maintenances:wait postgresql-sinuous-83720',
     '$ heroku data:maintenances:wait DATABASE --app production-app',
   ]
-
   static flags = {
     app: Flags.app(),
     remote: Flags.remote(),

--- a/src/commands/data/maintenances/window/index.ts
+++ b/src/commands/data/maintenances/window/index.ts
@@ -1,5 +1,5 @@
-import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {flags as Flags} from '@heroku-cli/command'
+import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 import BaseCommand from '../../../../lib/data/base-command.js'
@@ -12,14 +12,11 @@ export default class DataMaintenancesWindow extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'describe the maintenance window on an add-on'
-
   static examples = [
     '$ heroku data:maintenances:window postgresql-sinuous-92834',
     '$ heroku data:maintenances:window DATABASE --app production-app',
   ]
-
   static flags = {
     app: Flags.app({description: 'app to show addon maintenance window for'}),
     json: Flags.boolean({char: 'j', description: 'output result in json'}),

--- a/src/commands/data/maintenances/window/update.ts
+++ b/src/commands/data/maintenances/window/update.ts
@@ -1,5 +1,5 @@
-import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {flags as Flags} from '@heroku-cli/command'
+import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 import BaseCommand from '../../../../lib/data/base-command.js'
@@ -20,15 +20,12 @@ export default class DataMaintenancesWindowUpdate extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'update maintenance window on an add-on'
-
   static examples = [
     '$ heroku data:maintenances:window postgresql-sinuous-92834 sunday 13:30',
     '$ heroku data:maintenances:window postgresql-sinuous-92834 sunday 1:30PM',
     '$ heroku data:maintenances:window DATABASE sunday 1:30PM --app production-app',
   ]
-
   static flags = {
     app: Flags.app({description: 'app to update addon maintenance window for'}),
     json: Flags.boolean({char: 'j', description: 'output result in json'}),
@@ -41,9 +38,7 @@ export default class DataMaintenancesWindowUpdate extends BaseCommand {
     const addon = await addonResolver.resolve(args.addon, flags.app)
 
     const combinedWindowLabel = `${args.day_of_week} ${args.time_of_day}`
-    ux.action.start(
-      `Setting maintenance window for ${color.addon(addon.name!)} to ${combinedWindowLabel}`,
-    )
+    ux.action.start(`Setting maintenance window for ${color.addon(addon.name!)} to ${combinedWindowLabel}`)
 
     const {body: result} = await this.dataApi.post<Window>(
       `/data/maintenances/v1/${addon.id}/window`,

--- a/src/commands/data/pg/attachments/create.ts
+++ b/src/commands/data/pg/attachments/create.ts
@@ -1,6 +1,6 @@
-import {color, pg, utils} from '@heroku/heroku-cli-util'
 import {flags as Flags, HerokuAPIError} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {color, pg, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -16,9 +16,7 @@ export default class DataPgAttachmentsCreate extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'attach an existing Postgres Advanced database to an app'
-
   static flags = {
     app: Flags.app({required: true}),
     as: Flags.string({description: 'name for Postgres database attachment'}),
@@ -56,10 +54,8 @@ export default class DataPgAttachmentsCreate extends BaseCommand {
     if (!utils.pg.isAdvancedDatabase(addon)) {
       const cmd = `heroku addons:attach ${addon.name} -a ${app}${as ? ` --as ${as}` : ''}`
         + `${credential ? ` --credential ${credential}` : ''}`
-      ux.error(
-        'You can only use this command on Advanced-tier databases.\n'
-          + `Use ${color.code(cmd)} instead.`,
-      )
+      ux.error('You can only use this command on Advanced-tier databases.\n'
+          + `Use ${color.code(cmd)} instead.`)
     }
 
     const createAttachment = async (confirmed?: string): Promise<Required<Heroku.AddOnAttachment>> => {
@@ -99,25 +95,23 @@ export default class DataPgAttachmentsCreate extends BaseCommand {
     }
 
     if (credential) {
-      const {body: credentialConfig} = await this.heroku.get<Required<Heroku.AddOnConfig>[]>(
-        `/addons/${addon.name}/config/role:${encodeURIComponent(credential)}`,
-      )
+      const {body: credentialConfig} = await this.heroku.get<Required<Heroku.AddOnConfig>[]>(`/addons/${addon.name}/config/role:${encodeURIComponent(credential)}`)
       if (credentialConfig.length === 0) {
-        ux.error(heredoc`
+        ux.error(
+          heredoc`
           The credential ${color.name(credential)} doesn't exist on the database ${color.datastore(addon.name)}.
           Use ${color.code(`heroku data:pg:credentials ${addon.name} -a ${app}`)} to list the credentials on the database.`,
-        {exit: 1},
+          {exit: 1},
         )
       }
     } else if (pool) {
-      const {body: poolConfig} = await this.heroku.get<Required<Heroku.AddOnConfig>[]>(
-        `/addons/${addon.name}/config/pool:${encodeURIComponent(pool)}`,
-      )
+      const {body: poolConfig} = await this.heroku.get<Required<Heroku.AddOnConfig>[]>(`/addons/${addon.name}/config/pool:${encodeURIComponent(pool)}`)
       if (poolConfig.length === 0) {
-        ux.error(heredoc`
+        ux.error(
+          heredoc`
           The pool ${color.name(pool)} doesn't exist on the database ${color.datastore(addon.name)}.
           Use ${color.code(`heroku data:pg:info ${addon.name} -a ${app}`)} to list the pools on the database.`,
-        {exit: 1},
+          {exit: 1},
         )
       }
     }

--- a/src/commands/data/pg/attachments/destroy.ts
+++ b/src/commands/data/pg/attachments/destroy.ts
@@ -1,6 +1,6 @@
-import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {flags as Flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 import BaseCommand from '../../../../lib/data/base-command.js'
@@ -12,9 +12,7 @@ export default class DataPgAttachmentsDestroy extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'detach an existing database attachment from an app'
-
   static flags = {
     app: Flags.app({required: true}),
     confirm: Flags.string({char: 'c', description: 'pass in the app name to skip confirmation prompts'}),
@@ -25,25 +23,19 @@ export default class DataPgAttachmentsDestroy extends BaseCommand {
     const {args, flags} = await this.parse(DataPgAttachmentsDestroy)
     const {attachment_name: attachmentName} = args
     const {app, confirm} = flags
-    const {body: attachment} = await this.heroku.get<Required<Heroku.AddOnAttachment>>(
-      `/apps/${app}/addon-attachments/${attachmentName}`,
-    )
+    const {body: attachment} = await this.heroku.get<Required<Heroku.AddOnAttachment>>(`/apps/${app}/addon-attachments/${attachmentName}`)
     const addonResolver = new utils.AddonResolver(this.heroku)
     const addon = await addonResolver.resolve(attachment.addon.name, undefined, utils.pg.addonService())
 
     if (!utils.pg.isAdvancedDatabase(addon)) {
-      ux.error(
-        'You can only use this command on Advanced-tier databases.\n'
-          + `Use ${color.code(`heroku addons:detach ${attachmentName} -a ${app}`)} instead.`,
-      )
+      ux.error('You can only use this command on Advanced-tier databases.\n'
+          + `Use ${color.code(`heroku addons:detach ${attachmentName} -a ${app}`)} instead.`)
     }
 
     await hux.confirmCommand({comparison: app, confirmation: confirm})
 
     try {
-      ux.action.start(
-        `Detaching ${color.attachment(attachmentName)} on ${color.datastore(addon.name)} from ${color.app(app)}`,
-      )
+      ux.action.start(`Detaching ${color.attachment(attachmentName)} on ${color.datastore(addon.name)} from ${color.app(app)}`)
       await this.heroku.delete(`/addon-attachments/${attachment.id}`)
       ux.action.stop()
     } catch (error) {

--- a/src/commands/data/pg/attachments/index.ts
+++ b/src/commands/data/pg/attachments/index.ts
@@ -1,6 +1,6 @@
-import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {flags as Flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 import type {CredentialInfo, CredentialsInfo} from '../../../../lib/data/types.js'
@@ -14,13 +14,10 @@ export default class DataPgAttachmentsIndex extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'list attachments on a Postgres Advanced database'
-
   static examples = [
     '<%= config.bin %> <%= command.id %> database_name -a example-app',
   ]
-
   static flags = {
     app: Flags.app({required: true}),
     remote: Flags.remote(),
@@ -35,10 +32,8 @@ export default class DataPgAttachmentsIndex extends BaseCommand {
     const addon = await addonResolver.resolve(database, app, utils.pg.addonService())
 
     if (!utils.pg.isAdvancedDatabase(addon)) {
-      ux.error(
-        'You can only use this command on Advanced-tier databases.\n'
-          + `Use ${color.code(`heroku addons:info ${addon.name} -a ${app}`)} instead.`,
-      )
+      ux.error('You can only use this command on Advanced-tier databases.\n'
+          + `Use ${color.code(`heroku addons:info ${addon.name} -a ${app}`)} instead.`)
     }
 
     const [{body: {items: credentials}}, {body: attachments}] = await Promise.all([

--- a/src/commands/data/pg/create.ts
+++ b/src/commands/data/pg/create.ts
@@ -15,14 +15,13 @@ import {fetchLevelsAndPricing, renderPricingInfo} from '../../../lib/data/utils.
 import notify from '../../../lib/notify.js'
 
 const heredoc = tsheredoc.default
-// eslint-disable-next-line import/no-named-as-default-member
+
 const {prompt, Separator} = inquirer
 
 export default class DataPgCreate extends BaseCommand {
   static baseFlags = BaseCommand.baseFlagsWithoutPrompt()
   static description = 'create a Postgres Advanced database'
   static examples = ['<%= config.bin %> <%= command.id %> --level 4G-Performance -a example-app']
-
   static flags = {
     app: Flags.app({
       required: true,
@@ -56,9 +55,7 @@ export default class DataPgCreate extends BaseCommand {
       description: 'watch database creation status and exit when complete',
     }),
   }
-
   static promptFlagActive = false
-
   private addon: Heroku.AddOn | undefined
   private extendedLevelsInfo: ExtendedPostgresLevelInfo[] | undefined
   private followerInstanceCount: number = 0
@@ -139,9 +136,7 @@ export default class DataPgCreate extends BaseCommand {
     if (!level) {
       // Interactive mode
       await this.followerPoolConfigLoop()
-      process.stderr.write(
-        `Running ${color.code(`heroku data:pg:info ${this.addon.name!} --app=${app}`)}...\n\n`,
-      )
+      process.stderr.write(`Running ${color.code(`heroku data:pg:info ${this.addon.name!} --app=${app}`)}...\n\n`)
       await this.runCommand('data:pg:info', [this.addon.name!, `--app=${app}`])
     } else if (followers && followers > 0) {
       const poolInfo = await createPool(this.dataApi, this.addon!, {
@@ -192,16 +187,14 @@ export default class DataPgCreate extends BaseCommand {
 
         process.stderr.write('\n')
         this.followerInstanceCount += count
-        if (this.followerInstanceCount >= 13) {
-          oneMore = false
-        } else {
-          oneMore = (await this.prompt<{oneMore: boolean}>({
+        oneMore = this.followerInstanceCount >= 13
+          ? false
+          : (await this.prompt<{oneMore: boolean}>({
             default: false,
             message: 'Configure another follower pool?',
             name: 'oneMore',
             type: 'confirm',
           })).oneMore
-        }
       } else {
         oneMore = false
       }
@@ -209,10 +202,8 @@ export default class DataPgCreate extends BaseCommand {
   }
 
   private async highAvailabilityStep(): Promise<string> {
-    process.stderr.write(
-      'The leader pool has high availability enabled and includes a standby instance for redundancy.\n'
-      + 'If you disable high availability, you remove the standby and you won\'t have redundancy on your database.\n\n',
-    )
+    process.stderr.write('The leader pool has high availability enabled and includes a standby instance for redundancy.\n'
+      + 'If you disable high availability, you remove the standby and you won\'t have redundancy on your database.\n\n')
 
     const leaderPricing = this.extendedLevelsInfo!.find(level => level.name === this.leaderLevel)?.pricing
     const {action} = await this.prompt<{action: string}>({
@@ -246,11 +237,9 @@ export default class DataPgCreate extends BaseCommand {
     const instancePrice = renderPricingInfo(leaderLevelInfo?.pricing)
     process.stderr.write(heredoc`
       ${`${color.green('✓ Configure Leader Pool')} ${totalPrice}`}
-        ${color.gray(
-    `${this.leaderLevel} ${leaderLevelInfo?.vcpu} ${color.ansis.inverse('vCPU')} `
+        ${color.gray(`${this.leaderLevel} ${leaderLevelInfo?.vcpu} ${color.ansis.inverse('vCPU')} `
           + `${leaderLevelInfo?.memory_in_gb} GB ${color.ansis.inverse('MEM')} `
-          + instancePrice,
-  )}
+          + instancePrice)}
     `)
     if (this.highAvailability) {
       process.stderr.write(color.gray(`  Standby (High Availability) ${instancePrice}\n`))
@@ -298,50 +287,50 @@ export default class DataPgCreate extends BaseCommand {
 
     while (!configReady) {
       switch (currentStep) {
-      case 'leaderLevel': {
-        await this.leaderLevelStep()
-        currentStep = 'highAvailability'
-        break
-      }
+        case 'confirmation': {
+          switch (await this.leaderConfirmationStep()) {
+            case 'back': {
+              currentStep = 'highAvailability'
+              break
+            }
 
-      case 'highAvailability': {
-        switch (await this.highAvailabilityStep()) {
-        case 'keep': {
-          this.highAvailability = true
-          currentStep = 'confirmation'
+            case 'confirm': {
+              configReady = true
+              break
+            }
+          }
+
           break
         }
 
-        case 'remove': {
-          this.highAvailability = false
-          currentStep = 'confirmation'
+        case 'highAvailability': {
+          switch (await this.highAvailabilityStep()) {
+            case 'back': {
+              currentStep = 'leaderLevel'
+              break
+            }
+
+            case 'keep': {
+              this.highAvailability = true
+              currentStep = 'confirmation'
+              break
+            }
+
+            case 'remove': {
+              this.highAvailability = false
+              currentStep = 'confirmation'
+              break
+            }
+          }
+
           break
         }
 
-        case 'back': {
-          currentStep = 'leaderLevel'
-          break
-        }
-        }
-
-        break
-      }
-
-      case 'confirmation': {
-        switch (await this.leaderConfirmationStep()) {
-        case 'confirm': {
-          configReady = true
-          break
-        }
-
-        case 'back': {
+        case 'leaderLevel': {
+          await this.leaderLevelStep()
           currentStep = 'highAvailability'
           break
         }
-        }
-
-        break
-      }
       }
     }
   }

--- a/src/commands/data/pg/credentials/create.ts
+++ b/src/commands/data/pg/credentials/create.ts
@@ -14,13 +14,10 @@ export default class DataPgCredentialsCreate extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'create credentials for a Postgres database'
-
   static examples = [
     '<%= config.bin %> <%= command.id %> DATABASE --name my-credential --app example-app',
   ]
-
   static flags = {
     app: Flags.app({required: true}),
     name: Flags.string({char: 'n', description: 'name for the credential', required: true}),

--- a/src/commands/data/pg/credentials/destroy.ts
+++ b/src/commands/data/pg/credentials/destroy.ts
@@ -18,13 +18,10 @@ export default class DataPgCredentialsDestroy extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'destroy credentials on a Postgres database'
-
   static examples = [
     '<%= config.bin %> <%= command.id %> DATABASE --name my-credential --app example-app',
   ]
-
   static flags = {
     app: Flags.app({required: true}),
     confirm: Flags.string({char: 'c', description: 'pass in the app name to skip confirmation prompts'}),
@@ -60,37 +57,27 @@ export default class DataPgCredentialsDestroy extends BaseCommand {
     } else if (isLegacyEssentialTier || name === 'default') {
       ux.error('You can\'t destroy the default credential.')
     } else {
-      const {body: attachments} = await this.heroku.get<Required<AddOnAttachment>[]>(
-        `/addons/${addon.id}/addon-attachments`,
-      )
+      const {body: attachments} = await this.heroku.get<Required<AddOnAttachment>[]>(`/addons/${addon.id}/addon-attachments`)
       credAttachments = attachments.filter(a => a.namespace === `credential:${name}`)
     }
 
     const credAttachmentApps = [...new Set(credAttachments.map(a => a.app.name!))]
     if (credAttachmentApps.length > 0) {
-      ux.error(
-        `You must detach the credential ${color.name(name)} from the `
+      ux.error(`You must detach the credential ${color.name(name)} from the `
         + `app${credAttachmentApps.length > 1 ? 's' : ''} `
-        + `${credAttachmentApps.map(appName => color.app(appName || '')).join(', ')} before destroying it.`,
-      )
+        + `${credAttachmentApps.map(appName => color.app(appName || '')).join(', ')} before destroying it.`)
     }
 
     await confirmCommand({comparison: app, confirmation: confirm})
 
     try {
       ux.action.start(`Destroying credential ${color.name(name)}`)
-      if (isAdvancedTier) {
-        await this.dataApi.delete(`/data/postgres/v1/${addon.id}/credentials/${encodeURIComponent(name)}`)
-      } else {
-        await this.dataApi.delete(`/postgres/v0/databases/${addon.name}/credentials/${encodeURIComponent(name)}`)
-      }
+      await (isAdvancedTier ? this.dataApi.delete(`/data/postgres/v1/${addon.id}/credentials/${encodeURIComponent(name)}`) : this.dataApi.delete(`/postgres/v0/databases/${addon.name}/credentials/${encodeURIComponent(name)}`))
 
       ux.action.stop()
       ux.stdout(`We destroyed the credential ${color.name(name)} in ${color.datastore(addon.name)}.`)
-      ux.stdout(
-        `Database objects owned by ${color.name(name)} will be assigned to the `
-        + `${isAdvancedTier ? 'owner' : 'default'} credential.`,
-      )
+      ux.stdout(`Database objects owned by ${color.name(name)} will be assigned to the `
+        + `${isAdvancedTier ? 'owner' : 'default'} credential.`)
     } catch (error) {
       ux.action.stop(color.red('!'))
       throw error

--- a/src/commands/data/pg/credentials/index.ts
+++ b/src/commands/data/pg/credentials/index.ts
@@ -1,6 +1,6 @@
-import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {flags as Flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 import type {CredentialInfo, CredentialsInfo} from '../../../../lib/data/types.js'
@@ -17,13 +17,10 @@ export default class DataPgCredentialsIndex extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'list credentials on a Postgres Advanced database'
-
   static examples = [
     '<%= config.bin %> <%= command.id %> database_name -a example-app',
   ]
-
   static flags = {
     app: Flags.app({required: true}),
     'no-wrap': Flags.noWrap(),
@@ -37,17 +34,13 @@ export default class DataPgCredentialsIndex extends BaseCommand {
 
     const addonResolver = new utils.AddonResolver(this.heroku)
     const addon = await addonResolver.resolve(database, app, utils.pg.addonService())
-    const {body: attachments} = await this.heroku.get<Required<Heroku.AddOnAttachment>[]>(
-      `/addons/${addon.id}/addon-attachments`,
-    )
+    const {body: attachments} = await this.heroku.get<Required<Heroku.AddOnAttachment>[]>(`/addons/${addon.id}/addon-attachments`)
 
     if (!utils.pg.isAdvancedDatabase(addon)) {
       const appAttachment = attachments.find(a => a.app.name === app)
       const suggestedDatabase = appAttachment?.name || database
-      ux.error(
-        'You can only use this command on Advanced-tier databases.\n'
-          + `Use ${color.code(`heroku pg:credentials ${suggestedDatabase} -a ${app}`)} instead.`,
-      )
+      ux.error('You can only use this command on Advanced-tier databases.\n'
+          + `Use ${color.code(`heroku pg:credentials ${suggestedDatabase} -a ${app}`)} instead.`)
     }
 
     const {body: {items: credentials}} = await this.dataApi.get<CredentialsInfo>(`/data/postgres/v1/${addon.id}/credentials`)
@@ -56,11 +49,7 @@ export default class DataPgCredentialsIndex extends BaseCommand {
 
     const presentCredential = (cred: CredentialInfo): string => {
       let credAttachments = [] as Required<Heroku.AddOnAttachment>[]
-      if (cred.type === 'owner') {
-        credAttachments = attachments.filter(a => a.namespace === null)
-      } else {
-        credAttachments = attachments.filter(a => a.namespace === `role:${cred.name}`)
-      }
+      credAttachments = cred.type === 'owner' ? attachments.filter(a => a.namespace === null) : attachments.filter(a => a.namespace === `role:${cred.name}`)
 
       return presentCredentialAttachments(app, credAttachments, sortedCredentials, cred.name)
     }

--- a/src/commands/data/pg/credentials/rotate.ts
+++ b/src/commands/data/pg/credentials/rotate.ts
@@ -1,6 +1,6 @@
-import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {flags as Flags} from '@heroku-cli/command'
 import {AddOn, AddOnAttachment} from '@heroku-cli/schema'
+import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 import type {CredentialInfo, CredentialsInfo, NonAdvancedCredentialInfo} from '../../../../lib/data/types.js'
@@ -14,9 +14,7 @@ export default class Rotate extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'rotate credentials on a Postgres database'
-
   static flags = {
     all: Flags.boolean({
       description: 'rotate all credentials',
@@ -83,6 +81,7 @@ export default class Rotate extends BaseCommand {
     if (all) {
       try {
         ux.action.start(`Rotating all credentials on ${color.datastore(addon.name)}`)
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         isAdvancedTier
           ? await this.dataApi.post(`/data/postgres/v1/${addon.id}/rotate_credentials`, body)
           : await this.dataApi.post(`/postgres/v0/databases/${addon.id}/credentials_rotation`, body)
@@ -100,6 +99,7 @@ export default class Rotate extends BaseCommand {
 
       try {
         ux.action.start(`Rotating ${color.name(credName)} on ${color.datastore(addon.name)}`)
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
         isAdvancedTier
           ? await this.dataApi.post(`/data/postgres/v1/${addon.id}/credentials/${encodeURIComponent(credName)}/rotate`, body)
           : await this.dataApi.post(`/postgres/v0/databases/${addon.id}/credentials/${encodeURIComponent(credName)}/credentials_rotation`, body)
@@ -201,9 +201,7 @@ export default class Rotate extends BaseCommand {
     }
 
     if (all && force) {
-      warnings.push(
-        `You're force rotating the passwords for all credentials including the ${defaultCredName} credential.`,
-      )
+      warnings.push(`You're force rotating the passwords for all credentials including the ${defaultCredName} credential.`)
     }
 
     if (all && !force) {
@@ -217,10 +215,8 @@ export default class Rotate extends BaseCommand {
     }
 
     if (force) {
-      warnings.push(
-        'You can\'t access any followers lagging in replication until they\'re caught up. '
-        + `Use ${color.code(infoCommand)} to track progress.`,
-      )
+      warnings.push('You can\'t access any followers lagging in replication until they\'re caught up. '
+        + `Use ${color.code(infoCommand)} to track progress.`)
     }
 
     return warnings

--- a/src/commands/data/pg/credentials/url.ts
+++ b/src/commands/data/pg/credentials/url.ts
@@ -1,8 +1,8 @@
-import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {flags as Flags} from '@heroku-cli/command'
+import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
+import {URL} from 'node:url'
 import tsheredoc from 'tsheredoc'
-import {URL} from 'url'
 
 import type {
   AdvancedCredentialInfo,
@@ -23,13 +23,10 @@ export default class Url extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'show information on a Postgres database credential'
-
   static examples = [
     '<%= config.bin %> <%= command.id %> DATABASE --app myapp',
   ]
-
   static flags = {
     app: Flags.app({required: true}),
     name: Flags.string({
@@ -57,23 +54,17 @@ export default class Url extends BaseCommand {
     let credInfo: CredentialInfo
 
     if (isAdvancedTier) {
-      const {body: {items: availableCreds}} = await this.dataApi.get<CredentialsInfo>(
-        `/data/postgres/v1/${addon.id}/credentials`,
-      )
+      const {body: {items: availableCreds}} = await this.dataApi.get<CredentialsInfo>(`/data/postgres/v1/${addon.id}/credentials`)
       const ownerCred = availableCreds.find(cred => cred.type === 'owner')
       credName = name || ownerCred?.name
       if (!credName) {
         ux.error(`There are no active credentials on the database ${color.datastore(addon.name)}.`, {exit: 1})
       }
 
-      ({body: credInfo} = await this.dataApi.get<AdvancedCredentialInfo>(
-        `/data/postgres/v1/${addon.id}/credentials/${encodeURIComponent(credName)}`,
-      ))
+      ({body: credInfo} = await this.dataApi.get<AdvancedCredentialInfo>(`/data/postgres/v1/${addon.id}/credentials/${encodeURIComponent(credName)}`))
     } else {
       credName = name ?? 'default';
-      ({body: credInfo} = await this.dataApi.get<NonAdvancedCredentialInfo>(
-        `/postgres/v0/databases/${addon.id}/credentials/${encodeURIComponent(credName)}`,
-      ))
+      ({body: credInfo} = await this.dataApi.get<NonAdvancedCredentialInfo>(`/postgres/v0/databases/${addon.id}/credentials/${encodeURIComponent(credName)}`))
     }
 
     const activeCreds = isAdvancedCredentialInfo(credInfo)

--- a/src/commands/data/pg/destroy.ts
+++ b/src/commands/data/pg/destroy.ts
@@ -1,5 +1,5 @@
-import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {flags as Flags} from '@heroku-cli/command'
+import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 import destroyAddon from '../../../lib/addons/destroy-addon.js'
@@ -12,11 +12,8 @@ export default class DataPgDestroy extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'destroy a Postgres Advanced database'
-
   static examples = ['<%= config.bin %> <%= command.id %> database_name']
-
   static flags = {
     app: Flags.app(),
     confirm: Flags.string({char: 'c', description: 'pass in the app name to skip confirmation prompts'}),

--- a/src/commands/data/pg/docs.ts
+++ b/src/commands/data/pg/docs.ts
@@ -1,5 +1,5 @@
-import {hux} from '@heroku/heroku-cli-util'
 import {flags} from '@heroku-cli/command'
+import {hux} from '@heroku/heroku-cli-util'
 
 import BaseCommand from '../../../lib/data/base-command.js'
 

--- a/src/commands/data/pg/fork.ts
+++ b/src/commands/data/pg/fork.ts
@@ -1,13 +1,13 @@
-import {color, utils} from '@heroku/heroku-cli-util'
 import {flags as Flags} from '@heroku-cli/command'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
 import createAddon from '../../../lib/addons/create-addon.js'
 import BaseCommand from '../../../lib/data/base-command.js'
-import {lazyModuleLoader} from '../../../lib/lazy-module-loader.js'
 import {parseProvisionOpts} from '../../../lib/data/parse-provision-opts.js'
 import {InfoResponse} from '../../../lib/data/types.js'
+import {lazyModuleLoader} from '../../../lib/lazy-module-loader.js'
 import notify from '../../../lib/notify.js'
 
 const heredoc = tsheredoc.default
@@ -19,9 +19,7 @@ export default class Fork extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'fork or rollback a Postgres Advanced database'
-
   static examples = [
     heredoc`
       # Create a fork for an existing database
@@ -36,7 +34,6 @@ export default class Fork extends BaseCommand {
       <%= config.bin %> <%= command.id %> DATABASE --app my-app --as RESTORED --rollback-by '1 day 3 hours 20 minutes'
     `,
   ]
-
   static flags = {
     app: Flags.app({required: true}),
     as: Flags.string({description: 'name for the initial database attachment'}),
@@ -85,10 +82,8 @@ export default class Fork extends BaseCommand {
     const parsedDate = chrono.parseDate(timeString)
 
     if (!parsedDate) {
-      ux.error(
-        `${interval} isn't a supported time interval. Use a format like '1 day', '3 hours', '2 days 5 hours' for example. `
-        + 'See https://devcenter.heroku.com/articles/heroku-postgres-rollback.',
-      )
+      ux.error(`${interval} isn't a supported time interval. Use a format like '1 day', '3 hours', '2 days 5 hours' for example. `
+        + 'See https://devcenter.heroku.com/articles/heroku-postgres-rollback.')
     }
 
     return parsedDate
@@ -125,10 +120,8 @@ export default class Fork extends BaseCommand {
         + `${rollbackBy ? ` --by '${rollbackBy}'` : ''}`
 
     if (!utils.pg.isAdvancedDatabase(addon)) {
-      ux.error(
-        'You can only use this command on Advanced-tier databases.\n'
-          + `Use ${color.code(renderLegacyCommand())} instead.`,
-      )
+      ux.error('You can only use this command on Advanced-tier databases.\n'
+          + `Use ${color.code(renderLegacyCommand())} instead.`)
     }
 
     if (!level) {

--- a/src/commands/data/pg/info.ts
+++ b/src/commands/data/pg/info.ts
@@ -24,11 +24,8 @@ export default class DataPgInfo extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'get details on a Postgres Advanced database'
-
   static examples = ['<%= config.bin %> <%= command.id %> database_name']
-
   static flags = {
     app: Flags.app({required: true}),
     remote: Flags.remote(),
@@ -45,8 +42,7 @@ export default class DataPgInfo extends BaseCommand {
     if (!utils.pg.isAdvancedDatabase(addon)) {
       ux.error(heredoc`
         You can only use this command on Advanced-tier databases.
-        Run ${color.code(`heroku pg:info ${addon.name} -a ${app}`)} instead.`,
-      )
+        Run ${color.code(`heroku pg:info ${addon.name} -a ${app}`)} instead.`)
     }
 
     const [{body: info}, {body: attachments}] = await Promise.all([
@@ -112,9 +108,9 @@ export default class DataPgInfo extends BaseCommand {
       }
 
       if (otherPools.length > 0) {
-        otherPools.forEach(pool => {
+        for (const pool of otherPools) {
           renderPoolSummary(pool, attachments)
-        })
+        }
       }
     }
   }
@@ -142,10 +138,11 @@ export default class DataPgInfo extends BaseCommand {
 
   private renderQuotasInfo(quotas: Quota[]): Record<string, string> {
     const quotaInfo: Record<string, string> = {}
-    quotas.forEach(quota => {
+    for (const quota of quotas) {
       const usageMessage = formatQuotaStatus(quota)
       quotaInfo[`  ${hux.toTitleCase(quota.type)}`] = `${usageMessage}`
-    })
+    }
+
     return quotaInfo
   }
 
@@ -177,18 +174,12 @@ function renderPoolSummary(pool: PoolInfoResponse, attachments: Required<Heroku.
 
   const instances: string[] = []
   const {compute_instances: computeInstances, name: poolName} = pool
-  computeInstances.forEach(({id, role, status}) => {
-    let instanceName: string
-
-    if (role === 'standby') {
-      instanceName = color.inactive(`${role}.${id}`)
-    } else {
-      instanceName = `${role}.${id}`
-    }
+  for (const {id, role, status} of computeInstances) {
+    const instanceName = role === 'standby' ? color.inactive(`${role}.${id}`) : `${role}.${id}`
 
     const instanceStatus = status === 'up' ? color.success(status) : color.warning(status)
     instances.push(`  ${instanceName}: ${instanceStatus}`)
-  })
+  }
 
   if (poolName === 'leader') {
     hux.styledHeader(`Leader pool${poolAttachmentNames ? color.gray(` (attached as ${poolAttachmentNames})`) : ''}`)
@@ -196,10 +187,8 @@ function renderPoolSummary(pool: PoolInfoResponse, attachments: Required<Heroku.
     hux.styledHeader(`Follower pool ${color.name(poolName)}${poolAttachmentNames ? color.gray(` (attached as ${poolAttachmentNames})`) : ''}`)
   }
 
-  ux.stdout(
-    `  ${poolStatus}\n`
+  ux.stdout(`  ${poolStatus}\n`
     + `  ${connections}\n`
     + `  ${poolSize}\n`
-    + `  ${instances.join('\n  ')}\n`,
-  )
+    + `  ${instances.join('\n  ')}\n`)
 }

--- a/src/commands/data/pg/psql.ts
+++ b/src/commands/data/pg/psql.ts
@@ -1,5 +1,5 @@
-import {color, pg, utils} from '@heroku/heroku-cli-util'
 import {Command, flags as Flags} from '@heroku-cli/command'
+import {color, pg, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -14,21 +14,16 @@ export default class DataPgPsql extends Command {
       required: true,
     }),
   }
-
   static description = 'open a psql shell to the database'
-
   static examples = ['<%= config.bin %> <%= command.id %> database_name -a example-app']
-
   static flags = {
     app: Flags.app({required: true}),
     // prevent MITM attacks.
     'channel-binding': Flags.string({
       default: 'require',
-      description: heredoc(
-        'override the default channel binding behavior (required). '
+      description: heredoc('override the default channel binding behavior (required). '
         + 'Can be "disable" to disable channel binding if you run into compatibility issues with your libpq version '
-        + 'or if it was compiled without SSL support.',
-      ),
+        + 'or if it was compiled without SSL support.'),
       hidden: true,
       options: ['disable', 'require'],
     }),
@@ -60,8 +55,7 @@ export default class DataPgPsql extends Command {
         const addonResolver = new utils.AddonResolver(this.heroku)
         const addon = await addonResolver.resolve(databaseArg, app, utils.pg.addonService())
         const credCommand = utils.pg.isAdvancedDatabase(addon) ? 'data:pg:credentials' : 'pg:credentials'
-        throw new Error(
-          `The credential ${color.name(credential)} doesn't exist on the database ${color.datastore(databaseArg)}. `
+        throw new Error(`The credential ${color.name(credential)} doesn't exist on the database ${color.datastore(databaseArg)}. `
           + `Run ${color.code(`heroku ${credCommand} ${addon.name}`)} to list the credentials on the database.`)
       }
 
@@ -75,7 +69,7 @@ export default class DataPgPsql extends Command {
       let psqlCommand: string
 
       if (command) {
-        psqlCommand = `psql -c "${command.replaceAll('"', '\\"')}" --set sslmode=require `
+        psqlCommand = `psql -c "${command.replaceAll('"', String.raw`\"`)}" --set sslmode=require `
           + `--set channel_binding=${channelBinding} $${db.attachment!.name}_URL`
       } else {
         const prompt = `${db.attachment!.app.name}::${db.attachment!.name}%R%# `
@@ -123,7 +117,7 @@ export default class DataPgPsql extends Command {
     try {
       await dyno.start()
     } catch (error: unknown) {
-      const dynoError = error as {exitCode?: number} & Error
+      const dynoError = error as Error & {exitCode?: number}
       if (dynoError.exitCode) {
         ux.error(dynoError.message, {code: String(dynoError.exitCode), exit: dynoError.exitCode})
       } else {

--- a/src/commands/data/pg/quotas/index.ts
+++ b/src/commands/data/pg/quotas/index.ts
@@ -1,5 +1,5 @@
-import {utils} from '@heroku/heroku-cli-util'
 import {flags as Flags} from '@heroku-cli/command'
+import {utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 import type {Quota, Quotas} from '../../../../lib/data/types.js'
@@ -14,13 +14,10 @@ export default class DataPgQuotasIndex extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'display quotas set on a Postgres Advanced database'
-
   static examples = [
     '<%= config.bin %> <%= command.id %> database_name --app example-app',
   ]
-
   static flags = {
     app: Flags.app({required: true}),
     remote: Flags.remote(),
@@ -45,10 +42,10 @@ export default class DataPgQuotasIndex extends BaseCommand {
     } else {
       const {body: quotas} = await this.dataApi.get<Quotas>(`/data/postgres/v1/${addon.id}/quotas`)
 
-      quotas.items.forEach(quota => {
+      for (const quota of quotas.items) {
         displayQuota(quota)
         ux.stdout('')
-      })
+      }
     }
   }
 }

--- a/src/commands/data/pg/quotas/update.ts
+++ b/src/commands/data/pg/quotas/update.ts
@@ -1,5 +1,5 @@
-import {color, utils} from '@heroku/heroku-cli-util'
 import {flags as Flags} from '@heroku-cli/command'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -32,11 +32,8 @@ export default class DataPgQuotasUpdate extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'update quota settings on a Postgres Advanced database'
-
   static examples = ['<%= config.bin %> <%= command.id %> --app example-app --type storage --warning 12 --critical 15 --enforcement-action notify']
-
   static flags = {
     app: Flags.app({required: true}),
     critical: Flags.string({description: 'set critical threshold in GB, set to "none" to remove threshold'}),

--- a/src/commands/data/pg/settings.ts
+++ b/src/commands/data/pg/settings.ts
@@ -39,16 +39,13 @@ export default class DataPgSettings extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'get or update the settings of a Postgres Advanced database'
-
   static examples = [
     '# Get database settings\n'
     + '<%= config.bin %> <%= command.id %> database_name -a app_name',
     '# Change ‘log_min_duration_statement’ and ‘log_statement’ settings for database\n'
     + '<%= config.bin %> <%= command.id %> database_name --set=log_min_duration_statement:2000 --set=log_statement:ddl -a app_name',
   ]
-
   static flags = {
     app: Flags.app({
       required: true,
@@ -84,18 +81,13 @@ export default class DataPgSettings extends BaseCommand {
       const {body} = response
 
       if (body.changes.length === 0) {
-        ux.stdout(
-          `\nThose settings are already applied to ${color.addon(database.name)}. `
-          + `Use ${color.code(`heroku data:pg:settings ${database.name} -a ${app}`)} to see the current settings on the database.`,
-        )
+        ux.stdout(`\nThose settings are already applied to ${color.addon(database.name)}. `
+          + `Use ${color.code(`heroku data:pg:settings ${database.name} -a ${app}`)} to see the current settings on the database.`)
       } else {
         const tableData = settingsChangeTableData(body)
         ux.stdout('Updating these settings...')
         hux.table(tableData, settingsChangeHeaders)
-        ux.stdout(`Updating your database ${color.addon(database.name)} shortly. You can use ${color.code(
-          `data:pg:info ${database.name} -a ${app}`,
-        )} to track progress`,
-        )
+        ux.stdout(`Updating your database ${color.addon(database.name)} shortly. You can use ${color.code(`data:pg:info ${database.name} -a ${app}`)} to track progress`)
       }
     } else {
       const response = await this.dataApi.get<SettingsResponse>(`/data/postgres/v1/${database.id}/settings`)

--- a/src/commands/data/pg/update.ts
+++ b/src/commands/data/pg/update.ts
@@ -21,7 +21,7 @@ import {
 import {fetchLevelsAndPricing, renderPricingInfo} from '../../../lib/data/utils.js'
 
 const heredoc = tsheredoc.default
-// eslint-disable-next-line import/no-named-as-default-member
+
 const {prompt, Separator} = inquirer
 
 export default class DataPgUpdate extends BaseCommand {
@@ -30,19 +30,15 @@ export default class DataPgUpdate extends BaseCommand {
       description: 'database name, database attachment name, or related config var on an app',
     }),
   }
-
   static baseFlags = BaseCommand.baseFlagsWithoutPrompt()
   static description = 'update a Postgres Advanced database through interactive prompts'
-
   static flags = {
     app: Flags.app({
       required: true,
     }),
     remote: Flags.remote(),
   }
-
   static promptFlagActive = false
-
   private database: DeepRequired<Heroku.AddOn> | pg.ExtendedAddonAttachment['addon'] | undefined
   private extendedLevelsInfo: ExtendedPostgresLevelInfo[] | undefined
   private followerInstanceCount: number = 0
@@ -54,7 +50,7 @@ export default class DataPgUpdate extends BaseCommand {
   }
 
   public async followerPoolActionStep(pool: PoolInfoResponse): Promise<string> {
-    const choices: Array<DistinctChoice<{ action: string }, ListChoiceMap<{ action: string }>>> = [
+    const choices: Array<DistinctChoice<{action: string}, ListChoiceMap<{action: string}>>> = [
       {name: 'Change pool level', value: '__change_level'},
       {name: 'Update number of instances', value: '__update_count'},
       {name: 'Destroy pool', value: '__destroy_pool'},
@@ -73,71 +69,71 @@ export default class DataPgUpdate extends BaseCommand {
     let newCount: string | undefined
     const poolConfig = new PoolConfig(this.extendedLevelsInfo!, this.followerInstanceCount)
     switch (action) {
-    case '__change_level': {
-      newLevel = await poolConfig.levelStep('Follower', pool, true)
-      if (newLevel !== '__go_back') {
-        ux.action.start('Changing follower pool level')
+      case '__change_level': {
+        newLevel = await poolConfig.levelStep('Follower', pool, true)
+        if (newLevel !== '__go_back') {
+          ux.action.start('Changing follower pool level')
 
-        try {
-          await this.dataApi.patch(`/data/postgres/v1/${this.database!.id}/pools/${pool.id}`, {
-            body: {level: newLevel},
-          })
-          ux.action.stop()
-          ux.stdout(heredoc`
+          try {
+            await this.dataApi.patch(`/data/postgres/v1/${this.database!.id}/pools/${pool.id}`, {
+              body: {level: newLevel},
+            })
+            ux.action.stop()
+            ux.stdout(heredoc`
               ${color.green('✓ Success:')} Level changed from ${pool.expected_level} to ${newLevel} for follower pool ${pool.name}.
             `)
-          pool.expected_level = newLevel
-        } catch (error) {
-          ux.action.stop(color.red('!'))
-          throw error
+            pool.expected_level = newLevel
+          } catch (error) {
+            ux.action.stop(color.red('!'))
+            throw error
+          }
         }
+
+        break
       }
 
-      break
-    }
-
-    case '__update_count': {
-      newCount = await poolConfig.instanceCountStep(pool)
-      if (newCount !== '__go_back') {
-        ux.action.start('Updating follower pool instances count')
+      case '__destroy_pool': {
+        await this.confirmCommand(this.database!.app.name)
+        ux.action.start(`Destroying follower pool ${color.name(`${pool.name}`)} on ${color.datastore(`${this.database!.name}`)}`)
 
         try {
-          await this.dataApi.patch(`/data/postgres/v1/${this.database!.id}/pools/${pool.id}`, {
-            body: {count: Number(newCount)},
-          })
+          await this.dataApi.delete(`/data/postgres/v1/${this.database!.id}/pools/${pool.id}`)
           ux.action.stop()
-          ux.stdout(heredoc`
-              ${color.success('✓ Success:')} The ${color.name(pool.name)} follower pool now has ${newCount} instance${Number(newCount) === 1 ? '' : 's'}.
-            `)
-          this.followerInstanceCount = this.followerInstanceCount - pool.expected_count + Number(newCount)
-          pool.expected_count = Number(newCount)
         } catch (error) {
           ux.action.stop(color.red('!'))
           throw error
         }
+
+        break
       }
 
-      break
-    }
-
-    case '__destroy_pool': {
-      await this.confirmCommand(this.database!.app.name)
-      ux.action.start(`Destroying follower pool ${color.name(`${pool.name}`)} on ${color.datastore(`${this.database!.name}`)}`)
-
-      try {
-        await this.dataApi.delete(`/data/postgres/v1/${this.database!.id}/pools/${pool.id}`)
-        ux.action.stop()
-      } catch (error) {
-        ux.action.stop(color.red('!'))
-        throw error
+      case '__go_back': {
+        break
       }
 
-      break
-    }
+      case '__update_count': {
+        newCount = await poolConfig.instanceCountStep(pool)
+        if (newCount !== '__go_back') {
+          ux.action.start('Updating follower pool instances count')
 
-    case '__go_back': {
-      break
-    }
+          try {
+            await this.dataApi.patch(`/data/postgres/v1/${this.database!.id}/pools/${pool.id}`, {
+              body: {count: Number(newCount)},
+            })
+            ux.action.stop()
+            ux.stdout(heredoc`
+              ${color.success('✓ Success:')} The ${color.name(pool.name)} follower pool now has ${newCount} instance${Number(newCount) === 1 ? '' : 's'}.
+            `)
+            this.followerInstanceCount = this.followerInstanceCount - pool.expected_count + Number(newCount)
+            pool.expected_count = Number(newCount)
+          } catch (error) {
+            ux.action.stop(color.red('!'))
+            throw error
+          }
+        }
+
+        break
+      }
     }
 
     process.stderr.write('\n')
@@ -146,7 +142,7 @@ export default class DataPgUpdate extends BaseCommand {
 
   public async leaderPoolActionStep(pool: PoolInfoResponse): Promise<string> {
     const leaderPricing = this.extendedLevelsInfo!.find(level => level.name === pool.expected_level)?.pricing
-    const choices: Array<DistinctChoice<{ action: string }, ListChoiceMap<{ action: string }>>> = [
+    const choices: Array<DistinctChoice<{action: string}, ListChoiceMap<{action: string}>>> = [
       {name: 'Change pool level', value: '__change_level'},
     ]
 
@@ -160,15 +156,13 @@ export default class DataPgUpdate extends BaseCommand {
         value: '__remove_ha',
       })
     } else {
-      choices.push(
-        {
-          name: (
-            'Add a high availability (HA) standby instance'
+      choices.push({
+        name: (
+          'Add a high availability (HA) standby instance'
             + ` ${color.green(renderPricingInfo(leaderPricing))}`
-          ),
-          value: '__add_ha',
-        },
-      )
+        ),
+        value: '__add_ha',
+      })
     }
 
     choices.push(
@@ -186,66 +180,66 @@ export default class DataPgUpdate extends BaseCommand {
     let newLevel: string | undefined
     const poolConfig = new PoolConfig(this.extendedLevelsInfo!, this.followerInstanceCount)
     switch (action) {
-    case '__change_level': {
-      newLevel = await poolConfig.levelStep('Leader', pool, true)
-      if (newLevel !== '__go_back') {
-        ux.action.start('Changing leader pool level')
+      case '__add_ha': {
+        ux.action.start(`Adding a high availability (HA) standby instance for ${color.addon(`${this.database!.name}`)}`)
 
         try {
           await this.dataApi.patch(`/data/postgres/v1/${this.database!.id}/pools/${pool.id}`, {
-            body: {level: newLevel},
+            body: {count: 2},
           })
           ux.action.stop()
-          ux.stdout(heredoc`
-              ${color.green('✓ Success:')} Level changed from ${pool.expected_level} to ${newLevel} for leader pool.
-            `)
-          pool.expected_level = newLevel
+          pool.expected_count = 2
         } catch (error) {
           ux.action.stop(color.red('!'))
           throw error
         }
+
+        break
       }
 
-      break
-    }
+      case '__change_level': {
+        newLevel = await poolConfig.levelStep('Leader', pool, true)
+        if (newLevel !== '__go_back') {
+          ux.action.start('Changing leader pool level')
 
-    case '__remove_ha': {
-      ux.action.start(`Removing the high availability (HA) standby instance from ${color.addon(`${this.database!.name}`)}`)
+          try {
+            await this.dataApi.patch(`/data/postgres/v1/${this.database!.id}/pools/${pool.id}`, {
+              body: {level: newLevel},
+            })
+            ux.action.stop()
+            ux.stdout(heredoc`
+              ${color.green('✓ Success:')} Level changed from ${pool.expected_level} to ${newLevel} for leader pool.
+            `)
+            pool.expected_level = newLevel
+          } catch (error) {
+            ux.action.stop(color.red('!'))
+            throw error
+          }
+        }
 
-      try {
-        await this.dataApi.patch(`/data/postgres/v1/${this.database!.id}/pools/${pool.id}`, {
-          body: {count: 1},
-        })
-        ux.action.stop()
-        pool.expected_count = 1
-      } catch (error) {
-        ux.action.stop(color.red('!'))
-        throw error
+        break
       }
 
-      break
-    }
-
-    case '__add_ha': {
-      ux.action.start(`Adding a high availability (HA) standby instance for ${color.addon(`${this.database!.name}`)}`)
-
-      try {
-        await this.dataApi.patch(`/data/postgres/v1/${this.database!.id}/pools/${pool.id}`, {
-          body: {count: 2},
-        })
-        ux.action.stop()
-        pool.expected_count = 2
-      } catch (error) {
-        ux.action.stop(color.red('!'))
-        throw error
+      case '__go_back': {
+        break
       }
 
-      break
-    }
+      case '__remove_ha': {
+        ux.action.start(`Removing the high availability (HA) standby instance from ${color.addon(`${this.database!.name}`)}`)
 
-    case '__go_back': {
-      break
-    }
+        try {
+          await this.dataApi.patch(`/data/postgres/v1/${this.database!.id}/pools/${pool.id}`, {
+            body: {count: 1},
+          })
+          ux.action.stop()
+          pool.expected_count = 1
+        } catch (error) {
+          ux.action.stop(color.red('!'))
+          throw error
+        }
+
+        break
+      }
     }
 
     process.stderr.write('\n')
@@ -268,8 +262,7 @@ export default class DataPgUpdate extends BaseCommand {
       if (this.database && !utils.pg.isAdvancedDatabase(this.database)) {
         ux.error(heredoc`
           You can only use this command on Advanced-tier databases.
-          Use ${color.code(`heroku addons:upgrade ${this.database.name} -a ${app}`)} instead.`,
-        )
+          Use ${color.code(`heroku addons:upgrade ${this.database.name} -a ${app}`)} instead.`)
       }
     } else {
       const databases = await this.getAllAdvancedDatabases(app)
@@ -394,38 +387,34 @@ export default class DataPgUpdate extends BaseCommand {
     do {
       let action: string | undefined
       switch (currentStep) {
-      case 'poolSelectionStep': {
-        await this.poolSelectionStep()
-        if (this.selectedPoolOption === '__exit') {
-          currentStep = '__exit'
-        } else if (this.selectedPoolOption === '__add_follower_pool') {
-          currentStep = 'addFollowerPoolStage'
-        } else {
-          currentStep = 'poolActionStage'
-        }
-
-        break
-      }
-
-      case 'poolActionStage': {
-        if (this.pool!.name === 'leader') {
-          action = await this.leaderPoolActionStep(this.pool!)
-        } else {
-          action = await this.followerPoolActionStep(this.pool!)
-        }
-
-        if (action === '__go_back' || action === '__destroy_pool') {
+        case 'addFollowerPoolStage': {
+          await this.addFollowerPoolStage()
           currentStep = 'poolSelectionStep'
+          break
         }
 
-        break
-      }
+        case 'poolActionStage': {
+          action = await (this.pool!.name === 'leader' ? this.leaderPoolActionStep(this.pool!) : this.followerPoolActionStep(this.pool!))
 
-      case 'addFollowerPoolStage': {
-        await this.addFollowerPoolStage()
-        currentStep = 'poolSelectionStep'
-        break
-      }
+          if (action === '__go_back' || action === '__destroy_pool') {
+            currentStep = 'poolSelectionStep'
+          }
+
+          break
+        }
+
+        case 'poolSelectionStep': {
+          await this.poolSelectionStep()
+          if (this.selectedPoolOption === '__exit') {
+            currentStep = '__exit'
+          } else if (this.selectedPoolOption === '__add_follower_pool') {
+            currentStep = 'addFollowerPoolStage'
+          } else {
+            currentStep = 'poolActionStage'
+          }
+
+          break
+        }
       }
     } while (currentStep !== '__exit')
   }
@@ -454,13 +443,12 @@ export default class DataPgUpdate extends BaseCommand {
   }
 
   private renderDatabaseChoices(databases: Array<pg.ExtendedAddonAttachment['addon'] & {attachment_names?: string[]}>) {
-    const choices: Array<DistinctChoice<{ action: string }, ListChoiceMap<{ action: string }>>> = []
+    const choices: Array<DistinctChoice<{action: string}, ListChoiceMap<{action: string}>>> = []
 
-    databases.forEach(database => {
-      choices.push(
-        {name: `${database.name} (${database.attachment_names?.join(', ')})`, value: database.name},
-      )
-    })
+    for (const database of databases) {
+      choices.push({name: `${database.name} (${database.attachment_names?.join(', ')})`, value: database.name})
+    }
+
     choices.push(
       new Separator(),
       {name: 'Exit', value: '__exit'},
@@ -468,10 +456,10 @@ export default class DataPgUpdate extends BaseCommand {
     return choices
   }
 
-  private async renderPoolChoices(pools: PoolInfoResponse[]): Promise<Array<DistinctChoice<{ pool: string }, ListChoiceMap<{ pool: string }>>>> {
+  private async renderPoolChoices(pools: PoolInfoResponse[]): Promise<Array<DistinctChoice<{pool: string}, ListChoiceMap<{pool: string}>>>> {
     const leaderPool = pools.find(pool => pool.name === 'leader')
     const followerPools = pools.filter(pool => pool.name !== 'leader').sort((a, b) => a.name.localeCompare(b.name))
-    const choices: Array<DistinctChoice<{ pool: string }, ListChoiceMap<{ pool: string }>>> = []
+    const choices: Array<DistinctChoice<{pool: string}, ListChoiceMap<{pool: string}>>> = []
 
     if (leaderPool) {
       const levelInfo = this.extendedLevelsInfo!.find(level => level.name === leaderPool.expected_level)
@@ -479,29 +467,25 @@ export default class DataPgUpdate extends BaseCommand {
         name: `Leader: ${levelInfo!.name}`
           + ` ${`${levelInfo!.vcpu} ${color.ansis.inverse('vCPU')}`}`
           + ` ${`${levelInfo!.memory_in_gb} GB ${color.ansis.inverse('MEM')}`}`
-          + color.green(
-            ` ${leaderPool.expected_count} instance${leaderPool.expected_count === 1 ? '' : 's'}`
+          + color.green(` ${leaderPool.expected_count} instance${leaderPool.expected_count === 1 ? '' : 's'}`
             + ` ${`starting at ${renderPricingInfo(levelInfo!.pricing)}`}`
-            + `${leaderPool.expected_count === 1 ? '' : ' each'}`,
-          ),
+            + `${leaderPool.expected_count === 1 ? '' : ' each'}`),
         value: leaderPool.name,
       })
     }
 
-    followerPools.forEach(pool => {
+    for (const pool of followerPools) {
       const levelInfo = this.extendedLevelsInfo!.find(level => level.name === pool.expected_level)
       choices.push({
         name: `Follower ${color.bold(pool.name)}: ${levelInfo!.name}`
           + ` ${`${levelInfo!.vcpu} ${color.ansis.inverse('vCPU')}`}`
           + ` ${`${levelInfo!.memory_in_gb} GB ${color.ansis.inverse('MEM')}`}`
-          + color.green(
-            ` ${pool.expected_count} instance${pool.expected_count === 1 ? '' : 's'}`
+          + color.green(` ${pool.expected_count} instance${pool.expected_count === 1 ? '' : 's'}`
             + ` ${`starting at ${renderPricingInfo(levelInfo!.pricing)}`}`
-            + `${pool.expected_count === 1 ? '' : ' each'}`,
-          ),
+            + `${pool.expected_count === 1 ? '' : ' each'}`),
         value: pool.name,
       })
-    })
+    }
 
     choices.push(
       new Separator(),

--- a/src/commands/data/pg/upgrade/run.ts
+++ b/src/commands/data/pg/upgrade/run.ts
@@ -15,16 +15,13 @@ export default class DataPgUpgradeRun extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'upgrade the Postgres version on a Postgres Advanced database'
-
   static examples = [
     heredoc`
       # Upgrade a Postgres Advanced database to version 17
       ${color.code('<%= config.bin %> <%= command.id %> DATABASE --version 17 --app my-app')}
     `,
   ]
-
   static flags = {
     app: Flags.app({required: true}),
     confirm: Flags.string({char: 'c', description: 'pass in the app name to skip confirmation prompts'}),
@@ -41,10 +38,8 @@ export default class DataPgUpgradeRun extends BaseCommand {
     const {addon} = await dbResolver.getAttachment(app, database)
 
     if (!utils.pg.isAdvancedDatabase(addon)) {
-      ux.error(
-        'You can only use this command on Advanced-tier databases.\n'
-          + `Use ${color.code(`heroku pg:upgrade:run ${addon.name} --app ${app}`)} instead.`,
-      )
+      ux.error('You can only use this command on Advanced-tier databases.\n'
+          + `Use ${color.code(`heroku pg:upgrade:run ${addon.name} --app ${app}`)} instead.`)
     }
 
     const {body: databaseInfo} = await this.dataApi.get<InfoResponse>(`/data/postgres/v1/${addon.id}/info`)

--- a/src/commands/data/pg/upgrade/wait.ts
+++ b/src/commands/data/pg/upgrade/wait.ts
@@ -7,7 +7,6 @@ const heredoc = tsheredoc.default
 
 export default class DataPgUpgradeWait extends DataPgWait {
   static description = 'shows status of an upgrade until it\'s complete'
-
   static examples = [
     heredoc(`
       # Wait for upgrade to complete
@@ -18,6 +17,5 @@ export default class DataPgUpgradeWait extends DataPgWait {
       ${color.code('<%= config.bin %> <%= command.id %> DATABASE --app myapp --wait-interval 10')}
     `),
   ]
-
   protected classicWaitCommand: string = 'pg:upgrade:wait'
 }

--- a/src/commands/data/pg/wait.ts
+++ b/src/commands/data/pg/wait.ts
@@ -20,16 +20,13 @@ export default class DataPgWait extends BaseCommand {
       required: true,
     }),
   }
-
   static description = 'show status of an operation until it\'s complete'
-
   static examples = [
     heredoc(`
       # Wait for database to be available
       ${color.code('<%= config.bin %> <%= command.id %> DATABASE --app myapp')}
     `),
   ]
-
   static flags = {
     app: Flags.app({required: true}),
     'no-notify': Flags.boolean({
@@ -42,7 +39,6 @@ export default class DataPgWait extends BaseCommand {
       min: 1,
     }),
   }
-
   protected classicWaitCommand: string = 'pg:wait'
 
   public async notify(...args: Parameters<typeof notify>): Promise<void> {

--- a/src/commands/git/clone.ts
+++ b/src/commands/git/clone.ts
@@ -1,7 +1,6 @@
-import * as color from '@heroku/heroku-cli-util/color'
-
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import * as color from '@heroku/heroku-cli-util/color'
 import {Args} from '@oclif/core'
 
 import Git from '../../lib/git/git.js'
@@ -10,16 +9,15 @@ export class GitClone extends Command {
   static args = {
     DIRECTORY: Args.string({description: 'where to clone the app', optional: true}),
   }
-
   static description = 'clones a heroku app to your local machine at DIRECTORY (defaults to app name)'
-
   static example = `${color.command('heroku git:clone -a example')}
 Cloning into 'example'...
 remote: Counting objects: 42, done.
 ...`
-
   static flags = {
-    app: flags.string({char: 'a', description: 'the Heroku app to use', env: 'HEROKU_APP', required: true}),
+    app: flags.string({
+      char: 'a', description: 'the Heroku app to use', env: 'HEROKU_APP', required: true,
+    }),
     remote: flags.string({char: 'r', description: 'the git remote to create, default "heroku"'}),
   }
 

--- a/src/commands/git/credentials.ts
+++ b/src/commands/git/credentials.ts
@@ -2,35 +2,34 @@ import {Command} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
 export class GitCredentials extends Command {
-  static hidden = true
-
-  static description = 'internal command for git-credentials'
-
   static args = {
-    command: Args.string({required: true, description: 'command name of the git credentials'}),
+    command: Args.string({description: 'command name of the git credentials', required: true}),
   }
+  static description = 'internal command for git-credentials'
+  static hidden = true
 
   async run() {
     const {args} = await this.parse(GitCredentials)
     switch (args.command) {
-    case 'get': {
-      if (!this.heroku.auth) throw new Error('not logged in')
-      ux.stdout(`protocol=https
+      case 'erase':
+      // eslint-ignore-next-line no-fallthrough
+      case 'store': {
+      // ignore
+        break
+      }
+
+      case 'get': {
+        if (!this.heroku.auth) throw new Error('not logged in')
+        ux.stdout(`protocol=https
 host=git.heroku.com
 username=heroku
 password=${this.heroku.auth}`)
-      break
-    }
+        break
+      }
 
-    case 'erase':
-    case 'store': {
-      // ignore
-      break
-    }
-
-    default: {
-      throw new Error(`unknown command: ${args.command}`)
-    }
+      default: {
+        throw new Error(`unknown command: ${args.command}`)
+      }
     }
   }
 }

--- a/src/commands/git/remote.ts
+++ b/src/commands/git/remote.ts
@@ -1,7 +1,6 @@
-import * as color from '@heroku/heroku-cli-util/color'
-
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import * as color from '@heroku/heroku-cli-util/color'
 
 import Git from '../../lib/git/git.js'
 
@@ -9,19 +8,16 @@ export class GitRemote extends Command {
   static description = `adds a git remote to an app repo
 extra arguments will be passed to git remote add
 `
-
   static example = `
 # set git remote heroku to https://git.heroku.com/example.git
 ${color.command('heroku git:remote -a example')}
 
 # set git remote heroku-staging to https://git.heroku.com/example.git
 ${color.command('heroku git:remote --remote heroku-staging -a example-staging')}`
-
   static flags = {
     app: flags.string({char: 'a', description: 'the Heroku app to use'}),
     remote: flags.string({char: 'r', description: 'the git remote to create'}),
   }
-
   static strict = false
 
   async run() {
@@ -38,11 +34,9 @@ ${color.command('heroku git:remote --remote heroku-staging -a example-staging')}
     const remote = flags.remote || (await git.remoteFromGitConfig()) || 'heroku'
     const remotes = await git.exec(['remote'])
     const url = git.url(app.name!)
-    if (remotes.split('\n').includes(remote)) {
-      await git.exec(['remote', 'set-url', remote, url].concat(argv))
-    } else {
-      await git.exec(['remote', 'add', remote, url].concat(argv))
-    }
+    await (remotes.split('\n').includes(remote)
+      ? git.exec(['remote', 'set-url', remote, url].concat(argv))
+      : git.exec(['remote', 'add', remote, url].concat(argv)))
 
     const newRemote = await git.remoteUrl(remote)
     this.log(`set git remote ${color.cyan(remote)} to ${color.cyan(newRemote)}`)

--- a/src/commands/keys/add.ts
+++ b/src/commands/keys/add.ts
@@ -1,5 +1,5 @@
-import {color, hux} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
+import {color, hux} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 import fs from 'fs-extra'
 import {spawn} from 'node:child_process'
@@ -19,12 +19,10 @@ export default class Add extends Command {
   static args = {
     key: Args.string({description: 'absolute path to the key located on disk. If omitted, we use the default rsa key.'}),
   }
-
   static description = `
     add an SSH key for a user
     if no KEY is specified, will try to find ~/.ssh/id_rsa.pub
   `
-
   static example = `
 ${color.command('heroku keys:add')}
 Could not find an existing public key.
@@ -34,7 +32,6 @@ Uploading SSH public key /.ssh/id_rsa.pub... done
 
 ${color.command('heroku keys:add /my/key.pub')}
 Uploading SSH public key /my/key.pub... done`
-
   static flags = {
     quiet: flags.boolean({hidden: true}),
     yes: flags.boolean({char: 'y', description: 'automatically answer yes for all prompts'}),

--- a/src/commands/keys/remove.ts
+++ b/src/commands/keys/remove.ts
@@ -7,7 +7,6 @@ export default class Remove extends Command {
   static args = {
     key: Args.string({description: 'email address of the user', required: true}),
   }
-
   static description = 'remove an SSH key from the user'
   static example = `${color.command('heroku keys:remove email@example.com')}
 Removing email@example.com SSH key... done`

--- a/src/commands/labs/disable.ts
+++ b/src/commands/labs/disable.ts
@@ -1,6 +1,6 @@
-import {color, hux} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {color, hux} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 const SecurityExceptionFeatures: any = {
@@ -18,9 +18,7 @@ export default class LabsDisable extends Command {
   static args = {
     feature: Args.string({description: 'unique identifier or name of the account feature', required: true}),
   }
-
   static description = 'disables an experimental feature'
-
   static flags = {
     app: flags.app(),
     confirm: flags.string({required: false}),
@@ -39,13 +37,11 @@ export default class LabsDisable extends Command {
     let request
     let target
 
-    if (SecurityExceptionFeatures[feature]) {
-      if (flags.confirm !== flags.app) {
-        const {prompt} = SecurityExceptionFeatures[feature]
-        const confirm = await prompt(flags.app)
-        if (confirm !== flags.app) {
-          this.error('Confirmation name did not match app name. Try again.')
-        }
+    if (SecurityExceptionFeatures[feature] && flags.confirm !== flags.app) {
+      const {prompt} = SecurityExceptionFeatures[feature]
+      const confirm = await prompt(flags.app)
+      if (confirm !== flags.app) {
+        this.error('Confirmation name did not match app name. Try again.')
       }
     }
 

--- a/src/commands/labs/enable.ts
+++ b/src/commands/labs/enable.ts
@@ -7,14 +7,11 @@ export default class LabsEnable extends Command {
   static args = {
     feature: Args.string({description: 'unique identifier or name of the account feature', required: true}),
   }
-
   static description = 'enables an experimental feature'
-
   static flags = {
     app: flags.app({required: false}),
     remote: flags.remote(),
   }
-
   static topic = 'labs'
 
   async run() {

--- a/src/commands/labs/index.ts
+++ b/src/commands/labs/index.ts
@@ -16,7 +16,6 @@ export default class LabsIndex extends Command {
     json: flags.boolean({description: 'display as json', required: false}),
     remote: flags.remote(),
   }
-
   static topic = 'labs'
 
   async run() {
@@ -37,7 +36,7 @@ export default class LabsIndex extends Command {
     }
 
     // makes sure app isn't added to json object if null
-    // eslint-disable-next-line unicorn/no-negated-condition, no-negated-condition
+    // eslint-disable-next-line unicorn/no-negated-condition
     if (appResponse !== null) {
       app = appResponse?.body
       features.app = app

--- a/src/commands/labs/info.ts
+++ b/src/commands/labs/info.ts
@@ -1,6 +1,6 @@
-import {color, hux} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {color, hux} from '@heroku/heroku-cli-util'
 import {Args} from '@oclif/core'
 
 function print(feature: Record<string, string>) {
@@ -18,15 +18,12 @@ export default class LabsInfo extends Command {
   static args = {
     feature: Args.string({description: 'unique identifier or name of the account feature', required: true}),
   }
-
   static description = 'show feature info'
-
   static flags = {
     app: flags.app({required: false}),
     json: flags.boolean({description: 'display as json', required: false}),
     remote: flags.remote(),
   }
-
   static topic = 'labs'
 
   async run() {

--- a/src/commands/local/index.ts
+++ b/src/commands/local/index.ts
@@ -1,6 +1,6 @@
 import * as color from '@heroku/heroku-cli-util/color'
 import {Args, Command, Flags} from '@oclif/core'
-import fs from 'fs'
+import fs from 'node:fs'
 
 import {validateEnvFile} from '../../lib/local/env-file-validator.js'
 import {fork as foreman, isForemanExitError} from '../../lib/local/fork-foreman.js'
@@ -8,21 +8,17 @@ import {loadProc} from '../../lib/local/load-foreman-procfile.js'
 
 export default class Index extends Command {
   static aliases = ['local:start']
-
   static args = {
     processname: Args.string({description: 'name of the process', required: false}),
   }
-
   static description = `run heroku app locally
 Start the application specified by a Procfile (defaults to ./Procfile)`
-
   static examples = [
     color.command('heroku local'),
     color.command('heroku local web'),
     color.command('heroku local web=2'),
     color.command('heroku local web=1,worker=2'),
   ]
-
   static flags = {
     concurrency: Flags.string({
       char: 'c',
@@ -103,9 +99,7 @@ Start the application specified by a Procfile (defaults to ./Procfile)`
       execArgv.push(processes.join(','))
     } else {
       if (!startCmd) {
-        this.error(
-          `No ${procfile} found.\nAdd a Procfile to add process types.\nhttps://devcenter.heroku.com/articles/procfile\nOr specify a start command with --start-cmd.`,
-        )
+        this.error(`No ${procfile} found.\nAdd a Procfile to add process types.\nhttps://devcenter.heroku.com/articles/procfile\nOr specify a start command with --start-cmd.`)
       }
 
       const resolvedStartCmd = startCmd ?? ''

--- a/src/commands/local/run.ts
+++ b/src/commands/local/run.ts
@@ -7,11 +7,9 @@ import {revertSortedArgs} from '../../lib/run/helpers.js'
 
 export default class Run extends Command {
   static description = 'run a one-off command'
-
   static examples = [
     color.command('heroku local:run bin/migrate'),
   ]
-
   static flags = {
     env: Flags.string({
       char: 'e',
@@ -22,7 +20,6 @@ export default class Run extends Command {
       description: 'port to listen on',
     }),
   }
-
   static strict = false
 
   async run() {

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -2,7 +2,6 @@ import {Command, flags} from '@heroku-cli/command'
 import {ProcessTypeCompletion} from '@heroku-cli/command/lib/completions.js'
 import * as color from '@heroku/heroku-cli-util/color'
 import {ux} from '@oclif/core/ux'
-
 import tsheredoc from 'tsheredoc'
 
 import {LogDisplayer} from '../lib/run/log-displayer.js'
@@ -14,7 +13,6 @@ export default class Logs extends Command {
     display recent log output
     disable colors with --no-color, HEROKU_LOGS_COLOR=0, or HEROKU_COLOR=0
   `
-
   static examples = [
     `${color.command('heroku logs --app=my-app')}`,
     `${color.command('heroku logs --num=50 --app=my-app')}`,
@@ -22,7 +20,6 @@ export default class Logs extends Command {
     `${color.command('heroku logs --process-type=web --app=my-app')}`,
     `${color.command('heroku logs --app=my-app --tail')}`,
   ]
-
   static flags = {
     app: flags.app({required: true}),
     'dyno-name': flags.string({

--- a/src/commands/maintenance/index.ts
+++ b/src/commands/maintenance/index.ts
@@ -8,7 +8,6 @@ export default class MaintenanceIndex extends Command {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
   static topic = 'maintenance'
 
   async run() {

--- a/src/commands/maintenance/off.ts
+++ b/src/commands/maintenance/off.ts
@@ -9,7 +9,6 @@ export default class MaintenanceOff extends Command {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
   static topic = 'maintenance'
 
   async run() {

--- a/src/commands/maintenance/on.ts
+++ b/src/commands/maintenance/on.ts
@@ -9,7 +9,6 @@ export default class MaintenanceOn extends Command {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
   static topic = 'maintenance'
 
   async run() {

--- a/src/commands/mcp/start.ts
+++ b/src/commands/mcp/start.ts
@@ -1,13 +1,12 @@
 import {Command} from '@heroku-cli/command'
 import {spawn as cpSpawn} from 'node:child_process'
+import {dirname, join} from 'node:path'
 import {fileURLToPath} from 'node:url'
-import {dirname, join} from 'path'
 
 export default class MCPStart extends Command {
   static baseFlags = Command.baseFlagsWithoutPrompt()
   static description = 'starts the Heroku platform MCP server in stdio mode'
   static promptFlagActive = false
-
   static spawn: typeof cpSpawn = cpSpawn
 
   public async run() {

--- a/src/commands/members/add.ts
+++ b/src/commands/members/add.ts
@@ -26,9 +26,11 @@ export default class MembersAdd extends Command {
     const {role, team} = flags
     const {email} = args
 
-    await ((await isTeamInviteFeatureEnabled(team, this.heroku))
-      ? inviteMemberToTeam(email, role, team, this.heroku)
-      : addMemberToTeam(email, role, team, this.heroku)
-    )
+    const teamInviteEnabled = await isTeamInviteFeatureEnabled(team, this.heroku)
+    if (teamInviteEnabled) {
+      await inviteMemberToTeam(email, role, team, this.heroku)
+    } else {
+      await addMemberToTeam(email, role, team, this.heroku)
+    }
   }
 }

--- a/src/commands/members/add.ts
+++ b/src/commands/members/add.ts
@@ -1,36 +1,34 @@
 import {Command, flags} from '@heroku-cli/command'
-import {Args} from '@oclif/core'
 import {RoleCompletion} from '@heroku-cli/command/lib/completions.js'
-import {addMemberToTeam, inviteMemberToTeam} from '../../lib/members/util.js'
+import {Args} from '@oclif/core'
+
 import {isTeamInviteFeatureEnabled, ROLE_DESCRIPTION} from '../../lib/members/team-invite-utils.js'
+import {addMemberToTeam, inviteMemberToTeam} from '../../lib/members/util.js'
 
 export default class MembersAdd extends Command {
-  static topic = 'members'
+  static args = {
+    email: Args.string({description: 'email address of the team member', required: true}),
+  }
   static description = 'adds a user to a team'
-
   static flags = {
     role: flags.string({
       char: 'r',
-      required: true,
-      description: ROLE_DESCRIPTION,
       completion: RoleCompletion,
+      description: ROLE_DESCRIPTION,
+      required: true,
     }),
     team: flags.team({required: true}),
   }
-
-  static args = {
-    email: Args.string({required: true, description: 'email address of the team member'}),
-  }
+  static topic = 'members'
 
   public async run(): Promise<void> {
-    const {flags, args} = await this.parse(MembersAdd)
-    const {team, role} = flags
+    const {args, flags} = await this.parse(MembersAdd)
+    const {role, team} = flags
     const {email} = args
 
-    if (await isTeamInviteFeatureEnabled(team, this.heroku)) {
-      await inviteMemberToTeam(email, role, team, this.heroku)
-    } else {
-      await addMemberToTeam(email, role, team, this.heroku)
-    }
+    await ((await isTeamInviteFeatureEnabled(team, this.heroku))
+      ? inviteMemberToTeam(email, role, team, this.heroku)
+      : addMemberToTeam(email, role, team, this.heroku)
+    )
   }
 }

--- a/src/commands/members/index.ts
+++ b/src/commands/members/index.ts
@@ -6,7 +6,7 @@ import {ux} from '@oclif/core/ux'
 
 import {getTeamInvites, isTeamInviteFeatureEnabled} from '../../lib/members/team-invite-utils.js'
 
-type MemberWithStatus = Heroku.TeamMember & { status?: string }
+type MemberWithStatus = Heroku.TeamMember & {status?: string}
 
 const buildTableColumns = (teamInvites: MemberWithStatus[]) => {
   const baseColumns = {
@@ -45,7 +45,6 @@ export default class MembersIndex extends Command {
     }),
     team: flags.team({required: true}),
   }
-
   static topic = 'members'
 
   public async run(): Promise<void> {

--- a/src/commands/members/remove.ts
+++ b/src/commands/members/remove.ts
@@ -13,7 +13,8 @@ const revokeInvite = async (email: string, team: string, heroku: APIClient) => {
       headers: {
         Accept: 'application/vnd.heroku+json; version=3.team-invitations',
       },
-    })
+    },
+  )
   ux.action.stop()
 }
 
@@ -28,9 +29,7 @@ export default class MembersRemove extends Command {
   static flags = {
     team: flags.team({required: true}),
   }
-
   static strict = false
-
   static topic = 'members'
 
   public async run(): Promise<void> {
@@ -45,10 +44,6 @@ export default class MembersRemove extends Command {
       isInvitedUser = Boolean(invites.some(m => m.user?.email === email))
     }
 
-    if (teamInviteFeatureEnabled && isInvitedUser) {
-      await revokeInvite(email, team, this.heroku)
-    } else {
-      await removeUserMembership(email, team, this.heroku)
-    }
+    await (teamInviteFeatureEnabled && isInvitedUser ? revokeInvite(email, team, this.heroku) : removeUserMembership(email, team, this.heroku))
   }
 }

--- a/src/commands/members/set.ts
+++ b/src/commands/members/set.ts
@@ -1,25 +1,25 @@
 import {Command, flags} from '@heroku-cli/command'
 import {RoleCompletion} from '@heroku-cli/command/lib/completions.js'
-import {addMemberToTeam} from '../../lib/members/util.js'
+
 import {ROLE_DESCRIPTION} from '../../lib/members/team-invite-utils.js'
+import {addMemberToTeam} from '../../lib/members/util.js'
 
 export default class MembersSet extends Command {
-  static topic = 'members'
   static description = 'sets a members role in a team'
-  static strict = false
-
   static flags = {
     role: flags.string({
       char: 'r',
-      required: true,
-      description: ROLE_DESCRIPTION,
       completion: RoleCompletion,
+      description: ROLE_DESCRIPTION,
+      required: true,
     }),
     team: flags.team({required: true}),
   }
+  static strict = false
+  static topic = 'members'
 
   public async run(): Promise<void> {
-    const {flags, argv} = await this.parse(MembersSet)
+    const {argv, flags} = await this.parse(MembersSet)
     const {role, team} = flags
     const email = argv[0] as string
 

--- a/src/commands/notifications/index.ts
+++ b/src/commands/notifications/index.ts
@@ -16,7 +16,6 @@ export default class NotificationsIndex extends Command {
     read: flags.boolean({description: 'show notifications already read'}),
     remote: flags.remote(),
   }
-
   static topic = 'notifications'
 
   async run() {

--- a/src/commands/orgs/index.ts
+++ b/src/commands/orgs/index.ts
@@ -1,15 +1,16 @@
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+
 import {printGroups, printGroupsJSON} from '../../lib/orgs/utils.js'
 
 export default class OrgsIndex extends Command {
-  static topic = 'orgs'
   static description = 'list the teams that you are a member of'
   static flags = {
-    json: flags.boolean({description: 'output in json format'}),
     enterprise: flags.boolean({description: 'filter by enterprise teams'}),
+    json: flags.boolean({description: 'output in json format'}),
     teams: flags.boolean({description: 'filter by teams', hidden: true}),
   }
+  static topic = 'orgs'
 
   public async run(): Promise<void> {
     const {flags} = await this.parse(OrgsIndex)

--- a/src/commands/orgs/open.ts
+++ b/src/commands/orgs/open.ts
@@ -9,7 +9,6 @@ export default class OrgsOpen extends Command {
   static flags = {
     team: flags.team({required: true}),
   }
-
   static topic = 'orgs'
 
   public static async openUrl(url: string): Promise<void> {

--- a/src/commands/pg/backups/cancel.ts
+++ b/src/commands/pg/backups/cancel.ts
@@ -1,23 +1,23 @@
 import {Command, flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
 import {utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+
 import backupsFactory from '../../../lib/pg/backups.js'
 import {BackupTransfer} from '../../../lib/pg/types.js'
 
 export default class Cancel extends Command {
-  static topic = 'pg'
+  static args = {
+    backup_id: Args.string({description: 'ID of the backup. If omitted, we use the last unfinished backup ID.'}),
+  }
   static description = 'cancel an in-progress backup or restore (default newest)'
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
-  static args = {
-    backup_id: Args.string({description: 'ID of the backup. If omitted, we use the last unfinished backup ID.'}),
-  }
+  static topic = 'pg'
 
   public async run(): Promise<void> {
-    const {flags, args} = await this.parse(Cancel)
+    const {args, flags} = await this.parse(Cancel)
     const {app} = flags
     const {backup_id} = args
     const pgbackups = backupsFactory(app, this.heroku)

--- a/src/commands/pg/backups/capture.ts
+++ b/src/commands/pg/backups/capture.ts
@@ -1,6 +1,6 @@
+import {Command, flags} from '@heroku-cli/command'
 import {color, utils} from '@heroku/heroku-cli-util'
 import {HTTPError} from '@heroku/http-call'
-import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -14,7 +14,6 @@ export default class Capture extends Command {
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
   static description = 'capture a new backup'
   static flags = {
     app: flags.app({required: true}),
@@ -22,7 +21,6 @@ export default class Capture extends Command {
     verbose: flags.boolean({char: 'v'}),
     'wait-interval': flags.string(),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {

--- a/src/commands/pg/backups/delete.ts
+++ b/src/commands/pg/backups/delete.ts
@@ -1,5 +1,5 @@
-import {color, utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 import ConfirmCommand from '../../../lib/confirm-command.js'
@@ -9,19 +9,15 @@ export default class Delete extends Command {
   static args = {
     backup_id: Args.string({description: 'ID of the backup', required: true}),
   }
-
   static description = 'delete a backup'
-
   static examples = [
     color.command('heroku pg:backup:delete --app APP_ID BACKUP_ID'),
   ]
-
   static flags = {
     app: flags.app({required: true}),
     confirm: flags.string({char: 'c', hidden: true}),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {

--- a/src/commands/pg/backups/download.ts
+++ b/src/commands/pg/backups/download.ts
@@ -12,15 +12,12 @@ export default class Download extends Command {
   static args = {
     backup_id: Args.string({description: 'ID of the backup. If omitted, we use the last backup ID.'}),
   }
-
   static description = 'downloads database backup'
-
   static flags = {
     app: flags.app({required: true}),
     output: flags.string({char: 'o', description: 'location to download to. Defaults to latest.dump'}),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {

--- a/src/commands/pg/backups/index.ts
+++ b/src/commands/pg/backups/index.ts
@@ -18,7 +18,6 @@ export default class Index extends Command {
     verbose: flags.boolean({char: 'v', hidden: true}),
     'wait-interval': flags.string({hidden: true}),
   }
-
   static strict = false
   static topic = 'pg'
 

--- a/src/commands/pg/backups/info.ts
+++ b/src/commands/pg/backups/info.ts
@@ -1,6 +1,6 @@
 
-import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
+import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 import type {BackupTransfer} from '../../../lib/pg/types.js'
@@ -37,15 +37,12 @@ export default class Info extends Command {
   static args = {
     backup_id: Args.string({description: 'ID of the backup. If omitted, we use the last backup ID.'}),
   }
-
   static description = 'get information about a specific backup'
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
-
   displayBackup = (backup: BackupTransfer, app: string) => {
     const pgbackups = pgBackupsApi(app, this.heroku)
     hux.styledHeader(`Backup ${color.name(pgbackups.name(backup))}`)
@@ -61,14 +58,12 @@ export default class Info extends Command {
     /* eslint-enable perfectionist/sort-objects */
     ux.stdout('\n')
   }
-
   displayLogs = (backup: BackupTransfer) => {
     hux.styledHeader('Backup Logs')
     for (const log of backup.logs)
       ux.stdout(`${log.created_at} ${log.message}\n`)
     ux.stdout('\n')
   }
-
   getBackup = async (id: string | undefined, app: string) => {
     let backupID
     if (id) {
@@ -100,4 +95,3 @@ export default class Info extends Command {
     this.displayLogs(backup)
   }
 }
-

--- a/src/commands/pg/backups/restore.ts
+++ b/src/commands/pg/backups/restore.ts
@@ -16,9 +16,7 @@ export default class Restore extends Command {
     backup: Args.string({description: 'URL or backup ID from another app'}),
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
   static description = 'restore a backup (default latest) to a database'
-
   static examples = [
     heredoc(`
     # Basic Restore from Backup ID
@@ -45,7 +43,6 @@ export default class Restore extends Command {
     ${color.command('heroku pg:backups:restore b101 HEROKU_POSTGRESQL_PINK --app my-heroku-app')}
     `),
   ]
-
   static flags = {
     app: flags.app({required: true}),
     confirm: flags.string({char: 'c'}),
@@ -61,7 +58,6 @@ export default class Restore extends Command {
     verbose: flags.boolean({char: 'v'}),
     'wait-interval': flags.integer({default: 3}),
   }
-
   static topic = 'pg'
 
   protected getSortedExtensions(extensions: null | string | undefined): string[] | undefined {
@@ -78,11 +74,11 @@ export default class Restore extends Command {
     let backupURL
     let backupName = args.backup
 
-    if (backupName && backupName.match(/^https?:\/\//)) {
+    if (backupName && /^https?:\/\//.test(backupName)) {
       backupURL = dropboxURL(backupName)
     } else {
       let backupApp
-      if (backupName && backupName.match(/::/)) {
+      if (backupName && /::/.test(backupName)) {
         [backupApp, backupName] = backupName.split('::')
       } else {
         backupApp = app
@@ -138,7 +134,7 @@ export default class Restore extends Command {
 }
 
 function dropboxURL(url: string) {
-  if (url.match(/^https?:\/\/www\.dropbox\.com/) && !url.endsWith('dl=1')) {
+  if (/^https?:\/\/www\.dropbox\.com/.test(url) && !url.endsWith('dl=1')) {
     if (url.endsWith('dl=0'))
       url = url.replace('dl=0', 'dl=1')
     else if (url.includes('?'))

--- a/src/commands/pg/backups/schedule.ts
+++ b/src/commands/pg/backups/schedule.ts
@@ -48,16 +48,13 @@ export default class Schedule extends Command {
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
   static description = 'schedule daily backups for given database'
   static flags = {
     app: flags.app({required: true}),
     at: flags.string({description: "at a specific (24h) hour in the given timezone. Defaults to UTC. --at '[HOUR]:00 [TIMEZONE]'", required: true}),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
-
   parseDate = function (at: string): BackupSchedule {
     const m = at.match(/^(0?\d|1\d|2[0-3]):00 ?(\S*)$/)
 

--- a/src/commands/pg/backups/schedules.ts
+++ b/src/commands/pg/backups/schedules.ts
@@ -10,7 +10,6 @@ export default class Schedules extends Command {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {

--- a/src/commands/pg/backups/unschedule.ts
+++ b/src/commands/pg/backups/unschedule.ts
@@ -1,5 +1,5 @@
-import {color, utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 import {TransferSchedule} from '../../../lib/pg/types.js'
@@ -9,13 +9,11 @@ export default class Unschedule extends Command {
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:arbitrary:suffix')}`}),
   }
-
   static description = 'stop daily backups'
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {
@@ -57,4 +55,3 @@ export default class Unschedule extends Command {
     ux.action.stop()
   }
 }
-

--- a/src/commands/pg/backups/url.ts
+++ b/src/commands/pg/backups/url.ts
@@ -10,14 +10,11 @@ export default class Url extends Command {
   static args = {
     backup_id: Args.string({description: 'ID of the backup. If omitted, we use the last backup ID.'}),
   }
-
   static description = 'get secret but publicly accessible URL of a backup'
-
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {

--- a/src/commands/pg/bloat.ts
+++ b/src/commands/pg/bloat.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
 import {utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
 
 import {nls} from '../../nls.js'
 
@@ -68,19 +68,18 @@ ORDER BY raw_waste DESC, bloat DESC
 `
 
 export default class Bloat extends Command {
-  static description = 'show table and index bloat in your database ordered by most wasteful'
-  static topic = 'pg'
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
+  static description = 'show table and index bloat in your database ordered by most wasteful'
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
+  static topic = 'pg'
 
   public async run(): Promise<void> {
-    const {flags, args} = await this.parse(Bloat)
+    const {args, flags} = await this.parse(Bloat)
     const {app} = flags
     const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
     const db = await dbResolver.getDatabase(app, args.database)

--- a/src/commands/pg/blocking.ts
+++ b/src/commands/pg/blocking.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
 import {utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
 import {nls} from '../../nls.js'
@@ -8,19 +8,18 @@ import {nls} from '../../nls.js'
 const heredoc = tsheredoc.default
 
 export default class Blocking extends Command {
-  static description = 'display queries holding locks other queries are waiting to be released'
-  static topic = 'pg'
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
+  static description = 'display queries holding locks other queries are waiting to be released'
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
+  static topic = 'pg'
 
   public async run(): Promise<void> {
-    const {flags, args} = await this.parse(Blocking)
+    const {args, flags} = await this.parse(Blocking)
     const {app} = flags
     const query = heredoc`
       SELECT bl.pid AS blocked_pid,

--- a/src/commands/pg/connection-pooling/attach.ts
+++ b/src/commands/pg/connection-pooling/attach.ts
@@ -1,6 +1,6 @@
-import {color, utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -13,19 +13,15 @@ export default class Attach extends Command {
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
   static description = 'add an attachment to a database using connection pooling'
-
   static examples = [heredoc`
       ${color.command('heroku pg:connection-pooling:attach postgresql-something-12345')}
     `]
-
   static flags = {
     app: flags.app({required: true}),
     as: flags.string({description: 'name for add-on attachment'}),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {

--- a/src/commands/pg/copy.ts
+++ b/src/commands/pg/copy.ts
@@ -1,6 +1,6 @@
-import {color, utils} from '@heroku/heroku-cli-util'
 import {APIClient, Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 import type {NonAdvancedCredentialInfo} from '../../lib/data/types.js'
@@ -12,7 +12,7 @@ import backupsFactory from '../../lib/pg/backups.js'
 const getAttachmentInfo = async function (heroku: APIClient, db: string, app: string) {
   const dbResolver = new utils.pg.DatabaseResolver(heroku)
 
-  if (db.match(/^postgres:\/\//)) {
+  if (/^postgres:\/\//.test(db)) {
     const conn = utils.pg.DatabaseResolver.parsePostgresConnectionString(db)
     const host = `${conn.host}:${conn.port}`
     return {
@@ -47,7 +47,6 @@ export default class Copy extends Command {
     source: Args.string({description: 'config var exposed to the owning app containing the source database URL', required: true}),
     target: Args.string({description: 'config var exposed to the owning app containing the target database URL', required: true}),
   }
-
   static description = 'copy all data from source db to target'
   static flags = {
     app: flags.app({required: true}),
@@ -56,9 +55,7 @@ export default class Copy extends Command {
     verbose: flags.boolean(),
     'wait-interval': flags.string(),
   }
-
   static help = 'at least one of the databases must be a Heroku PostgreSQL DB'
-
   static topic = 'pg'
 
   public async run(): Promise<void> {
@@ -94,7 +91,8 @@ export default class Copy extends Command {
             Authorization: `Basic ${Buffer.from(`:${this.heroku.auth}`).toString('base64')}`,
           },
           hostname: utils.pg.host(),
-        })
+        },
+      )
       if (credentials.length > 1) {
         ux.warn('pg:copy will only copy your default credential and the data it has access to. Any additional credentials and data that only they can access will not be copied.')
       }

--- a/src/commands/pg/credentials.ts
+++ b/src/commands/pg/credentials.ts
@@ -1,6 +1,6 @@
-import {hux, utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {hux, utils} from '@heroku/heroku-cli-util'
 import {Args} from '@oclif/core'
 
 import type {NonAdvancedCredentialInfo} from '../../lib/data/types.js'
@@ -13,14 +13,12 @@ export default class Credentials extends Command {
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
   static description = 'show information on credentials in the database'
   static flags = {
     app: flags.app({required: true}),
     'no-wrap': flags.noWrap(),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
 
   protected isDefaultCredential(cred: NonAdvancedCredentialInfo): boolean {
@@ -48,11 +46,7 @@ export default class Credentials extends Command {
 
     const presentCredential = (cred: NonAdvancedCredentialInfo): string => {
       let credAttachments = [] as Required<Heroku.AddOnAttachment>[]
-      if (cred.name === 'default') {
-        credAttachments = attachments.filter(a => a.namespace === null)
-      } else {
-        credAttachments = attachments.filter(a => a.namespace === `credential:${cred.name}`)
-      }
+      credAttachments = cred.name === 'default' ? attachments.filter(a => a.namespace === null) : attachments.filter(a => a.namespace === `credential:${cred.name}`)
 
       return presentCredentialAttachments(app, credAttachments, sortedCredentials, cred.name)
     }

--- a/src/commands/pg/credentials/create.ts
+++ b/src/commands/pg/credentials/create.ts
@@ -12,7 +12,6 @@ export default class Create extends Command {
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
   static description = 'create credential within database'
   static example = `${color.command('heroku pg:credentials:create postgresql-something-12345 --name new-cred-name')}`
   static flags = {
@@ -20,7 +19,6 @@ export default class Create extends Command {
     name: flags.string({char: 'n', description: 'name of the new credential within the database', required: true}),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {

--- a/src/commands/pg/credentials/destroy.ts
+++ b/src/commands/pg/credentials/destroy.ts
@@ -11,17 +11,14 @@ export default class Destroy extends Command {
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
   static description = 'destroy credential within database'
   static example = `${color.command('heroku pg:credentials:destroy postgresql-transparent-56874 --name cred-name -a woodstock-production')}`
-
   static flags = {
     app: flags.app({required: true}),
     confirm: flags.string({char: 'c', description: 'set to app name to bypass confirm prompt'}),
     name: flags.string({char: 'n', description: 'unique identifier for the credential', required: true}),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {
@@ -40,7 +37,7 @@ export default class Destroy extends Command {
 
     const {body: attachments} = await this.heroku.get<Heroku.AddOnAttachment[]>(`/addons/${db.name}/addon-attachments`)
     const credAttachments = attachments.filter(a => a.namespace === `credential:${name}`)
-    const credAttachmentApps = Array.from(new Set(credAttachments.map(a => a.app?.name)))
+    const credAttachmentApps = [...new Set(credAttachments.map(a => a.app?.name))]
     if (credAttachmentApps.length > 0)
       throw new Error(`Credential ${name} must be detached from the app${credAttachmentApps.length > 1 ? 's' : ''} ${credAttachmentApps.map(appName => color.app(appName || ''))
         .join(', ')} before destroying.`)

--- a/src/commands/pg/credentials/repair-default.ts
+++ b/src/commands/pg/credentials/repair-default.ts
@@ -1,5 +1,5 @@
-import {color, utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -13,7 +13,6 @@ export default class RepairDefault extends Command {
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
   static description = 'repair the permissions of the default credential within database'
   static example = `${color.command('heroku pg:credentials:repair-default postgresql-something-12345')}`
   static flags = {
@@ -21,7 +20,6 @@ export default class RepairDefault extends Command {
     confirm: flags.string({char: 'c', description: 'set to app name to bypass confirm prompt'}),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {

--- a/src/commands/pg/credentials/rotate.ts
+++ b/src/commands/pg/credentials/rotate.ts
@@ -11,9 +11,7 @@ export default class Rotate extends Command {
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
   static description = 'rotate the database credentials'
-
   static flags = {
     all: flags.boolean({description: 'rotate all credentials', exclusive: ['name']}),
     app: flags.app({required: true}),
@@ -25,7 +23,6 @@ export default class Rotate extends Command {
     }),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {

--- a/src/commands/pg/credentials/url.ts
+++ b/src/commands/pg/credentials/url.ts
@@ -1,8 +1,8 @@
-import {color, utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
+import {URL} from 'node:url'
 import tsheredoc from 'tsheredoc'
-import {URL} from 'url'
 
 import type {NonAdvancedCredentialInfo} from '../../../lib/data/types.js'
 
@@ -14,7 +14,6 @@ export default class Url extends Command {
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
   static description = 'show information on a database credential'
   static flags = {
     app: flags.app({required: true}),
@@ -25,7 +24,6 @@ export default class Url extends Command {
     }),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {

--- a/src/commands/pg/diagnose.ts
+++ b/src/commands/pg/diagnose.ts
@@ -1,14 +1,18 @@
 import {Command, flags} from '@heroku-cli/command'
+import {
+  color, hux, pg, utils,
+} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
-import {color, hux, pg, utils} from '@heroku/heroku-cli-util'
 
 const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)
 import tsheredoc from 'tsheredoc'
+
 import type {
   PGDiagnoseCheck, PGDiagnoseRequest,
   PGDiagnoseResponse,
   PGDiagnoseResult,
 } from '../../lib/pg/types.js'
+
 import {essentialPlan} from '../../lib/pg/util.js'
 import {uuidValidate} from '../../lib/utils/uuid-validate.js'
 
@@ -16,26 +20,24 @@ const heredoc = tsheredoc.default
 const PGDIAGNOSE_HOST = process.env.PGDIAGNOSE_URL || 'pgdiagnose.herokai.com'
 
 export default class Diagnose extends Command {
-  static topic = 'pg'
+  static args = {
+    'DATABASE|REPORT_ID': Args.string({description: 'config var exposed to the owning app containing the database URL or the report ID'}),
+  }
   static description = heredoc(`
     run or view diagnostics report
     defaults to DATABASE_URL database if no DATABASE is specified
     if REPORT_ID is specified instead, a previous report is displayed
 
     `)
-
   static flags = {
-    json: flags.boolean({description: 'format output as JSON'}),
     app: flags.app({required: true}),
+    json: flags.boolean({description: 'format output as JSON'}),
     remote: flags.remote(),
   }
-
-  static args = {
-    'DATABASE|REPORT_ID': Args.string({description: 'config var exposed to the owning app containing the database URL or the report ID'}),
-  }
+  static topic = 'pg'
 
   public async run(): Promise<void> {
-    const {flags, args} = await this.parse(Diagnose)
+    const {args, flags} = await this.parse(Diagnose)
 
     const id = args['DATABASE|REPORT_ID']
     let report: PGDiagnoseResponse
@@ -46,6 +48,35 @@ export default class Diagnose extends Command {
     }
 
     this.displayReport(report, flags.json)
+  }
+
+  private display(checks: PGDiagnoseCheck[]) {
+    checks.forEach((check: PGDiagnoseCheck) => {
+      const colorFn = color[check.status] || ((txt: string) => txt)
+      ux.stdout(colorFn(`${check.status.toUpperCase()}: ${check.name}`))
+      const isNonEmptyArray = Array.isArray(check.results) && check.results.length > 0
+      const resultsKeys = Object.keys(check.results ?? {})
+      if (check.status === 'green' || (!isNonEmptyArray && resultsKeys.length === 0)) {
+        return
+      }
+
+      if (isNonEmptyArray) {
+        const keys = Object.keys(check.results[0]) as (keyof PGDiagnoseResult)[]
+        const cols = {} as Record<string, {get: (row: PGDiagnoseResult) => string}>
+        keys.forEach((key: number | string | symbol) => {
+          const keyStr = String(key)
+          cols[capitalize(keyStr)] = {
+            get: (row: PGDiagnoseResult): string => String(row[key as keyof PGDiagnoseResult]),
+          }
+        })
+        hux.table(check.results, cols)
+      } else {
+        const [key] = resultsKeys
+        ux.stdout(`${key.split('_')
+          .map(s => capitalize(s))
+          .join(' ')} ${check.results[key as keyof PGDiagnoseResult]}`)
+      }
+    })
   }
 
   private displayReport(report: PGDiagnoseResponse, json: boolean) {
@@ -62,41 +93,12 @@ export default class Diagnose extends Command {
     this.display(report.checks.filter((c: PGDiagnoseCheck) => !['green', 'red', 'yellow'].includes(c.status)))
   }
 
-  private display(checks: PGDiagnoseCheck[]) {
-    checks.forEach((check: PGDiagnoseCheck) => {
-      const colorFn = color[check.status] || ((txt: string) => txt)
-      ux.stdout(colorFn(`${check.status.toUpperCase()}: ${check.name}`))
-      const isNonEmptyArray = Array.isArray(check.results) && check.results.length > 0
-      const resultsKeys = Object.keys(check.results ?? {})
-      if (check.status === 'green' || (!isNonEmptyArray && resultsKeys.length === 0)) {
-        return
-      }
-
-      if (isNonEmptyArray) {
-        const keys = Object.keys(check.results[0]) as (keyof PGDiagnoseResult)[]
-        const cols = {} as Record<string, {get: (row: PGDiagnoseResult) => string}>
-        keys.forEach((key: string | number | symbol) => {
-          const keyStr = String(key)
-          cols[capitalize(keyStr)] = {
-            get: (row: PGDiagnoseResult): string => String(row[key as keyof PGDiagnoseResult]),
-          }
-        })
-        hux.table(check.results, cols)
-      } else {
-        const [key] = resultsKeys
-        ux.stdout(`${key.split('_')
-          .map(s => capitalize(s))
-          .join(' ')} ${check.results[key as keyof PGDiagnoseResult]}`)
-      }
-    })
-  }
-
   private async generateParams(url: string, db: pg.ExtendedAddonAttachment['addon'], dbName: string): Promise<PGDiagnoseRequest> {
     const base_params: PGDiagnoseRequest = {
-      url,
-      plan: db.plan.name.split(':')[1],
       app: db.app.name as string,
       database: dbName,
+      plan: db.plan.name.split(':')[1],
+      url,
     }
     if (!essentialPlan(db)) {
       const {body: metrics} = await this.heroku.get<unknown[]>(`/client/v11/databases/${db.id}/metrics`, {hostname: utils.pg.host()})
@@ -121,7 +123,7 @@ export default class Diagnose extends Command {
     const {url} = dbResolver.getConnectionDetails(attachment, config)
     const dbName = utils.pg.psql.getConfigVarNameFromAttachment(attachment, config)
     const body = await this.generateParams(url, db, dbName)
-    const {body: report} = await this.heroku.post<PGDiagnoseResponse>('/reports', {hostname: PGDIAGNOSE_HOST, body})
+    const {body: report} = await this.heroku.post<PGDiagnoseResponse>('/reports', {body, hostname: PGDIAGNOSE_HOST})
 
     return report
   }

--- a/src/commands/pg/info.ts
+++ b/src/commands/pg/info.ts
@@ -1,66 +1,35 @@
-import {color, hux, pg, utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
 import * as Heroku from '@heroku-cli/schema'
-import {configVarNamesFromValue, databaseNameFromUrl} from '../../lib/pg/util.js'
+import {
+  color, hux, pg, utils,
+} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+
 import {PgDatabaseTenant} from '../../lib/pg/types.js'
+import {configVarNamesFromValue, databaseNameFromUrl} from '../../lib/pg/util.js'
 import {nls} from '../../nls.js'
 
 type DBObject = {
   addon: pg.ExtendedAddonAttachment | pg.ExtendedAddonAttachment['addon'] & {attachment_names?: string[]},
-  configVars?: string[],
-  dbInfo: PgDatabaseTenant | null,
   config: Heroku.ConfigVars,
-}
-
-function displayDB(db: DBObject, app: string) {
-  if (db.addon.attachment_names) {
-    hux.styledHeader(db.addon.attachment_names.map((c: string) => color.attachment(c + '_URL'))
-      .join(', '))
-  } else {
-    hux.styledHeader(db.configVars?.map(c => color.name(c))
-      .join(', ') || '')
-  }
-
-  if (db.addon.app.name && db.addon.app.name !== app) {
-    db.dbInfo?.info.push({name: 'Billing App', values: [color.app(db.addon.app.name)]})
-  }
-
-  db.dbInfo?.info.push({name: 'Add-on', values: [color.addon(db.addon.name)]})
-  const info: Record<string, never> | Record<string, string> = {}
-  db.dbInfo?.info.forEach(infoObject => {
-    if (infoObject.values.length > 0) {
-      let valuesArray: string[]
-      if (infoObject.resolve_db_name) {
-        valuesArray = infoObject.values.map(v => databaseNameFromUrl(v, db.config))
-      } else {
-        valuesArray = infoObject.values
-      }
-
-      info[infoObject.name] = valuesArray.join(', ')
-    }
-  })
-  const keys = db.dbInfo?.info.map(i => i.name)
-  hux.styledObject(info, keys)
-  ux.stdout('')
+  configVars?: string[],
+  dbInfo: null | PgDatabaseTenant,
 }
 
 export default class Info extends Command {
-  static topic = 'pg'
+  static aliases = ['pg']
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:all-dbs:suffix')}`}),
+  }
   static description = 'show database information'
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
-  static args = {
-    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:all-dbs:suffix')}`}),
-  }
-
-  static aliases = ['pg']
+  static topic = 'pg'
 
   public async run(): Promise<void> {
-    const {flags, args} = await this.parse(Info)
+    const {args, flags} = await this.parse(Info)
     const {app} = flags
     const lodash = await import('lodash')
     const {sortBy} = lodash.default
@@ -85,7 +54,8 @@ export default class Info extends Command {
         `/client/v11/databases/${addon.id}`,
         {
           hostname: utils.pg.host(),
-        })
+        },
+      )
         .catch(error => {
           if (error.statusCode !== 404)
             throw error
@@ -99,10 +69,41 @@ export default class Info extends Command {
       }
     }))
     dbs = dbs.filter(db => db.dbInfo)
-    dbs.forEach(db => {
+    for (const db of dbs) {
       db.configVars = configVarNamesFromValue(db.config, db.dbInfo?.resource_url || '')
-    })
+    }
+
     dbs = sortBy(dbs, (db: DBObject) => db.configVars && db.configVars[0] !== 'DATABASE_URL', 'configVars[0]')
-    dbs.forEach(db => displayDB(db, app))
+    for (const db of dbs) displayDB(db, app)
   }
+}
+
+function displayDB(db: DBObject, app: string) {
+  if (db.addon.attachment_names) {
+    hux.styledHeader(db.addon.attachment_names.map((c: string) => color.attachment(c + '_URL'))
+      .join(', '))
+  } else {
+    hux.styledHeader(db.configVars?.map(c => color.name(c))
+      .join(', ') || '')
+  }
+
+  if (db.addon.app.name && db.addon.app.name !== app) {
+    db.dbInfo?.info.push({name: 'Billing App', values: [color.app(db.addon.app.name)]})
+  }
+
+  db.dbInfo?.info.push({name: 'Add-on', values: [color.addon(db.addon.name)]})
+  const info: Record<string, never> | Record<string, string> = {}
+  for (const infoObject of (db.dbInfo?.info || [])) {
+    if (infoObject.values.length > 0) {
+      const valuesArray = infoObject.resolve_db_name
+        ? infoObject.values.map(v => databaseNameFromUrl(v, db.config))
+        : infoObject.values
+
+      info[infoObject.name] = valuesArray.join(', ')
+    }
+  }
+
+  const keys = db.dbInfo?.info.map(i => i.name)
+  hux.styledObject(info, keys)
+  ux.stdout('')
 }

--- a/src/commands/pg/kill.ts
+++ b/src/commands/pg/kill.ts
@@ -1,29 +1,31 @@
 import {Command, flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
 import {utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
+
 import {nls} from '../../nls.js'
 
 const heredoc = tsheredoc.default
 
 export default class Kill extends Command {
-  static topic = 'pg'
-  static description = 'kill a query'
-  static flags = {
-    force: flags.boolean({char: 'f'}),
-    app: flags.app({required: true}),
-    remote: flags.remote(),
-  }
-
+  /* eslint-disable perfectionist/sort-objects */
   static args = {
-    pid: Args.string({required: true, description: 'ID of the process'}),
+    pid: Args.string({description: 'ID of the process', required: true}),
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
+  /* eslint-enable perfectionist/sort-objects */
+  static description = 'kill a query'
+  static flags = {
+    app: flags.app({required: true}),
+    force: flags.boolean({char: 'f'}),
+    remote: flags.remote(),
+  }
+  static topic = 'pg'
 
   public async run(): Promise<void> {
-    const {flags, args} = await this.parse(Kill)
+    const {args, flags} = await this.parse(Kill)
     const {app, force} = flags
-    const {pid, database} = args
+    const {database, pid} = args
 
     const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
     const db = await dbResolver.getDatabase(app, database)

--- a/src/commands/pg/killall.ts
+++ b/src/commands/pg/killall.ts
@@ -1,22 +1,22 @@
 import {Command, flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
 import {utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+
 import {nls} from '../../nls.js'
 
 export default class Killall extends Command {
-  static topic = 'pg'
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
+  }
   static description = 'terminates all connections for all credentials'
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
-  static args = {
-    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
-  }
+  static topic = 'pg'
 
   public async run(): Promise<void> {
-    const {flags, args} = await this.parse(Killall)
+    const {args, flags} = await this.parse(Killall)
     const {app} = flags
 
     ux.action.start('Terminating connections for all credentials')

--- a/src/commands/pg/links/create.ts
+++ b/src/commands/pg/links/create.ts
@@ -1,5 +1,5 @@
-import {color, utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 
 import type {Link} from '../../../lib/pg/types.js'
@@ -17,17 +17,13 @@ export default class Create extends Command {
     database: Args.string({description: nls('pg:database:arg:description'), required: true}),
   }
   /* eslint-enable perfectionist/sort-objects */
-
   static description = 'create a link between data stores'
-
   static example = `${color.command('heroku pg:links:create HEROKU_REDIS_RED HEROKU_POSTGRESQL_CERULEAN')}`
-
   static flags = {
     app: flags.app({required: true}),
     as: flags.string({description: 'name of link to create'}),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {
@@ -36,7 +32,7 @@ export default class Create extends Command {
 
     const service = async (remoteId: string) => {
       const addon = await addonResolver(this.heroku, app, remoteId)
-      if (!addon.plan.name.match(/^heroku-(redis|postgresql)/))
+      if (!/^heroku-(redis|postgresql)/.test(addon.plan.name))
         throw new Error('Remote database must be heroku-redis or heroku-postgresql')
       return addon
     }

--- a/src/commands/pg/links/destroy.ts
+++ b/src/commands/pg/links/destroy.ts
@@ -1,5 +1,5 @@
-import {color, utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -13,16 +13,13 @@ export default class Destroy extends Command {
     database: Args.string({description: nls('pg:database:arg:description'), required: true}),
     link: Args.string({description: 'name of the linked data store', required: true}),
   }
-
   static description = 'destroys a link between data stores'
   static example = `${color.command('heroku pg:links:destroy HEROKU_POSTGRESQL_CERULEAN redis-symmetrical-100')}`
-
   static flags = {
     app: flags.app({required: true}),
     confirm: flags.string({char: 'c'}),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {

--- a/src/commands/pg/links/index.ts
+++ b/src/commands/pg/links/index.ts
@@ -1,5 +1,5 @@
-import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
+import {color, hux, utils} from '@heroku/heroku-cli-util'
 import {Args} from '@oclif/core'
 
 import type {Link} from '../../../lib/pg/types.js'
@@ -10,13 +10,11 @@ export default class Index extends Command {
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
   static description = 'lists all databases and information on link'
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {
@@ -42,8 +40,8 @@ export default class Index extends Command {
       db.links = links
       return db
     }))
-    let once: boolean
-    dbs.forEach(db => {
+    let once: boolean = false
+    for (const db of dbs) {
       if (once)
         this.log()
       else
@@ -54,8 +52,11 @@ export default class Index extends Command {
       // thrown instead, because Promise.all will reject if any of the promises reject and there's no catch block for that.
       // if (db.links?.message)
       //   return this.log(db.links.message)
-      if (db.links?.length === 0)
-        return this.log('No data sources are linked into this database')
+      if (db.links?.length === 0) {
+        this.log('No data sources are linked into this database')
+        continue
+      }
+
       db.links?.forEach((link: Link) => {
         this.log(` * ${color.name(link.name)}`)
         const remoteAttachmentName = link.remote?.attachment_name || ''
@@ -66,6 +67,6 @@ export default class Index extends Command {
           remote: remoteLinkText,
         })
       })
-    })
+    }
   }
 }

--- a/src/commands/pg/locks.ts
+++ b/src/commands/pg/locks.ts
@@ -1,26 +1,26 @@
 import {Command, flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
 import {utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
+
 import {nls} from '../../nls.js'
 
 const heredoc = tsheredoc.default
 
 export default class Locks extends Command {
-  static topic = 'pg'
-  static description = 'display queries with active locks'
-  static flags = {
-    truncate: flags.boolean({char: 't', description: 'truncates queries to 40 characters'}),
-    app: flags.app({required: true}),
-    remote: flags.remote(),
-  }
-
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
+  static description = 'display queries with active locks'
+  static flags = {
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+    truncate: flags.boolean({char: 't', description: 'truncates queries to 40 characters'}),
+  }
+  static topic = 'pg'
 
   public async run(): Promise<void> {
-    const {flags, args} = await this.parse(Locks)
+    const {args, flags} = await this.parse(Locks)
     const {app, truncate} = flags
     const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
     const db = await dbResolver.getDatabase(app, args.database)

--- a/src/commands/pg/outliers.ts
+++ b/src/commands/pg/outliers.ts
@@ -1,57 +1,27 @@
 import {Command, flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
 import {utils} from '@heroku/heroku-cli-util'
-import {fetchVersion} from '../../lib/pg/psql.js'
+import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
+
+import {fetchVersion} from '../../lib/pg/psql.js'
 import {nls} from '../../nls.js'
 
 const heredoc = tsheredoc.default
 
 export default class Outliers extends Command {
-  static topic = 'pg'
-  static description = 'show 10 queries that have longest execution time in aggregate'
-  static flags = {
-    reset: flags.boolean({description: 'resets statistics gathered by pg_stat_statements'}),
-    truncate: flags.boolean({char: 't', description: 'truncate queries to 40 characters'}),
-    num: flags.string({char: 'n', description: 'the number of queries to display (default: 10)'}),
-    app: flags.app({required: true}),
-    remote: flags.remote(),
-  }
-
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
-  private psqlService: InstanceType<typeof utils.pg.PsqlService> | undefined
-
-  public async run(): Promise<void> {
-    const {flags, args} = await this.parse(Outliers)
-    const {app, reset, truncate, num} = flags
-
-    const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
-    const db = await dbResolver.getDatabase(app, args.database)
-    this.psqlService = new utils.pg.PsqlService(db)
-    const version = await fetchVersion(db)
-    await this.ensurePGStatStatement()
-
-    if (reset) {
-      await this.psqlService.execQuery('SELECT pg_stat_statements_reset();')
-      return
-    }
-
-    let limit = 10
-    if (num) {
-      if (/^(\d+)$/.exec(num)) {
-        limit = Number.parseInt(num, 10)
-      } else {
-        ux.error(`Cannot parse num param value "${num}" to a number`)
-      }
-    }
-
-    const query = this.outliersQuery(version, limit, truncate)
-    const output = await this.psqlService.execQuery(query)
-    ux.stdout(output)
+  static description = 'show 10 queries that have longest execution time in aggregate'
+  static flags = {
+    app: flags.app({required: true}),
+    num: flags.string({char: 'n', description: 'the number of queries to display (default: 10)'}),
+    remote: flags.remote(),
+    reset: flags.boolean({description: 'resets statistics gathered by pg_stat_statements'}),
+    truncate: flags.boolean({char: 't', description: 'truncate queries to 40 characters'}),
   }
+  static topic = 'pg'
+  private psqlService: InstanceType<typeof utils.pg.PsqlService> | undefined
 
   protected async ensurePGStatStatement() {
     const query = heredoc`
@@ -73,16 +43,14 @@ export default class Outliers extends Command {
   }
 
   protected outliersQuery(version: string | undefined, limit: number, truncate: boolean) {
-    const truncatedQueryString = truncate ? heredoc`
+    const truncatedQueryString = truncate
+      ? heredoc`
       CASE WHEN length(query) <= 40 THEN query ELSE substr(query, 0, 39) || '…' END
-    ` : 'query'
+    `
+      : 'query'
 
     let totalExecTimeField = ''
-    if (version && Number.parseInt(version, 10) >= 13) {
-      totalExecTimeField = 'total_exec_time'
-    } else {
-      totalExecTimeField = 'total_time'
-    }
+    totalExecTimeField = version && Number.parseInt(version, 10) >= 13 ? 'total_exec_time' : 'total_time'
 
     let blkReadTimeField = ''
     let blkWriteTimeField = ''
@@ -108,5 +76,34 @@ export default class Outliers extends Command {
         ORDER BY ${totalExecTimeField} DESC
         LIMIT ${limit};
       `
+  }
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(Outliers)
+    const {app, num, reset, truncate} = flags
+
+    const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
+    const db = await dbResolver.getDatabase(app, args.database)
+    this.psqlService = new utils.pg.PsqlService(db)
+    const version = await fetchVersion(db)
+    await this.ensurePGStatStatement()
+
+    if (reset) {
+      await this.psqlService.execQuery('SELECT pg_stat_statements_reset();')
+      return
+    }
+
+    let limit = 10
+    if (num) {
+      if (/^(\d+)$/.test(num)) {
+        limit = Number.parseInt(num, 10)
+      } else {
+        ux.error(`Cannot parse num param value "${num}" to a number`)
+      }
+    }
+
+    const query = this.outliersQuery(version, limit, truncate)
+    const output = await this.psqlService.execQuery(query)
+    ux.stdout(output)
   }
 }

--- a/src/commands/pg/promote.ts
+++ b/src/commands/pg/promote.ts
@@ -1,31 +1,31 @@
 /* eslint-disable complexity */
-import {color, utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
 import * as Heroku from '@heroku-cli/schema'
+import {color, utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
+
 import {getRelease} from '../../lib/pg/fetcher.js'
-import {PgStatus, PgDatabase} from '../../lib/pg/types.js'
+import {PgDatabase, PgStatus} from '../../lib/pg/types.js'
 import {nls} from '../../nls.js'
 
 const heredoc = tsheredoc.default
 
 export default class Promote extends Command {
-  static topic = 'pg'
+  static args = {
+    database: Args.string({description: nls('pg:database:arg:description'), required: true}),
+  }
   static description = 'sets DATABASE as your DATABASE_URL'
   static flags = {
-    force: flags.boolean({char: 'f'}),
     app: flags.app({required: true}),
+    force: flags.boolean({char: 'f'}),
     remote: flags.remote(),
   }
-
-  static args = {
-    database: Args.string({required: true, description: nls('pg:database:arg:description')}),
-  }
+  static topic = 'pg'
 
   public async run(): Promise<void> {
-    const {flags, args} = await this.parse(Promote)
-    const {force, app} = flags
+    const {args, flags} = await this.parse(Promote)
+    const {app, force} = flags
     const {database} = args
     const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
     const attachment = await dbResolver.getAttachment(app, database)
@@ -52,10 +52,10 @@ export default class Promote extends Command {
         // error, we can create a secondary attachment, just-in-time.
         const {body: backup} = await this.heroku.post<Heroku.AddOnAttachment>('/addon-attachments', {
           body: {
-            app: {name: app},
             addon: {name: current.addon?.name},
-            namespace: current.namespace,
+            app: {name: app},
             confirm: app,
+            namespace: current.namespace,
           },
         })
         ux.action.stop(color.attachment(backup.name + '_URL'))
@@ -77,21 +77,18 @@ export default class Promote extends Command {
       }
     }
 
-    let promotionMessage
-    if (attachment.namespace) {
-      promotionMessage = `Promoting ${color.attachment(attachment.name)} to ${color.datastore('DATABASE_URL')} on ${color.app(app)}`
-    } else {
-      promotionMessage = `Promoting ${color.datastore(attachment.addon.name)} to ${color.datastore('DATABASE_URL')} on ${color.app(app)}`
-    }
+    const promotionMessage = attachment.namespace
+      ? `Promoting ${color.attachment(attachment.name)} to ${color.datastore('DATABASE_URL')} on ${color.app(app)}`
+      : `Promoting ${color.datastore(attachment.addon.name)} to ${color.datastore('DATABASE_URL')} on ${color.app(app)}`
 
     ux.action.start(promotionMessage)
     await this.heroku.post('/addon-attachments', {
       body: {
-        name: 'DATABASE',
-        app: {name: app},
         addon: {name: attachment.addon.name},
-        namespace: attachment.namespace || null,
+        app: {name: app},
         confirm: app,
+        name: 'DATABASE',
+        namespace: attachment.namespace || null,
       },
     })
     ux.action.stop()
@@ -100,11 +97,11 @@ export default class Promote extends Command {
       ux.action.start('Reattaching pooler to new leader')
       await this.heroku.post('/addon-attachments', {
         body: {
-          name: currentPooler.name,
-          app: {name: app},
           addon: {name: attachment.addon.name},
-          namespace: 'connection-pooling:default',
+          app: {name: app},
           confirm: app,
+          name: currentPooler.name,
+          namespace: 'connection-pooling:default',
         },
       })
       ux.action.stop()
@@ -129,10 +126,10 @@ export default class Promote extends Command {
     if (releasePhase) {
       ux.action.start('Checking release phase')
       const {body: releases} = await this.heroku.get<Heroku.Release[]>(`/apps/${app}/releases`, {
-        partial: true,
         headers: {
           Range: 'version ..; max=5, order=desc',
         },
+        partial: true,
       })
 
       const attach = releases.find(release => release.description?.includes('Attach DATABASE'))
@@ -141,7 +138,7 @@ export default class Promote extends Command {
         ux.error('Unable to check release phase. Check your Attach DATABASE release for failures.')
       }
 
-      const endTime = Date.now() + 900000 // 15 minutes from now
+      const endTime = Date.now() + 900_000 // 15 minutes from now
       const [attachId, detachId] = [attach?.id as string, detach?.id as string]
       while (true) {
         const attach = await getRelease(this.heroku, app, attachId)
@@ -159,11 +156,9 @@ export default class Promote extends Command {
         if (attach && attach.status === 'failed') {
           let msg = `pg:promote failed because ${attach.description} release was unsuccessful. Your application is currently running `
           const detach = await getRelease(this.heroku, app, detachId)
-          if (detach && detach.status === 'succeeded') {
-            msg += 'without an attached DATABASE_URL.'
-          } else {
-            msg += `with ${current?.addon?.name} attached as DATABASE_URL.`
-          }
+          msg += detach && detach.status === 'succeeded'
+            ? 'without an attached DATABASE_URL.'
+            : `with ${current?.addon?.name} attached as DATABASE_URL.`
 
           msg += ' Check your release phase logs for failure causes.'
           ux.action.stop(msg)

--- a/src/commands/pg/ps.ts
+++ b/src/commands/pg/ps.ts
@@ -1,29 +1,28 @@
 import {Command, flags} from '@heroku-cli/command'
+import {utils} from '@heroku/heroku-cli-util'
 import {Args} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
-import {utils} from '@heroku/heroku-cli-util'
+
 import {nls} from '../../nls.js'
 
 const heredoc = tsheredoc.default
 
 export default class Ps extends Command {
-  static description = 'view active queries with execution time'
-  static flags = {
-    verbose: flags.boolean({char: 'v'}),
-    app: flags.app({required: true}),
-    remote: flags.remote(),
-  }
-
-  static topic = 'pg'
-
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
+  static description = 'view active queries with execution time'
+  static flags = {
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+    verbose: flags.boolean({char: 'v'}),
+  }
+  static topic = 'pg'
 
   public async run(): Promise<void> {
-    const {flags, args} = await this.parse(Ps)
+    const {args, flags} = await this.parse(Ps)
     const {database: databaseName} = args
-    const {verbose, app} = flags
+    const {app, verbose} = flags
     const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
     const db = await dbResolver.getDatabase(app, databaseName)
     const psqlService = new utils.pg.PsqlService(db)

--- a/src/commands/pg/psql.ts
+++ b/src/commands/pg/psql.ts
@@ -1,26 +1,25 @@
-import {color, utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args} from '@oclif/core'
+
 import {nls} from '../../nls.js'
 
 export default class Psql extends Command {
-  static description = 'open a psql shell to the database'
-  static flags = {
-    command: flags.string({char: 'c', description: 'SQL command to run'}),
-    file: flags.string({char: 'f', description: 'SQL file to run'}),
-    credential: flags.string({description: 'credential to use'}),
-    app: flags.app({required: true}),
-    remote: flags.remote(),
-  }
-
+  static aliases = ['psql']
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
-  static aliases = ['psql']
+  static description = 'open a psql shell to the database'
+  static flags = {
+    app: flags.app({required: true}),
+    command: flags.string({char: 'c', description: 'SQL command to run'}),
+    credential: flags.string({description: 'credential to use'}),
+    file: flags.string({char: 'f', description: 'SQL file to run'}),
+    remote: flags.remote(),
+  }
 
   public async run(): Promise<void> {
-    const {flags, args} = await this.parse(Psql)
+    const {args, flags} = await this.parse(Psql)
     const {app, command, credential, file} = flags
     const namespace = credential ? `credential:${credential}` : undefined
     let db

--- a/src/commands/pg/pull.ts
+++ b/src/commands/pg/pull.ts
@@ -1,10 +1,10 @@
 import {Command, flags} from '@heroku-cli/command'
+import {color, pg, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
-import tsheredoc from 'tsheredoc'
-import {color, utils, pg} from '@heroku/heroku-cli-util'
 // import {SpawnOptions, spawn} from 'node:child_process'
 import childProcess from 'node:child_process'
-import {nls} from '../../nls.js'
+import tsheredoc from 'tsheredoc'
+
 import {
   connArgs,
   maybeTunnel,
@@ -13,16 +13,16 @@ import {
   spawnPipe,
   verifyExtensionsMatch,
 } from '../../lib/pg/push-pull.js'
+import {nls} from '../../nls.js'
 
 const {env} = process
 const heredoc = tsheredoc.default
 
 export default class Pull extends Command {
   static args = {
-    source: Args.string({required: true, description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
-    target: Args.string({required: true, description: 'PostgreSQL connection string for the target database'}),
+    source: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`, required: true}),
+    target: Args.string({description: 'PostgreSQL connection string for the target database', required: true}),
   }
-
   static description = heredoc`
     pull Heroku database into local or remote database
     Pull from SOURCE into TARGET.
@@ -35,7 +35,6 @@ export default class Pull extends Command {
     To delete a local database run ${color.code('dropdb TARGET')}.
     To create an empty remote database, run ${color.code('createdb')} with connection command-line options (run ${color.code('createdb --help')} for details).
   `
-
   static examples = [heredoc`
     # pull Heroku DB named postgresql-swimmingly-100 into local DB mylocaldb that must not exist
     ${color.command('heroku pg:pull postgresql-swimmingly-100 mylocaldb --app sushi')}
@@ -43,19 +42,18 @@ export default class Pull extends Command {
     # pull Heroku DB named postgresql-swimmingly-100 into empty remote DB at postgres://myhost/mydb
     ${color.command('heroku pg:pull postgresql-swimmingly-100 postgres://myhost/mydb --app sushi')}
   `]
-
   static flags = {
     app: flags.app({required: true}),
     'exclude-table-data': flags.string({description: 'tables for which data should be excluded (use \';\' to split multiple names)', hasValue: true}),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
 
   protected async pull(
     sourceIn: pg.ConnectionDetails,
     targetIn: pg.ConnectionDetails,
-    exclusions: string[]) {
+    exclusions: string[],
+  ) {
     await prepare(targetIn)
 
     const source = await maybeTunnel(sourceIn)
@@ -66,11 +64,11 @@ export default class Pull extends Command {
 
     if (exclude !== '') dumpFlags.push(exclude)
 
-    const dumpOptions: { env: NodeJS.ProcessEnv } & childProcess.SpawnOptions = {
+    const dumpOptions: childProcess.SpawnOptions & {env: NodeJS.ProcessEnv} = {
       env: {
         PGSSLMODE: 'prefer',
         ...env,
-      } as { [key: string]: string },
+      } as {[key: string]: string},
       shell: true,
       stdio: ['pipe', 'pipe', 2],
     }
@@ -78,7 +76,7 @@ export default class Pull extends Command {
 
     const restoreFlags = ['--verbose', '-F', 'c', '--no-acl', '--no-owner', ...connArgs(target)]
 
-    const restoreOptions: { env: NodeJS.ProcessEnv } & childProcess.SpawnOptions = {
+    const restoreOptions: childProcess.SpawnOptions & {env: NodeJS.ProcessEnv} = {
       env: {...env},
       shell: true,
       stdio: ['pipe', 'pipe', 2],

--- a/src/commands/pg/push.ts
+++ b/src/commands/pg/push.ts
@@ -1,7 +1,9 @@
 import {Command, flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
-import tsheredoc from 'tsheredoc'
 import {color, pg, utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+import childProcess from 'node:child_process'
+import tsheredoc from 'tsheredoc'
+
 import {
   connArgs,
   maybeTunnel,
@@ -10,7 +12,6 @@ import {
   spawnPipe,
   verifyExtensionsMatch,
 } from '../../lib/pg/push-pull.js'
-import childProcess from 'node:child_process'
 import {nls} from '../../nls.js'
 
 const heredoc = tsheredoc.default
@@ -21,7 +22,6 @@ export default class Push extends Command {
     source: Args.string({description: 'PostgreSQL connection string for the source database', required: true}),
     target: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`, required: true}),
   }
-
   static description = heredoc`
     push local or remote into Heroku database
     Push from SOURCE into TARGET. TARGET must be empty.
@@ -31,7 +31,6 @@ export default class Push extends Command {
     SOURCE must be either the name of a database existing on your localhost or the
     fully qualified URL of a remote database.
   `
-
   static examples = [heredoc`
       # push mylocaldb into a Heroku DB named postgresql-swimmingly-100
       $ heroku pg:push mylocaldb postgresql-swimmingly-100 --app sushi
@@ -39,19 +38,18 @@ export default class Push extends Command {
       # push remote DB at postgres://myhost/mydb into a Heroku DB named postgresql-swimmingly-100
       $ heroku pg:push postgres://myhost/mydb postgresql-swimmingly-100 --app sushi
   `]
-
   static flags = {
     app: flags.app({required: true}),
     'exclude-table-data': flags.string({description: 'tables for which data should be excluded (use \';\' to split multiple names)', hasValue: true}),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
 
   protected async push(
     sourceIn: pg.ConnectionDetails,
     targetIn: pg.ConnectionDetails,
-    exclusions: string[]) {
+    exclusions: string[],
+  ) {
     await prepare(targetIn)
 
     const source = await maybeTunnel(sourceIn)
@@ -62,11 +60,11 @@ export default class Push extends Command {
 
     if (exclude !== '') dumpFlags.push(exclude)
 
-    const dumpOptions: { env: NodeJS.ProcessEnv } & childProcess.SpawnOptions = {
+    const dumpOptions: childProcess.SpawnOptions & {env: NodeJS.ProcessEnv} = {
       env: {
         PGSSLMODE: 'prefer',
         ...env,
-      } as { [key: string]: string },
+      } as {[key: string]: string},
       shell: true,
       stdio: ['pipe', 'pipe', 2],
     }
@@ -74,7 +72,7 @@ export default class Push extends Command {
 
     const restoreFlags = ['--verbose', '-F', 'c', '--no-acl', '--no-owner', ...connArgs(target)]
 
-    const restoreOptions: { env: NodeJS.ProcessEnv } & childProcess.SpawnOptions = {
+    const restoreOptions: childProcess.SpawnOptions & {env: NodeJS.ProcessEnv} = {
       env: {...env},
       shell: true,
       stdio: ['pipe', 'pipe', 2],

--- a/src/commands/pg/reset.ts
+++ b/src/commands/pg/reset.ts
@@ -1,5 +1,5 @@
-import {color, utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -12,7 +12,6 @@ export default class Reset extends Command {
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
   static description = 'delete all data in DATABASE'
   static flags = {
     app: flags.app({required: true}),
@@ -20,7 +19,6 @@ export default class Reset extends Command {
     extensions: flags.string({char: 'e', description: 'comma-separated list of extensions to pre-install in the public schema'}),
     remote: flags.remote(),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {

--- a/src/commands/pg/settings/auto-explain.ts
+++ b/src/commands/pg/settings/auto-explain.ts
@@ -1,33 +1,31 @@
 import {flags} from '@heroku-cli/command'
 import {Args} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
-import {BooleanAsString, booleanConverter, PGSettingsCommand} from '../../../lib/pg/setter.js'
+
 import type {Setting, SettingKey} from '../../../lib/pg/types.js'
+
+import {BooleanAsString, booleanConverter, PGSettingsCommand} from '../../../lib/pg/setter.js'
 import {nls} from '../../../nls.js'
 
 const heredoc = tsheredoc.default
 
 // ref: https://www.postgresql.org/docs/current/auto-explain.html
 export default class AutoExplain extends PGSettingsCommand {
-  static topic = 'pg'
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
+    value: Args.string({description: 'boolean indicating if execution plans of queries will be logged for future connections'}),
+  }
   static description = heredoc(`
   Automatically log execution plans of queries without running EXPLAIN by hand.
   The auto_explain module is loaded at session-time so existing connections will not be logged.
   Restart your Heroku app and/or restart existing connections for logging to start taking place.
   `)
-
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
-  static args = {
-    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
-    value: Args.string({description: 'boolean indicating if execution plans of queries will be logged for future connections'}),
-  }
-
   static strict = false
-
+  static topic = 'pg'
   protected settingKey: SettingKey = 'auto_explain'
 
   protected convertValue(val: BooleanAsString): boolean {

--- a/src/commands/pg/settings/auto-explain/log-analyze.ts
+++ b/src/commands/pg/settings/auto-explain/log-analyze.ts
@@ -1,25 +1,24 @@
 import {Args} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
-import {PGSettingsCommand, booleanConverter, BooleanAsString} from '../../../../lib/pg/setter.js'
-import {SettingKey, Setting} from '../../../../lib/pg/types.js'
+
+import {BooleanAsString, booleanConverter, PGSettingsCommand} from '../../../../lib/pg/setter.js'
+import {Setting, SettingKey} from '../../../../lib/pg/types.js'
 import {nls} from '../../../../nls.js'
 
 const heredoc = tsheredoc.default
 
 export default class LogAnalyze extends PGSettingsCommand {
-  static topic = 'pg'
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
+    value: Args.string({description: 'boolean indicating if execution plans get logged'}),
+  }
   static description = heredoc(`
     Shows actual run times on the execution plan.
     This is equivalent to calling EXPLAIN ANALYZE.
 
     WARNING: EXPLAIN ANALYZE will be run on ALL queries, not just logged queries. This can cause significant performance impacts to your database and should be used with caution.
   `)
-
-  static args = {
-    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
-    value: Args.string({description: 'boolean indicating if execution plans get logged'}),
-  }
-
+  static topic = 'pg'
   protected settingKey = 'auto_explain.log_analyze' as SettingKey
 
   protected convertValue(val: BooleanAsString): boolean {

--- a/src/commands/pg/settings/auto-explain/log-buffers.ts
+++ b/src/commands/pg/settings/auto-explain/log-buffers.ts
@@ -1,23 +1,22 @@
 import {Args} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
-import {BooleanAsString, PGSettingsCommand, booleanConverter} from '../../../../lib/pg/setter.js'
+
+import {BooleanAsString, booleanConverter, PGSettingsCommand} from '../../../../lib/pg/setter.js'
 import {Setting, SettingKey} from '../../../../lib/pg/types.js'
 import {nls} from '../../../../nls.js'
 
 const heredoc = tsheredoc.default
 
 export default class LogBuffersWaits extends PGSettingsCommand {
-  static topic = 'pg'
-  static description = heredoc(`
-    Includes buffer usage statistics when execution plans are logged.
-    This is equivalent to calling EXPLAIN BUFFERS and can only be used in conjunction with pg:settings:auto-explain:log-analyze turned on.
-  `)
-
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
     value: Args.string({description: 'boolean indicating if the database has buffer statistics enabled'}),
   }
-
+  static description = heredoc(`
+    Includes buffer usage statistics when execution plans are logged.
+    This is equivalent to calling EXPLAIN BUFFERS and can only be used in conjunction with pg:settings:auto-explain:log-analyze turned on.
+  `)
+  static topic = 'pg'
   protected settingKey: SettingKey = 'auto_explain.log_buffers'
 
   protected convertValue(val: BooleanAsString): boolean {

--- a/src/commands/pg/settings/auto-explain/log-format.ts
+++ b/src/commands/pg/settings/auto-explain/log-format.ts
@@ -1,29 +1,28 @@
 import {Args} from '@oclif/core'
+import tsheredoc from 'tsheredoc'
+
 import {PGSettingsCommand} from '../../../../lib/pg/setter.js'
 import {Setting, SettingKey} from '../../../../lib/pg/types.js'
-import tsheredoc from 'tsheredoc'
 import {nls} from '../../../../nls.js'
 
 const heredoc = tsheredoc.default
 
 export default class LogFormat extends PGSettingsCommand {
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
+    value: Args.string({description: 'format of the log output\n<options: text|json|yaml|xml>', options: ['text', 'json', 'yaml', 'xml']}),
+  }
   static description = heredoc(`
     selects the EXPLAIN output format to be used
     The allowed values are text, xml, json, and yaml. The default is text.
   `)
-
-  static args = {
-    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
-    value: Args.string({options: ['text', 'json', 'yaml', 'xml'], description: 'format of the log output\n<options: text|json|yaml|xml>'}),
-  }
-
   protected settingKey: SettingKey = 'auto_explain.log_format'
-
-  protected explain(setting: Setting<string>) {
-    return `Auto explain log output will log in ${setting.value} format.`
-  }
 
   protected convertValue(val: string): string {
     return val
+  }
+
+  protected explain(setting: Setting<string>) {
+    return `Auto explain log output will log in ${setting.value} format.`
   }
 }

--- a/src/commands/pg/settings/auto-explain/log-min-duration.ts
+++ b/src/commands/pg/settings/auto-explain/log-min-duration.ts
@@ -1,23 +1,22 @@
 import {Args} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
-import {PGSettingsCommand, numericConverter} from '../../../../lib/pg/setter.js'
+
+import {numericConverter, PGSettingsCommand} from '../../../../lib/pg/setter.js'
 import {Setting, SettingKey} from '../../../../lib/pg/types.js'
 import {nls} from '../../../../nls.js'
 
 const heredoc = tsheredoc.default
 
 export default class LogMinDuration extends PGSettingsCommand {
-  static topic = 'pg'
-  static description = heredoc(`
-    Sets the minimum execution time in milliseconds for a statement's plan to be logged.
-    Setting this value to 0 will log all queries. Setting this value to -1 will disable logging entirely.
-  `)
-
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
     value: Args.string({description: 'minimum duration in milliseconds for queries before logging execution plans. A value of -1 disables it. A value of 0 logs all query execution plans.'}),
   }
-
+  static description = heredoc(`
+    Sets the minimum execution time in milliseconds for a statement's plan to be logged.
+    Setting this value to 0 will log all queries. Setting this value to -1 will disable logging entirely.
+  `)
+  static topic = 'pg'
   protected settingKey: SettingKey = 'auto_explain.log_min_duration'
 
   protected convertValue(val: string): number {

--- a/src/commands/pg/settings/auto-explain/log-nested-statements.ts
+++ b/src/commands/pg/settings/auto-explain/log-nested-statements.ts
@@ -1,16 +1,16 @@
 import {Args} from '@oclif/core'
-import {type BooleanAsString, booleanConverter, PGSettingsCommand} from '../../../../lib/pg/setter.js'
+
 import type {Setting, SettingKey} from '../../../../lib/pg/types.js'
+
+import {type BooleanAsString, booleanConverter, PGSettingsCommand} from '../../../../lib/pg/setter.js'
 import {nls} from '../../../../nls.js'
 
 export default class LogNestedStatements extends PGSettingsCommand {
-  static description = "Nested statements are included in the execution plan's log."
-
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
     value: Args.string({description: 'boolean indicating if execution plan logs include nested statements'}),
   }
-
+  static description = "Nested statements are included in the execution plan's log."
   protected settingKey: SettingKey = 'auto_explain.log_nested_statements'
 
   protected convertValue(val: unknown): boolean {

--- a/src/commands/pg/settings/auto-explain/log-triggers.ts
+++ b/src/commands/pg/settings/auto-explain/log-triggers.ts
@@ -1,23 +1,22 @@
 import {Args} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
-import {PGSettingsCommand, booleanConverter, BooleanAsString} from '../../../../lib/pg/setter.js'
-import {SettingKey, Setting} from '../../../../lib/pg/types.js'
+
+import {BooleanAsString, booleanConverter, PGSettingsCommand} from '../../../../lib/pg/setter.js'
+import {Setting, SettingKey} from '../../../../lib/pg/types.js'
 import {nls} from '../../../../nls.js'
 
 const heredoc = tsheredoc.default
 
 export default class LogTriggers extends PGSettingsCommand {
-  static topic = 'pg'
-  static description = heredoc(`
-    Includes trigger execution statistics in execution plan logs.
-    This parameter can only be used in conjunction with pg:settings:auto-explain:log-analyze turned on.
-  `)
-
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
     value: Args.string({description: 'boolean indicating if the database has trigger execution statistics enabled'}),
   }
-
+  static description = heredoc(`
+    Includes trigger execution statistics in execution plan logs.
+    This parameter can only be used in conjunction with pg:settings:auto-explain:log-analyze turned on.
+  `)
+  static topic = 'pg'
   protected settingKey = 'auto_explain.log_triggers' as SettingKey
 
   protected convertValue(val: BooleanAsString): boolean {

--- a/src/commands/pg/settings/auto-explain/log-verbose.ts
+++ b/src/commands/pg/settings/auto-explain/log-verbose.ts
@@ -1,29 +1,31 @@
 import {flags} from '@heroku-cli/command'
 import {Args} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
-import {type BooleanAsString, booleanConverter, PGSettingsCommand} from '../../../../lib/pg/setter.js'
+
 import type {Setting, SettingKey} from '../../../../lib/pg/types.js'
+
+import {type BooleanAsString, booleanConverter, PGSettingsCommand} from '../../../../lib/pg/setter.js'
 import {nls} from '../../../../nls.js'
 
 const heredoc = tsheredoc.default
 
 export default class AutoExplainLogVerbose extends PGSettingsCommand {
-  static topic = 'pg'
-  static description = heredoc(
-    `Include verbose details in execution plans.
-    This is equivalent to calling EXPLAIN VERBOSE.`)
-
-  static flags = {
-    app: flags.app({required: true}),
-    remote: flags.remote(),
-  }
-
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
     value: Args.string({description: 'boolean indicating if the database has verbose execution plan logging enabled'}),
   }
-
+  static description = heredoc(`Include verbose details in execution plans.
+    This is equivalent to calling EXPLAIN VERBOSE.`)
+  static flags = {
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+  }
+  static topic = 'pg'
   protected settingKey: SettingKey = 'auto_explain.log_verbose'
+
+  protected convertValue(val: unknown): boolean {
+    return booleanConverter(val as BooleanAsString)
+  }
 
   protected explain(setting: Setting<unknown>) {
     if (setting.value) {
@@ -31,9 +33,5 @@ export default class AutoExplainLogVerbose extends PGSettingsCommand {
     }
 
     return 'Verbose execution plan logging has been disabled for auto_explain.'
-  }
-
-  protected convertValue(val: unknown): boolean {
-    return booleanConverter(val as BooleanAsString)
   }
 }

--- a/src/commands/pg/settings/data-connector-details-logs.ts
+++ b/src/commands/pg/settings/data-connector-details-logs.ts
@@ -1,28 +1,27 @@
 import {flags} from '@heroku-cli/command'
 import {Args} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
-import {type BooleanAsString, booleanConverter, PGSettingsCommand} from '../../../lib/pg/setter.js'
+
 import type {Setting, SettingKey} from '../../../lib/pg/types.js'
+
+import {type BooleanAsString, booleanConverter, PGSettingsCommand} from '../../../lib/pg/setter.js'
 import {nls} from '../../../nls.js'
 
 const heredoc = tsheredoc.default
 
 export default class DataConnectorDetailsLogs extends PGSettingsCommand {
   static aliases = ['pg:settings:explain-data-connector-details']
-  static description = heredoc(`
-  displays stats on replication slots on your database, the default value is "off"
-  `)
-
-  static flags = {
-    app: flags.app({required: true}),
-    remote: flags.remote(),
-  }
-
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
     value: Args.string({description: 'boolean indicating if data replication slot details get logged'}),
   }
-
+  static description = heredoc(`
+  displays stats on replication slots on your database, the default value is "off"
+  `)
+  static flags = {
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+  }
   protected settingKey: SettingKey = 'data_connector_details_logs'
 
   protected convertValue(val: BooleanAsString): boolean {

--- a/src/commands/pg/settings/index.ts
+++ b/src/commands/pg/settings/index.ts
@@ -1,24 +1,25 @@
 import {Command, flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
 import {hux, utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+
 import type {SettingKey, SettingsResponse} from '../../../lib/pg/types.js'
+
 import {essentialPlan} from '../../../lib/pg/util.js'
 import {nls} from '../../../nls.js'
 
 export default class Index extends Command {
-  static topic = 'pg'
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
+  }
   static description = 'show your current database settings'
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
-  static args = {
-    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
-  }
+  static topic = 'pg'
 
   public async run(): Promise<void> {
-    const {flags, args} = await this.parse(Index)
+    const {args, flags} = await this.parse(Index)
     const {app} = flags
     const {database} = args
     const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
@@ -31,9 +32,10 @@ export default class Index extends Command {
     const {body: settings} = await this.heroku.get<SettingsResponse>(`/postgres/v0/databases/${db.id}/config`, {hostname: utils.pg.host()})
     hux.styledHeader(db.name)
     const remapped: Record<string, unknown> = {}
-    Object.keys(settings).sort().forEach(k => {
-      remapped[k.replace(/_/g, '-')] = settings[k as SettingKey].value
-    })
+    for (const k of Object.keys(settings).sort()) {
+      remapped[k.replaceAll('_', '-')] = settings[k as SettingKey].value
+    }
+
     hux.styledObject(remapped)
   }
 }

--- a/src/commands/pg/settings/log-connections.ts
+++ b/src/commands/pg/settings/log-connections.ts
@@ -1,28 +1,27 @@
 import {flags} from '@heroku-cli/command'
 import {Args} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
-import {type BooleanAsString, booleanConverter, PGSettingsCommand} from '../../../lib/pg/setter.js'
+
 import type {Setting, SettingKey} from '../../../lib/pg/types.js'
+
+import {type BooleanAsString, booleanConverter, PGSettingsCommand} from '../../../lib/pg/setter.js'
 import {nls} from '../../../nls.js'
 
 const heredoc = tsheredoc.default
 
 export default class LogConnections extends PGSettingsCommand {
-  static topic = 'pg'
-  static description = heredoc(`
-  Controls whether a log message is produced when a login attempt is made. Default is true.
-  Setting log_connections to false stops emitting log messages for all attempts to login to the database.`)
-
-  static flags = {
-    app: flags.app({required: true}),
-    remote: flags.remote(),
-  }
-
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
     value: Args.string({description: 'boolean indicating if database login attempts get logged'}),
   }
-
+  static description = heredoc(`
+  Controls whether a log message is produced when a login attempt is made. Default is true.
+  Setting log_connections to false stops emitting log messages for all attempts to login to the database.`)
+  static flags = {
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+  }
+  static topic = 'pg'
   protected settingKey: SettingKey = 'log_connections'
 
   protected convertValue(val: unknown): unknown {

--- a/src/commands/pg/settings/log-lock-waits.ts
+++ b/src/commands/pg/settings/log-lock-waits.ts
@@ -1,24 +1,24 @@
 import {Args} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
-import {type BooleanAsString, booleanConverter, PGSettingsCommand} from '../../../lib/pg/setter.js'
+
 import type {Setting, SettingKey} from '../../../lib/pg/types.js'
+
+import {type BooleanAsString, booleanConverter, PGSettingsCommand} from '../../../lib/pg/setter.js'
 import {nls} from '../../../nls.js'
 
 const heredoc = tsheredoc.default
 
 export default class LogLockWaits extends PGSettingsCommand {
-  static topic = 'pg'
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
+    value: Args.string({description: 'boolean indicating if a message gets logged when a session waits longer than the deadlock_timeout to acquire a lock'}),
+  }
   static description = heredoc(`
     Controls whether a log message is produced when a session waits longer than the deadlock_timeout to acquire a lock. deadlock_timeout is set to 1 second
     Delays due to lock contention occur when multiple transactions are trying to access the same resource at the same time.
     Applications and their query patterns should try to avoid changes to many different tables within the same transaction.
   `)
-
-  static args = {
-    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
-    value: Args.string({description: 'boolean indicating if a message gets logged when a session waits longer than the deadlock_timeout to acquire a lock'}),
-  }
-
+  static topic = 'pg'
   protected settingKey: SettingKey = 'log_lock_waits'
 
   protected convertValue(val: unknown): boolean {

--- a/src/commands/pg/settings/log-min-duration-statement.ts
+++ b/src/commands/pg/settings/log-min-duration-statement.ts
@@ -1,23 +1,23 @@
 import {Args} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
-import {PGSettingsCommand} from '../../../lib/pg/setter.js'
+
 import type {Setting, SettingKey} from '../../../lib/pg/types.js'
+
+import {PGSettingsCommand} from '../../../lib/pg/setter.js'
 import {nls} from '../../../nls.js'
 
 const heredoc = tsheredoc.default
 
 export default class LogMinDurationStatement extends PGSettingsCommand {
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
+    value: Args.string({description: 'milliseconds to wait for a statement to complete before logging it'}),
+  }
   static description = heredoc(`
     The duration of each completed statement will be logged if the statement completes after the time specified by VALUE.
     VALUE needs to specified as a whole number, in milliseconds.
     Setting log_min_duration_statement to zero prints all statement durations and -1 will disable logging statement durations.
   `)
-
-  static args = {
-    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
-    value: Args.string({description: 'milliseconds to wait for a statement to complete before logging it'}),
-  }
-
   protected settingKey: SettingKey = 'log_min_duration_statement'
 
   protected convertValue(val: unknown): number {

--- a/src/commands/pg/settings/log-min-error-statement.ts
+++ b/src/commands/pg/settings/log-min-error-statement.ts
@@ -1,23 +1,23 @@
 import {Args} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
-import {PGSettingsCommand} from '../../../lib/pg/setter.js'
+
 import type {Setting, SettingKey} from '../../../lib/pg/types.js'
+
+import {PGSettingsCommand} from '../../../lib/pg/setter.js'
 import {nls} from '../../../nls.js'
 
 const heredoc = tsheredoc.default
 
 export default class LogMinErrorStatement extends PGSettingsCommand {
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
+    value: Args.string({options: ['error', 'log', 'fatal', 'panic']}),
+  }
   static description = heredoc(`
     log-min-error-statement controls the logging of SQL statements that cause an error at a specified severity level.
     This setting is useful to prevent logging SQL statements that might contain sensitive information.
     Use this setting to prevent logging SQL queries that contain sensitive information. Default is "error".
   `)
-
-  static args = {
-    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
-    value: Args.string({options: ['error', 'log', 'fatal', 'panic']}),
-  }
-
   protected settingKey: SettingKey = 'log_min_error_statement'
 
   protected convertValue(val: string): string {

--- a/src/commands/pg/settings/log-statement.ts
+++ b/src/commands/pg/settings/log-statement.ts
@@ -1,12 +1,18 @@
 import {Args} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
-import {PGSettingsCommand} from '../../../lib/pg/setter.js'
+
 import type {Setting, SettingKey} from '../../../lib/pg/types.js'
+
+import {PGSettingsCommand} from '../../../lib/pg/setter.js'
 import {nls} from '../../../nls.js'
 
 const heredoc = tsheredoc.default
 
 export default class LogStatement extends PGSettingsCommand {
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
+    value: Args.string({description: 'type of SQL statements to log\n<options: none|ddl|mod|all>', options: ['none', 'ddl', 'mod', 'all']}),
+  }
   static description = heredoc(`
     log_statement controls which SQL statements are logged.
     Valid values for VALUE:
@@ -15,12 +21,6 @@ export default class LogStatement extends PGSettingsCommand {
     mod  - Includes all statements from ddl as well as data-modifying statements such as INSERT, UPDATE, DELETE, TRUNCATE, COPY
     all  - All statements are logged
   `)
-
-  static args = {
-    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
-    value: Args.string({options: ['none', 'ddl', 'mod', 'all'], description: 'type of SQL statements to log\n<options: none|ddl|mod|all>'}),
-  }
-
   protected settingKey: SettingKey = 'log_statement'
 
   protected convertValue(val: string): string {

--- a/src/commands/pg/settings/track-functions.ts
+++ b/src/commands/pg/settings/track-functions.ts
@@ -1,25 +1,25 @@
 import {Args} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
-import {PGSettingsCommand} from '../../../lib/pg/setter.js'
+
 import type {Setting, SettingKey} from '../../../lib/pg/types.js'
+
+import {PGSettingsCommand} from '../../../lib/pg/setter.js'
 import {nls} from '../../../nls.js'
 
 const heredoc = tsheredoc.default
 
 // ref: https://www.postgresql.org/docs/current/runtime-config-statistics.html#GUC-TRACK-FUNCTIONS
 export default class TrackFunctions extends PGSettingsCommand {
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
+    value: Args.string({description: 'function type to track\n<options: none|pl|all>', options: ['none', 'pl', 'all']}),
+  }
   static description = heredoc(`
     track_functions controls tracking of function call counts and time used. Default is none.
     Valid values for VALUE:
     none - No functions are tracked (default)
     pl   - Only procedural language functions are tracked
     all  - All functions, including SQL and C language functions, are tracked. Simple SQL-language that are inlined are not tracked`)
-
-  static args = {
-    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
-    value: Args.string({options: ['none', 'pl', 'all'], description: 'function type to track\n<options: none|pl|all>'}),
-  }
-
   protected settingKey: SettingKey = 'track_functions'
 
   protected convertValue(val: unknown): unknown {

--- a/src/commands/pg/unfollow.ts
+++ b/src/commands/pg/unfollow.ts
@@ -1,30 +1,30 @@
 import {Command, flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
 import * as Heroku from '@heroku-cli/schema'
-import {utils, color} from '@heroku/heroku-cli-util'
-import {databaseNameFromUrl} from '../../lib/pg/util.js'
+import {color, utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+import tsheredoc from 'tsheredoc'
+
 import ConfirmCommand from '../../lib/confirm-command.js'
 import {PgDatabase} from '../../lib/pg/types.js'
-import tsheredoc from 'tsheredoc'
+import {databaseNameFromUrl} from '../../lib/pg/util.js'
 import {nls} from '../../nls.js'
 
 const heredoc = tsheredoc.default
 
 export default class Unfollow extends Command {
-  static topic = 'pg'
+  static args = {
+    database: Args.string({description: nls('pg:database:arg:description'), required: true}),
+  }
   static description = 'stop a replica from following and make it a writeable database'
   static flags = {
-    confirm: flags.string({char: 'c'}),
     app: flags.app({required: true}),
+    confirm: flags.string({char: 'c'}),
     remote: flags.remote(),
   }
-
-  static args = {
-    database: Args.string({required: true, description: nls('pg:database:arg:description')}),
-  }
+  static topic = 'pg'
 
   public async run(): Promise<void> {
-    const {flags, args} = await this.parse(Unfollow)
+    const {args, flags} = await this.parse(Unfollow)
     const {app, confirm} = flags
     const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
     const {addon: db} = await dbResolver.getAttachment(app, args.database)

--- a/src/commands/pg/upgrade/cancel.ts
+++ b/src/commands/pg/upgrade/cancel.ts
@@ -1,5 +1,5 @@
-import {color, utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -14,16 +14,13 @@ export default class Upgrade extends Command {
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
   static description = heredoc(`
     cancels a scheduled upgrade. You can't cancel a version upgrade that's in progress.
   `)
-
   static flags = {
     app: flags.app({required: true}),
     confirm: flags.string({char: 'c'}),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {

--- a/src/commands/pg/upgrade/dryrun.ts
+++ b/src/commands/pg/upgrade/dryrun.ts
@@ -1,5 +1,5 @@
-import {color, utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -14,17 +14,14 @@ export default class Upgrade extends Command {
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
   static description = heredoc(`
     simulates a Postgres version upgrade on a Standard-tier and higher leader database by creating and upgrading a follower database. Heroku sends the results of the test upgrade via email.
   `)
-
   static flags = {
     app: flags.app({required: true}),
     confirm: flags.string({char: 'c'}),
     version: flags.string({char: 'v', description: 'Postgres version to upgrade to'}),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {

--- a/src/commands/pg/upgrade/prepare.ts
+++ b/src/commands/pg/upgrade/prepare.ts
@@ -1,5 +1,5 @@
-import {color, utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -14,17 +14,14 @@ export default class Upgrade extends Command {
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
   static description = heredoc(`
     prepares the upgrade for Standard-tier and higher leader databases and schedules it for the next available maintenance window. To start a version upgrade on Essential-tier and follower databases, use ${color.code('heroku pg:upgrade:run')} instead.
   `)
-
   static flags = {
     app: flags.app({required: true}),
     confirm: flags.string({char: 'c'}),
     version: flags.string({char: 'v', description: 'Postgres version to upgrade to'}),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {
@@ -54,7 +51,7 @@ export default class Upgrade extends Command {
     try {
       const data = {version}
       ux.action.start(`Preparing upgrade on ${color.addon(db.name)}`)
-      const response = await this.heroku.post<PgUpgradeResponse>(`/client/v11/databases/${db.id}/upgrade/prepare`, {hostname: utils.pg.host(), body: data})
+      const response = await this.heroku.post<PgUpgradeResponse>(`/client/v11/databases/${db.id}/upgrade/prepare`, {body: data, hostname: utils.pg.host()})
       ux.action.stop(heredoc(`done\n${formatResponseWithCommands(response.body.message)}`))
     } catch (error) {
       const response = error as PgUpgradeError

--- a/src/commands/pg/upgrade/run.ts
+++ b/src/commands/pg/upgrade/run.ts
@@ -1,6 +1,6 @@
-import {color, utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -15,7 +15,6 @@ export default class Upgrade extends Command {
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
   }
-
   static description = heredoc(`
     starts a Postgres version upgrade
 
@@ -25,7 +24,6 @@ export default class Upgrade extends Command {
 
     On follower databases, this command unfollows the leader database before upgrading the follower's Postgres version.
     `)
-
   static examples = [
     heredoc`
       # Upgrade an Essential-tier database to a specific version
@@ -40,14 +38,12 @@ export default class Upgrade extends Command {
       ${color.command('heroku pg:upgrade:run DATABASE_URL --app myapp')}
     `,
   ]
-
   static flags = {
     app: flags.app({required: true}),
     confirm: flags.string({char: 'c'}),
     remote: flags.remote({char: 'r'}),
     version: flags.string({char: 'v', description: 'Postgres version to upgrade to'}),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {
@@ -92,7 +88,7 @@ export default class Upgrade extends Command {
     try {
       const data = {version}
       ux.action.start(`Starting upgrade on ${color.datastore(db.name)}`)
-      const response = await this.heroku.post<PgUpgradeResponse>(`/client/v11/databases/${db.id}/upgrade/run`, {hostname: utils.pg.host(), body: data})
+      const response = await this.heroku.post<PgUpgradeResponse>(`/client/v11/databases/${db.id}/upgrade/run`, {body: data, hostname: utils.pg.host()})
       ux.action.stop(heredoc(`done\n${formatResponseWithCommands(response.body.message)}`))
     } catch (error) {
       if (error instanceof Error && 'body' in error) {

--- a/src/commands/pg/upgrade/wait.ts
+++ b/src/commands/pg/upgrade/wait.ts
@@ -1,6 +1,6 @@
+import {Command, flags} from '@heroku-cli/command'
 import {color, pg, utils} from '@heroku/heroku-cli-util'
 import {HTTPError} from '@heroku/http-call'
-import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 import debug from 'debug'
 import tsheredoc from 'tsheredoc'
@@ -20,7 +20,6 @@ export default class Wait extends Command {
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')}`}),
   }
-
   static description = 'provides the status of an upgrade and blocks it until the operation is complete'
   static examples = [
     heredoc(`
@@ -36,14 +35,12 @@ export default class Wait extends Command {
       ${color.command('heroku pg:upgrade:wait postgresql-curved-12345 --app myapp --no-notify')}
     `),
   ]
-
   static flags = {
     app: flags.app({required: true}),
     'no-notify': flags.boolean({description: 'do not show OS notification'}),
     remote: flags.remote(),
     'wait-interval': flags.integer({description: 'how frequently to poll in seconds (to avoid rate limiting)'}),
   }
-
   static topic = 'pg'
 
   public async run(): Promise<void> {

--- a/src/commands/pg/vacuum-stats.ts
+++ b/src/commands/pg/vacuum-stats.ts
@@ -1,25 +1,25 @@
 import {Command, flags} from '@heroku-cli/command'
-import {Args, ux} from '@oclif/core'
 import {utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
+
 import {nls} from '../../nls.js'
 
 const heredoc = tsheredoc.default
 
 export default class VacuumStats extends Command {
-  static topic = 'pg'
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
+  }
   static description = 'show dead rows and whether an automatic vacuum is expected to be triggered'
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),
   }
-
-  static args = {
-    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`}),
-  }
+  static topic = 'pg'
 
   public async run(): Promise<void> {
-    const {flags, args} = await this.parse(VacuumStats)
+    const {args, flags} = await this.parse(VacuumStats)
     const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
     const db = await dbResolver.getDatabase(flags.app, args.database)
     const psqlService = new utils.pg.PsqlService(db)

--- a/src/commands/pg/wait.ts
+++ b/src/commands/pg/wait.ts
@@ -1,10 +1,11 @@
 import {Command, flags} from '@heroku-cli/command'
+import {color, pg, utils} from '@heroku/heroku-cli-util'
+import {HTTPError} from '@heroku/http-call'
 import {Args, ux} from '@oclif/core'
 import debug from 'debug'
-import {utils, pg, color} from '@heroku/heroku-cli-util'
+
 import notify from '../../lib/notify.js'
 import {PgStatus} from '../../lib/pg/types.js'
-import {HTTPError} from '@heroku/http-call'
 import {nls} from '../../nls.js'
 
 const wait = (ms: number) => new Promise(resolve => {
@@ -12,21 +13,20 @@ const wait = (ms: number) => new Promise(resolve => {
 })
 
 export default class Wait extends Command {
-  static topic = 'pg'
-  static description = 'blocks until database is available'
-  static flags = {
-    'wait-interval': flags.string({description: 'how frequently to poll in seconds (to avoid rate limiting)'}),
-    'no-notify': flags.boolean({description: 'do not show OS notification'}),
-    app: flags.app({required: true}),
-    remote: flags.remote(),
-  }
-
   static args = {
     database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:all-dbs:suffix')}`}),
   }
+  static description = 'blocks until database is available'
+  static flags = {
+    app: flags.app({required: true}),
+    'no-notify': flags.boolean({description: 'do not show OS notification'}),
+    remote: flags.remote(),
+    'wait-interval': flags.string({description: 'how frequently to poll in seconds (to avoid rate limiting)'}),
+  }
+  static topic = 'pg'
 
   public async run(): Promise<void> {
-    const {flags, args} = await this.parse(Wait)
+    const {args, flags} = await this.parse(Wait)
     const {app, 'wait-interval': waitInterval} = flags
     const dbName = args.database
     const pgDebug = debug('pg')
@@ -50,7 +50,7 @@ export default class Wait extends Command {
           pgDebug(httpError)
           if (!retries || httpError.statusCode !== 404) throw httpError
           retries--
-          status = {'waiting?': true, message: notFoundMessage}
+          status = {message: notFoundMessage, 'waiting?': true}
         }
 
         if (status['error?']) {


### PR DESCRIPTION
## Summary
This PR applies automated lint formatting to command files in preparation for migration to ESLint 9. Changes include import ordering, class property ordering, object property ordering, and whitespace cleanup.

Affected command groups: git, keys, labs, local, logs, maintenance, mcp, members, notifications, orgs, data, pg.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
These are purely formatting changes with no behavioral modifications. Part of a series of PRs to break up linting changes in preparation for ESLint 9 migration.

**Steps**:
1. Passing CI suffices.

## Related Issues
Part of a series of PRs to reduce what is implemented in https://github.com/heroku/cli/pull/3661