### PR TITLE
feat: implement heroku git:credentials as a git credential helper

### DIFF
--- a/src/commands/apps/create.ts
+++ b/src/commands/apps/create.ts
@@ -90,6 +90,7 @@ async function configureGitRemote(context: Interfaces.ParserOutput, app: Heroku.
   const remoteUrl = git.httpGitUrl(app.name || '')
   if (!context.flags['no-remote'] && git.inGitRepo()) {
     await git.createRemote(context.flags.remote || 'heroku', remoteUrl)
+    await git.configureCredentialHelper()
   }
 
   return remoteUrl

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -2,6 +2,8 @@ import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
 
+import Git from '../../lib/git/git.js'
+
 export default class Login extends Command {
   static aliases = ['login']
 
@@ -21,6 +23,14 @@ export default class Login extends Command {
     await this.heroku.login({browser: flags.browser, expiresIn: flags['expires-in'], method})
     const {body: account} = await this.heroku.get<Heroku.Account>('/account', {retryAuth: false})
     this.log(`Logged in as ${color.user(account.email!)}`)
+
+    const git = new Git()
+    try {
+      await git.configureCredentialHelper()
+    } catch {
+      // ignore
+    }
+
     await this.config.runHook('recache', {type: 'login'})
   }
 }

--- a/src/commands/git/clone.ts
+++ b/src/commands/git/clone.ts
@@ -30,5 +30,6 @@ remote: Counting objects: 42, done.
     const directory = args.DIRECTORY || (app.name as string)
     const remote = flags.remote || 'heroku'
     await git.spawn(['clone', '-o', remote, git.url(app.name!), directory])
+    await git.configureCredentialHelper()
   }
 }

--- a/src/commands/git/credentials.ts
+++ b/src/commands/git/credentials.ts
@@ -14,9 +14,9 @@ export class GitCredentials extends Command {
   /**
    * Reads git-credential input from stdin
    * Format: key=value pairs, one per line, terminated by blank line
-   * Returns parsed object with protocol, host, username, password
+   * Returns parsed object with protocol, host, username, and path
    */
-  private async readInput(): Promise<{protocol?: string; host?: string; username?: string; password?: string}> {
+  private async readInput(): Promise<{protocol?: string; host?: string; username?: string; path?: string}> {
     return new Promise(resolve => {
       const rl = readline.createInterface({
         input: process.stdin,

--- a/src/commands/git/credentials.ts
+++ b/src/commands/git/credentials.ts
@@ -1,5 +1,6 @@
-import {Command} from '@heroku-cli/command'
+import {Command, vars} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
+import * as readline from 'node:readline'
 
 export class GitCredentials extends Command {
   static hidden = true
@@ -10,13 +11,56 @@ export class GitCredentials extends Command {
     command: Args.string({required: true, description: 'command name of the git credentials'}),
   }
 
+  /**
+   * Reads git-credential input from stdin
+   * Format: key=value pairs, one per line, terminated by blank line
+   * Returns parsed object with protocol, host, username, password
+   */
+  private async readInput(): Promise<{protocol?: string; host?: string; username?: string; password?: string}> {
+    return new Promise(resolve => {
+      const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+        terminal: false,
+      })
+
+      const input: Record<string, string> = {}
+
+      rl.on('line', (line: string) => {
+        if (!line.trim()) {
+          rl.close()
+          return
+        }
+
+        const [key, value] = line.split('=', 2)
+        if (key && value) {
+          input[key] = value
+        }
+      })
+
+      rl.on('close', () => {
+        resolve(input)
+      })
+    })
+  }
+
   async run() {
     const {args} = await this.parse(GitCredentials)
     switch (args.command) {
     case 'get': {
-      if (!this.heroku.auth) throw new Error('not logged in')
+      const {protocol, host} = await this.readInput()
+
+      const {httpGitHost} = vars
+      if (protocol !== 'https' || host !== httpGitHost) {
+        return
+      }
+
+      if (!this.heroku.auth) {
+        throw new Error('not logged in')
+      }
+
       ux.stdout(`protocol=https
-host=git.heroku.com
+host=${httpGitHost}
 username=heroku
 password=${this.heroku.auth}`)
       break

--- a/src/commands/git/remote.ts
+++ b/src/commands/git/remote.ts
@@ -46,5 +46,7 @@ ${color.command('heroku git:remote --remote heroku-staging -a example-staging')}
 
     const newRemote = await git.remoteUrl(remote)
     this.log(`set git remote ${color.cyan(remote)} to ${color.cyan(newRemote)}`)
+
+    await git.configureCredentialHelper()
   }
 }

--- a/src/lib/git/git.ts
+++ b/src/lib/git/git.ts
@@ -4,16 +4,18 @@ import {ux} from '@oclif/core/ux'
 
 import fs from 'fs'
 import {promisify} from 'node:util'
-const execFile = promisify(cp.execFile)
+const execFilePromise = promisify(cp.execFile)
 
 import debug from 'debug'
 const gitDebug = debug('git')
 
 export default class Git {
+  private readonly execFile = execFilePromise
+
   public async exec(args: string[]): Promise<string> {
     gitDebug('exec: git %o', args)
     try {
-      const {stdout, stderr} = await execFile('git', args)
+      const {stdout, stderr} = await this.execFile('git', args)
       if (stderr) process.stderr.write(stderr)
       return stdout.trim()
     } catch (error: any) {
@@ -31,7 +33,11 @@ export default class Git {
       const s = cp.spawn('git', args, {stdio: [0, 1, 2]})
       s.on('error', (err: Error & {code?: string}) => {
         if (err.code === 'ENOENT') {
-          ux.error('Git must be installed to use the Heroku CLI.  See instructions here: https://git-scm.com')
+          try {
+            ux.error('Git must be installed to use the Heroku CLI.  See instructions here: https://git-scm.com')
+          } catch (error) {
+            reject(error)
+          }
         } else reject(err)
       })
       s.on('close', resolve)
@@ -88,6 +94,7 @@ export default class Git {
       return true
     } catch (error: any) {
       if (error.code !== 'ENOENT') throw error
+      return false
     }
   }
 
@@ -100,6 +107,19 @@ export default class Git {
   createRemote(remote: string, url: string) {
     return this.hasGitRemote(remote)
       .then(exists => exists ? null : this.exec(['remote', 'add', remote, url]))
+  }
+
+  /** Configures `heroku git:credentials` as a Git credential helper
+  * that is URL-scoped to Heroku Git operations only.
+  */
+  async configureCredentialHelper() {
+    const {httpGitHost} = vars
+    await this.exec([
+      'config',
+      '--global',
+      `credential.https://${httpGitHost}.helper`,
+      '!heroku git:credentials',
+    ])
   }
 }
 

--- a/test/helpers/credential-manager-stub.ts
+++ b/test/helpers/credential-manager-stub.ts
@@ -5,20 +5,28 @@ import {
 } from '@heroku-cli/command/lib/credential-manager-core/index.js'
 import {setCredentialManagerProvider} from '@heroku-cli/command/lib/credential-manager.js'
 
-export function stubCredentialManager() {
+interface Provider {
+  getAuth: () => Promise<{account: string | undefined, token: string | undefined}>
+  removeAuth: () => Promise<void>
+  saveAuth: () => Promise<void>
+}
+
+export function stubCredentialManager(provider?: Partial<Provider>) {
   const originalProvider = {
     getAuth: originalGetAuth,
     removeAuth: originalRemoveAuth,
     saveAuth: originalSaveAuth,
   }
 
-  setCredentialManagerProvider({
+  const defaultProvider : Provider = {
     async getAuth() {
       return {account: undefined, token: undefined}
     },
     async removeAuth() {},
     async saveAuth() {},
-  })
+  }
+
+  setCredentialManagerProvider({...defaultProvider, ...provider})
 
   return {
     restore() {

--- a/test/unit/commands/apps/create.unit.test.ts
+++ b/test/unit/commands/apps/create.unit.test.ts
@@ -1,30 +1,29 @@
 import {expect} from 'chai'
 import nock from 'nock'
-import {execSync} from 'node:child_process'
 import sinon from 'sinon'
 
 import CreateCommand from '../../../../src/commands/apps/create.js'
+import Git from '../../../../src/lib/git/git.js'
 import {runCommand} from '../../../helpers/run-command.js'
 
 describe('apps:create', function () {
   let api: nock.Scope
+  let configureCredentialHelperStub: sinon.SinonStub
+  let gitCreateRemoteStub: sinon.SinonStub
 
   beforeEach(function () {
     api = nock('https://api.heroku.com')
+
+    configureCredentialHelperStub = sinon.stub(Git.prototype, 'configureCredentialHelper').resolves()
+    gitCreateRemoteStub = sinon.stub(Git.prototype, 'createRemote').resolves()
   })
 
   afterEach(function () {
     api.done()
     nock.cleanAll()
-    // Clean up any heroku git remotes created by the tests
-    try {
-      const remotes = execSync('git remote', {encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore']})
-      if (remotes.includes('heroku')) {
-        execSync('git remote remove heroku', {stdio: 'ignore'})
-      }
-    } catch {
-      // Ignore errors
-    }
+
+    configureCredentialHelperStub.restore()
+    gitCreateRemoteStub.restore()
   })
 
   it('creates an app', async function () {
@@ -253,5 +252,82 @@ describe('apps:create', function () {
 
     expect(stderr).to.contain('Creating app... done, ⬢ foobar, stack is test')
     expect(stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n')
+  })
+
+  describe('git operations', function () {
+    it('creates a remote when in a git repository and --no-remote is not used', async function () {
+      api
+        .post('/apps', {})
+        .reply(200, {
+          name: 'foobar',
+          stack: {name: 'cedar-14'},
+          web_url: 'https://foobar.com',
+        })
+
+      await runCommand(CreateCommand, [])
+
+      expect(gitCreateRemoteStub.calledOnce).to.be.true
+    })
+
+    it('does not create a remote when not in a git repository', async function () {
+      const inGitRepoStub = sinon.stub(Git.prototype, 'inGitRepo').returns(false)
+
+      api
+        .post('/apps', {})
+        .reply(200, {
+          name: 'foobar',
+          stack: {name: 'cedar-14'},
+          web_url: 'https://foobar.com',
+        })
+
+      try {
+        await runCommand(CreateCommand, [])
+        expect(gitCreateRemoteStub.called).to.be.false
+      } finally {
+        inGitRepoStub.restore()
+      }
+    })
+
+    it('does not create a remote when --no-remote is used', async function () {
+      api
+        .post('/apps', {})
+        .reply(200, {
+          name: 'foobar',
+          stack: {name: 'cedar-14'},
+          web_url: 'https://foobar.com',
+        })
+
+      await runCommand(CreateCommand, ['--no-remote'])
+
+      expect(gitCreateRemoteStub.called).to.be.false
+    })
+
+    it('configures git credential helper when creating a remote', async function () {
+      api
+        .post('/apps', {})
+        .reply(200, {
+          name: 'foobar',
+          stack: {name: 'cedar-14'},
+          web_url: 'https://foobar.com',
+        })
+
+      await runCommand(CreateCommand, [])
+
+      expect(configureCredentialHelperStub.calledOnce).to.be.true
+    })
+
+    it('does not configure git credential helper when --no-remote is used', async function () {
+      api
+        .post('/apps', {})
+        .reply(200, {
+          name: 'foobar',
+          stack: {name: 'cedar-14'},
+          web_url: 'https://foobar.com',
+        })
+
+      await runCommand(CreateCommand, ['--no-remote'])
+
+      expect(configureCredentialHelperStub.called).to.be.false
+    })
   })
 })

--- a/test/unit/commands/auth/login.unit.test.ts
+++ b/test/unit/commands/auth/login.unit.test.ts
@@ -12,9 +12,14 @@ describe('auth:login', function () {
   let api: nock.Scope
   let configureCredentialHelperStub: sinon.SinonStub
   let loginStub: sinon.SinonStub
+  let savedApiKey: string | undefined
 
   beforeEach(function () {
     api = nock('https://api.heroku.com')
+
+    savedApiKey = process.env.HEROKU_API_KEY
+    delete process.env.HEROKU_API_KEY
+
     configureCredentialHelperStub = sinon.stub(Git.prototype, 'configureCredentialHelper').resolves()
     loginStub = sinon.stub(APIClient.prototype, 'login').resolves()
   })
@@ -22,6 +27,10 @@ describe('auth:login', function () {
   afterEach(function () {
     api.done()
     nock.cleanAll()
+
+    if (savedApiKey !== undefined) {
+      process.env.HEROKU_API_KEY = savedApiKey
+    }
 
     configureCredentialHelperStub.restore()
     loginStub.restore()

--- a/test/unit/commands/auth/login.unit.test.ts
+++ b/test/unit/commands/auth/login.unit.test.ts
@@ -1,0 +1,74 @@
+import {expect} from 'chai'
+import nock from 'nock'
+import sinon from 'sinon'
+
+import {APIClient} from '@heroku-cli/command'
+
+import Login from '../../../../src/commands/auth/login.js'
+import Git from '../../../../src/lib/git/git.js'
+import {runCommand} from '../../../helpers/run-command.js'
+
+describe('auth:login', function () {
+  let api: nock.Scope
+  let configureCredentialHelperStub: sinon.SinonStub
+  let loginStub: sinon.SinonStub
+
+  beforeEach(function () {
+    api = nock('https://api.heroku.com')
+    configureCredentialHelperStub = sinon.stub(Git.prototype, 'configureCredentialHelper').resolves()
+    loginStub = sinon.stub(APIClient.prototype, 'login').resolves()
+  })
+
+  afterEach(function () {
+    api.done()
+    nock.cleanAll()
+
+    configureCredentialHelperStub.restore()
+    loginStub.restore()
+  })
+
+  it('displays the logged in user', async function () {
+    api
+      .get('/account')
+      .reply(200, {email: 'user@example.com'})
+
+    const {stdout} = await runCommand(Login, [])
+
+    expect(stdout).to.contain('Logged in as user@example.com')
+  })
+
+  it('configures git credential helper after successful login', async function () {
+    api
+      .get('/account')
+      .reply(200, {
+        email: 'user@example.com',
+      })
+
+    await runCommand(Login, [])
+
+    expect(configureCredentialHelperStub.calledOnce).to.be.true
+  })
+
+  it('does not configure git credential helper if not logged in', async function () {
+    loginStub.rejects(new Error('Not logged in'))
+
+    await runCommand(Login, [])
+
+    expect(configureCredentialHelperStub.notCalled).to.be.true
+  })
+
+  it('does not fail login if git credential helper configuration fails', async function () {
+    configureCredentialHelperStub.rejects(new Error('Git not found'))
+
+    api
+      .get('/account')
+      .reply(200, {
+        email: 'user@example.com',
+      })
+
+    const {error} = await runCommand(Login, [])
+
+    expect(error).to.be.undefined
+    expect(configureCredentialHelperStub.calledOnce).to.be.true
+  })
+})

--- a/test/unit/commands/git/clone.unit.test.ts
+++ b/test/unit/commands/git/clone.unit.test.ts
@@ -1,12 +1,46 @@
 import {expect} from 'chai'
+import nock from 'nock'
+import sinon from 'sinon'
 
 import {GitClone as Clone} from '../../../../src/commands/git/clone.js'
+import Git from '../../../../src/lib/git/git.js'
 import {runCommand} from '../../../helpers/run-command.js'
 
 describe('git:clone', function () {
+  let api: nock.Scope
+  let configureCredentialHelperStub: sinon.SinonStub
+  let spawnStub: sinon.SinonStub
+
+  beforeEach(function () {
+    api = nock('https://api.heroku.com')
+
+    configureCredentialHelperStub = sinon.stub(Git.prototype, 'configureCredentialHelper').resolves()
+    spawnStub = sinon.stub(Git.prototype, 'spawn').resolves()
+  })
+
+  afterEach(function () {
+    api.done()
+    nock.cleanAll()
+
+    configureCredentialHelperStub.restore()
+    spawnStub.restore()
+  })
+
   it('errors if no app given', async function () {
     const {error} = await runCommand(Clone, [])
 
     expect(error?.message).to.contain('Missing required flag app')
+  })
+
+  it('configures git credential helper after cloning', async function () {
+    api
+      .get('/apps/test-app')
+      .reply(200, {
+        name: 'test-app',
+      })
+
+    await runCommand(Clone, ['-a', 'test-app'])
+
+    expect(configureCredentialHelperStub.calledOnce).to.be.true
   })
 })

--- a/test/unit/commands/git/credentials.unit.test.ts
+++ b/test/unit/commands/git/credentials.unit.test.ts
@@ -1,12 +1,111 @@
 import {expect} from 'chai'
+import mockStdin from 'mock-stdin'
 
+import {stubCredentialManager} from '../../../helpers/credential-manager-stub.js'
 import {GitCredentials as Credentials} from '../../../../src/commands/git/credentials.js'
 import {runCommand} from '../../../helpers/run-command.js'
 
 describe('git:credentials', function () {
+  let stdin: mockStdin.MockSTDIN
+
+  beforeEach(function () {
+    stdin = mockStdin.stdin()
+  })
+
+  afterEach(function () {
+    stdin.restore()
+  })
+
   it('errors if no app given', async function () {
     const {error} = await runCommand(Credentials, [])
 
     expect(error?.message).to.contain('Missing 1 required arg')
+  })
+
+  describe('get operation', function () {
+    it('outputs credentials', async function () {
+      stubCredentialManager({
+        getAuth: async () => ({account: 'test@example.com', token: 'test-token'}),
+      })
+
+      setTimeout(() => {
+        stdin.send('protocol=https\nhost=git.heroku.com\n\n')
+      }, 0)
+
+      const {stdout, error} = await runCommand(Credentials, ['get'])
+
+      expect(error).to.be.undefined
+      expect(stdout).to.equal('protocol=https\nhost=git.heroku.com\nusername=heroku\npassword=test-token\n')
+    })
+
+    it('does not output credentials for non-Heroku hosts', async function () {
+      stubCredentialManager({
+        getAuth: async () => ({account: 'test@example.com', token: 'test-token'}),
+      })
+
+      setTimeout(() => {
+        stdin.send('protocol=https\nhost=github.com\n\n')
+      }, 0)
+
+      const {stdout, error} = await runCommand(Credentials, ['get'])
+
+      expect(error).to.be.undefined
+      expect(stdout).to.equal('')
+    })
+
+    it('does not output credentials when protocol is not https', async function () {
+      stubCredentialManager({
+        getAuth: async () => ({account: 'test@example.com', token: 'test-token'}),
+      })
+
+      setTimeout(() => {
+        stdin.send('protocol=http\nhost=git.heroku.com\n\n')
+      }, 0)
+
+      const {stdout, error} = await runCommand(Credentials, ['get'])
+
+      expect(error).to.be.undefined
+      expect(stdout).to.equal('')
+    })
+
+    it('errors when not logged in', async function () {
+      stubCredentialManager({
+        getAuth: async () => ({account: undefined, token: undefined}),
+      })
+
+      setTimeout(() => {
+        stdin.send('protocol=https\nhost=git.heroku.com\n\n')
+      }, 0)
+
+      const {error} = await runCommand(Credentials, ['get'])
+
+      expect(error?.message).to.contain('not logged in')
+    })
+  })
+
+  describe('store operation', function () {
+    it('accepts input without error', async function () {
+      setTimeout(() => {
+        stdin.send('protocol=https\nhost=git.heroku.com\nusername=heroku\npassword=test-token\n\n')
+      }, 0)
+
+      const {error, stdout} = await runCommand(Credentials, ['store'])
+
+      expect(error).to.be.undefined
+      expect(stdout).to.equal('')
+    })
+  })
+
+  describe('erase operation', function () {
+    it('accepts input without error', async function () {
+      setTimeout(() => {
+        stdin.send('protocol=https\nhost=git.heroku.com\n\n')
+      }, 0)
+
+      const {error, stdout} = await runCommand(Credentials, ['erase'])
+
+      expect(error).to.be.undefined
+      expect(stdout).to.equal('')
+    })
   })
 })

--- a/test/unit/commands/git/credentials.unit.test.ts
+++ b/test/unit/commands/git/credentials.unit.test.ts
@@ -7,12 +7,20 @@ import {runCommand} from '../../../helpers/run-command.js'
 
 describe('git:credentials', function () {
   let stdin: mockStdin.MockSTDIN
+  let savedApiKey: string | undefined
 
   beforeEach(function () {
+    savedApiKey = process.env.HEROKU_API_KEY
+    delete process.env.HEROKU_API_KEY
+
     stdin = mockStdin.stdin()
   })
 
   afterEach(function () {
+    if (savedApiKey !== undefined) {
+      process.env.HEROKU_API_KEY = savedApiKey
+    }
+
     stdin.restore()
   })
 

--- a/test/unit/commands/git/remote.unit.test.ts
+++ b/test/unit/commands/git/remote.unit.test.ts
@@ -1,12 +1,46 @@
 import {expect} from 'chai'
+import nock from 'nock'
+import sinon from 'sinon'
 
 import {GitRemote as Remote} from '../../../../src/commands/git/remote.js'
+import Git from '../../../../src/lib/git/git.js'
 import {runCommand} from '../../../helpers/run-command.js'
 
 describe('git:remote', function () {
+  let api: nock.Scope
+  let configureCredentialHelperStub: sinon.SinonStub
+  let execStub: sinon.SinonStub
+
+  beforeEach(function () {
+    api = nock('https://api.heroku.com')
+
+    configureCredentialHelperStub = sinon.stub(Git.prototype, 'configureCredentialHelper').resolves()
+    execStub = sinon.stub(Git.prototype, 'exec').resolves('')
+  })
+
+  afterEach(function () {
+    api.done()
+    nock.cleanAll()
+
+    configureCredentialHelperStub.restore()
+    execStub.restore()
+  })
+
   it('errors if no app given', async function () {
     const {error} = await runCommand(Remote, [])
 
     expect(error?.message).to.contain('Specify an app with --app')
+  })
+
+  it('configures git credential helper after adding remote', async function () {
+    api
+      .get('/apps/test-app')
+      .reply(200, {
+        name: 'test-app',
+      })
+
+    await runCommand(Remote, ['-a', 'test-app'])
+
+    expect(configureCredentialHelperStub.calledOnce).to.be.true
   })
 })

--- a/test/unit/lib/git/git.unit.test.ts
+++ b/test/unit/lib/git/git.unit.test.ts
@@ -1,5 +1,4 @@
 'use strict'
-/* global beforeEach afterEach */
 
 import sinon from 'sinon'
 import {expect} from 'chai'
@@ -8,85 +7,127 @@ import {EventEmitter} from 'events'
 import Git from '../../../../src/lib/git/git.js'
 
 describe('git', function () {
-  let mock: sinon.SinonMock
+  let execFileStub: sinon.SinonStub
+  let spawnStub: sinon.SinonStub
   let git: Git
 
   beforeEach(function () {
-    mock = sinon.mock(cp)
     git = new Git()
+    execFileStub = sinon.stub(git as any, 'execFile')
+    spawnStub = sinon.stub(cp, 'spawn')
   })
 
   afterEach(function () {
-    return mock.restore()
+    execFileStub.restore()
+    spawnStub.restore()
   })
 
-  it.skip('runs exec', function () {
-    mock.expects('execFile').withArgs('git', ['remote']).yieldsAsync(null, 'foo')
-    return git.exec(['remote'])
-      .then((data: string) => {
-        expect(data).to.equal('foo')
-        mock.verify()
-      })
+  it('runs exec', async function () {
+    execFileStub.resolves({stdout: 'foo', stderr: ''})
+
+    const data = await git.exec(['remote'])
+
+    expect(data).to.equal('foo')
+    expect(execFileStub.calledOnceWith('git', ['remote'])).to.be.true
   })
 
-  it.skip('translates exec Errno::ENOENT to a friendlier error message', function () {
+  it('translates exec Errno::ENOENT to a friendlier error message', async function () {
     const err: any = new Error('err')
     err.code = 'ENOENT'
 
-    mock.expects('execFile').withArgs('git', ['remote']).yieldsAsync(err, null)
+    execFileStub.rejects(err)
 
-    return expect(git.exec(['remote'])).to.throw(Error, 'Git must be installed to use the Heroku CLI.  See instructions here: https://git-scm.com')
+    try {
+      await git.exec(['remote'])
+      expect.fail('Should have thrown an error')
+    } catch (error: any) {
+      expect(error.message).to.contain('Git must be installed to use the Heroku CLI.  See instructions here: https://git-scm.com')
+    }
   })
 
-  it.skip('exec passes through all other errors', function () {
+  it('exec passes through all other errors', async function () {
     const err = new Error('Some other error message')
 
-    mock.expects('execFile').withArgs('git', ['remote']).yieldsAsync(err, null)
+    execFileStub.rejects(err)
 
-    return expect(git.exec(['remote'])).to.throw(err.message)
+    try {
+      await git.exec(['remote'])
+      expect.fail('Should have thrown an error')
+    } catch (error: any) {
+      expect(error.message).to.equal('Some other error message')
+    }
   })
 
-  it.skip('runs spawn', function () {
+  it('runs spawn', async function () {
     const emitter = new EventEmitter()
-    mock.expects('spawn').withExactArgs('git', ['remote'], {stdio: [0, 1, 2]}).returns(emitter)
-    process.nextTick(() => emitter.emit('close'))
-    return git.spawn(['remote'])
-      .then(() => mock.verify())
+    spawnStub.returns(emitter)
+
+    const spawnPromise = git.spawn(['remote'])
+
+    process.nextTick(() => emitter.emit('close', 0))
+
+    await spawnPromise
+    expect(spawnStub.calledOnceWith('git', ['remote'], {stdio: [0, 1, 2]})).to.be.true
   })
 
-  it.skip('translates spawn Errno::ENOENT to a friendlier error message', function () {
-    const err = new Error('err')
-    err.name = 'ENOENT'
+  it('translates spawn Errno::ENOENT to a friendlier error message', async function () {
+    const err: any = new Error('err')
+    err.code = 'ENOENT'
 
     const emitter = new EventEmitter()
-    mock.expects('spawn').withExactArgs('git', ['remote'], {stdio: [0, 1, 2]}).returns(emitter)
+    spawnStub.returns(emitter)
+
+    const spawnPromise = git.spawn(['remote'])
+
     process.nextTick(() => emitter.emit('error', err))
 
-    return expect(git.spawn(['remote'])).to.throw('Git must be installed to use the Heroku CLI.  See instructions here: https://git-scm.com')
+    try {
+      await spawnPromise
+      expect.fail('Should have thrown an error')
+    } catch (error: any) {
+      expect(error.message).to.contain('Git must be installed to use the Heroku CLI.  See instructions here: https://git-scm.com')
+    }
   })
 
-  it.skip('spawn passes through all other errors', function () {
+  it('spawn passes through all other errors', async function () {
     const err = new Error('Some other error message')
 
     const emitter = new EventEmitter()
-    mock.expects('spawn').withExactArgs('git', ['remote'], {stdio: [0, 1, 2]}).returns(emitter)
+    spawnStub.returns(emitter)
+
+    const spawnPromise = git.spawn(['remote'])
+
     process.nextTick(() => emitter.emit('error', err))
 
-    return expect(git.spawn(['remote'])).to.throw(err.message)
+    try {
+      await spawnPromise
+      expect.fail('Should have thrown an error')
+    } catch (error: any) {
+      expect(error.message).to.equal('Some other error message')
+    }
   })
 
-  it.skip('gets heroku git remote config', function () {
-    mock.expects('execFile').withArgs('git', ['config', 'heroku.remote']).yieldsAsync(null, 'staging')
-    return git.remoteFromGitConfig()
-      .then((remote: string | void) => expect(remote).to.equal('staging'))
-      .then(() => mock.verify())
+  it('gets heroku git remote config', async function () {
+    execFileStub.resolves({stdout: 'staging', stderr: ''})
+
+    const remote = await git.remoteFromGitConfig()
+
+    expect(remote).to.equal('staging')
+    expect(execFileStub.calledOnceWith('git', ['config', 'heroku.remote'])).to.be.true
   })
 
-  it.skip('returns an http git url', function () {
+  it('returns an https git url', function () {
     expect(git.url('foo')).to.equal('https://git.heroku.com/foo.git')
   })
 
-  it.skip('returns an ssh git url', function () {
-    expect(git.url('foo')).to.equal('git@heroku.com:foo.git')
+  it('configures git credential helper globally for the Heroku Git host', async function () {
+    execFileStub.resolves({stdout: '', stderr: ''})
+
+    await git.configureCredentialHelper()
+
+    expect(execFileStub.calledOnce).to.be.true
+    const [cmd, args] = execFileStub.firstCall.args
+    expect(cmd).to.equal('git')
+    expect(args).to.deep.equal(['config', '--global', 'credential.https://git.heroku.com.helper', '!heroku git:credentials'])
   })
 })


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
This PR implements `heroku git:credentials` as a git credential helper for Heroku Git authentication.

When git needs credentials for git.heroku.com, it will call `heroku git:credentials get`, which reads the stored Heroku auth token and outputs it in the format git expects.

### Changes:
- `src/commands/git/credentials.ts`
   - Implements the git-credential protocol (get, store, erase operations)
   - Reads key=value pairs from stdin — terminated by a blank line
   - Validates protocol=https and host=git.heroku.com before outputting credentials
- `src/lib/git/git.ts`
   - Added `configureCredentialHelper()`, which writes `!heroku git:credentials` as a URL-scoped global git credential helper. Since the helper starts with `!`, Git executes it as a shell command.
   - Wrapped `ux.error()` with try/catch in spawn's error handler to route errors through the Promise rejection channel
- `src/commands/auth/login.ts`
   - Calls `configureCredentialHelper()` after successful login; silently ignores errors
- `src/commands/apps/create.ts`, `src/commands/git/clone.ts`, `src/commands/git/remote.ts`
  - Each command calls `configureCredentialHelper()` after git operations to handle the case where git was not installed when `heroku login` was run

### Tests:
- Added tests for `git:credentials` covering protocol operations and host validation
- Added git credential helper tests to `apps:create`, `git:remote`, and `git:clone`
- Created new test file for `auth:login` covering login validation and git credential helper configuration
- Updated `credentialManagerStub` to allow custom return values per test
- Fixed previously skipped tests in `test/unit/lib/git/git.unit.test.ts`; made `execFilePromise` accessible as an instance property to properly stub `cp.execFile` after promisify

**Note on git unit tests:** The git commands are not well tested, tracked in [W-13589124](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001TnPbpYAF/view). This PR fixes the skipped tests and adds coverage for the new functionality. Remaining improvements are tracked in that work item.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
<!-- Add any context/setup necessary for testing. -->                                           
You need access to a Heroku app with a git remote for testing `git push heroku main`. The test steps will temporarily replace your installed Heroku CLI with the local build and modify your global git config — both are restored in the cleanup steps.

**Steps:**
  1. Pull down this branch
  2. `heroku logout`
  3. `npm install && npm run build`
  4. `npm link` — replaces the installed version of Heroku with this local build
  5. restart the terminal
  6. `which heroku` — confirm it shows a local/npm path rather than homebrew
  7. `heroku login`
  8. `git config --global credential.https://git.heroku.com.helper` — should return `!heroku git:credentials`
  9. Edit `~/.netrc` and remove any lines for `git.heroku.com` — this forces git to use the credential helper instead of netrc directly
  10. `cd` into a local app directory with a Heroku remote                                 
  11. `GIT_TRACE=1 git push heroku main` — in the trace output, confirm you see `run_command: 'heroku git:credentials get'` near the start of authentication
  12. Confirm the push completes successfully or "Already up to date"
 
**Cleanup:**
  13. `heroku logout`                                                                    
  14. `npm unlink -g heroku`                                                              
  15. `which heroku` — confirm the original Heroku path is restored                       
  16. `git config --unset --global credential.https://git.heroku.com.helper`              
  17. `heroku login`— re-authenticates and writes fresh credentials to ~/.netrc

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-22182925](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002YfW1IYAV/view)