### PR TITLE
fix: flag value completion for autocomplete is broken

### DIFF
--- a/src/commands/autocomplete/options.ts
+++ b/src/commands/autocomplete/options.ts
@@ -134,7 +134,7 @@ export default class Options extends AutocompleteBase {
       // variable arg (strict: false)
       if (!Klass.strict) {
         cacheKey = cmdArgs[0] && cmdArgs[0].name.toLowerCase()
-        cacheCompletion = this.findCompletion(cacheKey, id)
+        cacheCompletion = this.findCompletion(id, cacheKey)
         if (!cacheCompletion) this.throwError(`Cannot complete variable arg position for ${id}`)
       } else if (argsIndex > cmdArgs.length - 1) {
         this.throwError(`Cannot complete arg position ${argsIndex} for ${id}`)
@@ -146,7 +146,7 @@ export default class Options extends AutocompleteBase {
 
     // try to auto-populate the completion object
     if (!cacheCompletion) {
-      cacheCompletion = this.findCompletion(cacheKey, id)
+      cacheCompletion = this.findCompletion(id, cacheKey)
     }
 
     return {cacheCompletion, cacheKey}

--- a/test/unit/commands/autocomplete/options.unit.test.ts
+++ b/test/unit/commands/autocomplete/options.unit.test.ts
@@ -136,4 +136,48 @@ describe('AutocompleteOptions', function () {
       })
     })
   })
+
+  describe('#determineCompletion', function () {
+    it('resolves app completion for an app arg', function () {
+      const commandStateVars = {
+        argsIndex: 0,
+        curPositionIsFlag: false,
+        curPositionIsFlagValue: false,
+        id: 'apps:info',
+        Klass: {args: [{name: 'app'}], flags: {}, strict: true},
+        slicedArgv: [],
+      }
+      const {cacheCompletion, cacheKey} = cmd.determineCompletion(commandStateVars)
+      expect(cacheKey).to.eq('app')
+      expect(cacheCompletion).to.not.be.undefined
+    })
+
+    it('resolves completion via key alias for config:get key arg', function () {
+      const commandStateVars = {
+        argsIndex: 0,
+        curPositionIsFlag: false,
+        curPositionIsFlagValue: false,
+        id: 'config:get',
+        Klass: {args: [{name: 'key'}], flags: {}, strict: true},
+        slicedArgv: [],
+      }
+      const {cacheCompletion, cacheKey} = cmd.determineCompletion(commandStateVars)
+      expect(cacheKey).to.eq('key')
+      expect(cacheCompletion).to.not.be.undefined
+    })
+
+    it('resolves app completion for a non-strict command', function () {
+      const commandStateVars = {
+        argsIndex: -1,
+        curPositionIsFlag: false,
+        curPositionIsFlagValue: false,
+        id: 'apps:info',
+        Klass: {args: [{name: 'app'}], flags: {}, strict: false},
+        slicedArgv: [],
+      }
+      const {cacheCompletion, cacheKey} = cmd.determineCompletion(commandStateVars)
+      expect(cacheKey).to.eq('app')
+      expect(cacheCompletion).to.not.be.undefined
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Completion of flag values such as app names after `--app=` has been non-functional for a long time.

The issue stems from a refactor as part of another fix in 2018. PR #1039 swapped the order of the arguments around for the `#findCompletion` method in AutocompleteBase, but missed two places the method is used in the `Options` class.

Adds tests to catch the issue and fixes the argument order to restore completion behaviour for flag values.

Fixes #2275

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [X] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
Test coverage has been added

**Steps**:

On main / with the latest release:
1. Open a terminal
2. Run `heroku autocomplete:options "heroku apps:info --app="` => nothing is returned even though apps are available
3. Run `heroku autocomplete:options "heroku apps --team="` => nothing is returned even though team are available

With this patch:
1. Open a terminal
2. Run `heroku autocomplete:options "heroku apps:info --app="` => get a list of apps
3. Run `heroku autocomplete:options "heroku apps --team="` => get a list of teams

## Screenshots (if applicable)

## Related Issues
GitHub issue: #2275
GUS work item: [WI number](WI link)
