### PR TITLE
refactor: updates apps and apps:create commands to use sdk

### DIFF
--- a/.claude/skills/sdk-command-migration/SKILL.md
+++ b/.claude/skills/sdk-command-migration/SKILL.md
@@ -67,8 +67,18 @@ Save the `tsc` baseline. Any errors present here are NOT your responsibility —
 ### Step P3: Verify the command's call surface
 
 Read the target command file. Confirm:
-- The command uses raw `this.heroku.<verb>(path)` calls (otherwise this skill doesn't apply).
+- The command makes Platform/Data API calls. They may appear in one of two shapes:
+  - **Direct**: `this.heroku.<verb>(path, ...)` inside `run()`. The codemod handles these.
+  - **Helper-threaded**: `run()` passes `this.heroku` (an `APIClient`) into helper functions that call `heroku.<verb>(path, ...)`. The codemod will produce "no change" (it only matches the `this.heroku.<verb>` shape); follow Step 1.2a for these.
 - No call site streams a response, uses raw fetch, or sets custom auth (the codemod flags these but they may indicate this command needs manual migration).
+
+Quick diagnostic for the helper-threading shape:
+
+```bash
+grep -nE "(^|[^.])\bheroku\.(get|post|patch|put|delete)\(" src/commands/<command-path>.ts
+```
+
+A non-empty result with no `this.` prefix means at least one call site is in a helper that received `heroku` as a parameter — plan for manual migration.
 
 ---
 
@@ -119,8 +129,42 @@ The second argument to a write-method call wasn't a recognizable `{body: ...}` w
 **"this.heroku.<verb>(...) has an extra argument (request options?) ..."**
 The CLI passed http-call options the SDK doesn't accept. For data routes, a lone `{hostname: utils.pg.host()}` is dropped silently and won't appear here — anything that reaches this flag has additional unrecognized properties. If the call is hitting a non-default host (other than the Platform or Data hostname the SDK knows about), escalate. Otherwise, drop the unused options and replace manually.
 
+**Body silently dropped at runtime (route metadata gap)**
+The SDK's dispatcher only forwards a request body when the route metadata has `hasRequestBody: true`. If `@heroku/types` is missing that flag for a route, the generated SDK method's TS signature won't accept a body parameter *and* the dispatcher will silently drop any body you cast through. Symptoms: tests fail with "request body did not match" or the migrated PATCH/POST behaves as if it sent an empty payload. Diagnostic:
+
+```bash
+npx tsx -e "
+import {RouteIndex} from './scripts/codemods/sdk-migration/routes-index.ts';
+const r = RouteIndex.load().lookup('PATCH', '/apps/example/config-vars');
+console.log('hasRequestBody:', r?.entry.hasRequestBody, 'method:', r?.entry.resource + '.' + r?.entry.method);
+"
+```
+
+If `hasRequestBody` is `false` but the endpoint logically requires a body, the fix is upstream: the user (or you) needs to bump `@heroku/types` to a version where the route metadata is correct. Stop and ask the user before working around this — escape-hatching to the underlying client defeats the migration's purpose. Once the dependency is updated, re-run `npm install`, re-verify the diagnostic shows `hasRequestBody: true`, and refresh the Pre-flight P2 baseline (the bump may resolve unrelated `tsc` errors too).
+
 **`Warning: name collision with SDK service(s)`** (non-blocking)
 A local variable in `run()` shadows the destructured `data` or `platform` service. The codemod still produces the migration, but the inner scope's SDK calls will fail at runtime. Rename the local before merging.
+
+### Step 1.2a: Helper-threaded commands (codemod returned "no change")
+
+The codemod only rewrites `this.heroku.<verb>(...)` call sites. Some commands route API calls through private helpers and pass the `APIClient` as a parameter — the codemod produces "no change" for those because none of the call sites match its pattern. Migrate these by hand:
+
+1. **Convert helpers from `APIClient` to a `Platform` parameter.** At the top of the file (after the imports), declare:
+   ```ts
+   type Platform = HerokuSDK['platform']
+   ```
+   Then change each helper signature: replace `heroku: APIClient` with `platform: Platform` (or `data: HerokuSDK['data']` for data-service helpers). Inside the helper, replace each `heroku.<verb>(path, {body: x})` with the corresponding `platform.<resource>.<method>(...)` call — same lookup as Step 1.1 (use `scripts/codemods/sdk-migration/routes-index.ts` to find the resource/method for `(verb, path)`).
+2. **Construct the SDK once in `run()`.** Replace the original `this.heroku` thread with:
+   ```ts
+   const {platform} = new HerokuSDK()
+   ```
+   then pass `platform` to the helpers.
+3. **Drop the `APIClient` import** from `@heroku-cli/command` if it's no longer used; keep `Command` and `flags`.
+4. **Drop `{body: app}` destructure at call sites** the same way the codemod does for the simple shape. The SDK returns the body directly — `const app = await platform.app.create(params)`.
+
+For body shapes the codemod would have unwrapped, do the unwrap by hand. The pattern `await heroku.post<Heroku.App>('/apps', {body: params})` becomes `await platform.app.create(params)`. Cast to the `*CreateOpts` type from `@heroku/types/3.sdk` if the local body shape isn't structurally assignable.
+
+Both shapes (direct and helper-threaded) can coexist in the same command. If the codemod migrated some call sites and "no change"d others, finish the remaining ones manually using this step before moving on.
 
 ### Step 1.3: Type-check
 
@@ -143,12 +187,9 @@ Do NOT modify type files in `src/lib/types/` to satisfy a cast in a command file
 npx mocha 'test/unit/commands/<command-path>.unit.test.ts' --reporter min 2>&1 | tail -5
 ```
 
-Expected: same pass count as Pre-flight Step P2.
+The existing nock-based tests will likely fail at this stage with "Mocks not yet satisfied" or similar — the SDK uses `@heroku/heroku-fetch` (built on `undici`) which `nock` does not intercept on Node 20+. **Do not try to make these tests pass in Task 1.** Note the failure mode and move on to Task 2; the test rewrite is the fix.
 
-If tests fail, the most likely causes:
-- **The SDK call returns a slightly different shape** than the raw HTTP response. Adjust the post-call code (often: drop the `.body` destructuring) until the data flow matches what the test expects.
-- **An assertion checks specific URL shape**. Skip ahead to Task 2 — the rewrite will replace the assertion with an SDK-stub assertion anyway.
-- **The output formatting changed** because the SDK normalized a field. Verify against the original output format in version control before changing the assertion.
+The exception: if a test fails for a *different* reason (e.g., a TypeError thrown inside the migrated code), that's a real regression. Diagnose and fix before continuing. Useful filter: failures whose stack traces point into `src/commands/...` are real; failures whose only assertion is "Mocks not yet satisfied" or "expected … to include …" with empty output are nock-no-longer-intercepts noise.
 
 ### Step 1.5: Lint and commit Task 1
 
@@ -159,6 +200,12 @@ git commit -m "refactor: use @heroku/sdk for <command> command"
 ```
 
 Lint warnings that pre-existed are acceptable. Do NOT introduce new violations; if eslint flags something, fix it (or re-run with `--fix` for stylistic-only issues, then verify the autofix didn't change semantics).
+
+Common lint surprises on migrated files:
+- `n/no-extraneous-import` flags `import type {...} from '@heroku/types/3.sdk'`. The package is a transitive dependency, but the rule only complains about the type-only form. Drop the `type` modifier — `import {AppCreateOpts, ...} from '@heroku/types/3.sdk'` lints clean. Match the value-form pattern used in `src/commands/pipelines/create.ts`.
+- `@stylistic/operator-linebreak`, `@stylistic/object-curly-newline` — stylistic and autofixable. Run `npx eslint --fix` once, then re-lint to confirm no new errors.
+
+If the source migration required a `package.json`/`package-lock.json` bump (typically because of a route-metadata gap caught in Step 1.2), include the lockfile in this commit and explain the bump in the commit body. Don't split the lockfile change into its own commit — it's load-bearing for the source migration in the same PR.
 
 ---
 
@@ -272,14 +319,16 @@ Each PR migrates exactly one command. Don't bundle multiple command migrations �
 Before opening the PR:
 
 - [ ] No `this.heroku.<verb>` calls remain in the migrated file.
+- [ ] No bare `heroku.<verb>(...)` calls remain in helper functions (helper-threading shape — see Step 1.2a).
 - [ ] No `// TODO(sdk-migration):` markers remain.
 - [ ] No `import * as Heroku from '@heroku-cli/schema'` if no longer used.
+- [ ] No `import {APIClient} from '@heroku-cli/command'` if no longer used.
 - [ ] No `as unknown as X` cast where `as X` would suffice.
 - [ ] No new `tsc` errors (verify against the Pre-flight P2 baseline).
 - [ ] Tests rewritten per Task 2: `nock` removed, SDK stubbed via `HerokuSDK.prototype.platform`.
 - [ ] Lint clean on changed files.
-- [ ] One file changed per source commit; commit messages follow the convention.
-- [ ] No incidental edits to unrelated files (lockfile, type defs, sibling commands).
+- [ ] One source file changed per source commit; commit messages follow the convention. A `package-lock.json` bump driven by a route-metadata gap (Step 1.2) is allowed in the source commit and should be called out in the commit body.
+- [ ] No incidental edits to other unrelated files (type defs, sibling commands).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3111,8 +3111,8 @@
       }
     },
     "node_modules/@heroku/sdk": {
-      "version": "0.4.0",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#19e799844a066c17b32a137840ce4630f18215d2",
+      "version": "0.4.1",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#2185faf883eceec18f923853438bb2c252371fc0",
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku/heroku-fetch": "github:heroku/heroku-fetch#main",
@@ -3136,8 +3136,8 @@
       }
     },
     "node_modules/@heroku/types": {
-      "version": "0.2.0",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-types.git#79824d98bef9a78f2441d6b3c04b9eb9a060bb60",
+      "version": "0.3.2",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-types.git#3530cbcf5841869030b6d97069cd69864452ebcb",
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3111,8 +3111,8 @@
       }
     },
     "node_modules/@heroku/sdk": {
-      "version": "0.4.1",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#2185faf883eceec18f923853438bb2c252371fc0",
+      "version": "0.4.3",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#4a13a9fe2ee7e2a1a6d94b548926366bd95bd6a3",
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku/heroku-fetch": "github:heroku/heroku-fetch#main",
@@ -3136,8 +3136,8 @@
       }
     },
     "node_modules/@heroku/types": {
-      "version": "0.3.2",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-types.git#3530cbcf5841869030b6d97069cd69864452ebcb",
+      "version": "0.3.3",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-types.git#ab5c431bac52b5225c385777391e70d8e23bd5f9",
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {

--- a/src/commands/apps/create.ts
+++ b/src/commands/apps/create.ts
@@ -8,13 +8,15 @@ import {
 import {color, hux} from '@heroku/heroku-cli-util'
 import {HerokuSDK} from '@heroku/sdk'
 import {
-  App, AppCreateOpts, ConfigVarUpdateOpts, TeamAppCreateOpts,
+  AppCreateOpts, ConfigVarUpdateOpts, TeamAppCreateOpts,
 } from '@heroku/types/3.sdk'
 import {Args, Interfaces, ux} from '@oclif/core'
 import fs from 'fs-extra'
 
 import Git from '../../lib/git/git.js'
 import {lazyModuleLoader} from '../../lib/lazy-module-loader.js'
+
+import {App} from '../../lib/types/app.js'
 
 const git = new Git()
 
@@ -44,7 +46,7 @@ async function createApp(context: Interfaces.ParserOutput, platform: Platform, n
   }
 
   const app = (params.space || params.team)
-    ? await platform.teamApp.create(params as TeamAppCreateOpts) as unknown as App
+    ? await platform.teamApp.create(params as TeamAppCreateOpts) as App
     : await platform.app.create(params as AppCreateOpts)
 
   let status = name ? 'done' : `done, ${color.app(app.name || '')}`

--- a/src/commands/apps/create.ts
+++ b/src/commands/apps/create.ts
@@ -1,12 +1,15 @@
-import {APIClient, Command, flags} from '@heroku-cli/command'
+import {Command, flags} from '@heroku-cli/command'
 import {
   BuildpackCompletion,
   RegionCompletion,
   SpaceCompletion,
   StackCompletion,
 } from '@heroku-cli/command/lib/completions.js'
-import * as Heroku from '@heroku-cli/schema'
 import {color, hux} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
+import {
+  App, AppCreateOpts, ConfigVarUpdateOpts, TeamAppCreateOpts,
+} from '@heroku/types/3.sdk'
 import {Args, Interfaces, ux} from '@oclif/core'
 import fs from 'fs-extra'
 
@@ -14,6 +17,8 @@ import Git from '../../lib/git/git.js'
 import {lazyModuleLoader} from '../../lib/lazy-module-loader.js'
 
 const git = new Git()
+
+type Platform = HerokuSDK['platform']
 
 function createText(name: string, space: string) {
   let text = `Creating ${name ? color.app(name) : 'app'}`
@@ -24,7 +29,7 @@ function createText(name: string, space: string) {
   return text
 }
 
-async function createApp(context: Interfaces.ParserOutput, heroku: APIClient, name: string, stack: string) {
+async function createApp(context: Interfaces.ParserOutput, platform: Platform, name: string, stack: string) {
   const {flags} = context
   const params = {
     feature_flags: flags.features,
@@ -38,10 +43,9 @@ async function createApp(context: Interfaces.ParserOutput, heroku: APIClient, na
     team: flags.team,
   }
 
-  const requestPath = (params.space || params.team) ? '/teams/apps' : '/apps'
-  const {body: app} = await heroku.post<Heroku.App>(requestPath, {
-    body: params,
-  })
+  const app = (params.space || params.team)
+    ? await platform.teamApp.create(params as TeamAppCreateOpts) as unknown as App
+    : await platform.app.create(params as AppCreateOpts)
 
   let status = name ? 'done' : `done, ${color.app(app.name || '')}`
   if (flags.region) {
@@ -57,7 +61,7 @@ async function createApp(context: Interfaces.ParserOutput, heroku: APIClient, na
   return app
 }
 
-async function addAddons(heroku: APIClient, app: Heroku.App, addons: {as?: string, plan: string}[]) {
+async function addAddons(platform: Platform, app: App, addons: {as?: string, plan: string}[]) {
   for (const addon of addons) {
     const body = {
       attachment: addon.as ? {name: addon.as} : undefined,
@@ -65,17 +69,15 @@ async function addAddons(heroku: APIClient, app: Heroku.App, addons: {as?: strin
     }
 
     ux.action.start(`Adding ${color.addon(addon.plan)}`)
-    await heroku.post(`/apps/${app.name}/addons`, {body})
+    await platform.addOn.create(app.name!, body)
     ux.action.stop()
   }
 }
 
-async function addConfigVars(heroku: APIClient, app: Heroku.App, configVars: Heroku.ConfigVars) {
+async function addConfigVars(platform: Platform, app: App, configVars: ConfigVarUpdateOpts) {
   if (Object.keys(configVars).length > 0) {
     ux.action.start('Setting config vars')
-    await heroku.patch(`/apps/${app.name}/config-vars`, {
-      body: configVars,
-    })
+    await platform.configVar.update(app.name!, configVars)
     ux.action.stop()
   }
 }
@@ -86,7 +88,7 @@ function addonsFromPlans(plans: string[]) {
   }))
 }
 
-async function configureGitRemote(context: Interfaces.ParserOutput, app: Heroku.App) {
+async function configureGitRemote(context: Interfaces.ParserOutput, app: App) {
   const remoteUrl = git.httpGitUrl(app.name || '')
   if (!context.flags['no-remote'] && git.inGitRepo()) {
     await git.createRemote(context.flags.remote || 'heroku', remoteUrl)
@@ -95,7 +97,7 @@ async function configureGitRemote(context: Interfaces.ParserOutput, app: Heroku.
   return remoteUrl
 }
 
-function printAppSummary(context: Interfaces.ParserOutput, app: Heroku.App, remoteUrl: string) {
+function printAppSummary(context: Interfaces.ParserOutput, app: App, remoteUrl: string) {
   if (context.flags.json) {
     hux.styledJSON(app)
   } else {
@@ -103,7 +105,7 @@ function printAppSummary(context: Interfaces.ParserOutput, app: Heroku.App, remo
   }
 }
 
-async function runFromFlags(context: Interfaces.ParserOutput, heroku: APIClient, config: Interfaces.Config) {
+async function runFromFlags(context: Interfaces.ParserOutput, platform: Platform, config: Interfaces.Config) {
   const {args, flags} = context
   if (flags['internal-routing'] && !flags.space) {
     throw new Error('Space name required.\nInternal Web Apps are only available for Private Spaces.\nUSAGE: heroku apps:create --space my-space --internal-routing')
@@ -111,23 +113,20 @@ async function runFromFlags(context: Interfaces.ParserOutput, heroku: APIClient,
 
   const name = flags.app || args.app || process.env.HEROKU_APP
 
-  async function addBuildpack(app: Heroku.App, buildpack: string) {
+  async function addBuildpack(app: App, buildpack: string) {
     ux.action.start(`Setting buildpack to ${color.info(buildpack)}`)
-    await heroku.put(`/apps/${app.name}/buildpack-installations`, {
-      body: {updates: [{buildpack}]},
-      headers: {Range: ''},
-    })
+    await platform.buildpackInstallation.update(app.name!, {updates: [{buildpack}]})
     ux.action.stop()
   }
 
   ux.action.start(createText(name, flags.space))
-  const app = await createApp(context, heroku, name, flags.stack)
+  const app = await createApp(context, platform, name, flags.stack)
   ux.action.stop()
 
   if (flags.addons) {
     const plans = flags.addons.split(',')
     const addons = addonsFromPlans(plans)
-    await addAddons(heroku, app, addons)
+    await addAddons(platform, app, addons)
   }
 
   if (flags.buildpack) {
@@ -197,15 +196,16 @@ ${color.command('heroku apps:create --region eu')}`]
   async run() {
     const context = await this.parse(Create)
     const {flags} = context
+    const {platform} = new HerokuSDK()
 
     if (flags.manifest) {
-      return this.runFromManifest(context, this.heroku)
+      return this.runFromManifest(context, platform)
     }
 
-    await runFromFlags(context, this.heroku, this.config)
+    await runFromFlags(context, platform, this.config)
   }
 
-  async runFromManifest(context: Interfaces.ParserOutput, heroku: APIClient) {
+  async runFromManifest(context: Interfaces.ParserOutput, platform: Platform) {
     const {args, flags} = context
     const name = flags.app || args.app || process.env.HEROKU_APP
 
@@ -214,15 +214,15 @@ ${color.command('heroku apps:create --region eu')}`]
     ux.action.stop()
 
     ux.action.start(createText(name, flags.space))
-    const app = await createApp(context, heroku, name, 'container')
+    const app = await createApp(context, platform, name, 'container')
     ux.action.stop()
 
     const setup = (manifest as any)?.setup ?? {}
     const addons = setup.addons || []
     const configVars = setup.config || {}
 
-    await addAddons(heroku, app, addons)
-    await addConfigVars(heroku, app, configVars)
+    await addAddons(platform, app, addons)
+    await addConfigVars(platform, app, configVars)
     const remoteUrl = await configureGitRemote(context, app)
 
     printAppSummary(context, app, remoteUrl)

--- a/src/commands/apps/index.ts
+++ b/src/commands/apps/index.ts
@@ -55,9 +55,9 @@ export default class AppsIndex extends Command {
       platform.account.info(),
     ])
 
-    let apps = appsList as unknown as App[]
+    let apps = appsList as App[]
 
-    apps = _.sortBy(apps, 'name')
+    apps.sort((a, b) => a.name.localeCompare(b.name))
     if (space) {
       apps = apps.filter((a: App) => a.space && (a.space.name === space || a.space.id === space))
     }

--- a/src/commands/apps/index.ts
+++ b/src/commands/apps/index.ts
@@ -1,7 +1,7 @@
 import {Command, flags} from '@heroku-cli/command'
 import {SpaceCompletion} from '@heroku-cli/command/lib/completions.js'
-import * as Heroku from '@heroku-cli/schema'
 import {color, hux} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
 import {ux} from '@oclif/core/ux'
 
 import {lazyModuleLoader} from '../../lib/lazy-module-loader.js'
@@ -37,20 +37,25 @@ export default class AppsIndex extends Command {
     let team = (!flags.personal && teamIdentifier) ? teamIdentifier : null
     const {all, json, space} = flags
     const internalRouting = flags['internal-routing']
+
+    const sdk = new HerokuSDK()
+    const {platform} = sdk
+
     if (space) {
-      const teamResponse = await this.heroku.get<Heroku.Team>(`/spaces/${space}`)
-      team = teamResponse.body.team.name
+      const spaceInfo = await platform.space.info(space)
+      team = spaceInfo.team?.name ?? null
     }
 
-    let path = '/users/~/apps'
-    if (team) path = `/teams/${team}/apps`
-    else if (all) path = '/apps'
-    const [appsResponse, userResponse] = await Promise.all([
-      this.heroku.get<Heroku.App>(path),
-      this.heroku.get<Heroku.Account>('/account'),
+    const [appsList, user] = await Promise.all([
+      (async () => {
+        if (team) return platform.teamApp.listByTeam(team)
+        if (all) return platform.app.list()
+        return platform.app.listOwnedAndCollaborated('~')
+      })(),
+      platform.account.info(),
     ])
-    let apps = appsResponse.body
-    const user = userResponse.body
+
+    let apps = appsList as unknown as App[]
 
     apps = _.sortBy(apps, 'name')
     if (space) {
@@ -82,11 +87,11 @@ function annotateAppName(app: App) {
   return name
 }
 
-function listApps(apps: Heroku.App) {
+function listApps(apps: App[]) {
   apps.forEach((app: App) => ux.stdout(regionizeAppName(app)))
 }
 
-function print(apps: Heroku.App, user: Heroku.Account, space: string | undefined, team: null | string | undefined, _: any) {
+function print(apps: App[], user: {email?: string}, space: string | undefined, team: null | string | undefined, _: any) {
   if (apps.length === 0) {
     if (space) ux.stdout(`There are no apps in space ${color.space(space)}.`)
     else if (team) ux.stdout(`There are no apps in team ${color.team(team)}.`)
@@ -98,10 +103,10 @@ function print(apps: Heroku.App, user: Heroku.Account, space: string | undefined
     hux.styledHeader(`Apps in team ${color.team(team)}`)
     listApps(apps)
   } else {
-    apps = _.partition(apps, (app: App) => app.owner.email === user.email)
-    if (apps[0].length > 0) {
+    const [ownedApps, collabApps] = _.partition(apps, (app: App) => app.owner.email === user.email)
+    if (ownedApps.length > 0) {
       hux.styledHeader(`${color.user(user.email!)} Apps`)
-      listApps(apps[0])
+      listApps(ownedApps)
     }
 
     const columns = {
@@ -110,9 +115,9 @@ function print(apps: Heroku.App, user: Heroku.Account, space: string | undefined
       Email: {get: ({owner}: any) => color.user(owner.email)},
     }
 
-    if (apps[1].length > 0) {
+    if (collabApps.length > 0) {
       ux.stdout()
-      hux.table(apps[1], columns, {title: 'Collaborated Apps\n', titleOptions: {bold: true}})
+      hux.table(collabApps, columns, {title: 'Collaborated Apps\n', titleOptions: {bold: true}})
     }
   }
 }

--- a/src/lib/types/app.d.ts
+++ b/src/lib/types/app.d.ts
@@ -1,23 +1,4 @@
-export type App = {
-  name: string,
-  stack: {
-    name: string
-  },
-  build_stack: {
-    name: string
-  },
-  locked: boolean,
-  internal_routing: boolean,
-  region: {
-    name: string
-  }
-  owner: {
-    email: string
-  }
-  space: {
-    id: string,
-    name: string
-  }
-}
+import type {App as BaseApp, TeamApp} from '@heroku/types/3.sdk'
 
+export type App = BaseApp & Pick<TeamApp, 'locked' | 'joined'>
 export type Apps = App[]

--- a/test/unit/commands/apps/create.unit.test.ts
+++ b/test/unit/commands/apps/create.unit.test.ts
@@ -1,21 +1,40 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
 import {execSync} from 'node:child_process'
-import {SinonStub, stub} from 'sinon'
+import * as sinon from 'sinon'
+import {SinonStub} from 'sinon'
 
 import CreateCommand from '../../../../src/commands/apps/create.js'
 
+type FakePlatform = {
+  addOn: {create: sinon.SinonStub}
+  app: {create: sinon.SinonStub}
+  buildpackInstallation: {update: sinon.SinonStub}
+  configVar: {update: sinon.SinonStub}
+  teamApp: {create: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    addOn: {create: sinon.stub()},
+    app: {create: sinon.stub()},
+    buildpackInstallation: {update: sinon.stub()},
+    configVar: {update: sinon.stub()},
+    teamApp: {create: sinon.stub()},
+  }
+}
+
 describe('apps:create', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
     // Clean up any heroku git remotes created by the tests
     try {
       const remotes = execSync('git remote', {encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore']})
@@ -28,69 +47,64 @@ describe('apps:create', function () {
   })
 
   it('creates an app', async function () {
-    api
-      .post('/apps', {})
-      .reply(200, {
-        name: 'foobar',
-        stack: {name: 'cedar-14'},
-        web_url: 'https://foobar.com',
-      })
+    fakePlatform.app.create.resolves({
+      name: 'foobar',
+      stack: {name: 'cedar-14'},
+      web_url: 'https://foobar.com',
+    })
 
     const {stderr, stdout} = await runCommand(CreateCommand, [])
 
     expect(stderr).to.contain('Creating app... done, ⬢ foobar')
     expect(stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n')
+    expect(fakePlatform.app.create.calledOnce).to.equal(true)
   })
 
   it('creates an app with feature flags', async function () {
-    api
-      .post('/apps', {feature_flags: 'feature-1,feature-2'})
-      .reply(200, {
-        name: 'foobar',
-        stack: {name: 'cedar-14'},
-        web_url: 'https://foobar.com',
-      })
+    fakePlatform.app.create.resolves({
+      name: 'foobar',
+      stack: {name: 'cedar-14'},
+      web_url: 'https://foobar.com',
+    })
 
     const {stderr, stdout} = await runCommand(CreateCommand, ['--features', 'feature-1,feature-2'])
 
     expect(stderr).to.contain('Creating app... done, ⬢ foobar')
     expect(stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n')
+    expect(fakePlatform.app.create.firstCall.args[0]).to.include({feature_flags: 'feature-1,feature-2'})
   })
 
   it('creates an app in a space', async function () {
-    api
-      .post('/teams/apps', {
-        space: 'my-space-name',
-      })
-      .reply(200, {
-        name: 'foobar',
-        stack: {name: 'cedar-14'},
-        web_url: 'https://foobar.com',
-      })
+    fakePlatform.teamApp.create.resolves({
+      name: 'foobar',
+      stack: {name: 'cedar-14'},
+      web_url: 'https://foobar.com',
+    })
 
     const {stderr, stdout} = await runCommand(CreateCommand, ['--space', 'my-space-name'])
 
     expect(stderr).to.contain('Creating app in space my-space-name... done, ⬢ foobar')
     expect(stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n')
+    expect(fakePlatform.teamApp.create.firstCall.args[0]).to.include({space: 'my-space-name'})
+    expect(fakePlatform.app.create.called).to.equal(false)
   })
 
   it('creates an Internal Web App in a space', async function () {
-    api
-      .post('/teams/apps', {
-        internal_routing: true,
-        space: 'my-space-name',
-      })
-      .reply(200, {
-        internal_routing: true,
-        name: 'foobar',
-        stack: {name: 'cedar-14'},
-        web_url: 'https://foobar.com',
-      })
+    fakePlatform.teamApp.create.resolves({
+      internal_routing: true,
+      name: 'foobar',
+      stack: {name: 'cedar-14'},
+      web_url: 'https://foobar.com',
+    })
 
     const {stderr, stdout} = await runCommand(CreateCommand, ['--space', 'my-space-name', '--internal-routing'])
 
     expect(stderr).to.contain('Creating app in space my-space-name... done, ⬢ foobar')
     expect(stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n')
+    expect(fakePlatform.teamApp.create.firstCall.args[0]).to.include({
+      internal_routing: true,
+      space: 'my-space-name',
+    })
   })
 
   it('does not create an Internal Web App outside of a space', async function () {
@@ -98,6 +112,8 @@ describe('apps:create', function () {
 
     expect(error).to.be.an.instanceof(Error)
     expect(error?.message).to.equal('Space name required.\nInternal Web Apps are only available for Private Spaces.\nUSAGE: heroku apps:create --space my-space --internal-routing')
+    expect(fakePlatform.app.create.called).to.equal(false)
+    expect(fakePlatform.teamApp.create.called).to.equal(false)
   })
 
   it('creates an app & returns as json', async function () {
@@ -107,9 +123,7 @@ describe('apps:create', function () {
       web_url: 'https://foobar.com',
     }
 
-    api
-      .post('/apps', {})
-      .reply(200, json)
+    fakePlatform.app.create.resolves(json)
 
     const {stderr, stdout} = await runCommand(CreateCommand, ['--json'])
 
@@ -137,7 +151,7 @@ describe('apps:create', function () {
     let readManifestStub: SinonStub
 
     beforeEach(async function () {
-      readManifestStub = stub(CreateCommand.prototype, 'readManifest').resolves(manifest)
+      readManifestStub = sinon.stub(CreateCommand.prototype, 'readManifest').resolves(manifest)
     })
 
     afterEach(function () {
@@ -145,17 +159,13 @@ describe('apps:create', function () {
     })
 
     it('sets config vars when manifest flag is present', async function () {
-      api
-        .post('/apps', {name: 'foo', stack: 'container'})
-        .reply(200, {
-          name: appName,
-          stack: {name: 'cedar-14'},
-          web_url: 'https://foobar.com',
-        })
-        .post(`/apps/${appName}/addons`)
-        .reply(200, [])
-        .patch(`/apps/${appName}/config-vars`, {S3_BUCKET: 'my-example-bucket'})
-        .reply(200, [])
+      fakePlatform.app.create.resolves({
+        name: appName,
+        stack: {name: 'cedar-14'},
+        web_url: 'https://foobar.com',
+      })
+      fakePlatform.addOn.create.resolves({})
+      fakePlatform.configVar.update.resolves({})
 
       // Override channel using environment variable for this test
       process.env.HEROKU_UPDATE_CHANNEL = 'beta'
@@ -167,6 +177,12 @@ describe('apps:create', function () {
       expect(stderr).to.contain('Adding heroku-postgresql... done')
       expect(stderr).to.contain('Setting config vars... done')
       expect(stdout).to.equal('https://foobar.com | https://git.heroku.com/foo.git\n')
+      expect(fakePlatform.app.create.firstCall.args[0]).to.include({name: 'foo', stack: 'container'})
+      expect(fakePlatform.addOn.create.calledOnceWithExactly(appName, {
+        attachment: {name: 'DATABASE'},
+        plan: 'heroku-postgresql',
+      })).to.equal(true)
+      expect(fakePlatform.configVar.update.calledOnceWithExactly(appName, {S3_BUCKET: 'my-example-bucket'})).to.equal(true)
 
       delete process.env.HEROKU_UPDATE_CHANNEL
     })
@@ -177,17 +193,12 @@ describe('apps:create', function () {
     const addon = 'foobar, secondPlan'
 
     it('adds addon if addons flag is present', async function () {
-      api
-        .post('/apps', {name: 'foo'})
-        .reply(200, {
-          name: appName,
-          stack: {name: 'cedar-14'},
-          web_url: 'https://foobar.com',
-        })
-        .post(`/apps/${appName}/addons`, {plan: 'foobar'})
-        .reply(200, [])
-        .post(`/apps/${appName}/addons`, {plan: 'secondPlan'})
-        .reply(200, [])
+      fakePlatform.app.create.resolves({
+        name: appName,
+        stack: {name: 'cedar-14'},
+        web_url: 'https://foobar.com',
+      })
+      fakePlatform.addOn.create.resolves({})
 
       const {stderr, stdout} = await runCommand(CreateCommand, ['--app', appName, '--addons', addon])
 
@@ -195,24 +206,21 @@ describe('apps:create', function () {
       expect(stderr).to.contain('Adding foobar... done')
       expect(stderr).to.contain('Adding secondPlan... done')
       expect(stdout).to.equal('https://foobar.com | https://git.heroku.com/foo.git\n')
+      expect(fakePlatform.addOn.create.callCount).to.equal(2)
+      expect(fakePlatform.addOn.create.firstCall.args).to.deep.equal([appName, {attachment: undefined, plan: 'foobar'}])
+      expect(fakePlatform.addOn.create.secondCall.args).to.deep.equal([appName, {attachment: undefined, plan: 'secondPlan'}])
     })
 
     it('sets buildpack if buildpack flag is present', async function () {
       const exampleBuildpack = 'https://github.com/some/buildpack.git'
 
-      api
-        .post('/apps', {name: 'foo'})
-        .reply(200, {
-          name: appName,
-          stack: {name: 'cedar-14'},
-          web_url: 'https://foobar.com',
-        })
-        .post(`/apps/${appName}/addons`, {plan: 'foobar'})
-        .reply(200, [])
-        .post(`/apps/${appName}/addons`, {plan: 'secondPlan'})
-        .reply(200, [])
-        .put(`/apps/${appName}/buildpack-installations`, {updates: [{buildpack: 'https://github.com/some/buildpack.git'}]})
-        .reply(200, [])
+      fakePlatform.app.create.resolves({
+        name: appName,
+        stack: {name: 'cedar-14'},
+        web_url: 'https://foobar.com',
+      })
+      fakePlatform.addOn.create.resolves({})
+      fakePlatform.buildpackInstallation.update.resolves([])
 
       const {stderr, stdout} = await runCommand(CreateCommand, ['--app', appName, '--addons', addon, '--buildpack', exampleBuildpack])
 
@@ -221,37 +229,38 @@ describe('apps:create', function () {
       expect(stderr).to.contain('Adding secondPlan... done')
       expect(stderr).to.contain('Setting buildpack to https://github.com/some/buildpack.git')
       expect(stdout).to.equal('https://foobar.com | https://git.heroku.com/foo.git\n')
+      expect(fakePlatform.buildpackInstallation.update.calledOnceWithExactly(appName, {
+        updates: [{buildpack: exampleBuildpack}],
+      })).to.equal(true)
     })
   })
 
   it('creates an app in the region', async function () {
-    api
-      .post('/apps', {region: 'eu'})
-      .reply(200, {
-        name: 'foobar',
-        region: {name: 'eu'},
-        stack: {name: 'cedar-14'},
-        web_url: 'https://foobar.com',
-      })
+    fakePlatform.app.create.resolves({
+      name: 'foobar',
+      region: {name: 'eu'},
+      stack: {name: 'cedar-14'},
+      web_url: 'https://foobar.com',
+    })
 
     const {stderr, stdout} = await runCommand(CreateCommand, ['--region', 'eu'])
 
     expect(stderr).to.contain('Creating app... done, ⬢ foobar, region is eu')
     expect(stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n')
+    expect(fakePlatform.app.create.firstCall.args[0]).to.include({region: 'eu'})
   })
 
   it('creates an with stack', async function () {
-    api
-      .post('/apps', {stack: 'test'})
-      .reply(200, {
-        name: 'foobar',
-        stack: {name: 'test'},
-        web_url: 'https://foobar.com',
-      })
+    fakePlatform.app.create.resolves({
+      name: 'foobar',
+      stack: {name: 'test'},
+      web_url: 'https://foobar.com',
+    })
 
     const {stderr, stdout} = await runCommand(CreateCommand, ['--stack', 'test'])
 
     expect(stderr).to.contain('Creating app... done, ⬢ foobar, stack is test')
     expect(stdout).to.equal('https://foobar.com | https://git.heroku.com/foobar.git\n')
+    expect(fakePlatform.app.create.firstCall.args[0]).to.include({stack: 'test'})
   })
 })

--- a/test/unit/commands/apps/index.unit.test.ts
+++ b/test/unit/commands/apps/index.unit.test.ts
@@ -1,9 +1,32 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Apps from '../../../../src/commands/apps/index.js'
 import removeAllWhitespace from '../../../helpers/utils/remove-whitespaces.js'
+
+type FakePlatform = {
+  account: {info: sinon.SinonStub}
+  app: {
+    list: sinon.SinonStub
+    listOwnedAndCollaborated: sinon.SinonStub
+  }
+  space: {info: sinon.SinonStub}
+  teamApp: {listByTeam: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    account: {info: sinon.stub()},
+    app: {
+      list: sinon.stub(),
+      listOwnedAndCollaborated: sinon.stub(),
+    },
+    space: {info: sinon.stub()},
+    teamApp: {listByTeam: sinon.stub()},
+  }
+}
 
 describe('apps', function () {
   const example = {
@@ -76,40 +99,32 @@ describe('apps', function () {
     space: {id: 'test-space-id', name: 'test-space'},
   }
 
-  let euLockedApp = {}
-  let euInternalApp = {}
-  let euInternalLockedApp = {}
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   describe('with no args', function () {
     it('displays a message when the user has no apps', async function () {
-      api
-        .get('/account')
-        .reply(200, {email: 'foo@bar.com'})
-        .get('/users/~/apps')
-        .reply(200, [])
+      fakePlatform.account.info.resolves({email: 'foo@bar.com'})
+      fakePlatform.app.listOwnedAndCollaborated.resolves([])
 
       const {stderr, stdout} = await runCommand(Apps, [])
 
       expect(stderr).to.equal('')
       expect(stdout).to.equal('You have no apps.\n')
+      expect(fakePlatform.app.listOwnedAndCollaborated.calledOnceWithExactly('~')).to.equal(true)
     })
 
     it('list all user apps', async function () {
-      api
-        .get('/account')
-        .reply(200, {email: 'foo@bar.com'})
-        .get('/users/~/apps')
-        .reply(200, [example, collabApp])
+      fakePlatform.account.info.resolves({email: 'foo@bar.com'})
+      fakePlatform.app.listOwnedAndCollaborated.resolves([example, collabApp])
 
       const {stderr, stdout} = await runCommand(Apps, [])
 
@@ -126,11 +141,8 @@ describe('apps', function () {
     })
 
     it('lists all apps', async function () {
-      api
-        .get('/account')
-        .reply(200, {email: 'foo@bar.com'})
-        .get('/apps')
-        .reply(200, [example, collabApp, teamApp1])
+      fakePlatform.account.info.resolves({email: 'foo@bar.com'})
+      fakePlatform.app.list.resolves([example, collabApp, teamApp1])
 
       const {stderr, stdout} = await runCommand(Apps, ['--all'])
 
@@ -144,14 +156,13 @@ describe('apps', function () {
       expect(actual).to.include(expectedPersonalApps)
       expect(actual).to.include(expectedCollaboratedAppsHeader)
       expect(actual).to.include(expectedCollaboratedApps)
+      expect(fakePlatform.app.list.calledOnce).to.equal(true)
+      expect(fakePlatform.app.listOwnedAndCollaborated.called).to.equal(false)
     })
 
     it('shows as json', async function () {
-      api
-        .get('/account')
-        .reply(200, {email: 'foo@bar.com'})
-        .get('/users/~/apps')
-        .reply(200, [example, collabApp])
+      fakePlatform.account.info.resolves({email: 'foo@bar.com'})
+      fakePlatform.app.listOwnedAndCollaborated.resolves([example, collabApp])
 
       const {stderr, stdout} = await runCommand(Apps, ['--json'])
 
@@ -160,11 +171,8 @@ describe('apps', function () {
     })
 
     it('shows region if not us', async function () {
-      api
-        .get('/account')
-        .reply(200, {email: 'foo@bar.com'})
-        .get('/users/~/apps')
-        .reply(200, [example, euApp])
+      fakePlatform.account.info.resolves({email: 'foo@bar.com'})
+      fakePlatform.app.listOwnedAndCollaborated.resolves([example, euApp])
 
       const {stderr, stdout} = await runCommand(Apps, [])
 
@@ -173,11 +181,8 @@ describe('apps', function () {
     })
 
     it('shows locked app', async function () {
-      api
-        .get('/account')
-        .reply(200, {email: 'foo@bar.com'})
-        .get('/users/~/apps')
-        .reply(200, [example, euApp, lockedApp])
+      fakePlatform.account.info.resolves({email: 'foo@bar.com'})
+      fakePlatform.app.listOwnedAndCollaborated.resolves([example, euApp, lockedApp])
 
       const {stderr, stdout} = await runCommand(Apps, [])
 
@@ -186,13 +191,9 @@ describe('apps', function () {
     })
 
     it('shows locked eu app', async function () {
-      euLockedApp = Object.assign(lockedApp, {region: {name: 'eu'}})
-
-      api
-        .get('/account')
-        .reply(200, {email: 'foo@bar.com'})
-        .get('/users/~/apps')
-        .reply(200, [example, euApp, euLockedApp])
+      const euLockedApp = {...lockedApp, region: {name: 'eu'}}
+      fakePlatform.account.info.resolves({email: 'foo@bar.com'})
+      fakePlatform.app.listOwnedAndCollaborated.resolves([example, euApp, euLockedApp])
 
       const {stderr, stdout} = await runCommand(Apps, [])
 
@@ -201,11 +202,8 @@ describe('apps', function () {
     })
 
     it('shows internal app', async function () {
-      api
-        .get('/account')
-        .reply(200, {email: 'foo@bar.com'})
-        .get('/users/~/apps')
-        .reply(200, [example, euApp, internalApp])
+      fakePlatform.account.info.resolves({email: 'foo@bar.com'})
+      fakePlatform.app.listOwnedAndCollaborated.resolves([example, euApp, internalApp])
 
       const {stderr, stdout} = await runCommand(Apps, [])
 
@@ -214,11 +212,8 @@ describe('apps', function () {
     })
 
     it('shows internal locked app', async function () {
-      api
-        .get('/account')
-        .reply(200, {email: 'foo@bar.com'})
-        .get('/users/~/apps')
-        .reply(200, [example, euApp, internalLockedApp])
+      fakePlatform.account.info.resolves({email: 'foo@bar.com'})
+      fakePlatform.app.listOwnedAndCollaborated.resolves([example, euApp, internalLockedApp])
 
       const {stderr, stdout} = await runCommand(Apps, [])
 
@@ -227,13 +222,9 @@ describe('apps', function () {
     })
 
     it('shows internal eu app', async function () {
-      euInternalApp = Object.assign(internalApp, {region: {name: 'eu'}})
-
-      api
-        .get('/account')
-        .reply(200, {email: 'foo@bar.com'})
-        .get('/users/~/apps')
-        .reply(200, [example, euApp, euInternalApp])
+      const euInternalApp = {...internalApp, region: {name: 'eu'}}
+      fakePlatform.account.info.resolves({email: 'foo@bar.com'})
+      fakePlatform.app.listOwnedAndCollaborated.resolves([example, euApp, euInternalApp])
 
       const {stderr, stdout} = await runCommand(Apps, [])
 
@@ -242,13 +233,9 @@ describe('apps', function () {
     })
 
     it('shows internal locked eu app', async function () {
-      euInternalLockedApp = Object.assign(internalLockedApp, {region: {name: 'eu'}})
-
-      api
-        .get('/account')
-        .reply(200, {email: 'foo@bar.com'})
-        .get('/users/~/apps')
-        .reply(200, [example, euApp, euInternalLockedApp])
+      const euInternalLockedApp = {...internalLockedApp, region: {name: 'eu'}}
+      fakePlatform.account.info.resolves({email: 'foo@bar.com'})
+      fakePlatform.app.listOwnedAndCollaborated.resolves([example, euApp, euInternalLockedApp])
 
       const {stderr, stdout} = await runCommand(Apps, [])
 
@@ -259,24 +246,19 @@ describe('apps', function () {
 
   describe('with team', function () {
     it('displays a message when the team has no apps', async function () {
-      api
-        .get('/account')
-        .reply(200, {email: 'foo@bar.com'})
-        .get('/teams/test-team/apps')
-        .reply(200, [])
+      fakePlatform.account.info.resolves({email: 'foo@bar.com'})
+      fakePlatform.teamApp.listByTeam.resolves([])
 
       const {stderr, stdout} = await runCommand(Apps, ['--team', 'test-team'])
 
       expect(stderr).to.equal('')
       expect(stdout).to.equal('There are no apps in team test-team.\n')
+      expect(fakePlatform.teamApp.listByTeam.calledOnceWithExactly('test-team')).to.equal(true)
     })
 
     it('list all in a team', async function () {
-      api
-        .get('/account')
-        .reply(200, {email: 'foo@bar.com'})
-        .get('/teams/test-team/apps')
-        .reply(200, [teamApp1, teamApp2])
+      fakePlatform.account.info.resolves({email: 'foo@bar.com'})
+      fakePlatform.teamApp.listByTeam.resolves([teamApp1, teamApp2])
 
       const {stderr, stdout} = await runCommand(Apps, ['--team', 'test-team'])
 
@@ -287,28 +269,22 @@ describe('apps', function () {
 
   describe('with space', function () {
     it('displays a message when the space has no apps', async function () {
-      api
-        .get('/account')
-        .reply(200, {email: 'foo@bar.com'})
-        .get('/spaces/test-space')
-        .reply(200, {team: {name: 'test-team'}})
-        .get('/teams/test-team/apps')
-        .reply(200, [])
+      fakePlatform.account.info.resolves({email: 'foo@bar.com'})
+      fakePlatform.space.info.resolves({team: {name: 'test-team'}})
+      fakePlatform.teamApp.listByTeam.resolves([])
 
       const {stderr, stdout} = await runCommand(Apps, ['--space', 'test-space'])
 
       expect(stderr).to.equal('')
       expect(stdout).to.equal('There are no apps in space ⬡ test-space.\n')
+      expect(fakePlatform.space.info.calledOnceWithExactly('test-space')).to.equal(true)
+      expect(fakePlatform.teamApp.listByTeam.calledOnceWithExactly('test-team')).to.equal(true)
     })
 
     it('lists only apps in spaces by name', async function () {
-      api
-        .get('/account')
-        .reply(200, {email: 'foo@bar.com'})
-        .get('/spaces/test-space')
-        .reply(200, {team: {name: 'test-team'}})
-        .get('/teams/test-team/apps')
-        .reply(200, [teamSpaceApp1, teamSpaceApp2, teamApp1])
+      fakePlatform.account.info.resolves({email: 'foo@bar.com'})
+      fakePlatform.space.info.resolves({team: {name: 'test-team'}})
+      fakePlatform.teamApp.listByTeam.resolves([teamSpaceApp1, teamSpaceApp2, teamApp1])
 
       const {stderr, stdout} = await runCommand(Apps, ['--space', 'test-space'])
 
@@ -317,13 +293,9 @@ describe('apps', function () {
     })
 
     it('lists only internal apps in spaces by name', async function () {
-      api
-        .get('/account')
-        .reply(200, {email: 'foo@bar.com'})
-        .get('/spaces/test-space')
-        .reply(200, {team: {name: 'test-team'}})
-        .get('/teams/test-team/apps')
-        .reply(200, [teamSpaceApp1, teamSpaceApp2, teamApp1, teamSpaceInternalApp])
+      fakePlatform.account.info.resolves({email: 'foo@bar.com'})
+      fakePlatform.space.info.resolves({team: {name: 'test-team'}})
+      fakePlatform.teamApp.listByTeam.resolves([teamSpaceApp1, teamSpaceApp2, teamApp1, teamSpaceInternalApp])
 
       const {stderr, stdout} = await runCommand(Apps, ['--space', 'test-space', '--internal-routing'])
 


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->

- Updates the `apps` and `apps:create` commands to use SDK instead of `heroku-client`
- Updates corresponding tests to mock the SDK functions, instead of mocking network calls
- Updates the `sdk-command-migration` skill to handle cases where the API client is passed into the command

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
- Passing tests should suffice

## Related Issues
GUS work item: [W-22264732](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Z03bAYAR/view)
