### PR TITLE
deps: resolve ip-address GHSA-v2v4-37r5-5v8g via scoped overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13567,12 +13567,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -13585,9 +13585,9 @@
       }
     },
     "node_modules/express-rate-limit/node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -22680,12 +22680,12 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+      "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -22708,9 +22708,9 @@
       }
     },
     "node_modules/socks/node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -370,7 +370,9 @@
   "license": "ISC",
   "main": "dist/index.js",
   "overrides": {
-    "serialize-javascript": "^7.0.4"
+    "serialize-javascript": "^7.0.4",
+    "socks": "^2.8.8",
+    "express-rate-limit": "^8.5.1"
   },
   "repository": "heroku/cli",
   "scripts": {


### PR DESCRIPTION
## Summary

Adds two scoped `npm` overrides — `socks: ^2.8.8` and `express-rate-limit: ^8.5.1` — to pull patched `ip-address` (≥ 10.1.1) into every chain that's API-compatible with v10. The remaining `ip-address@5.9.4` install under `@heroku/socksv5@0.0.9` is intentionally retained because socksv5 calls the v5 API (`addr.valid`, `addr.parsedAddress`) and is not compatible with ip-address v10.

After this change, `npm ls ip-address --all`:

```
├─┬ @heroku/mcp-server → @modelcontextprotocol/sdk → express-rate-limit@8.5.1 (overridden)
│   └── ip-address@10.2.0                                                       (PATCHED)
├── @heroku/socksv5@0.0.9
│   └── ip-address@5.9.4                                                        (retained — see below)
├── @oclif/plugin-plugins → npm@10.9.6 (bundled) → socks@2.8.7 → ip-address@10.1.0
│                                                                                (bundled-npm chain — fixed by #3694)
└── @oclif/plugin-update → proxy-agent → socks@2.8.8 (overridden)
    └── ip-address@10.2.0                                                       (PATCHED)
```

## Advisory closed

- https://github.com/heroku/cli/security/dependabot/309 — GHSA-v2v4-37r5-5v8g (`ip-address` XSS in `Address6.group()`, `link()`, `spanAll()`, and `AddressError.parseMessage`, MEDIUM CVSSv4 5.3)

## Why scoped overrides instead of a top-level `ip-address` pin

A top-level `"ip-address": "^10.1.1"` override would also rewrite the version inside `@heroku/socksv5@0.0.9`. socksv5 calls `new Address6(str)` and reads `addr.valid` / `addr.parsedAddress`. In ip-address v10 the constructor *throws* on invalid input rather than setting `addr.valid`, and the `valid` instance property no longer exists. Forcing v10 here would break SOCKS5 IPv6 parsing. Pinning the *parents* (`socks`, `express-rate-limit`) avoids this and keeps socksv5's v5 install intact.

## Note on residual `ip-address@5.9.4` exposure

The advisory's vulnerable surfaces are HTML-emitting methods (`Address6.group()`, `Address6.link()`, `v6.helpers.spanAll()`, `AddressError.parseMessage`) that produce HTML for browser rendering. The Heroku CLI is a Node.js command-line tool with no DOM, no HTML sink, and no `innerHTML` path. The advisory itself notes "real-world exposure is believed to be extremely limited — analysis of all 425 dependent npm packages and GitHub code search found zero consumers of `group()`, `link()`, or `spanAll()`." `@heroku/socksv5` only consumes `parsedAddress` and never invokes any of the vulnerable methods, so the remaining `5.9.4` install has no realistic exploit path.

## Interaction with #3694

The bundled `npm@10.9.6` chain inside `@oclif/plugin-plugins@5.4.58` reaches `socks@2.8.7 → ip-address@10.1.0` via npm's vendored bundle, which doesn't honor the parent project's overrides. PR #3694 (bumping `@oclif/plugin-plugins` to ^5.4.64) replaces that with `npm@11.x`, which has a refreshed bundle. Either PR independently leaves the alert closeable; together they close it cleanly.

## Test plan

- [x] `npm install` clean
- [x] `npm ls ip-address --all` shows patched 10.x via `socks` and `express-rate-limit` overrides
- [x] `npm run build` succeeds
- [x] `npm run lint` succeeds (0 errors)
- [x] `npm test` passes (1955 passing)
- [ ] Manual smoke test of any SOCKS5 proxy code path that exercises `@heroku/socksv5` (regression check that retaining ip-address@5.9.4 there is fine)