### PR TITLE
fix: migrate release scripts from qqjs to script-exec helpers

### DIFF
--- a/scripts/release/win
+++ b/scripts/release/win
@@ -1,16 +1,11 @@
 #!/usr/bin/env node
 
-import qq from 'qqjs'
 import getVersion from '../utils/version.js'
+import {run, shell, x} from '../utils/script-exec.js'
 
-qq.config.silent = false
-qq.run(async () => {
+await run(async () => {
   const version = await getVersion()
-  await qq.x('./node_modules/.bin/oclif pack:win')
-  await qq.x(`mv dist/win/heroku-v${version}-x86.exe dist/win/heroku-v${version}-x86-unsigned.exe`)
-  await qq.x(`mv dist/win/heroku-v${version}-x64.exe dist/win/heroku-v${version}-x64-unsigned.exe`)
-  // await qq.x('echo "$HEROKU_WINDOWS_KEY" | base64 --decode > /tmp/heroku-windows-key')
-  // await qq.x(`osslsigncode -pkcs12 /tmp/heroku-windows-key -pass "$HEROKU_WINDOWS_SIGNING_PASS" -n 'Heroku CLI' -i https://toolbelt.heroku.com/ -h sha512 -in dist/win/heroku-v${version}-x86-unsigned.exe -out dist/win/heroku-v${version}-x86.exe`)
-  // await qq.x(`osslsigncode -pkcs12 /tmp/heroku-windows-key -pass "$HEROKU_WINDOWS_SIGNING_PASS" -n 'Heroku CLI' -i https://toolbelt.heroku.com/ -h sha512 -in dist/win/heroku-v${version}-x64-unsigned.exe -out dist/win/heroku-v${version}-x64.exe`)
-  // await qq.x('./node_modules/.bin/oclif upload:win')
+  await x('./node_modules/.bin/oclif', ['pack:win'])
+  await shell(`mv dist/win/heroku-v${version}-x86.exe dist/win/heroku-v${version}-x86-unsigned.exe`)
+  await shell(`mv dist/win/heroku-v${version}-x64.exe dist/win/heroku-v${version}-x64-unsigned.exe`)
 })

--- a/scripts/upload/deb
+++ b/scripts/upload/deb
@@ -1,12 +1,11 @@
 #!/usr/bin/env node
 
-import qq from 'qqjs'
 import getHerokuS3Bucket from '../utils/get-heroku-s3-bucket.js'
+import {run, shell, x} from '../utils/script-exec.js'
 
-qq.config.silent = false
-qq.run(async () => {
-  await qq.x('./node_modules/.bin/oclif upload:deb')
+await run(async () => {
+  await x('./node_modules/.bin/oclif', ['upload:deb'])
   const HEROKU_S3_BUCKET = await getHerokuS3Bucket()
 
-  await qq.x(`aws s3 cp --content-type text/plain --cache-control "max-age: 604800" /home/runner/work/cli/cli/dist/apt/release.key "s3://${HEROKU_S3_BUCKET}/channels/stable/apt/release.key"`)
+  await shell(`aws s3 cp --content-type text/plain --cache-control "max-age: 604800" /home/runner/work/cli/cli/dist/apt/release.key "s3://${HEROKU_S3_BUCKET}/channels/stable/apt/release.key"`)
 })


### PR DESCRIPTION
## Summary

Removes a release-time regression by migrating the remaining `qqjs`-based scripts to the shared `script-exec` helpers, aligning release automation with the repo’s [execa migration](https://github.com/heroku/cli/commit/ad81615b2d4e6bd470be5ef10b3d35f94d8bed40). This scope is limited to packaging/upload scripts used by prerelease/release flows.

- **Migrate** `scripts/upload/deb` from `qqjs` to `run`/`x`/`shell` in `scripts/utils/script-exec.js`
- **Migrate** `scripts/release/win` from `qqjs` to `run`/`x`/`shell` in `scripts/utils/script-exec.js`
- **Remove** legacy `qqjs` execution calls and switch to argument-safe `x('./node_modules/.bin/oclif', [...])` usage
- **Fix** prerelease packaging failure in `pack-upload / upload-deb-and-tarballs` caused by missing `qqjs` at runtime

## Type of Change

- [x] **fix**: Bug fix or issue (patch semvar update)
- [ ] **feat**: Introduces a new feature to the codebase (minor semvar update)
- [ ] **perf**: Performance improvement
- [ ] **docs**: Documentation only changes
- [ ] **tests**: Adding missing tests or correcting existing tests
- [ ] **chore**: Code cleanup tasks, dependency updates, or other changes

## Verification

```bash
npm ci
npm run lint
```

```bash
# Optional targeted script smoke checks
node ./scripts/upload/deb
node ./scripts/release/win
```

```bash
# Full validation via CI path
# Trigger start-prerelease and confirm:
# create-prerelease / pack-upload / upload-deb-and-tarballs succeeds
```

## Additional Context

- **Root cause:** `scripts/upload/deb` and `scripts/release/win` still imported `qqjs` after `qqjs` was removed in the execa migration commit.
- **Risk:** low; behavior is preserved while swapping execution helpers.
- **Breaking:** none.