### PR TITLE
refactor: use @heroku/sdk for maintenance commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2669,7 +2669,7 @@
     },
     "node_modules/@heroku/sdk": {
       "version": "0.2.0",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#4af40e64f30c593f671888ed7115ad000720acb1",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#c00ebbecdaff16260fa0a1b66d4ae82af8196e7c",
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku/api-client": "github:heroku/heroku-fetch",

--- a/src/commands/maintenance/index.ts
+++ b/src/commands/maintenance/index.ts
@@ -1,5 +1,5 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
+import {createPlatformClient} from '@heroku/sdk/platform'
 import {ux} from '@oclif/core/ux'
 
 export default class MaintenanceIndex extends Command {
@@ -12,8 +12,8 @@ export default class MaintenanceIndex extends Command {
 
   async run() {
     const {flags} = await this.parse(MaintenanceIndex)
-    const appResponse = await this.heroku.get<Heroku.App>(`/apps/${flags.app}`)
-    const app = appResponse.body
+    const heroku = createPlatformClient()
+    const app = await heroku.app.info(flags.app)
     ux.stdout(app.maintenance ? 'on' : 'off')
   }
 }

--- a/src/commands/maintenance/off.ts
+++ b/src/commands/maintenance/off.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {disableMaintenanceMode} from '@heroku/sdk/compositions/app'
 import {ux} from '@oclif/core/ux'
 
 export default class MaintenanceOff extends Command {
@@ -14,7 +14,7 @@ export default class MaintenanceOff extends Command {
   async run() {
     const {flags} = await this.parse(MaintenanceOff)
     ux.action.start(`Disabling maintenance mode for ${color.app(flags.app)}`)
-    await this.heroku.patch<Heroku.App>(`/apps/${flags.app}`, {body: {maintenance: false}})
+    await disableMaintenanceMode(flags.app)
     ux.action.stop()
   }
 }

--- a/src/commands/maintenance/on.ts
+++ b/src/commands/maintenance/on.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {enableMaintenanceMode} from '@heroku/sdk/compositions/app'
 import {ux} from '@oclif/core/ux'
 
 export default class MaintenanceOn extends Command {
@@ -14,7 +14,7 @@ export default class MaintenanceOn extends Command {
   async run() {
     const {flags} = await this.parse(MaintenanceOn)
     ux.action.start(`Enabling maintenance mode for ${color.app(flags.app)}`)
-    await this.heroku.patch<Heroku.App>(`/apps/${flags.app}`, {body: {maintenance: true}})
+    await enableMaintenanceMode(flags.app)
     ux.action.stop()
   }
 }

--- a/test/helpers/init.mjs
+++ b/test/helpers/init.mjs
@@ -3,10 +3,6 @@ import chaiAsPromised from 'chai-as-promised'
 import nock from 'nock'
 import path from 'node:path'
 
-globalThis.setInterval = () => ({unref() {}})
-const tm = globalThis.setTimeout
-globalThis.setTimeout = cb => tm(cb)
-
 process.env.TS_NODE_PROJECT = path.resolve('test/tsconfig.json')
 // Env var used to prevent some expensive
 // prerun and postrun hooks from initializing

--- a/test/unit/commands/maintenance/off.unit.test.ts
+++ b/test/unit/commands/maintenance/off.unit.test.ts
@@ -19,7 +19,7 @@ describe('maintenance:off', function () {
   it('turns maintenance mode off', async function () {
     api
       .patch('/apps/myapp', {maintenance: false})
-      .reply(200)
+      .reply(200, {maintenance: false})
 
     const {stderr, stdout} = await runCommand(Off, ['-a', 'myapp'])
 

--- a/test/unit/commands/maintenance/on.unit.test.ts
+++ b/test/unit/commands/maintenance/on.unit.test.ts
@@ -19,7 +19,7 @@ describe('maintenance:on', function () {
   it('turns maintenance mode on', async function () {
     api
       .patch('/apps/myapp', {maintenance: true})
-      .reply(200)
+      .reply(200, {maintenance: true})
 
     const {stderr, stdout} = await runCommand(On, ['-a', 'myapp'])
 


### PR DESCRIPTION
## Summary
- Replace direct Platform API calls in `maintenance:on`, `maintenance:off`, and `maintenance` (status) with `@heroku/sdk` equivalents: `enableMaintenanceMode`, `disableMaintenanceMode`, and `createPlatformClient().app.info()`.
- Bump `@heroku/sdk` to the commit that ships a `prepare` script so the SDK's `dist/` folder is built when installed from GitHub.
- Remove a `setTimeout`/`setInterval` stub in `test/helpers/init.mjs` that forced ky's internal timeout to fire immediately and triggered fetch-retry loops against nock.

## Type of Change
- [x] **refactor**: Refactoring existing code without changing behavior

## Testing
**Notes**: SDK calls hit the same endpoints with the same payloads as before, so existing nock fixtures still apply. Tests now reply with a JSON body (`{maintenance: true|false}`) since the SDK dispatcher calls `response.json()`.

**Steps**:
1. `npm test` — unit suite passes.
2. Manually verify via `./bin/run.js` against a test app: `maintenance:on`, `maintenance`, `maintenance:off`.

## Related Issues
GUS work item: [W-22265433](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Z0UrJYAV/view)