### PR TITLE
fix: call _heroku.pg_stat_statements_reset() on Essential and Advanced plans

### DIFF
--- a/src/commands/pg/outliers.ts
+++ b/src/commands/pg/outliers.ts
@@ -83,14 +83,13 @@ export default class Outliers extends Command {
     const {app, num, reset, truncate} = flags
 
     const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
-    const {addon} = await dbResolver.getAttachment(app, args.database)
     const db = await dbResolver.getDatabase(app, args.database)
     this.psqlService = new utils.pg.PsqlService(db)
     const version = await fetchVersion(db)
     await this.ensurePGStatStatement()
 
     if (reset) {
-      const resetFn = utils.pg.isEssentialDatabase(addon) || utils.pg.isAdvancedDatabase(addon)
+      const resetFn = utils.pg.isEssentialDatabase(db.attachment!.addon) || utils.pg.isAdvancedDatabase(db.attachment!.addon)
         ? '_heroku.pg_stat_statements_reset()'
         : 'pg_stat_statements_reset()'
       await this.psqlService.execQuery(`SELECT ${resetFn};`)

--- a/src/commands/pg/outliers.ts
+++ b/src/commands/pg/outliers.ts
@@ -89,7 +89,10 @@ export default class Outliers extends Command {
     await this.ensurePGStatStatement()
 
     if (reset) {
-      await this.psqlService.execQuery('SELECT pg_stat_statements_reset();')
+      const resetFn = (db as any).plan && (utils.pg.isEssentialDatabase(db as any) || utils.pg.isAdvancedDatabase(db as any))
+        ? '_heroku.pg_stat_statements_reset()'
+        : 'pg_stat_statements_reset()'
+      await this.psqlService.execQuery(`SELECT ${resetFn};`)
       return
     }
 

--- a/src/commands/pg/outliers.ts
+++ b/src/commands/pg/outliers.ts
@@ -83,13 +83,14 @@ export default class Outliers extends Command {
     const {app, num, reset, truncate} = flags
 
     const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
+    const {addon} = await dbResolver.getAttachment(app, args.database)
     const db = await dbResolver.getDatabase(app, args.database)
     this.psqlService = new utils.pg.PsqlService(db)
     const version = await fetchVersion(db)
     await this.ensurePGStatStatement()
 
     if (reset) {
-      const resetFn = (db as any).plan && (utils.pg.isEssentialDatabase(db as any) || utils.pg.isAdvancedDatabase(db as any))
+      const resetFn = utils.pg.isEssentialDatabase(addon) || utils.pg.isAdvancedDatabase(addon)
         ? '_heroku.pg_stat_statements_reset()'
         : 'pg_stat_statements_reset()'
       await this.psqlService.execQuery(`SELECT ${resetFn};`)

--- a/test/unit/commands/pg/outliers.unit.test.ts
+++ b/test/unit/commands/pg/outliers.unit.test.ts
@@ -7,11 +7,27 @@ import Cmd from '../../../../src/commands/pg/outliers.js'
 
 describe('pg:outliers', function () {
   let sandbox: sinon.SinonSandbox
-  let getDatabaseStub: sinon.SinonStub
   let execQueryStub: sinon.SinonStub
   const expectedOutputText = 'slow things'
 
-  const mockDb: pg.ConnectionDetails = {
+  const mockEssentialDb = {
+    attachment: {
+      addon: {
+        id: 'addon-id',
+        name: 'postgres-addon-name',
+        plan: {
+          id: 'essential-0-plan-id',
+          name: 'heroku-postgresql:essential-0',
+        },
+      },
+      app: {
+        id: 'myapp-id',
+        name: 'myapp',
+      },
+      config_vars: ['DATABASE_URL'],
+      id: 'database-attachment-id',
+      name: 'DATABASE',
+    },
     database: 'testdb',
     host: 'localhost',
     password: 'testpass',
@@ -19,18 +35,38 @@ describe('pg:outliers', function () {
     port: '5432',
     url: 'postgres://localhost:5432/testdb',
     user: 'testuser',
-  }
+  } as unknown as pg.ConnectionDetails
 
-  const mockStandardAddon = {plan: {name: 'heroku-postgresql:standard-0'}} as any
-  const mockEssentialAddon = {plan: {name: 'heroku-postgresql:essential-0'}} as any
-  const mockAdvancedAddon = {plan: {name: 'heroku-postgresql:advanced'}} as any
+  const mockStandardDb = {
+    ...mockEssentialDb,
+    attachment: {
+      ...mockEssentialDb.attachment,
+      addon: {
+        ...mockEssentialDb.attachment!.addon,
+        plan: {
+          id: 'standard-0-plan-id',
+          name: 'heroku-postgresql:standard-0',
+        },
+      },
+    },
+  } as unknown as pg.ConnectionDetails
 
-  let getAttachmentStub: sinon.SinonStub
+  const mockAdvancedDb = {
+    ...mockEssentialDb,
+    attachment: {
+      ...mockEssentialDb.attachment,
+      addon: {
+        ...mockEssentialDb.attachment!.addon,
+        plan: {
+          id: 'advanced-plan-id',
+          name: 'heroku-postgresql:advanced',
+        },
+      },
+    },
+  } as unknown as pg.ConnectionDetails
 
   beforeEach(function () {
     sandbox = sinon.createSandbox()
-    getDatabaseStub = sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockDb)
-    getAttachmentStub = sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getAttachment').resolves({addon: mockStandardAddon} as any)
     execQueryStub = sandbox.stub(utils.pg.PsqlService.prototype, 'execQuery')
   })
 
@@ -47,6 +83,7 @@ describe('pg:outliers', function () {
   }
 
   it('resets query stats on standard plan using real function', async function () {
+    sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockStandardDb)
     execQueryStub.onCall(0).resolves('server_version\n---------\n13.7')
     execQueryStub.onCall(1).resolves('t')
     execQueryStub.onCall(2).resolves('')
@@ -59,7 +96,7 @@ describe('pg:outliers', function () {
   })
 
   it('resets query stats on essential plan using _heroku wrapper', async function () {
-    getAttachmentStub.resolves({addon: mockEssentialAddon} as any)
+    sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockEssentialDb)
     execQueryStub.onCall(0).resolves('server_version\n---------\n17.7')
     execQueryStub.onCall(1).resolves('t')
     execQueryStub.onCall(2).resolves('')
@@ -72,7 +109,7 @@ describe('pg:outliers', function () {
   })
 
   it('resets query stats on advanced plan using _heroku wrapper', async function () {
-    getAttachmentStub.resolves({addon: mockAdvancedAddon} as any)
+    sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockAdvancedDb)
     execQueryStub.onCall(0).resolves('server_version\n---------\n17.7')
     execQueryStub.onCall(1).resolves('t')
     execQueryStub.onCall(2).resolves('')
@@ -85,6 +122,7 @@ describe('pg:outliers', function () {
   })
 
   it('returns query outliers for version 11', async function () {
+    sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockEssentialDb)
     setupVersionStub('11.16')
 
     const {stdout} = await runCommand(Cmd, [
@@ -101,6 +139,7 @@ describe('pg:outliers', function () {
   })
 
   it('uses an updated query for version 13+', async function () {
+    sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockEssentialDb)
     setupVersionStub('13.7')
 
     const {stdout} = await runCommand(Cmd, [
@@ -116,6 +155,7 @@ describe('pg:outliers', function () {
   })
 
   it('uses updated block time fields for version 17+', async function () {
+    sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockEssentialDb)
     setupVersionStub('17.0')
 
     await runCommand(Cmd, [
@@ -130,6 +170,7 @@ describe('pg:outliers', function () {
   })
 
   it('respects the --num flag', async function () {
+    sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockEssentialDb)
     setupVersionStub('13.7')
 
     await runCommand(Cmd, [
@@ -144,6 +185,7 @@ describe('pg:outliers', function () {
   })
 
   it('truncates queries with --truncate flag', async function () {
+    sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockEssentialDb)
     setupVersionStub('13.7')
 
     await runCommand(Cmd, [

--- a/test/unit/commands/pg/outliers.unit.test.ts
+++ b/test/unit/commands/pg/outliers.unit.test.ts
@@ -21,12 +21,16 @@ describe('pg:outliers', function () {
     user: 'testuser',
   }
 
-  const mockEssentialDb = {...mockDb, plan: {name: 'heroku-postgresql:essential-0'}} as unknown as pg.ConnectionDetails
-  const mockAdvancedDb = {...mockDb, plan: {name: 'heroku-postgresql:advanced'}} as unknown as pg.ConnectionDetails
+  const mockStandardAddon = {plan: {name: 'heroku-postgresql:standard-0'}} as any
+  const mockEssentialAddon = {plan: {name: 'heroku-postgresql:essential-0'}} as any
+  const mockAdvancedAddon = {plan: {name: 'heroku-postgresql:advanced'}} as any
+
+  let getAttachmentStub: sinon.SinonStub
 
   beforeEach(function () {
     sandbox = sinon.createSandbox()
     getDatabaseStub = sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockDb)
+    getAttachmentStub = sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getAttachment').resolves({addon: mockStandardAddon} as any)
     execQueryStub = sandbox.stub(utils.pg.PsqlService.prototype, 'execQuery')
   })
 
@@ -55,7 +59,7 @@ describe('pg:outliers', function () {
   })
 
   it('resets query stats on essential plan using _heroku wrapper', async function () {
-    getDatabaseStub.resolves(mockEssentialDb)
+    getAttachmentStub.resolves({addon: mockEssentialAddon} as any)
     execQueryStub.onCall(0).resolves('server_version\n---------\n17.7')
     execQueryStub.onCall(1).resolves('t')
     execQueryStub.onCall(2).resolves('')
@@ -68,7 +72,7 @@ describe('pg:outliers', function () {
   })
 
   it('resets query stats on advanced plan using _heroku wrapper', async function () {
-    getDatabaseStub.resolves(mockAdvancedDb)
+    getAttachmentStub.resolves({addon: mockAdvancedAddon} as any)
     execQueryStub.onCall(0).resolves('server_version\n---------\n17.7')
     execQueryStub.onCall(1).resolves('t')
     execQueryStub.onCall(2).resolves('')

--- a/test/unit/commands/pg/outliers.unit.test.ts
+++ b/test/unit/commands/pg/outliers.unit.test.ts
@@ -21,6 +21,9 @@ describe('pg:outliers', function () {
     user: 'testuser',
   }
 
+  const mockEssentialDb = {...mockDb, plan: {name: 'heroku-postgresql:essential-0'}} as unknown as pg.ConnectionDetails
+  const mockAdvancedDb = {...mockDb, plan: {name: 'heroku-postgresql:advanced'}} as unknown as pg.ConnectionDetails
+
   beforeEach(function () {
     sandbox = sinon.createSandbox()
     getDatabaseStub = sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockDb)
@@ -39,22 +42,42 @@ describe('pg:outliers', function () {
     execQueryStub.onCall(2).resolves(expectedOutputText) // main query
   }
 
-  it('resets query stats', async function () {
-    // For reset: 1) fetchVersion, 2) ensurePGStatStatement, 3) reset
+  it('resets query stats on standard plan using real function', async function () {
     execQueryStub.onCall(0).resolves('server_version\n---------\n13.7')
     execQueryStub.onCall(1).resolves('t')
     execQueryStub.onCall(2).resolves('')
 
-    await runCommand(Cmd, [
-      '--app',
-      'myapp',
-      '--reset',
-    ])
+    await runCommand(Cmd, ['--app', 'myapp', '--reset'])
 
-    expect(getDatabaseStub.calledOnce).to.be.true
     expect(execQueryStub.calledThrice).to.be.true
     const resetQuery = execQueryStub.getCall(2).args[0]
     expect(resetQuery.trim()).to.eq('SELECT pg_stat_statements_reset();')
+  })
+
+  it('resets query stats on essential plan using _heroku wrapper', async function () {
+    getDatabaseStub.resolves(mockEssentialDb)
+    execQueryStub.onCall(0).resolves('server_version\n---------\n17.7')
+    execQueryStub.onCall(1).resolves('t')
+    execQueryStub.onCall(2).resolves('')
+
+    await runCommand(Cmd, ['--app', 'myapp', '--reset'])
+
+    expect(execQueryStub.calledThrice).to.be.true
+    const resetQuery = execQueryStub.getCall(2).args[0]
+    expect(resetQuery.trim()).to.eq('SELECT _heroku.pg_stat_statements_reset();')
+  })
+
+  it('resets query stats on advanced plan using _heroku wrapper', async function () {
+    getDatabaseStub.resolves(mockAdvancedDb)
+    execQueryStub.onCall(0).resolves('server_version\n---------\n17.7')
+    execQueryStub.onCall(1).resolves('t')
+    execQueryStub.onCall(2).resolves('')
+
+    await runCommand(Cmd, ['--app', 'myapp', '--reset'])
+
+    expect(execQueryStub.calledThrice).to.be.true
+    const resetQuery = execQueryStub.getCall(2).args[0]
+    expect(resetQuery.trim()).to.eq('SELECT _heroku.pg_stat_statements_reset();')
   })
 
   it('returns query outliers for version 11', async function () {


### PR DESCRIPTION
## Summary

- `heroku pg:outliers --reset` was calling `pg_stat_statements_reset()` directly for all plans
- On Essential/Advanced, the real function is no longer granted to tenants — they have a `SECURITY DEFINER` wrapper `_heroku.pg_stat_statements_reset()` scoped to the current database only
- Now uses `getAttachment` to detect the plan and calls the right function per fleet:
  - **Essential & Advanced** : `SELECT _heroku.pg_stat_statements_reset()`
  - **Standard and below** : `SELECT pg_stat_statements_reset()`

Change is not in shogun yet, it will be merged on Monday evening, right before the minor release.
There will be a brief period of time where the reset cli command won't work for essential & performance plans, in-between shogun release & cli release.

It can be tested using my shogun as below.

## Type of Change
- [x] fix: Bug fix

## Testing

Tests:
```
npx mocha --require ts-node/register test/unit/commands/pg/outliers.unit.test.ts

getting statement count:
SELECT count(*) FROM pg_stat_statements WHERE dbid = (SELECT   oid FROM pg_database WHERE datname = current_database())  AND userid = (SELECT usesysid FROM pg_user WHERE usename =  current_user);

calling reset:
HEROKU_DATA_HOST=shogun.dasofiei.herokudev.com HEROKU_DATA_SERVICE=heroku-postgresql-dasofiei ./bin/run pg:outliers --reset HEROKU_POSTGRESQL_DASOFIEI_RED_URL --app dasofiei-public
```

End-to-end:
1. Build: \`npm run build\`
2. On an **Essential** database: \`heroku pg:outliers --reset --app <app>\` — should succeed and return cleanly
3. Verify the reset only cleared that database's stats — connect to a second Essential on the same cluster, confirm its \`pg_stat_statements\` count is unchanged
4. On a **Standard** database: \`heroku pg:outliers --reset --app <app>\` — should succeed using the real function directly

## Related

Shogun PR: https://github.com/heroku/shogun/pull/22200
Reset docs -> https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-pg-outliers-database
