### PR TITLE
fix: updates @heroku-cli/command to address 2FA token prompting bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "11.3.0",
       "license": "ISC",
       "dependencies": {
-        "@heroku-cli/command": "^12.3.1",
+        "@heroku-cli/command": "^12.3.3",
         "@heroku-cli/notifications": "^1.2.6",
         "@heroku-cli/schema": "^1.0.25",
         "@heroku/buildpack-registry": "^1.0.1",
@@ -140,7 +140,7 @@
         "sinon": "^21.0.2",
         "source-map-support": "^0.5.21",
         "ts-node": "^10.9.2",
-        "typescript": "4.9.5"
+        "typescript": "5.8.3"
       },
       "engines": {
         "node": ">=20"
@@ -2286,9 +2286,9 @@
       }
     },
     "node_modules/@heroku-cli/command": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@heroku-cli/command/-/command-12.3.1.tgz",
-      "integrity": "sha512-q97+aMJt2WbCLOtXcnrWt7MtfMr1U5BesLwXgOL3Fetw0FqJa7ARILRJ+I3qN/ic+TblcweS2Fu0kaLrhBvGFQ==",
+      "version": "12.3.3",
+      "resolved": "https://registry.npmjs.org/@heroku-cli/command/-/command-12.3.3.tgz",
+      "integrity": "sha512-JXgzzpJS6WdNf51FqaqzjA2ydNUw6fnGCFod8CbHofTKYgveIdTUQxXQJdInLKeRLPIoogEOZs1/inJTsT9zkg==",
       "license": "ISC",
       "dependencies": {
         "@heroku/http-call": "^5.4.0",
@@ -23857,16 +23857,16 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-eslint": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": "./bin/run.js",
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
-    "@heroku-cli/command": "^12.3.1",
+    "@heroku-cli/command": "^12.3.3",
     "@heroku-cli/notifications": "^1.2.6",
     "@heroku-cli/schema": "^1.0.25",
     "@heroku/buildpack-registry": "^1.0.1",
@@ -134,7 +134,7 @@
     "sinon": "^21.0.2",
     "source-map-support": "^0.5.21",
     "ts-node": "^10.9.2",
-    "typescript": "4.9.5"
+    "typescript": "5.8.3"
   },
   "oclif": {
     "additionalHelpFlags": [

--- a/test/unit/commands/run/index.unit.test.ts
+++ b/test/unit/commands/run/index.unit.test.ts
@@ -1,10 +1,25 @@
+import {prompter} from '@heroku-cli/command'
 import {runCommand} from '@heroku-cli/test-utils'
 import {expect} from 'chai'
 import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Run from '../../../../src/commands/run/index.js'
 
 describe('run', function () {
+  const originalProcessArgv = [...process.argv]
+
+  const runWithCliArgv = async (args: string[]) => {
+    process.argv = [
+      '/usr/local/bin/node',
+      '/usr/local/bin/heroku',
+      'run',
+      ...args,
+    ]
+
+    return runCommand(Run, args)
+  }
+
   beforeEach(function () {
     nock.cleanAll()
     nock.disableNetConnect()
@@ -12,6 +27,8 @@ describe('run', function () {
 
   afterEach(function () {
     nock.enableNetConnect()
+    process.argv = [...originalProcessArgv]
+    sinon.restore()
   })
 
   it('requires a command', async function () {
@@ -119,5 +136,47 @@ describe('run', function () {
     ]).catch(() => {
       // Expected to fail when trying to connect
     })
+  })
+
+  it('prompts for 2FA via prompter and retries with Heroku-Two-Factor-Code header on 403 two_factor', async function () {
+    const promptStub = sinon.stub(prompter, 'prompt').resolves({factor: '123456'})
+
+    const api = nock('https://api.heroku.com')
+      .get('/apps/myapp')
+      .reply(200, {name: 'myapp', stack: {name: 'heroku-20'}})
+      .get('/account')
+      .reply(403, {id: 'two_factor', message: 'Two-factor code required'})
+      .get('/account', undefined, {reqheaders: {'heroku-two-factor-code': '123456'}})
+      .reply(200, {email: 'test@example.com'})
+      .post('/apps/myapp/dynos')
+      .reply(201, {
+        attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
+        command: 'echo test',
+        created_at: '2020-01-01T00:00:00Z',
+        id: '12345678-1234-1234-1234-123456789012',
+        name: 'run.1234',
+        size: 'basic',
+        state: 'starting',
+        type: 'run',
+        updated_at: '2020-01-01T00:00:00Z',
+      })
+
+    await runWithCliArgv([
+      '--app',
+      'myapp',
+      'echo',
+      'test',
+    ]).catch(() => {
+      // Expected to fail when trying to connect to rendezvous
+    })
+
+    expect(promptStub.calledOnce, 'prompter.prompt should be called exactly once').to.be.true
+    expect(promptStub.firstCall.args[0]).to.deep.equal([{
+      mask: '*',
+      message: 'Two-factor code',
+      name: 'factor',
+      type: 'password',
+    }])
+    expect(api.isDone(), 'all expected requests including the 2FA-retried /account should be made').to.be.true
   })
 })


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->

Updates `@heroku-cli/command` to v12.3.3, which contains a fix to how we're prompting. Prior to our use of the `inquirer` package, we were using OCLIF's `prompt` function; this function wrote to `stderr`. `inquirer`, by default, writes to `stdout`. This caused issues for some users, as it polluted `stdout` with information intended for `stderr`.

This PR also updates Typescript to version `5.8.3`. This was necessary to support type definitions exported from `@heroku-cli/command`, derived from type definitions provided by the `inquirer` package.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
- Passing CI suffices

## Related Issues
GUS work item: [W-22383481](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002ZSRHxYAP/view)
