### PR TITLE
fix: inherit secrets in reusable workflow

### DIFF
--- a/.github/workflows/create-cli-release.yml
+++ b/.github/workflows/create-cli-release.yml
@@ -61,6 +61,7 @@ jobs:
     if: ${{ fromJSON(needs.get-version-channel.outputs.isStableRelease) }}
     ## Calls publish-to-fig-autocomplete workflow during post release jobs
     uses: ./.github/workflows/publish-to-fig-autocomplete.yml
+    secrets: inherit
 
   publish-docs:
     needs: [get-version-channel, promote]


### PR DESCRIPTION
## Summary

This change updates the release workflow so the reusable Fig autocomplete publish job receives inherited secrets during stable releases, for [example](https://github.com/heroku/cli/actions/runs/25828312619/job/75888655436). The scope is limited to CI workflow wiring to prevent post-release failures caused by missing secrets.

- **Fix** secret propagation for the `publish-to-fig-autocomplete` reusable workflow call
- **Update** `.github/workflows/create-cli-release.yml` to include `secrets: inherit` on that job

## Type of Change

- [x] **fix**: Bug fix or issue (patch semvar update)
- [ ] **feat**: Introduces a new feature to the codebase (minor semvar update)
- [ ] **perf**: Performance improvement
- [ ] **docs**: Documentation only changes
- [ ] **tests**: Adding missing tests or correcting existing tests
- [ ] **chore**: Code cleanup tasks, dependency updates, or other changes

## Verification

Confirmed the workflow now passes inherited secrets to the reusable `publish-to-fig-autocomplete` job.

## Additional Context

- **Breaking:** none
- **Risk:** low; scoped to a single workflow job configuration
- **Expected impact:** avoids failures in post-release autocomplete publishing when secrets are required

## Related Issue

Closes #[Github issue number]