### PR TITLE
chore: upload arm64 win installer to Stampy unsigned bucket (W-22733412)

### DIFF
--- a/.github/workflows/upload-to-stampy.yml
+++ b/.github/workflows/upload-to-stampy.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           SHA=$(npm view heroku@${{ inputs.version }} --json | jq -r '.gitHead[0:7]')
           FILEBASE=heroku-v${{inputs.version}}-$SHA
+          aws s3 cp s3://heroku-cli-assets/versions/${{inputs.version}}/$SHA/$FILEBASE-arm64.exe .
           aws s3 cp s3://heroku-cli-assets/versions/${{inputs.version}}/$SHA/$FILEBASE-x86.exe .
           aws s3 cp s3://heroku-cli-assets/versions/${{inputs.version}}/$SHA/$FILEBASE-x64.exe .
       - name: upload unsigned Windows installers to Stampy
@@ -39,5 +40,6 @@ jobs:
           export AWS_ACCESS_KEY_ID=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.AccessKeyId')
           export AWS_SECRET_ACCESS_KEY=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SecretAccessKey')
           export AWS_SESSION_TOKEN=$(echo "${TEMP_ROLE}" | jq -r '.Credentials.SessionToken')
+          aws s3 cp $FILEBASE-arm64.exe s3://$STAMPY_UNSIGNED_BUCKET/$FILEBASE-arm64.exe
           aws s3 cp $FILEBASE-x86.exe s3://$STAMPY_UNSIGNED_BUCKET/$FILEBASE-x86.exe
           aws s3 cp $FILEBASE-x64.exe s3://$STAMPY_UNSIGNED_BUCKET/$FILEBASE-x64.exe


### PR DESCRIPTION
## Summary

We were currently building the Windows installer for the ARM64 architecture, but we weren't including it in the Stampy signing workflow because it was missed from the Github workflow that uploads the installers to the unsigned installers bucket. Here we fix that omission.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [X] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing

Passing CI suffices

## Related Issues
GUS work item: [W-22733412](https://gus.lightning.force.com/a07EE00002b998AYAQ)
