### PR TITLE
feat: update accounts:set to work with keychain managers

### DIFF
--- a/src/commands/accounts/set.ts
+++ b/src/commands/accounts/set.ts
@@ -6,10 +6,10 @@ import AccountsModule from '../../lib/accounts/accounts.js'
 
 export default class Set extends Command {
   static args = {
-    name: Args.string({description: 'name of account to set', required: true}),
+    name: Args.string({description: 'name or username of account to set', required: true}),
   }
 
-  static description = 'set the current Heroku account from your cache'
+  static description = 'set the current Heroku account from your accounts cache or system keychain'
 
   static example = `${color.command('heroku accounts:set my-account')}`
 
@@ -17,10 +17,13 @@ export default class Set extends Command {
     const {args} = await this.parse(Set)
     const {name} = args
 
-    if (!(await AccountsModule.list()).some(account => account.name === name)) {
-      ux.error(`${name} does not exist in your accounts cache.`)
+    const accounts = await AccountsModule.list()
+    const accountExists = accounts.some(account => account.name === name || account.username === name)
+
+    if (!(accountExists)) {
+      ux.error(`${name} does not exist in your accounts cache or system keychain.`)
     }
 
-    AccountsModule.set(name)
+    await AccountsModule.set(name, this.config.dataDir)
   }
 }

--- a/src/commands/accounts/set.ts
+++ b/src/commands/accounts/set.ts
@@ -18,12 +18,15 @@ export default class Set extends Command {
     const {name} = args
 
     const accounts = await AccountsModule.list()
-    const accountExists = accounts.some(account => account.name === name || account.username === name)
+    const netrcAccount = accounts.find(account => account.name === name)
+    const keychainAccount = accounts.find(account => !account.name && account.username === name)
 
-    if (!(accountExists)) {
+    if (!netrcAccount && !keychainAccount) {
       ux.error(`${name} does not exist in your accounts cache or system keychain.`)
     }
 
-    await AccountsModule.set(name, this.config.dataDir)
+    const account = netrcAccount ?? keychainAccount
+
+    await AccountsModule.set(account!, this.config.dataDir)
   }
 }

--- a/src/commands/git/credentials.ts
+++ b/src/commands/git/credentials.ts
@@ -38,6 +38,7 @@ export class GitCredentials extends Command {
       })
 
       rl.on('close', () => {
+        process.stdin.pause()
         resolve(input)
       })
     })

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -17,7 +17,8 @@ export interface IAccountsWrapper {
   add(name: string, username: string, password: string): void
   remove(name: string): void
   set(account: AccountEntry, dataDir: string): Promise<void>
-  writeLoginState(configDir: string, name: string): Promise<void>
+  getStorageConfig(): ReturnType<typeof getStorageConfig>
+  writeLoginState(dataDir: string, name: string): Promise<void>
 }
 
 export class AccountsWrapper implements IAccountsWrapper {

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -1,4 +1,4 @@
-import {APIClient, listKeychainAccounts, getStorageConfig} from '@heroku-cli/command'
+import {APIClient, listKeychainAccounts, getStorageConfig, writeLoginState} from '@heroku-cli/command'
 import {removeAuth} from '@heroku-cli/command/lib/credential-manager.js'
 import * as Heroku from '@heroku-cli/schema'
 import fs from 'node:fs'
@@ -16,7 +16,8 @@ export interface IAccountsWrapper {
   current(heroku: APIClient): Promise<string | null>
   add(name: string, username: string, password: string): void
   remove(name: string): void
-  set(name: string): Promise<void>
+  set(name: string, dataDir: string): Promise<void>
+  writeLoginState(configDir: string, name: string): Promise<void>
 }
 
 export class AccountsWrapper implements IAccountsWrapper {
@@ -63,6 +64,10 @@ export class AccountsWrapper implements IAccountsWrapper {
 
   getStorageConfig() {
     return getStorageConfig()
+  }
+
+  async writeLoginState(dataDir: string, name: string): Promise<void> {
+    return writeLoginState(dataDir, name)
   }
 
   async list(): Promise<AccountEntry[]> {
@@ -130,7 +135,13 @@ export class AccountsWrapper implements IAccountsWrapper {
     fs.unlinkSync(path.join(basedir, name))
   }
 
-  async set(name: string): Promise<void> {
+  async set(name: string, dataDir: string): Promise<void> {
+    const config = this.getStorageConfig()
+    if (config.credentialStore) {
+      await this.writeLoginState(dataDir, name)
+      return
+    }
+
     const netrcInstance = await this.initNetrc()
     const current = this.account(name)
     netrcInstance.machines['git.heroku.com'] = {login: current.username, password: current.password}

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -16,7 +16,7 @@ export interface IAccountsWrapper {
   current(heroku: APIClient): Promise<string | null>
   add(name: string, username: string, password: string): void
   remove(name: string): void
-  set(name: string, dataDir: string): Promise<void>
+  set(account: AccountEntry, dataDir: string): Promise<void>
   writeLoginState(configDir: string, name: string): Promise<void>
 }
 
@@ -135,18 +135,20 @@ export class AccountsWrapper implements IAccountsWrapper {
     fs.unlinkSync(path.join(basedir, name))
   }
 
-  async set(name: string, dataDir: string): Promise<void> {
+  async set(account: AccountEntry, dataDir: string): Promise<void> {
     const config = this.getStorageConfig()
-    if (config.credentialStore) {
-      await this.writeLoginState(dataDir, name)
+    if (config.credentialStore && !account.name) {
+      await this.writeLoginState(dataDir, account.username)
       return
     }
 
-    const netrcInstance = await this.initNetrc()
-    const current = this.account(name)
-    netrcInstance.machines['git.heroku.com'] = {login: current.username, password: current.password}
-    netrcInstance.machines['api.heroku.com'] = {login: current.username, password: current.password}
-    await netrcInstance.save()
+    if (config.useNetrc && account.name) {
+      const netrcInstance = await this.initNetrc()
+      const current = this.account(account.name)
+      netrcInstance.machines['git.heroku.com'] = {login: current.username, password: current.password}
+      netrcInstance.machines['api.heroku.com'] = {login: current.username, password: current.password}
+      await netrcInstance.save()
+    }
   }
 }
 

--- a/test/unit/commands/accounts/set.unit.test.ts
+++ b/test/unit/commands/accounts/set.unit.test.ts
@@ -22,7 +22,7 @@ describe('accounts:set', function () {
     listStub.resolves([{name: 'test-account', username: 'user1'}, {name: 'test-account-2', username: 'user2'}])
     await runCommand(Cmd, ['test-account-2'])
     expect(setStub.calledOnce).to.be.true
-    expect(setStub.firstCall.args[0]).to.equal('test-account-2')
+    expect(setStub.firstCall.args[0]).to.deep.equal({name: 'test-account-2', username: 'user2'})
     expect(setStub.firstCall.args[1].toLowerCase()).to.contain('local')
     expect(setStub.firstCall.args[1]).to.contain('heroku')
   })
@@ -31,16 +31,19 @@ describe('accounts:set', function () {
     listStub.resolves([{username: 'user1@example.com'}, {username: 'user2@example.com'}])
     await runCommand(Cmd, ['user1@example.com'])
     expect(setStub.calledOnce).to.be.true
-    expect(setStub.firstCall.args[0]).to.equal('user1@example.com')
+    expect(setStub.firstCall.args[0]).to.deep.equal({username: 'user1@example.com'})
     expect(setStub.firstCall.args[1].toLowerCase()).to.contain('local')
     expect(setStub.firstCall.args[1]).to.contain('heroku')
   })
 
   it('returns an error if the account is not in the list', async function () {
     listStub.resolves([{name: 'test-account', username: 'user1'}, {name: 'test-account-2', username: 'user2'}])
-    await runCommand(Cmd, ['test-account-3'])
-      .catch((error: Error) => {
-        expect(error.message).to.contain('test-account-3 does not exist in your accounts cache or system keychain.')
-      })
+
+    try {
+      await runCommand(Cmd, ['test-account-3'])
+      expect.fail('Expected command to throw error')
+    } catch (error: any) {
+      expect(error.message).to.contain('test-account-3 does not exist in your accounts cache or system keychain.')
+    }
   })
 })

--- a/test/unit/commands/accounts/set.unit.test.ts
+++ b/test/unit/commands/accounts/set.unit.test.ts
@@ -1,33 +1,44 @@
 import {expect} from 'chai'
-import runCommand from '../../../helpers/runCommand.js'
-import * as sinon from 'sinon'
+import {restore, SinonStub, stub} from 'sinon'
+
 import Cmd from '../../../../src/commands/accounts/set.js'
 import AccountsModule from '../../../../src/lib/accounts/accounts.js'
+import runCommand from '../../../helpers/runCommand.js'
 
 describe('accounts:set', function () {
-  let listStub: sinon.SinonStub
-  let setStub: sinon.SinonStub
+  let listStub: SinonStub
+  let setStub: SinonStub
 
   beforeEach(function () {
-    listStub = sinon.stub(AccountsModule, 'list')
-    setStub = sinon.stub(AccountsModule, 'set')
+    listStub = stub(AccountsModule, 'list')
+    setStub = stub(AccountsModule, 'set').resolves()
   })
 
   afterEach(function () {
-    sinon.restore()
+    restore()
   })
 
-  it('calls the set function with the account name when the account exists', async function () {
+  it('calls set with the account name and dataDir when matched by name', async function () {
     listStub.resolves([{name: 'test-account', username: 'user1'}, {name: 'test-account-2', username: 'user2'}])
     await runCommand(Cmd, ['test-account-2'])
-    expect(setStub.calledWith('test-account-2'))
+    expect(setStub.calledOnce).to.be.true
+    expect(setStub.firstCall.args[0]).to.equal('test-account-2')
+    expect(setStub.firstCall.args[1]).to.contain('.local/share/heroku')
   })
 
-  it('should return an error if the selected account name is not included in the account list', async function () {
+  it('calls set with the account name and dataDir when matched by username', async function () {
+    listStub.resolves([{username: 'user1@example.com'}, {username: 'user2@example.com'}])
+    await runCommand(Cmd, ['user1@example.com'])
+    expect(setStub.calledOnce).to.be.true
+    expect(setStub.firstCall.args[0]).to.equal('user1@example.com')
+    expect(setStub.firstCall.args[1]).to.contain('.local/share/heroku')
+  })
+
+  it('returns an error if the account is not in the list', async function () {
     listStub.resolves([{name: 'test-account', username: 'user1'}, {name: 'test-account-2', username: 'user2'}])
     await runCommand(Cmd, ['test-account-3'])
       .catch((error: Error) => {
-        expect(error.message).to.contain('test-account-3 does not exist in your accounts cache.')
+        expect(error.message).to.contain('test-account-3 does not exist in your accounts cache or system keychain.')
       })
   })
 })

--- a/test/unit/commands/accounts/set.unit.test.ts
+++ b/test/unit/commands/accounts/set.unit.test.ts
@@ -23,7 +23,8 @@ describe('accounts:set', function () {
     await runCommand(Cmd, ['test-account-2'])
     expect(setStub.calledOnce).to.be.true
     expect(setStub.firstCall.args[0]).to.equal('test-account-2')
-    expect(setStub.firstCall.args[1]).to.contain('.local/share/heroku')
+    expect(setStub.firstCall.args[1].toLowerCase()).to.contain('local')
+    expect(setStub.firstCall.args[1]).to.contain('heroku')
   })
 
   it('calls set with the account name and dataDir when matched by username', async function () {
@@ -31,7 +32,8 @@ describe('accounts:set', function () {
     await runCommand(Cmd, ['user1@example.com'])
     expect(setStub.calledOnce).to.be.true
     expect(setStub.firstCall.args[0]).to.equal('user1@example.com')
-    expect(setStub.firstCall.args[1]).to.contain('.local/share/heroku')
+    expect(setStub.firstCall.args[1].toLowerCase()).to.contain('local')
+    expect(setStub.firstCall.args[1]).to.contain('heroku')
   })
 
   it('returns an error if the account is not in the list', async function () {

--- a/test/unit/lib/accounts/accounts.unit.test.ts
+++ b/test/unit/lib/accounts/accounts.unit.test.ts
@@ -164,7 +164,7 @@ describe('accounts', function () {
   })
 
   describe('set()', function () {
-    describe('with credentialStore', function () {
+    describe('with credentialStore and no account name', function () {
       let writeLoginStateStub: sinon.SinonStub
 
       beforeEach(function () {
@@ -172,16 +172,24 @@ describe('accounts', function () {
         writeLoginStateStub = sinon.stub(AccountsModule, 'writeLoginState').resolves()
       })
 
-      it('calls writeLoginState with the dataDir and account name', async function () {
-        await AccountsModule.set('my-account', '/data/heroku')
+      it('calls writeLoginState with the dataDir and account username', async function () {
+        const account = {username: 'user@example.com'}
+        await AccountsModule.set(account, '/data/heroku')
 
         expect(writeLoginStateStub.calledOnce).to.be.true
         expect(writeLoginStateStub.firstCall.args[0]).to.equal('/data/heroku')
-        expect(writeLoginStateStub.firstCall.args[1]).to.equal('my-account')
+        expect(writeLoginStateStub.firstCall.args[1]).to.equal('user@example.com')
+      })
+
+      it('does not call writeLoginState when account has a name', async function () {
+        const account = {name: 'my-account', username: 'user@example.com'}
+        await AccountsModule.set(account, '/data/heroku')
+
+        expect(writeLoginStateStub.called).to.be.false
       })
     })
 
-    describe('without credentialStore', function () {
+    describe('with useNetrc and account name', function () {
       let fakeNetrc: {machines: Record<string, {login: string, password: string}>, save: sinon.SinonStub}
 
       function setNetrc(value: typeof fakeNetrc | undefined) {
@@ -189,6 +197,7 @@ describe('accounts', function () {
       }
 
       beforeEach(function () {
+        sinon.stub(AccountsModule, 'getStorageConfig').returns({credentialStore: null, useNetrc: true})
         fakeNetrc = {machines: {}, save: sinon.stub().resolves()}
         setNetrc(fakeNetrc)
         fsReadFileStub.withArgs(sinon.match(/my-account$/), 'utf8')
@@ -200,16 +209,25 @@ describe('accounts', function () {
       })
 
       it('writes credentials to api.heroku.com and git.heroku.com machines', async function () {
-        await AccountsModule.set('my-account', '/data/heroku')
+        const account = {name: 'my-account', username: 'user@example.com'}
+        await AccountsModule.set(account, '/data/heroku')
 
         expect(fakeNetrc.machines['api.heroku.com']).to.deep.equal({login: 'user@example.com', password: 'secret'})
         expect(fakeNetrc.machines['git.heroku.com']).to.deep.equal({login: 'user@example.com', password: 'secret'})
       })
 
       it('saves the netrc file', async function () {
-        await AccountsModule.set('my-account', '/data/heroku')
+        const account = {name: 'my-account', username: 'user@example.com'}
+        await AccountsModule.set(account, '/data/heroku')
 
         expect(fakeNetrc.save.calledOnce).to.be.true
+      })
+
+      it('does not update netrc when account has no name', async function () {
+        const account = {username: 'user@example.com'}
+        await AccountsModule.set(account, '/data/heroku')
+
+        expect(fakeNetrc.save.called).to.be.false
       })
     })
   })

--- a/test/unit/lib/accounts/accounts.unit.test.ts
+++ b/test/unit/lib/accounts/accounts.unit.test.ts
@@ -163,6 +163,57 @@ describe('accounts', function () {
     })
   })
 
+  describe('set()', function () {
+    describe('with credentialStore', function () {
+      let writeLoginStateStub: sinon.SinonStub
+
+      beforeEach(function () {
+        sinon.stub(AccountsModule, 'getStorageConfig').returns({credentialStore: 'keychain' as any, useNetrc: false})
+        writeLoginStateStub = sinon.stub(AccountsModule, 'writeLoginState').resolves()
+      })
+
+      it('calls writeLoginState with the dataDir and account name', async function () {
+        await AccountsModule.set('my-account', '/data/heroku')
+
+        expect(writeLoginStateStub.calledOnce).to.be.true
+        expect(writeLoginStateStub.firstCall.args[0]).to.equal('/data/heroku')
+        expect(writeLoginStateStub.firstCall.args[1]).to.equal('my-account')
+      })
+    })
+
+    describe('without credentialStore', function () {
+      let fakeNetrc: {machines: Record<string, {login: string, password: string}>, save: sinon.SinonStub}
+
+      function setNetrc(value: typeof fakeNetrc | undefined) {
+        (AccountsModule as unknown as {netrc: typeof fakeNetrc | undefined}).netrc = value
+      }
+
+      beforeEach(function () {
+        fakeNetrc = {machines: {}, save: sinon.stub().resolves()}
+        setNetrc(fakeNetrc)
+        fsReadFileStub.withArgs(sinon.match(/my-account$/), 'utf8')
+          .returns('username: user@example.com\npassword: secret\n')
+      })
+
+      afterEach(function () {
+        setNetrc(null as unknown as typeof fakeNetrc)
+      })
+
+      it('writes credentials to api.heroku.com and git.heroku.com machines', async function () {
+        await AccountsModule.set('my-account', '/data/heroku')
+
+        expect(fakeNetrc.machines['api.heroku.com']).to.deep.equal({login: 'user@example.com', password: 'secret'})
+        expect(fakeNetrc.machines['git.heroku.com']).to.deep.equal({login: 'user@example.com', password: 'secret'})
+      })
+
+      it('saves the netrc file', async function () {
+        await AccountsModule.set('my-account', '/data/heroku')
+
+        expect(fakeNetrc.save.calledOnce).to.be.true
+      })
+    })
+  })
+
   describe('remove', function () {
     let unlinkStub: sinon.SinonStub
     let osHomeStub: sinon.SinonStub


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
Updates the `accounts:set` command to work with keychain managers.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
<!-- Add any context/setup necessary for testing. -->
1. Check out this branch and run `npm i && npm run build`
2. Run `./bin/run login` to log in to your first account.
3. Run `heroku accounts:add account1` to add this account to your accounts cache for .netrc
4. Logout of this account in the browser and then log in to a second account
5. Run `./bin/run login` to log in to your second account
6. Run `heroku accounts:add account2` to add this second account to your accounts cache for .netrc

**Steps**:
1. Run `./bin/run accounts:set <username for account 1>`
2. Run `./bin/run apps` and you should see the apps for account 1
3. Run `./bin/run accounts:set <username for account 2>`
4. Run `./bin/run apps` and you should see the apps for account 2
5. Run `HEROKU_NETRC_WRITE=true ./bin/run accounts:set account1`
6. Run `HEROKU_NETRC_WRITE=true ./bin/run apps` and you should see the apps for account 1
7. Run `HEROKU_NETRC_WRITE=true ./bin/run accounts:set account2`
8. Run `HEROKU_NETRC_WRITE=true ./bin/run apps` and you should see the apps for account 2

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-20867209](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Sjj7rYAB/view)
