### PR TITLE
fix: restore git configuration on logout

### DIFF
--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -27,6 +27,7 @@ export default class Login extends Command {
     const git = new Git()
     try {
       await git.configureCredentialHelper()
+      await git.eraseCredentials()
     } catch {
       // ignore
     }

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -2,6 +2,8 @@
 import {Command} from '@heroku-cli/command'
 import {ux} from '@oclif/core/ux'
 
+import Git from '../../lib/git/git.js'
+
 export default class Logout extends Command {
   static aliases = ['logout']
   static baseFlags = Command.baseFlagsWithoutPrompt()
@@ -13,6 +15,15 @@ export default class Logout extends Command {
 
     ux.action.start('Logging out')
     await this.heroku.logout()
+
+    const git = new Git()
+    try {
+      await git.removeCredentialHelper()
+      await git.eraseCredentials()
+    } catch {
+      // ignore
+    }
+
     await this.config.runHook('recache', {type: 'logout'})
     ux.action.stop()
   }

--- a/src/commands/ci/config/unset.ts
+++ b/src/commands/ci/config/unset.ts
@@ -38,7 +38,7 @@ export default class CiConfigUnset extends Command {
 
     await ux.action.start(`Unsetting ${Object.keys(vars).join(', ')}`)
 
-    setPipelineConfigVars(this.heroku, pipeline.id, vars)
+    await setPipelineConfigVars(this.heroku, pipeline.id, vars)
 
     ux.action.stop()
   }

--- a/src/commands/git/credentials.ts
+++ b/src/commands/git/credentials.ts
@@ -27,7 +27,7 @@ export class GitCredentials extends Command {
 
       rl.on('line', (line: string) => {
         if (!line.trim()) {
-          setImmediate(() => rl.close())
+          rl.close()
           return
         }
 

--- a/src/lib/git/git.ts
+++ b/src/lib/git/git.ts
@@ -27,10 +27,16 @@ export default class Git {
     }
   }
 
-  public spawn(args: string[]) {
+  public spawn(args: string[], options: {stdio?: cp.StdioOptions; input?: string} = {}) {
     return new Promise((resolve, reject) => {
       gitDebug('spawn: git %o', args)
-      const s = cp.spawn('git', args, {stdio: [0, 1, 2]})
+      const s = cp.spawn('git', args, {stdio: options.stdio ?? [0, 1, 2]})
+
+      if (options.input && s.stdin) {
+        s.stdin.write(options.input)
+        s.stdin.end()
+      }
+
       s.on('error', (err: Error & {code?: string}) => {
         if (err.code === 'ENOENT') {
           try {
@@ -120,6 +126,21 @@ export default class Git {
       `credential.https://${httpGitHost}.helper`,
       '!heroku git:credentials',
     ])
+  }
+
+  /** Removes `heroku git:credentials` from the global config */
+  async removeCredentialHelper() {
+    const {httpGitHost} = vars
+    await this.exec(['config', '--global', '--unset-all', `credential.https://${httpGitHost}.helper`])
+  }
+
+  /** Erases stored credentials for the Heroku Git host */
+  async eraseCredentials() {
+    const {httpGitHost} = vars
+    await this.spawn(['credential', 'reject'], {
+      stdio: ['pipe', 'ignore', 'ignore'],
+      input: `protocol=https\nhost=${httpGitHost}\n\n`,
+    })
   }
 }
 

--- a/test/unit/commands/auth/login.unit.test.ts
+++ b/test/unit/commands/auth/login.unit.test.ts
@@ -11,6 +11,7 @@ import {runCommand} from '../../../helpers/run-command.js'
 describe('auth:login', function () {
   let api: nock.Scope
   let configureCredentialHelperStub: sinon.SinonStub
+  let eraseCredentialsStub: sinon.SinonStub
   let loginStub: sinon.SinonStub
   let savedApiKey: string | undefined
 
@@ -21,6 +22,7 @@ describe('auth:login', function () {
     delete process.env.HEROKU_API_KEY
 
     configureCredentialHelperStub = sinon.stub(Git.prototype, 'configureCredentialHelper').resolves()
+    eraseCredentialsStub = sinon.stub(Git.prototype, 'eraseCredentials').resolves()
     loginStub = sinon.stub(APIClient.prototype, 'login').resolves()
   })
 
@@ -33,6 +35,7 @@ describe('auth:login', function () {
     }
 
     configureCredentialHelperStub.restore()
+    eraseCredentialsStub.restore()
     loginStub.restore()
   })
 
@@ -58,12 +61,25 @@ describe('auth:login', function () {
     expect(configureCredentialHelperStub.calledOnce).to.be.true
   })
 
-  it('does not configure git credential helper if not logged in', async function () {
+  it('rejects stale git credentials after successful login', async function () {
+    api
+      .get('/account')
+      .reply(200, {
+        email: 'user@example.com',
+      })
+
+    await runCommand(Login, [])
+
+    expect(eraseCredentialsStub.calledOnce).to.be.true
+  })
+
+  it('does not perform git operations if not logged in', async function () {
     loginStub.rejects(new Error('Not logged in'))
 
     await runCommand(Login, [])
 
     expect(configureCredentialHelperStub.notCalled).to.be.true
+    expect(eraseCredentialsStub.notCalled).to.be.true
   })
 
   it('does not fail login if git credential helper configuration fails', async function () {
@@ -79,5 +95,20 @@ describe('auth:login', function () {
 
     expect(error).to.be.undefined
     expect(configureCredentialHelperStub.calledOnce).to.be.true
+  })
+
+  it('does not fail login if git credential deletion fails', async function () {
+    eraseCredentialsStub.rejects(new Error('Git not found'))
+
+    api
+      .get('/account')
+      .reply(200, {
+        email: 'user@example.com',
+      })
+
+    const {error} = await runCommand(Login, [])
+
+    expect(error).to.be.undefined
+    expect(eraseCredentialsStub.calledOnce).to.be.true
   })
 })

--- a/test/unit/commands/auth/logout.unit.test.ts
+++ b/test/unit/commands/auth/logout.unit.test.ts
@@ -1,11 +1,46 @@
 import {expect} from 'chai'
+import sinon from 'sinon'
 
 import Logout from '../../../../src/commands/auth/logout.js'
+import Git from '../../../../src/lib/git/git.js'
 import {runCommand} from '../../../helpers/run-command.js'
 
 describe('auth:logout', function () {
+  let eraseCredentialsStub: sinon.SinonStub
+  let removeCredentialHelperStub: sinon.SinonStub
+
+  beforeEach(function () {
+    eraseCredentialsStub = sinon.stub(Git.prototype, 'eraseCredentials').resolves()
+    removeCredentialHelperStub = sinon.stub(Git.prototype, 'removeCredentialHelper').resolves()
+  })
+
+  afterEach(function () {
+    eraseCredentialsStub.restore()
+    removeCredentialHelperStub.restore()
+  })
+
   it('shows cli logging user out', async function () {
     const {stderr} = await runCommand(Logout, [])
     expect(stderr).to.equal('Logging out... done\n')
+  })
+
+  it('removes git credential helper on logout', async function () {
+    await runCommand(Logout, [])
+
+    expect(removeCredentialHelperStub.calledOnce).to.be.true
+  })
+
+  it('erases stale git credentials on logout', async function () {
+    await runCommand(Logout, [])
+
+    expect(eraseCredentialsStub.calledOnce).to.be.true
+  })
+
+  it('does not fail logout if git operations fail', async function () {
+    eraseCredentialsStub.rejects(new Error('Git not found'))
+
+    const {error} = await runCommand(Logout, [])
+
+    expect(error).to.be.undefined
   })
 })

--- a/test/unit/commands/git/credentials.unit.test.ts
+++ b/test/unit/commands/git/credentials.unit.test.ts
@@ -36,9 +36,7 @@ describe('git:credentials', function () {
         getAuth: async () => ({account: 'test@example.com', token: 'test-token'}),
       })
 
-      setTimeout(() => {
-        stdin.send('protocol=https\nhost=git.heroku.com\n\n')
-      }, 0)
+      process.stdin.push('protocol=https\nhost=git.heroku.com\n\n')
 
       const {stdout, error} = await runCommand(Credentials, ['get'])
 
@@ -51,9 +49,7 @@ describe('git:credentials', function () {
         getAuth: async () => ({account: 'test@example.com', token: 'test-token'}),
       })
 
-      setTimeout(() => {
-        stdin.send('protocol=https\nhost=github.com\n\n')
-      }, 0)
+      process.stdin.push('protocol=https\nhost=github.com\n\n')
 
       const {stdout, error} = await runCommand(Credentials, ['get'])
 
@@ -66,9 +62,7 @@ describe('git:credentials', function () {
         getAuth: async () => ({account: 'test@example.com', token: 'test-token'}),
       })
 
-      setTimeout(() => {
-        stdin.send('protocol=http\nhost=git.heroku.com\n\n')
-      }, 0)
+      process.stdin.push('protocol=http\nhost=git.heroku.com\n\n')
 
       const {stdout, error} = await runCommand(Credentials, ['get'])
 
@@ -81,9 +75,7 @@ describe('git:credentials', function () {
         getAuth: async () => ({account: undefined, token: undefined}),
       })
 
-      setTimeout(() => {
-        stdin.send('protocol=https\nhost=git.heroku.com\n\n')
-      }, 0)
+      process.stdin.push('protocol=https\nhost=git.heroku.com\n\n')
 
       const {error} = await runCommand(Credentials, ['get'])
 
@@ -93,9 +85,7 @@ describe('git:credentials', function () {
 
   describe('store operation', function () {
     it('accepts input without error', async function () {
-      setTimeout(() => {
-        stdin.send('protocol=https\nhost=git.heroku.com\nusername=heroku\npassword=test-token\n\n')
-      }, 0)
+      process.stdin.push('protocol=https\nhost=git.heroku.com\nusername=heroku\npassword=test-token\n\n')
 
       const {error, stdout} = await runCommand(Credentials, ['store'])
 
@@ -106,9 +96,7 @@ describe('git:credentials', function () {
 
   describe('erase operation', function () {
     it('accepts input without error', async function () {
-      setTimeout(() => {
-        stdin.send('protocol=https\nhost=git.heroku.com\n\n')
-      }, 0)
+      process.stdin.push('protocol=https\nhost=git.heroku.com\n\n')
 
       const {error, stdout} = await runCommand(Credentials, ['erase'])
 

--- a/test/unit/lib/git/git.unit.test.ts
+++ b/test/unit/lib/git/git.unit.test.ts
@@ -130,4 +130,31 @@ describe('git', function () {
     expect(cmd).to.equal('git')
     expect(args).to.deep.equal(['config', '--global', 'credential.https://git.heroku.com.helper', '!heroku git:credentials'])
   })
+
+  it('removes git credential helper from global config', async function () {
+    execFileStub.resolves({stdout: '', stderr: ''})
+
+    await git.removeCredentialHelper()
+
+    expect(execFileStub.calledOnce).to.be.true
+    const [cmd, args] = execFileStub.firstCall.args
+    expect(cmd).to.equal('git')
+    expect(args).to.deep.equal(['config', '--global', '--unset-all', 'credential.https://git.heroku.com.helper'])
+  })
+
+  it('erases stored credentials for the Heroku Git host', async function () {
+    const emitter = new EventEmitter() as any
+    emitter.stdin = {write: sinon.stub(), end: sinon.stub()}
+    spawnStub.returns(emitter)
+
+    const erasePromise = git.eraseCredentials()
+
+    process.nextTick(() => emitter.emit('close', 0))
+
+    await erasePromise
+
+    expect(spawnStub.calledOnceWith('git', ['credential', 'reject'], {stdio: ['pipe', 'ignore', 'ignore']})).to.be.true
+    expect(emitter.stdin.write.calledOnceWith('protocol=https\nhost=git.heroku.com\n\n')).to.be.true
+    expect(emitter.stdin.end.calledOnce).to.be.true
+  })
 })


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
This PR restores the git configuration when a user runs `heroku logout`. It removes the global git credential helper and erases all credentials stored for `git.heroku.com`.

### Changes Made:
- Added `eraseCredentials()` to remove credentials for `git.heroku.com` from all configured git credential helpers
- Added `removeCredentialHelper()` to remove the URL-scoped git credential helper config for `git.heroku.com` from the global git config
- Updated `login.ts` to erase stale credentials after login, in case a user logs in to a different account without logging out first
- Updated `logout.ts` to erase credentials and remove the credential helper config on logout
- Updated tests in `git.unit.test.ts`, `login.unit.test.ts`, and `logout.unit.test.ts`

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes:**
You need access to a Heroku app with a git remote for testing `git push heroku main`. The test steps will temporarily replace your installed Heroku CLI with the local build and modify your global git config — both are restored in the cleanup steps.

**Steps:**
1. Pull down this branch
2. `heroku logout`
3. `npm install && npm run build`
4. `npm link` — replaces the installed version of Heroku with this local build
5. Restart the terminal
6. `which heroku` — confirm it shows a local/npm path rather than homebrew
7. `HEROKU_NATIVE_STORE_WRITE=true heroku login`
8. `git config --global credential.https://git.heroku.com.helper` — should return `!heroku git:credentials`
9. `cd` into a local app directory with a Heroku remote
10. `git push heroku main`
11. Check Keychain Access for a `git.heroku.com` entry
12. `heroku logout` 
13. Check Keychain Access for a `git.heroku.com` entry — should've been removed
14. `git config --global credential.https://git.heroku.com.helper` — should return nothing

**Cleanup:**
1. `npm unlink -g heroku`
2. `which heroku` — confirm the original Heroku path is restored
3. `heroku login` — re-authenticates and writes fresh credentials to `~/.netrc`

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-22418614](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002ZdjOtYAJ/view)