### PR TITLE
fix: 'run:inside' args ordering (W-22693654)

### DIFF
--- a/src/commands/run/inside.ts
+++ b/src/commands/run/inside.ts
@@ -11,16 +11,18 @@ const debug = debugFactory('heroku:run:inside')
 const heredoc = tsheredoc.default
 
 export default class RunInside extends Command {
+  /* eslint-disable perfectionist/sort-objects */
   static args = {
-    command: Args.string({
-      description: 'command to run (Heroku automatically prepends \'launcher\' to the command)',
-      required: true,
-    }),
     dyno_name: Args.string({
       description: 'name of the dyno to run command inside',
       required: true,
     }),
+    command: Args.string({
+      description: 'command to run (Heroku automatically prepends \'launcher\' to the command)',
+      required: true,
+    }),
   }
+  /* eslint-enable perfectionist/sort-objects */
   static description = 'run a command inside an existing dyno (for Fir-generation apps only)'
   static examples = [
     heredoc`


### PR DESCRIPTION
## Summary
In PR [#3633](https://github.com/heroku/cli/pull/3633) we provided a fix for the issue reported on Github issue [#3631](https://github.com/heroku/cli/issues/3631). The fix included reordering the static class member `args` to ensure `dyno_name` was the first positional argument.

In PR [#3667](https://github.com/heroku/cli/pull/3667) we inadvertently reverted that ordering because the `perfectionist/sort-objects` rule was applied. That linter rule shouldn't be ever applied to the args static class member, because positioning is relevant for the commands to work correctly.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [X] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
There's a Fir test app available in our Fir Test space named `test-cli-run-inside` or you can use your own test app.

**Steps**:
1. Checkout this branch and run ```npm install && npm run build```.
2. Check that you have the most recent version of Heroku CLI (v11.4.0) and run ```heroku run:inside web-c8c859bf9-2rk6q bash -a test-cli-run-inside```, you'll observe the error `bash is either not "up" or doesn't exist.` being raised.
3. Check the fixed implementation with ```./bin/run run:inside web-c8c859bf9-2rk6q bash -a test-cli-run-inside```, the dyno connection should be correctly established and a bash session opened. Use ```exit``` to quit the session and close the connection to the dyno.

## Screenshots (if applicable)
<img width="1156" height="434" alt="Captura de pantalla 2026-05-27 a la(s) 11 46 08" src="https://github.com/user-attachments/assets/1d44b23d-6e2d-4191-bc38-54cf93cdc6f3" />

## Related Issues
GitHub issue: #3726 
GUS work item: [W-22693654](https://gus.lightning.force.com/a07EE00002azNS0YAM)
