### PR TITLE
feat: update accounts:remove to work with credential manager

### DIFF
--- a/src/commands/accounts/remove.ts
+++ b/src/commands/accounts/remove.ts
@@ -17,14 +17,14 @@ export default class Remove extends Command {
     const {args} = await this.parse(Remove)
     const {name} = args
 
-    if (!(await AccountsModule.list()).some(account => account.name === name)) {
+    if (!(await AccountsModule.list()).some(account => account.name === name || account.username === name)) {
       ux.error(`${name} doesn't exist in your accounts cache.`)
     }
 
     if (await AccountsModule.current(this.heroku) === name) {
-      ux.error(`${name} is the current account.`)
+      ux.error(`${name} is the current account. To log out, run ${color.command('heroku logout')}.`)
     }
 
-    AccountsModule.remove(name)
+    await AccountsModule.remove(name)
   }
 }

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -1,4 +1,5 @@
-import {APIClient, listKeychainAccounts, getStorageConfig, removeAuth} from '@heroku-cli/command'
+import {APIClient, listKeychainAccounts, getStorageConfig} from '@heroku-cli/command'
+import {removeAuth} from '@heroku-cli/command/lib/credential-manager.js'
 import * as Heroku from '@heroku-cli/schema'
 import fs from 'node:fs'
 import os from 'node:os'
@@ -64,10 +65,6 @@ export class AccountsWrapper implements IAccountsWrapper {
     return getStorageConfig()
   }
 
-  removeKeychainAuth(account: string, hosts: string[]) {
-    return removeAuth(account, hosts)
-  }
-
   async list(): Promise<AccountEntry[]> {
     const config = this.getStorageConfig()
     if (config.credentialStore) {
@@ -125,7 +122,7 @@ export class AccountsWrapper implements IAccountsWrapper {
   async remove(name: string): Promise<void> {
     const config = this.getStorageConfig()
     if (config.credentialStore) {
-      await this.removeKeychainAuth(name, ['api.heroku.com', 'git.heroku.com'])
+      await removeAuth(name, ['api.heroku.com', 'git.heroku.com'])
       return
     }
 

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -1,4 +1,4 @@
-import {APIClient, listKeychainAccounts, getStorageConfig} from '@heroku-cli/command'
+import {APIClient, listKeychainAccounts, getStorageConfig, removeAuth} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import fs from 'node:fs'
 import os from 'node:os'
@@ -64,6 +64,10 @@ export class AccountsWrapper implements IAccountsWrapper {
     return getStorageConfig()
   }
 
+  removeKeychainAuth(account: string, hosts: string[]) {
+    return removeAuth(account, hosts)
+  }
+
   async list(): Promise<AccountEntry[]> {
     const config = this.getStorageConfig()
     if (config.credentialStore) {
@@ -87,7 +91,7 @@ export class AccountsWrapper implements IAccountsWrapper {
   }
 
   async current(heroku: APIClient): Promise<string | null> {
-    const config = getStorageConfig()
+    const config = this.getStorageConfig()
     if (config.credentialStore) {
       const authEntry = await heroku.getAuthEntry()
       return authEntry?.account ?? null
@@ -118,7 +122,13 @@ export class AccountsWrapper implements IAccountsWrapper {
     }
   }
 
-  remove(name: string): void {
+  async remove(name: string): Promise<void> {
+    const config = this.getStorageConfig()
+    if (config.credentialStore) {
+      await this.removeKeychainAuth(name, ['api.heroku.com', 'git.heroku.com'])
+      return
+    }
+
     const basedir = path.join(this.configDir(), 'accounts')
     fs.unlinkSync(path.join(basedir, name))
   }

--- a/test/unit/commands/accounts/remove.unit.test.ts
+++ b/test/unit/commands/accounts/remove.unit.test.ts
@@ -22,8 +22,9 @@ describe('accounts:remove', function () {
   it('calls the remove function with the account name when the account exists and it is not the current account', async function () {
     currentStub.resolves('test-account')
     listStub.resolves([{name: 'test-account', username: 'user1'}, {name: 'test-account-2', username: 'user2'}])
+    removeStub.resolves()
     await runCommand(Cmd, ['test-account-2'])
-    expect(removeStub.calledWith('test-account-2'))
+    expect(removeStub.calledWith('test-account-2')).to.be.true
   })
 
   it('should return an error if the selected account name is not included in the account list', async function () {

--- a/test/unit/lib/accounts/accounts.unit.test.ts
+++ b/test/unit/lib/accounts/accounts.unit.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import sinon from 'sinon'
 
 import AccountsModule from '../../../../src/lib/accounts/accounts.js'
+import {stubCredentialManager} from '../../../helpers/credential-manager-stub.js'
 
 describe('accounts', function () {
   let fsReaddirStub: sinon.SinonStub
@@ -197,37 +198,43 @@ describe('accounts', function () {
     })
 
     describe('with credentialStore', function () {
-      let removeKeychainAuthStub: sinon.SinonStub
+      let credStub: ReturnType<typeof stubCredentialManager>
+      let removeAuthStub: sinon.SinonStub
 
       beforeEach(function () {
-        removeKeychainAuthStub = sinon.stub(AccountsModule, 'removeKeychainAuth')
+        removeAuthStub = sinon.stub().resolves()
+        credStub = stubCredentialManager({
+          removeAuth: removeAuthStub,
+        })
         sinon.stub(AccountsModule, 'getStorageConfig').returns({credentialStore: 'keychain' as any, useNetrc: false})
       })
 
-      it('should call removeKeychainAuth with account name and hosts', async function () {
+      afterEach(function () {
+        credStub.restore()
+      })
+
+      it('should call removeAuth with account name and hosts', async function () {
         const accountName = 'test-account@example.com'
-        removeKeychainAuthStub.resolves()
 
         await AccountsModule.remove(accountName)
 
-        expect(removeKeychainAuthStub.calledOnce).to.be.true
-        expect(removeKeychainAuthStub.firstCall.args[0]).to.equal(accountName)
-        expect(removeKeychainAuthStub.firstCall.args[1]).to.deep.equal(['api.heroku.com', 'git.heroku.com'])
+        expect(removeAuthStub.calledOnce).to.be.true
+        expect(removeAuthStub.firstCall.args[0]).to.equal(accountName)
+        expect(removeAuthStub.firstCall.args[1]).to.deep.equal(['api.heroku.com', 'git.heroku.com'])
       })
 
       it('should not call unlinkSync when credentialStore is set', async function () {
         const accountName = 'test-account@example.com'
-        removeKeychainAuthStub.resolves()
 
         await AccountsModule.remove(accountName)
 
         expect(unlinkStub.called).to.be.false
       })
 
-      it('should throw an error if removeKeychainAuth fails', async function () {
+      it('should throw an error if removeAuth fails', async function () {
         const accountName = 'test-account@example.com'
         const error = new Error('Keychain removal failed')
-        removeKeychainAuthStub.rejects(error)
+        removeAuthStub.rejects(error)
 
         await expect(AccountsModule.remove(accountName)).to.be.rejectedWith('Keychain removal failed')
       })

--- a/test/unit/lib/accounts/accounts.unit.test.ts
+++ b/test/unit/lib/accounts/accounts.unit.test.ts
@@ -173,14 +173,14 @@ describe('accounts', function () {
       existsSyncStub = sinon.stub(fs, 'existsSync')
     })
 
-    it('should remove the account file with the given name', function () {
+    it('should remove the account file with the given name', async function () {
       const accountName = 'test-account'
       const basedir = '/user/home'
 
       osHomeStub.returns(basedir)
       existsSyncStub.returns(false)
 
-      AccountsModule.remove(accountName)
+      await AccountsModule.remove(accountName)
 
       expect(unlinkStub.calledOnce).to.be.true
       expect(unlinkStub.firstCall.args[0]).to.equal(
@@ -188,12 +188,49 @@ describe('accounts', function () {
       )
     })
 
-    it('should throw an error if the file cannot be removed', function () {
+    it('should throw an error if the file cannot be removed', async function () {
       const accountName = 'non-existent-account'
       const error = new Error('File not found')
       unlinkStub.throws(error)
 
-      expect(() => AccountsModule.remove(accountName)).to.throw(Error)
+      await expect(AccountsModule.remove(accountName)).to.be.rejectedWith(Error)
+    })
+
+    describe('with credentialStore', function () {
+      let removeKeychainAuthStub: sinon.SinonStub
+
+      beforeEach(function () {
+        removeKeychainAuthStub = sinon.stub(AccountsModule, 'removeKeychainAuth')
+        sinon.stub(AccountsModule, 'getStorageConfig').returns({credentialStore: 'keychain' as any, useNetrc: false})
+      })
+
+      it('should call removeKeychainAuth with account name and hosts', async function () {
+        const accountName = 'test-account@example.com'
+        removeKeychainAuthStub.resolves()
+
+        await AccountsModule.remove(accountName)
+
+        expect(removeKeychainAuthStub.calledOnce).to.be.true
+        expect(removeKeychainAuthStub.firstCall.args[0]).to.equal(accountName)
+        expect(removeKeychainAuthStub.firstCall.args[1]).to.deep.equal(['api.heroku.com', 'git.heroku.com'])
+      })
+
+      it('should not call unlinkSync when credentialStore is set', async function () {
+        const accountName = 'test-account@example.com'
+        removeKeychainAuthStub.resolves()
+
+        await AccountsModule.remove(accountName)
+
+        expect(unlinkStub.called).to.be.false
+      })
+
+      it('should throw an error if removeKeychainAuth fails', async function () {
+        const accountName = 'test-account@example.com'
+        const error = new Error('Keychain removal failed')
+        removeKeychainAuthStub.rejects(error)
+
+        await expect(AccountsModule.remove(accountName)).to.be.rejectedWith('Keychain removal failed')
+      })
     })
   })
 })


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
Updates the `accounts:remove` command to work with the credential manager.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
<!-- Add any context/setup necessary for testing. -->
1. Check out this branch and run `npm i && npm run build`
2. Run `./bin/run login` to log in to your first account.
3. Run `heroku accounts:add account1` to add this account to your accounts cache for .netrc
4. Logout of this account in the browser and then log in to a second account
5. Run `./bin/run login` to log in to your second account
6. Run `heroku accounts:add account2` to add this second account to your accounts cache for .netrc

**Steps**:
1. Run `./bin/run accounts` and you should see the email addresses for the two accounts
2. While logged in to account2, run `./bin/run accounts:remove <email address for account1>`
3. Run `./bin/run accounts` and you should only see the email address for account2
4. Run `HEROKU_NETRC_WRITE ./bin/run accounts` and you should see the email addresses for the two accounts again.
5. Run `HEROKU_NETRC_WRITE ./bin/run accounts:remove <email address for account1>`
6. Run `HEROKU_NETRC_WRITE ./bin/run accounts` and you should only see the email address for account2

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-22247998](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002YvbGIYAZ/view)
