### PR TITLE
fix: pass empty string to rl.write in repl finally block (W-22295448)

### DIFF
--- a/src/lib/repl.ts
+++ b/src/lib/repl.ts
@@ -168,7 +168,7 @@ export class HerokuRepl {
       this.createInterface()
       this.start()
       // Force readline to refresh the current line
-      this.rl.write(null, {ctrl: true, name: 'u'})
+      this.rl.write('', {ctrl: true, name: 'u'})
     }
   }
   /**

--- a/test/unit/lib/repl.unit.test.ts
+++ b/test/unit/lib/repl.unit.test.ts
@@ -172,6 +172,41 @@ describe('HerokuRepl', function () {
     })
   })
 
+  describe('processLine', function () {
+    it('passes an empty string to rl.write when clearing the line after command execution', async function () {
+      const writeSpy = stub()
+      const mockRl = {
+        close: stub(),
+        history: [],
+        off: stub(),
+        on: stub(),
+        once: stub(),
+        prompt: stub(),
+        setPrompt: stub(),
+        write: writeSpy,
+      }
+
+      stub(HerokuRepl.prototype, 'createInterface' as any).callsFake(function (this: any) {
+        this.rl = mockRl
+      })
+
+      config = {
+        commands: [],
+        findCommand: stub().returns({flags: {}, id: 'apps:info'}),
+        root: '/fake/root',
+        runCommand: stub().resolves(),
+      } as any
+
+      repl = new HerokuRepl(config)
+
+      await (repl as any).processLine('apps:info')
+
+      const writeCall = writeSpy.args.find((args: any[]) => args[1]?.ctrl === true && args[1]?.name === 'u')
+      expect(writeCall, 'rl.write should be called for ctrl+u line clear').to.exist
+      expect(writeCall![0]).to.equal('')
+    })
+  })
+
   describe('readline interface creation', function () {
     it('should create readline interface with correct configuration', function () {
       stub(HerokuRepl.prototype, 'fsExistsSync' as any).returns(false)


### PR DESCRIPTION
## Summary

Fixes a TypeError thrown by rl.write(null, ...) in the REPL's finally block. Node's readline/promises interface requires a string as the first argument.

## Type of Change
[X] fix: Bug fix

## Testing
1. Passing CI suffices.
or 
2.  If you want to exercise it end-to-end in the actual REPL:                                                                                                                                             

### Build first
`npm run build`                                             

### Launch the REPL                                                                                  
`./bin/run repl`

Then at the heroku > prompt, run any valid command (e.g. apps:info --app <your-app>), and prompt returns cleanly 

## Related Issues
Github Issue: [#3684](https://github.com/heroku/cli/issues/3684)
GUS work item: [W-22295448](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Z7CYpYAN/view)

