### PR TITLE
fix: add missing warning to 'data:pg:migrate' (W-22544849)

### DIFF
--- a/src/commands/data/pg/migrate.ts
+++ b/src/commands/data/pg/migrate.ts
@@ -170,6 +170,7 @@ export default class DataPgMigrate extends BaseCommand {
     let currentStep = '__select_source'
     let sourceDatabaseId: string | undefined
     let targetDatabaseId: string | undefined
+    let targetDatabaseName: string | undefined
 
     while (currentStep !== '__exit') {
       switch (currentStep) {
@@ -181,6 +182,7 @@ export default class DataPgMigrate extends BaseCommand {
           You'll receive an email when the preparation is complete or if there's an error.
           You have 24 hours to begin migration after the preparation is complete.
           Your source database will be unavailable during the migration.
+          Preparing the migration deletes all the data on the destination database ${color.datastore(targetDatabaseName!)}.
 
         `))
           const {action} = await this.prompt<{action: string}>({
@@ -281,6 +283,7 @@ export default class DataPgMigrate extends BaseCommand {
             name: 'database',
             type: 'list',
           })).database
+          targetDatabaseName = this.advancedDatabases.find(db => db.id === targetDatabaseId)?.name
 
           if (targetDatabaseId === '__go_back') {
             currentStep = '__select_source'
@@ -288,6 +291,7 @@ export default class DataPgMigrate extends BaseCommand {
             const addon = await this.createTargetDatabase(sourceDatabaseId!)
             if (addon) {
               targetDatabaseId = addon.id
+              targetDatabaseName = addon.name
               currentStep = '__confirm_migration'
             } else {
               currentStep = '__select_target'

--- a/test/unit/commands/data/pg/migrate.unit.test.ts
+++ b/test/unit/commands/data/pg/migrate.unit.test.ts
@@ -368,6 +368,7 @@ describe('data:pg:migrate', function () {
 
       // Verify the confirmation message is shown
       expect(stdout).to.contain('By continuing, we prepare the necessary steps for the migration.')
+      expect(stdout).to.contain('Preparing the migration deletes all the data on the destination database ⛁ postgresql-obscured-12345.')
       expect(stderr).to.equal('Configuring migration... done\n')
       // Verify the new migration is shown on the configured migrations table
       expect(stdout).to.match(/⛁ postgresql-convex-12345\s+⛁ postgresql-obscured-12345\s+Preparing/)


### PR DESCRIPTION
## Summary

The 'data:pg:migration' flow resets the target database when starting to prepare the tooling for the migration. We were requested to add a message that clearly states that risk on the interactive confirmation stage.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [X] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [X] **test**: Add/update/remove tests

## Testing

In order to test it's required to have at least a classic database (Standard, Premium, etc.) and an Advanced database available on the same app.

**Steps**:
1. Checkout this branch and then run ```npm install && npm run build```.
2. Run `./bin/run data:pg:migrate --app test-app` using the interactive flow to select the source and destination databases. On the confirmation prompt, check that the legend `Preparing the migration deletes all the data on the destination database ${addon.name}.` is shown.

## Screenshots (if applicable)

<img width="1117" height="636" alt="Captura de pantalla 2026-05-18 a la(s) 15 18 03" src="https://github.com/user-attachments/assets/f32d2c5e-60b7-4757-ae9f-e68183f38dce" />

## Related Issues

GUS work item: [W-22544849](https://gus.lightning.force.com/a07EE00002aILtMYAW)
