### PR TITLE
feat: adds alias support for keychain-based accounts

### DIFF
--- a/src/commands/accounts/add.ts
+++ b/src/commands/accounts/add.ts
@@ -24,6 +24,11 @@ export default class Add extends Command {
     const {body: account} = await this.heroku.get<Heroku.Account>('/account')
     const email = account.email!
 
+    const existingAlias = accounts.find(account => account.name && account.username === email)
+    if (existingAlias) {
+      ux.error(`Account ${email} already has an alias: ${existingAlias.name}`)
+    }
+
     const token = this.heroku.auth!
 
     AccountsModule.add(name, email, token)

--- a/src/commands/accounts/add.ts
+++ b/src/commands/accounts/add.ts
@@ -7,9 +7,9 @@ import AccountsModule from '../../lib/accounts/accounts.js'
 
 export default class Add extends Command {
   static args = {
-    name: Args.string({description: 'name of Heroku account to add', required: true}),
+    name: Args.string({description: 'alias for Heroku account to add', required: true}),
   }
-  static description = 'add a Heroku account to your cache'
+  static description = 'add the current Heroku account to your accounts cache'
   static example = `${color.command('heroku accounts:add my-account')}`
 
   async run() {

--- a/src/commands/accounts/remove.ts
+++ b/src/commands/accounts/remove.ts
@@ -15,11 +15,16 @@ export default class Remove extends Command {
     const {args} = await this.parse(Remove)
     const {name} = args
 
-    if (!(await AccountsModule.list()).some(account => account.name === name || account.username === name)) {
+    const accounts = await AccountsModule.list()
+    const account = accounts.find(a => a.name === name || a.username === name)
+
+    if (!account) {
       ux.error(`${name} doesn't exist in your accounts cache.`)
     }
 
-    if (await AccountsModule.current(this.heroku) === name) {
+    const currentAccount = await AccountsModule.current(this.heroku)
+    // Check both alias (name) and email (username) against current account
+    if (currentAccount === name || currentAccount === account.username) {
       ux.error(`${name} is the current account. To log out, run ${color.command('heroku logout')}.`)
     }
 

--- a/src/commands/accounts/set.ts
+++ b/src/commands/accounts/set.ts
@@ -16,15 +16,12 @@ export default class Set extends Command {
     const {name} = args
 
     const accounts = await AccountsModule.list()
-    const netrcAccount = accounts.find(account => account.name === name)
-    const keychainAccount = accounts.find(account => !account.name && account.username === name)
+    const account = accounts.find(account => account.name === name || account.username === name)
 
-    if (!netrcAccount && !keychainAccount) {
+    if (!account) {
       ux.error(`${name} does not exist in your accounts cache or system keychain.`)
     }
 
-    const account = netrcAccount ?? keychainAccount
-
-    await AccountsModule.set(account!, this.config.dataDir)
+    await AccountsModule.set(account, this.config.dataDir)
   }
 }

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -26,7 +26,7 @@ export default class Logout extends Command {
     }
 
     if (cachedNetrcAccount) {
-      AccountsModule.removeNetrc(cachedNetrcAccount)
+      await AccountsModule.remove(cachedNetrcAccount)
     }
 
     await this.config.runHook('recache', {type: 'logout'})

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -32,7 +32,7 @@ export class AccountsWrapper implements IAccountsWrapper {
 
   add(name: string, username: string, password: string): void {
     const config = this.getStorageConfig()
-    const basedir = path.join(this.configDir(), 'accounts')
+    const basedir = this.accountsDir()
     fs.mkdirSync(basedir, {recursive: true})
 
     if (config.credentialStore) {
@@ -112,7 +112,7 @@ export class AccountsWrapper implements IAccountsWrapper {
   }
 
   listNetrc(): AccountEntry[] {
-    const basedir = path.join(this.configDir(), 'accounts')
+    const basedir = this.accountsDir()
     try {
       return fs.readdirSync(basedir)
         .map(name => ({name, username: this.account(name).username ?? ''}))
@@ -131,8 +131,7 @@ export class AccountsWrapper implements IAccountsWrapper {
       if (email) {
         // Aliased keychain account
         await removeAuth(email, ['api.heroku.com', 'git.heroku.com'])
-        const basedir = path.join(this.configDir(), 'accounts')
-        fs.unlinkSync(path.join(basedir, name))
+        fs.unlinkSync(path.join(this.accountsDir(), name))
       } else {
         // Non-aliased keychain account (name IS the email)
         await removeAuth(name, ['api.heroku.com', 'git.heroku.com'])
@@ -143,8 +142,7 @@ export class AccountsWrapper implements IAccountsWrapper {
     }
 
     // Netrc mode: always remove alias file
-    const basedir = path.join(this.configDir(), 'accounts')
-    fs.unlinkSync(path.join(basedir, name))
+    fs.unlinkSync(path.join(this.accountsDir(), name))
   }
 
   async set(account: AccountEntry, dataDir: string): Promise<void> {
@@ -181,8 +179,7 @@ export class AccountsWrapper implements IAccountsWrapper {
   }
 
   private account(name: string): Heroku.Account {
-    const basedir = path.join(this.configDir(), 'accounts')
-    const file = fs.readFileSync(path.join(basedir, name), 'utf8')
+    const file = fs.readFileSync(path.join(this.accountsDir(), name), 'utf8')
     const account = parse(file)
     if (account[':username']) {
       // convert from ruby symbols
@@ -197,8 +194,7 @@ export class AccountsWrapper implements IAccountsWrapper {
 
   private getAliasEmail(alias: string): string | null {
     try {
-      const basedir = path.join(this.configDir(), 'accounts')
-      const filePath = path.join(basedir, alias)
+      const filePath = path.join(this.accountsDir(), alias)
 
       if (!fs.existsSync(filePath)) {
         return null
@@ -220,10 +216,9 @@ export class AccountsWrapper implements IAccountsWrapper {
 
   private listAliasFiles(): Map<string, string> {
     try {
-      const basedir = path.join(this.configDir(), 'accounts')
       const aliasMap = new Map<string, string>()
 
-      const files = fs.readdirSync(basedir)
+      const files = fs.readdirSync(this.accountsDir())
       for (const alias of files) {
         const email = this.getAliasEmail(alias)
         if (email) {
@@ -235,6 +230,10 @@ export class AccountsWrapper implements IAccountsWrapper {
     } catch {
       return new Map()
     }
+  }
+
+  private accountsDir(): string {
+    return path.join(this.configDir(), 'accounts')
   }
 
   private configDir() {

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -32,26 +32,15 @@ export class AccountsWrapper implements IAccountsWrapper {
 
   add(name: string, username: string, password: string): void {
     const config = this.getStorageConfig()
-    const basedir = this.accountsDir()
-    fs.mkdirSync(basedir, {recursive: true})
+    fs.mkdirSync(this.accountsDir(), {recursive: true})
 
     if (config.credentialStore) {
-      fs.writeFileSync(
-        path.join(basedir, name),
-        stringify({username}),
-        'utf8',
-      )
-      fs.chmodSync(path.join(basedir, name), 0o600)
+      this.writeAccountFile(name, {username})
     }
 
     if (config.useNetrc) {
-      fs.writeFileSync(
-        path.join(basedir, name),
-        // eslint-disable-next-line perfectionist/sort-objects
-        stringify({username, password}),
-        'utf8',
-      )
-      fs.chmodSync(path.join(basedir, name), 0o600)
+      // eslint-disable-next-line perfectionist/sort-objects
+      this.writeAccountFile(name, {username, password})
     }
   }
 
@@ -232,6 +221,12 @@ export class AccountsWrapper implements IAccountsWrapper {
       delete account[':username']
       delete account[':password']
     }
+  }
+
+  private writeAccountFile(name: string, content: Record<string, string>): void {
+    const filePath = path.join(this.accountsDir(), name)
+    fs.writeFileSync(filePath, stringify(content), 'utf8')
+    fs.chmodSync(filePath, 0o600)
   }
 
   private configDir() {

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -173,6 +173,25 @@ export class AccountsWrapper implements IAccountsWrapper {
     }
   }
 
+  private listAliasFiles(): Map<string, string> {
+    try {
+      const basedir = path.join(this.configDir(), 'accounts')
+      const aliasMap = new Map<string, string>()
+
+      const files = fs.readdirSync(basedir)
+      for (const alias of files) {
+        const email = this.getAliasEmail(alias)
+        if (email) {
+          aliasMap.set(alias, email)
+        }
+      }
+
+      return aliasMap
+    } catch {
+      return new Map()
+    }
+  }
+
   private configDir() {
     const legacyDir = path.join(os.homedir(), '.heroku')
     if (fs.existsSync(legacyDir)) {

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -23,7 +23,6 @@ export interface IAccountsWrapper {
   getStorageConfig(): ReturnType<typeof getStorageConfig>
   list(): Promise<AccountEntry[]>
   remove(name: string): void
-  removeNetrc(name: string): void
   set(account: AccountEntry, dataDir: string): Promise<void>
   writeLoginState(dataDir: string, name: string): Promise<void>
 }
@@ -149,6 +148,29 @@ export class AccountsWrapper implements IAccountsWrapper {
     }
 
     return account
+  }
+
+  private getAliasEmail(alias: string): string | null {
+    try {
+      const basedir = path.join(this.configDir(), 'accounts')
+      const filePath = path.join(basedir, alias)
+
+      if (!fs.existsSync(filePath)) {
+        return null
+      }
+
+      const file = fs.readFileSync(filePath, 'utf8')
+      const account = parse(file)
+
+      // Handle Ruby-style symbol keys for backward compatibility with legacy Ruby CLI
+      if (account[':username']) {
+        account.username = account[':username']
+      }
+
+      return account.username ?? null
+    } catch {
+      return null
+    }
   }
 
   private configDir() {

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -123,10 +123,26 @@ export class AccountsWrapper implements IAccountsWrapper {
 
   async remove(name: string): Promise<void> {
     const config = this.getStorageConfig()
+
     if (config.credentialStore) {
-      await removeAuth(name, ['api.heroku.com', 'git.heroku.com'])
+      // Try to resolve alias to email
+      const email = this.getAliasEmail(name)
+
+      if (email) {
+        // Aliased keychain account
+        await removeAuth(email, ['api.heroku.com', 'git.heroku.com'])
+        const basedir = path.join(this.configDir(), 'accounts')
+        fs.unlinkSync(path.join(basedir, name))
+      } else {
+        // Non-aliased keychain account (name IS the email)
+        await removeAuth(name, ['api.heroku.com', 'git.heroku.com'])
+        // No alias file to remove
+      }
+
+      return
     }
 
+    // Netrc mode: always remove alias file
     const basedir = path.join(this.configDir(), 'accounts')
     fs.unlinkSync(path.join(basedir, name))
   }

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -36,9 +36,7 @@ export class AccountsWrapper implements IAccountsWrapper {
 
     if (config.credentialStore) {
       this.writeAccountFile(name, {username})
-    }
-
-    if (config.useNetrc) {
+    } else if (config.useNetrc) {
       // eslint-disable-next-line perfectionist/sort-objects
       this.writeAccountFile(name, {username, password})
     }

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -33,11 +33,19 @@ export class AccountsWrapper implements IAccountsWrapper {
 
   add(name: string, username: string, password: string): void {
     const config = this.getStorageConfig()
+    const basedir = path.join(this.configDir(), 'accounts')
+    fs.mkdirSync(basedir, {recursive: true})
+
+    if (config.credentialStore) {
+      fs.writeFileSync(
+        path.join(basedir, name),
+        stringify({username}),
+        'utf8',
+      )
+      fs.chmodSync(path.join(basedir, name), 0o600)
+    }
 
     if (config.useNetrc) {
-      const basedir = path.join(this.configDir(), 'accounts')
-      fs.mkdirSync(basedir, {recursive: true})
-
       fs.writeFileSync(
         path.join(basedir, name),
         // eslint-disable-next-line perfectionist/sort-objects

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -133,9 +133,22 @@ export class AccountsWrapper implements IAccountsWrapper {
 
   async set(account: AccountEntry, dataDir: string): Promise<void> {
     const config = this.getStorageConfig()
-    if (config.credentialStore && !account.name) {
-      await this.writeLoginState(dataDir, account.username)
-      return
+
+    if (config.credentialStore) {
+      if (account.name) {
+        // Aliased keychain account: read email from alias file
+        const email = this.getAliasEmail(account.name)
+        if (email) {
+          await this.writeLoginState(dataDir, email)
+          return
+        }
+
+        throw new Error(`Alias file for ${account.name} not found`)
+      } else {
+        // Non-aliased account: use username directly
+        await this.writeLoginState(dataDir, account.username)
+        return
+      }
     }
 
     if (config.useNetrc && account.name) {

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -10,7 +10,10 @@ import * as color from '@heroku/heroku-cli-util/color'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import tsheredoc from 'tsheredoc'
 import {parse, stringify} from 'yaml'
+
+const heredoc = tsheredoc.default
 
 export interface AccountEntry {
   name?: string
@@ -120,10 +123,10 @@ export class AccountsWrapper implements IAccountsWrapper {
         // Aliased account - check if it was created in netrc mode
         const accountData = this.account(name)
         if (accountData.password) {
-          throw new Error(
-            `Cannot remove ${name}: this account was created in netrc mode.\n` +
-            `To remove it, run: ${color.command(`HEROKU_NETRC_WRITE=true heroku accounts:remove ${name}`)}`
-          )
+          throw new Error(heredoc(`
+            Cannot remove ${name}: this account was created in netrc mode.
+            To remove it, run: ${color.command(`HEROKU_NETRC_WRITE=true heroku accounts:remove ${name}`)}
+          `))
         }
 
         // Aliased keychain account
@@ -143,11 +146,11 @@ export class AccountsWrapper implements IAccountsWrapper {
     if (email) {
       const accountData = this.account(name)
       if (!accountData.password) {
-        throw new Error(
-          `Cannot remove ${name}: this account is saved to your computer's keychain application.\n` +
-          `To remove it, run: ${color.command(`heroku accounts:remove ${name}`)}\n` +
-          `(without HEROKU_NETRC_WRITE set)`
-        )
+        throw new Error(heredoc(`
+          Cannot remove ${name}: this account is saved to your computer's keychain application.
+          To remove it, run: ${color.command(`heroku accounts:remove ${name}`)}
+          (without HEROKU_NETRC_WRITE set)
+        `))
       }
     }
 
@@ -195,7 +198,29 @@ export class AccountsWrapper implements IAccountsWrapper {
     return account
   }
 
-  private getAliasEmail(alias: string): string | null {
+  private accountsDir(): string {
+    return path.join(this.configDir(), 'accounts')
+  }
+
+  private configDir() {
+    const legacyDir = path.join(os.homedir(), '.heroku')
+    if (fs.existsSync(legacyDir)) {
+      return legacyDir
+    }
+
+    return path.join(os.homedir(), '.config', 'heroku')
+  }
+
+  private convertRubySymbols(account: any): void {
+    if (account[':username']) {
+      account.username = account[':username']
+      account.password = account[':password']
+      delete account[':username']
+      delete account[':password']
+    }
+  }
+
+  private getAliasEmail(alias: string): null | string {
     try {
       const filePath = path.join(this.accountsDir(), alias)
 
@@ -211,6 +236,17 @@ export class AccountsWrapper implements IAccountsWrapper {
     } catch {
       return null
     }
+  }
+
+  private async initNetrc() {
+    if (!this.netrc) {
+      const NetrcModule = await import('netrc-parser')
+      const NetrcClass = (NetrcModule as any).Netrc || (NetrcModule as any).default.constructor
+      this.netrc = new NetrcClass()
+      await this.netrc.load()
+    }
+
+    return this.netrc
   }
 
   private listAliasFiles(): Map<string, string> {
@@ -231,43 +267,10 @@ export class AccountsWrapper implements IAccountsWrapper {
     }
   }
 
-  private accountsDir(): string {
-    return path.join(this.configDir(), 'accounts')
-  }
-
-  private convertRubySymbols(account: any): void {
-    if (account[':username']) {
-      account.username = account[':username']
-      account.password = account[':password']
-      delete account[':username']
-      delete account[':password']
-    }
-  }
-
   private writeAccountFile(name: string, content: Record<string, string>): void {
     const filePath = path.join(this.accountsDir(), name)
     fs.writeFileSync(filePath, stringify(content), 'utf8')
     fs.chmodSync(filePath, 0o600)
-  }
-
-  private configDir() {
-    const legacyDir = path.join(os.homedir(), '.heroku')
-    if (fs.existsSync(legacyDir)) {
-      return legacyDir
-    }
-
-    return path.join(os.homedir(), '.config', 'heroku')
-  }
-
-  private async initNetrc() {
-    if (!this.netrc) {
-      const NetrcModule = await import('netrc-parser')
-      const NetrcClass = (NetrcModule as any).Netrc || (NetrcModule as any).default.constructor
-      this.netrc = new NetrcClass()
-      await this.netrc.load()
-    }
-
-    return this.netrc
   }
 }
 

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -110,13 +110,8 @@ export class AccountsWrapper implements IAccountsWrapper {
     const config = this.getStorageConfig()
     if (config.credentialStore) {
       await removeAuth(name, ['api.heroku.com', 'git.heroku.com'])
-      return
     }
 
-    this.removeNetrc(name)
-  }
-
-  removeNetrc(name: string) {
     const basedir = path.join(this.configDir(), 'accounts')
     fs.unlinkSync(path.join(basedir, name))
   }

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -6,6 +6,7 @@ import {
 } from '@heroku-cli/command'
 import {removeAuth} from '@heroku-cli/command/lib/credential-manager.js'
 import * as Heroku from '@heroku-cli/schema'
+import * as color from '@heroku/heroku-cli-util/color'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -112,10 +113,19 @@ export class AccountsWrapper implements IAccountsWrapper {
     const config = this.getStorageConfig()
 
     if (config.credentialStore) {
-      // Try to resolve alias to email
+      // Keychain mode
       const email = this.getAliasEmail(name)
 
       if (email) {
+        // Aliased account - check if it was created in netrc mode
+        const accountData = this.account(name)
+        if (accountData.password) {
+          throw new Error(
+            `Cannot remove ${name}: this account was created in netrc mode.\n` +
+            `To remove it, run: ${color.command(`HEROKU_NETRC_WRITE=true heroku accounts:remove ${name}`)}`
+          )
+        }
+
         // Aliased keychain account
         await removeAuth(email, ['api.heroku.com', 'git.heroku.com'])
         fs.unlinkSync(path.join(this.accountsDir(), name))
@@ -128,7 +138,20 @@ export class AccountsWrapper implements IAccountsWrapper {
       return
     }
 
-    // Netrc mode: always remove alias file
+    // Netrc mode - check if account is saved in keychain
+    const email = this.getAliasEmail(name)
+    if (email) {
+      const accountData = this.account(name)
+      if (!accountData.password) {
+        throw new Error(
+          `Cannot remove ${name}: this account is saved to your computer's keychain application.\n` +
+          `To remove it, run: ${color.command(`heroku accounts:remove ${name}`)}\n` +
+          `(without HEROKU_NETRC_WRITE set)`
+        )
+      }
+    }
+
+    // Netrc mode: remove alias file
     fs.unlinkSync(path.join(this.accountsDir(), name))
   }
 

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -181,14 +181,7 @@ export class AccountsWrapper implements IAccountsWrapper {
   private account(name: string): Heroku.Account {
     const file = fs.readFileSync(path.join(this.accountsDir(), name), 'utf8')
     const account = parse(file)
-    if (account[':username']) {
-      // convert from ruby symbols
-      account.username = account[':username']
-      account.password = account[':password']
-      delete account[':username']
-      delete account[':password']
-    }
-
+    this.convertRubySymbols(account)
     return account
   }
 
@@ -202,11 +195,7 @@ export class AccountsWrapper implements IAccountsWrapper {
 
       const file = fs.readFileSync(filePath, 'utf8')
       const account = parse(file)
-
-      // Handle Ruby-style symbol keys for backward compatibility with legacy Ruby CLI
-      if (account[':username']) {
-        account.username = account[':username']
-      }
+      this.convertRubySymbols(account)
 
       return account.username ?? null
     } catch {
@@ -234,6 +223,15 @@ export class AccountsWrapper implements IAccountsWrapper {
 
   private accountsDir(): string {
     return path.join(this.configDir(), 'accounts')
+  }
+
+  private convertRubySymbols(account: any): void {
+    if (account[':username']) {
+      account.username = account[':username']
+      account.password = account[':password']
+      delete account[':username']
+      delete account[':password']
+    }
   }
 
   private configDir() {

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -86,10 +86,26 @@ export class AccountsWrapper implements IAccountsWrapper {
   async list(): Promise<AccountEntry[]> {
     const config = this.getStorageConfig()
     if (config.credentialStore) {
-      const accounts = await this.getKeychainAccounts()
-      return accounts
-        .filter((account): account is string => account !== null && account !== undefined)
-        .map(account => ({username: account}))
+      const keychainEmails = await this.getKeychainAccounts()
+      const aliasMap = this.listAliasFiles()
+
+      // Create reverse map: email → alias (for lookup)
+      const emailToAlias = new Map<string, string>()
+      for (const [alias, email] of aliasMap.entries()) {
+        // If multiple aliases point to same email, keep first
+        if (!emailToAlias.has(email)) {
+          emailToAlias.set(email, alias)
+        }
+      }
+
+      return keychainEmails
+        .filter((email): email is string => email !== null && email !== undefined)
+        .map(email => {
+          const alias = emailToAlias.get(email)
+          return alias
+            ? {name: alias, username: email}
+            : {username: email}
+        })
     }
 
     return this.listNetrc()

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -155,8 +155,8 @@ export class AccountsWrapper implements IAccountsWrapper {
     if (config.useNetrc && account.name) {
       const netrcInstance = await this.initNetrc()
       const current = this.account(account.name)
-      netrcInstance.machines['git.heroku.com'] = {login: current.username, password: current.password}
-      netrcInstance.machines['api.heroku.com'] = {login: current.username, password: current.password}
+      netrcInstance.machines['git.heroku.com'] = {login: current.username, password: current.password || ''}
+      netrcInstance.machines['api.heroku.com'] = {login: current.username, password: current.password || ''}
       await netrcInstance.save()
     }
   }

--- a/test/unit/commands/accounts/add.unit.test.ts
+++ b/test/unit/commands/accounts/add.unit.test.ts
@@ -73,5 +73,22 @@ describe('accounts:add', function () {
         expect((error as Error).message).to.contain('testAccountName already exists')
       }
     })
+
+    it('should error if the email already has an alias', async function () {
+      stubCredentialManager({
+        getAuth: async () => ({account: 'testEmail', token: 'testHerokuAPIKey'}),
+      })
+
+      api.get('/account')
+        .reply(200, {email: 'testEmail'})
+
+      listStub.resolves([{name: 'existingAlias', username: 'testEmail'}])
+
+      try {
+        await runCommand(Cmd, ['newAlias'])
+      } catch (error: unknown) {
+        expect((error as Error).message).to.contain('testEmail already has an alias: existingAlias')
+      }
+    })
   })
 })

--- a/test/unit/commands/accounts/remove.unit.test.ts
+++ b/test/unit/commands/accounts/remove.unit.test.ts
@@ -1,4 +1,5 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import ansis from 'ansis'
 import {expect} from 'chai'
 import * as sinon from 'sinon'
 
@@ -42,7 +43,16 @@ describe('accounts:remove', function () {
     listStub.resolves([{name: 'test-account', username: 'user1'}, {name: 'test-account-2', username: 'user2'}])
     await runCommand(Cmd, ['test-account'])
       .catch((error: Error) => {
-        expect(error.message).to.contain('test-account is the current account.')
+        expect(ansis.strip(error.message)).to.equal('test-account is the current account. To log out, run heroku logout.')
+      })
+  })
+
+  it('should return an error if the selected account is the current account (aliased)', async function () {
+    currentStub.resolves('user1@example.com')
+    listStub.resolves([{name: 'test-account', username: 'user1@example.com'}, {name: 'test-account-2', username: 'user2@example.com'}])
+    await runCommand(Cmd, ['test-account'])
+      .catch((error: Error) => {
+        expect(ansis.strip(error.message)).to.equal('test-account is the current account. To log out, run heroku logout.')
       })
   })
 })

--- a/test/unit/commands/auth/logout.unit.test.ts
+++ b/test/unit/commands/auth/logout.unit.test.ts
@@ -10,13 +10,13 @@ describe('auth:logout', function () {
   let eraseCredentialsStub: sinon.SinonStub
   let removeCredentialHelperStub: sinon.SinonStub
   let currentNetrcStub: sinon.SinonStub
-  let removeNetrcStub: sinon.SinonStub
+  let removeStub: sinon.SinonStub
 
   beforeEach(function () {
     eraseCredentialsStub = sinon.stub(Git.prototype, 'eraseCredentials').resolves()
     removeCredentialHelperStub = sinon.stub(Git.prototype, 'removeCredentialHelper').resolves()
     currentNetrcStub = sinon.stub(AccountsModule, 'currentNetrc').resolves(null)
-    removeNetrcStub = sinon.stub(AccountsModule, 'removeNetrc')
+    removeStub = sinon.stub(AccountsModule, 'remove').resolves()
   })
 
   afterEach(function () {
@@ -59,8 +59,8 @@ describe('auth:logout', function () {
 
     await runCommand(Logout, [])
 
-    expect(removeNetrcStub.calledOnce).to.be.true
-    expect(removeNetrcStub.firstCall.args[0]).to.equal('my-account')
+    expect(removeStub.calledOnce).to.be.true
+    expect(removeStub.firstCall.args[0]).to.equal('my-account')
   })
 
   it('does not remove account when no cached netrc account', async function () {
@@ -68,6 +68,6 @@ describe('auth:logout', function () {
 
     await runCommand(Logout, [])
 
-    expect(removeNetrcStub.called).to.be.false
+    expect(removeStub.called).to.be.false
   })
 })

--- a/test/unit/lib/accounts/accounts.unit.test.ts
+++ b/test/unit/lib/accounts/accounts.unit.test.ts
@@ -471,7 +471,7 @@ describe('accounts', function () {
       existsSyncStub.returns(false)
       existsSyncStub.withArgs('/user/home/.heroku').returns(true)
       existsSyncStub.withArgs(match(/production$/)).returns(true)
-      fsReadFileStub.withArgs(match(/\.heroku.*production$/), 'utf8')
+      fsReadFileStub.withArgs(match(/production$/), 'utf8')
         .returns('username: user@example.com\n')
 
       const email = (AccountsModule as any).getAliasEmail('production')

--- a/test/unit/lib/accounts/accounts.unit.test.ts
+++ b/test/unit/lib/accounts/accounts.unit.test.ts
@@ -662,6 +662,47 @@ describe('accounts', function () {
 
         await expect(AccountsModule.remove(email)).to.be.rejectedWith('Keychain removal failed')
       })
+
+      it('should error when trying to remove netrc account in keychain mode', async function () {
+        const alias = 'netrc-account'
+        existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+        existsSyncStub.withArgs(match(/netrc-account$/)).returns(true)
+        fsReadFileStub.withArgs(match(/netrc-account$/), 'utf8')
+          .returns('username: user@example.com\npassword: token123\n')
+
+        await expect(AccountsModule.remove(alias))
+          .to.be.rejectedWith(/this account was created in netrc mode/)
+      })
+    })
+
+    describe('with netrc mode', function () {
+      beforeEach(function () {
+        stub(AccountsModule, 'getStorageConfig').returns({credentialStore: null, useNetrc: true})
+      })
+
+      it('should remove netrc account successfully', async function () {
+        const alias = 'netrc-account'
+        existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+        existsSyncStub.withArgs(match(/netrc-account$/)).returns(true)
+        fsReadFileStub.withArgs(match(/netrc-account$/), 'utf8')
+          .returns('username: user@example.com\npassword: token123\n')
+
+        await AccountsModule.remove(alias)
+
+        expect(unlinkStub.calledOnce).to.be.true
+        expect(unlinkStub.firstCall.args[0]).to.match(/netrc-account$/)
+      })
+
+      it('should error when trying to remove keychain account in netrc mode', async function () {
+        const alias = 'keychain-account'
+        existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+        existsSyncStub.withArgs(match(/keychain-account$/)).returns(true)
+        fsReadFileStub.withArgs(match(/keychain-account$/), 'utf8')
+          .returns('username: user@example.com\n')
+
+        await expect(AccountsModule.remove(alias))
+          .to.be.rejectedWith(/this account is saved to your computer's keychain application/)
+      })
     })
   })
 })

--- a/test/unit/lib/accounts/accounts.unit.test.ts
+++ b/test/unit/lib/accounts/accounts.unit.test.ts
@@ -591,30 +591,63 @@ describe('accounts', function () {
         credStub.restore()
       })
 
-      it('should call removeAuth with account name and hosts', async function () {
-        const accountName = 'test-account@example.com'
+      it('should remove aliased keychain account by resolving email from alias file', async function () {
+        const alias = 'production'
+        existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+        existsSyncStub.withArgs(match(/production$/)).returns(true)
+        fsReadFileStub.withArgs(match(/production$/), 'utf8')
+          .returns('username: prod@example.com\n')
 
-        await AccountsModule.remove(accountName)
+        await AccountsModule.remove(alias)
 
         expect(removeAuthStub.calledOnce).to.be.true
-        expect(removeAuthStub.firstCall.args[0]).to.equal(accountName)
+        expect(removeAuthStub.firstCall.args[0]).to.equal('prod@example.com')
         expect(removeAuthStub.firstCall.args[1]).to.deep.equal(['api.heroku.com', 'git.heroku.com'])
       })
 
-      it('should also remove the alias file when credentialStore is set', async function () {
-        const accountName = 'test-account@example.com'
+      it('should remove alias file after removing from keychain for aliased account', async function () {
+        const alias = 'production'
+        existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+        existsSyncStub.withArgs(match(/production$/)).returns(true)
+        fsReadFileStub.withArgs(match(/production$/), 'utf8')
+          .returns('username: prod@example.com\n')
 
-        await AccountsModule.remove(accountName)
+        await AccountsModule.remove(alias)
 
         expect(unlinkStub.calledOnce).to.be.true
+        expect(unlinkStub.firstCall.args[0]).to.match(/production$/)
+      })
+
+      it('should remove non-aliased keychain account using email directly', async function () {
+        const email = 'user@example.com'
+        existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+        existsSyncStub.withArgs(match(/user@example\.com$/)).returns(false)
+
+        await AccountsModule.remove(email)
+
+        expect(removeAuthStub.calledOnce).to.be.true
+        expect(removeAuthStub.firstCall.args[0]).to.equal(email)
+        expect(removeAuthStub.firstCall.args[1]).to.deep.equal(['api.heroku.com', 'git.heroku.com'])
+      })
+
+      it('should not try to remove alias file for non-aliased account', async function () {
+        const email = 'user@example.com'
+        existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+        existsSyncStub.withArgs(match(/user@example\.com$/)).returns(false)
+
+        await AccountsModule.remove(email)
+
+        expect(unlinkStub.called).to.be.false
       })
 
       it('should throw an error if removeAuth fails', async function () {
-        const accountName = 'test-account@example.com'
+        const email = 'user@example.com'
+        existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+        existsSyncStub.withArgs(match(/user@example\.com$/)).returns(false)
         const error = new Error('Keychain removal failed')
         removeAuthStub.rejects(error)
 
-        await expect(AccountsModule.remove(accountName)).to.be.rejectedWith('Keychain removal failed')
+        await expect(AccountsModule.remove(email)).to.be.rejectedWith('Keychain removal failed')
       })
     })
   })

--- a/test/unit/lib/accounts/accounts.unit.test.ts
+++ b/test/unit/lib/accounts/accounts.unit.test.ts
@@ -342,6 +342,17 @@ describe('accounts', function () {
 
         expect(fakeNetrc.save.called).to.be.false
       })
+
+      it('handles alias file without password (created in keychain mode)', async function () {
+        fsReadFileStub.withArgs(match(/keychain-alias$/), 'utf8')
+          .returns('username: user@example.com\n')
+        const account = {name: 'keychain-alias', username: 'user@example.com'}
+        await AccountsModule.set(account, '/data/heroku')
+
+        expect(fakeNetrc.machines['api.heroku.com']).to.deep.equal({login: 'user@example.com', password: ''})
+        expect(fakeNetrc.machines['git.heroku.com']).to.deep.equal({login: 'user@example.com', password: ''})
+        expect(fakeNetrc.save.calledOnce).to.be.true
+      })
     })
   })
 

--- a/test/unit/lib/accounts/accounts.unit.test.ts
+++ b/test/unit/lib/accounts/accounts.unit.test.ts
@@ -278,53 +278,105 @@ describe('accounts', function () {
     })
   })
 
-  describe('removeNetrc()', function () {
+  describe('getAliasEmail()', function () {
+    let existsSyncStub: SinonStub
+    let osHomeStub: SinonStub
+
+    beforeEach(function () {
+      existsSyncStub = stub(fs, 'existsSync')
+      osHomeStub = stub(os, 'homedir').returns('/user/home')
+    })
+
+    it('should return email when valid alias file exists', function () {
+      existsSyncStub.returns(false)
+      existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+      existsSyncStub.withArgs(match(/production$/)).returns(true)
+      fsReadFileStub.withArgs(match(/production$/), 'utf8')
+        .returns('username: user@example.com\n')
+
+      const email = (AccountsModule as any).getAliasEmail('production')
+
+      expect(email).to.equal('user@example.com')
+    })
+
+    it('should return null when alias file does not exist', function () {
+      existsSyncStub.returns(false)
+      existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+      existsSyncStub.withArgs(match(/nonexistent$/)).returns(false)
+
+      const email = (AccountsModule as any).getAliasEmail('nonexistent')
+
+      expect(email).to.equal(null)
+    })
+
+    it('should handle ruby-style symbol keys', function () {
+      existsSyncStub.returns(false)
+      existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+      existsSyncStub.withArgs(match(/legacy$/)).returns(true)
+      fsReadFileStub.withArgs(match(/legacy$/), 'utf8')
+        .returns('{":username": "legacy@example.com"}')
+
+      const email = (AccountsModule as any).getAliasEmail('legacy')
+
+      expect(email).to.equal('legacy@example.com')
+    })
+
+    it('should return null when file exists but username is missing', function () {
+      existsSyncStub.returns(false)
+      existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+      existsSyncStub.withArgs(match(/invalid$/)).returns(true)
+      fsReadFileStub.withArgs(match(/invalid$/), 'utf8')
+        .returns('other_field: value\n')
+
+      const email = (AccountsModule as any).getAliasEmail('invalid')
+
+      expect(email).to.equal(null)
+    })
+
+    it('should return null when file is malformed', function () {
+      existsSyncStub.returns(false)
+      existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+      existsSyncStub.withArgs(match(/malformed$/)).returns(true)
+      fsReadFileStub.withArgs(match(/malformed$/), 'utf8')
+        .throws(new Error('Parse error'))
+
+      const email = (AccountsModule as any).getAliasEmail('malformed')
+
+      expect(email).to.equal(null)
+    })
+
+    it('should use legacy .heroku directory when it exists', function () {
+      existsSyncStub.returns(false)
+      existsSyncStub.withArgs('/user/home/.heroku').returns(true)
+      existsSyncStub.withArgs(match(/production$/)).returns(true)
+      fsReadFileStub.withArgs(match(/\.heroku.*production$/), 'utf8')
+        .returns('username: user@example.com\n')
+
+      const email = (AccountsModule as any).getAliasEmail('production')
+
+      expect(email).to.equal('user@example.com')
+    })
+  })
+
+  describe('remove', function () {
     let unlinkStub: SinonStub
     let osHomeStub: SinonStub
     let existsSyncStub: SinonStub
 
     beforeEach(function () {
       unlinkStub = stub(fs, 'unlinkSync')
-      osHomeStub = stub(os, 'homedir')
+      osHomeStub = stub(os, 'homedir').returns('/user/home')
       existsSyncStub = stub(fs, 'existsSync')
     })
 
-    it('should remove the account file with the given name', function () {
+    it('should remove the alias file when no credential store', async function () {
       const accountName = 'test-account'
-      const basedir = '/user/home'
-
-      osHomeStub.returns(basedir)
       existsSyncStub.returns(false)
-
-      AccountsModule.removeNetrc(accountName)
-
-      expect(unlinkStub.calledOnce).to.be.true
-      expect(unlinkStub.firstCall.args[0]).to.equal(path.join(`${basedir}/.config/heroku/accounts`, accountName))
-    })
-
-    it('should throw an error if the file cannot be removed', function () {
-      const accountName = 'non-existent-account'
-      const error = new Error('File not found')
-      unlinkStub.throws(error)
-
-      expect(() => AccountsModule.removeNetrc(accountName)).to.throw(Error)
-    })
-  })
-
-  describe('remove', function () {
-    let removeNetrcStub: SinonStub
-
-    beforeEach(function () {
-      removeNetrcStub = stub(AccountsModule, 'removeNetrc')
-    })
-
-    it('should call removeNetrc when no credential store', async function () {
-      const accountName = 'test-account'
 
       await AccountsModule.remove(accountName)
 
-      expect(removeNetrcStub.calledOnce).to.be.true
-      expect(removeNetrcStub.firstCall.args[0]).to.equal(accountName)
+      expect(unlinkStub.calledOnce).to.be.true
+      expect(unlinkStub.firstCall.args[0]).to.match(/test-account$/)
     })
 
     describe('with credentialStore', function () {
@@ -353,12 +405,12 @@ describe('accounts', function () {
         expect(removeAuthStub.firstCall.args[1]).to.deep.equal(['api.heroku.com', 'git.heroku.com'])
       })
 
-      it('should not call removeNetrc when credentialStore is set', async function () {
+      it('should also remove the alias file when credentialStore is set', async function () {
         const accountName = 'test-account@example.com'
 
         await AccountsModule.remove(accountName)
 
-        expect(removeNetrcStub.called).to.be.false
+        expect(unlinkStub.calledOnce).to.be.true
       })
 
       it('should throw an error if removeAuth fails', async function () {

--- a/test/unit/lib/accounts/accounts.unit.test.ts
+++ b/test/unit/lib/accounts/accounts.unit.test.ts
@@ -204,11 +204,13 @@ describe('accounts', function () {
       chmodSyncStub = stub(fs, 'chmodSync')
     })
 
-    it('should not run if useNetrc is false', function () {
+    it('should write only username for credentialStore mode', function () {
       stub(AccountsModule, 'getStorageConfig').returns({credentialStore: 'macos-keychain', useNetrc: false})
       AccountsModule.add('test-user', 'username123', 'password123')
 
-      expect(mkdirSyncStub.calledOnce).to.be.false
+      expect(writeFileSyncStub.calledOnce).to.be.true
+      expect(writeFileSyncStub.firstCall.args[1]).to.equal('username: username123\n')
+      expect(writeFileSyncStub.firstCall.args[1]).to.not.include('password')
     })
 
     it('should create directory with recursive option', function () {

--- a/test/unit/lib/accounts/accounts.unit.test.ts
+++ b/test/unit/lib/accounts/accounts.unit.test.ts
@@ -241,15 +241,19 @@ describe('accounts', function () {
   })
 
   describe('set()', function () {
-    describe('with credentialStore and no account name', function () {
+    describe('with credentialStore', function () {
       let writeLoginStateStub: SinonStub
+      let existsSyncStub: SinonStub
+      let osHomeStub: SinonStub
 
       beforeEach(function () {
         stub(AccountsModule, 'getStorageConfig').returns({credentialStore: 'keychain' as any, useNetrc: false})
         writeLoginStateStub = stub(AccountsModule, 'writeLoginState').resolves()
+        existsSyncStub = stub(fs, 'existsSync')
+        osHomeStub = stub(os, 'homedir').returns('/user/home')
       })
 
-      it('calls writeLoginState with the dataDir and account username', async function () {
+      it('calls writeLoginState with username for non-aliased account', async function () {
         const account = {username: 'user@example.com'}
         await AccountsModule.set(account, '/data/heroku')
 
@@ -258,11 +262,41 @@ describe('accounts', function () {
         expect(writeLoginStateStub.firstCall.args[1]).to.equal('user@example.com')
       })
 
-      it('does not call writeLoginState when account has a name', async function () {
-        const account = {name: 'my-account', username: 'user@example.com'}
+      it('calls writeLoginState with email from alias file for aliased account', async function () {
+        const account = {name: 'production', username: 'prod@example.com'}
+        existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+        existsSyncStub.withArgs(match(/production$/)).returns(true)
+        fsReadFileStub.withArgs(match(/production$/), 'utf8')
+          .returns('username: prod@example.com\n')
+
         await AccountsModule.set(account, '/data/heroku')
 
-        expect(writeLoginStateStub.called).to.be.false
+        expect(writeLoginStateStub.calledOnce).to.be.true
+        expect(writeLoginStateStub.firstCall.args[0]).to.equal('/data/heroku')
+        expect(writeLoginStateStub.firstCall.args[1]).to.equal('prod@example.com')
+      })
+
+      it('throws error when alias file does not exist', async function () {
+        const account = {name: 'nonexistent', username: 'user@example.com'}
+        existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+        existsSyncStub.withArgs(match(/nonexistent$/)).returns(false)
+
+        await expect(AccountsModule.set(account, '/data/heroku'))
+          .to.be.rejectedWith('Alias file for nonexistent not found')
+      })
+
+      it('writes email to login.json not alias name', async function () {
+        const account = {name: 'production', username: 'prod@example.com'}
+        existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+        existsSyncStub.withArgs(match(/production$/)).returns(true)
+        fsReadFileStub.withArgs(match(/production$/), 'utf8')
+          .returns('username: prod@example.com\n')
+
+        await AccountsModule.set(account, '/data/heroku')
+
+        // Verify it writes EMAIL not alias
+        expect(writeLoginStateStub.firstCall.args[1]).to.equal('prod@example.com')
+        expect(writeLoginStateStub.firstCall.args[1]).to.not.equal('production')
       })
     })
 

--- a/test/unit/lib/accounts/accounts.unit.test.ts
+++ b/test/unit/lib/accounts/accounts.unit.test.ts
@@ -358,6 +358,93 @@ describe('accounts', function () {
     })
   })
 
+  describe('listAliasFiles()', function () {
+    let existsSyncStub: SinonStub
+    let osHomeStub: SinonStub
+
+    beforeEach(function () {
+      existsSyncStub = stub(fs, 'existsSync')
+      osHomeStub = stub(os, 'homedir').returns('/user/home')
+    })
+
+    it('should return empty Map when directory does not exist', function () {
+      existsSyncStub.returns(false)
+      fsReaddirStub.throws(new Error('Directory not found'))
+
+      const aliasMap = (AccountsModule as any).listAliasFiles()
+
+      expect(aliasMap).to.be.instanceof(Map)
+      expect(aliasMap.size).to.equal(0)
+    })
+
+    it('should return empty Map when directory is empty', function () {
+      existsSyncStub.returns(false)
+      existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+      fsReaddirStub.returns([])
+
+      const aliasMap = (AccountsModule as any).listAliasFiles()
+
+      expect(aliasMap).to.be.instanceof(Map)
+      expect(aliasMap.size).to.equal(0)
+    })
+
+    it('should return Map with valid alias files', function () {
+      existsSyncStub.returns(false)
+      existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+      existsSyncStub.withArgs(match(/production$/)).returns(true)
+      existsSyncStub.withArgs(match(/staging$/)).returns(true)
+      fsReaddirStub.returns(['production', 'staging'])
+      fsReadFileStub.withArgs(match(/production$/), 'utf8')
+        .returns('username: prod@example.com\n')
+      fsReadFileStub.withArgs(match(/staging$/), 'utf8')
+        .returns('username: stage@example.com\n')
+
+      const aliasMap = (AccountsModule as any).listAliasFiles()
+
+      expect(aliasMap).to.be.instanceof(Map)
+      expect(aliasMap.size).to.equal(2)
+      expect(aliasMap.get('production')).to.equal('prod@example.com')
+      expect(aliasMap.get('staging')).to.equal('stage@example.com')
+    })
+
+    it('should skip invalid files and return only valid entries', function () {
+      existsSyncStub.returns(false)
+      existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+      existsSyncStub.withArgs(match(/production$/)).returns(true)
+      existsSyncStub.withArgs(match(/invalid$/)).returns(true)
+      fsReaddirStub.returns(['production', 'invalid'])
+      fsReadFileStub.withArgs(match(/production$/), 'utf8')
+        .returns('username: prod@example.com\n')
+      fsReadFileStub.withArgs(match(/invalid$/), 'utf8')
+        .returns('other_field: value\n')
+
+      const aliasMap = (AccountsModule as any).listAliasFiles()
+
+      expect(aliasMap).to.be.instanceof(Map)
+      expect(aliasMap.size).to.equal(1)
+      expect(aliasMap.get('production')).to.equal('prod@example.com')
+      expect(aliasMap.has('invalid')).to.be.false
+    })
+
+    it('should handle files with parse errors gracefully', function () {
+      existsSyncStub.returns(false)
+      existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+      existsSyncStub.withArgs(match(/production$/)).returns(true)
+      existsSyncStub.withArgs(match(/malformed$/)).returns(true)
+      fsReaddirStub.returns(['production', 'malformed'])
+      fsReadFileStub.withArgs(match(/production$/), 'utf8')
+        .returns('username: prod@example.com\n')
+      fsReadFileStub.withArgs(match(/malformed$/), 'utf8')
+        .throws(new Error('Parse error'))
+
+      const aliasMap = (AccountsModule as any).listAliasFiles()
+
+      expect(aliasMap).to.be.instanceof(Map)
+      expect(aliasMap.size).to.equal(1)
+      expect(aliasMap.get('production')).to.equal('prod@example.com')
+    })
+  })
+
   describe('remove', function () {
     let unlinkStub: SinonStub
     let osHomeStub: SinonStub

--- a/test/unit/lib/accounts/accounts.unit.test.ts
+++ b/test/unit/lib/accounts/accounts.unit.test.ts
@@ -61,13 +61,20 @@ describe('accounts', function () {
   })
 
   describe('list() with credentialStore', function () {
+    let existsSyncStub: SinonStub
+    let osHomeStub: SinonStub
+
     beforeEach(function () {
       delete process.env.HEROKU_NETRC_WRITE
       stub(AccountsModule, 'getStorageConfig').returns({credentialStore: 'keychain' as any, useNetrc: false})
+      existsSyncStub = stub(fs, 'existsSync')
+      osHomeStub = stub(os, 'homedir').returns('/user/home')
     })
 
-    it('should return AccountEntry objects with only username when credentialStore is set', async function () {
+    it('should return AccountEntry objects with only username when no alias files exist', async function () {
       stub(AccountsModule, 'getKeychainAccounts').resolves(['user1@example.com', 'user2@example.com'])
+      existsSyncStub.returns(false)
+      fsReaddirStub.throws(new Error('Directory not found'))
 
       const result = await AccountsModule.list()
 
@@ -78,6 +85,8 @@ describe('accounts', function () {
 
     it('should return an empty array when the keychain has no accounts', async function () {
       stub(AccountsModule, 'getKeychainAccounts').resolves([])
+      existsSyncStub.returns(false)
+      fsReaddirStub.throws(new Error('Directory not found'))
 
       const result = await AccountsModule.list()
 
@@ -86,12 +95,78 @@ describe('accounts', function () {
 
     it('should filter out null and undefined keychain entries', async function () {
       stub(AccountsModule, 'getKeychainAccounts').resolves(['user1@example.com', null, undefined, 'user2@example.com'])
+      existsSyncStub.returns(false)
+      fsReaddirStub.throws(new Error('Directory not found'))
 
       const result = await AccountsModule.list()
 
       expect(result).to.have.lengthOf(2)
       expect(result[0]).to.deep.equal({username: 'user1@example.com'})
       expect(result[1]).to.deep.equal({username: 'user2@example.com'})
+    })
+
+    it('should return AccountEntry objects with name when alias files exist', async function () {
+      stub(AccountsModule, 'getKeychainAccounts').resolves(['prod@example.com', 'stage@example.com'])
+      existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+      existsSyncStub.withArgs(match(/production$/)).returns(true)
+      existsSyncStub.withArgs(match(/staging$/)).returns(true)
+      fsReaddirStub.returns(['production', 'staging'])
+      fsReadFileStub.withArgs(match(/production$/), 'utf8')
+        .returns('username: prod@example.com\n')
+      fsReadFileStub.withArgs(match(/staging$/), 'utf8')
+        .returns('username: stage@example.com\n')
+
+      const result = await AccountsModule.list()
+
+      expect(result).to.be.an('array').that.has.lengthOf(2)
+      expect(result[0]).to.deep.equal({name: 'production', username: 'prod@example.com'})
+      expect(result[1]).to.deep.equal({name: 'staging', username: 'stage@example.com'})
+    })
+
+    it('should return mixed results when some accounts have aliases', async function () {
+      stub(AccountsModule, 'getKeychainAccounts').resolves(['prod@example.com', 'user@example.com'])
+      existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+      existsSyncStub.withArgs(match(/production$/)).returns(true)
+      fsReaddirStub.returns(['production'])
+      fsReadFileStub.withArgs(match(/production$/), 'utf8')
+        .returns('username: prod@example.com\n')
+
+      const result = await AccountsModule.list()
+
+      expect(result).to.be.an('array').that.has.lengthOf(2)
+      expect(result[0]).to.deep.equal({name: 'production', username: 'prod@example.com'})
+      expect(result[1]).to.deep.equal({username: 'user@example.com'})
+    })
+
+    it('should use first alias when multiple aliases point to same email', async function () {
+      stub(AccountsModule, 'getKeychainAccounts').resolves(['prod@example.com'])
+      existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+      existsSyncStub.withArgs(match(/production$/)).returns(true)
+      existsSyncStub.withArgs(match(/prod$/)).returns(true)
+      fsReaddirStub.returns(['production', 'prod'])
+      fsReadFileStub.withArgs(match(/production$/), 'utf8')
+        .returns('username: prod@example.com\n')
+      fsReadFileStub.withArgs(match(/prod$/), 'utf8')
+        .returns('username: prod@example.com\n')
+
+      const result = await AccountsModule.list()
+
+      expect(result).to.be.an('array').that.has.lengthOf(1)
+      expect(result[0]).to.deep.equal({name: 'production', username: 'prod@example.com'})
+    })
+
+    it('should ignore orphaned alias files (no keychain entry)', async function () {
+      stub(AccountsModule, 'getKeychainAccounts').resolves(['user@example.com'])
+      existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
+      existsSyncStub.withArgs(match(/orphaned$/)).returns(true)
+      fsReaddirStub.returns(['orphaned'])
+      fsReadFileStub.withArgs(match(/orphaned$/), 'utf8')
+        .returns('username: orphaned@example.com\n')
+
+      const result = await AccountsModule.list()
+
+      expect(result).to.be.an('array').that.has.lengthOf(1)
+      expect(result[0]).to.deep.equal({username: 'user@example.com'})
     })
   })
 


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
Adds alias file support for keychain-based accounts, enabling users to use friendly names instead of email addresses when managing accounts.

  Key Changes:
  - Keychain accounts can now be added with aliases via accounts:add <alias>
  - Alias files store email mappings in ~/.config/heroku/accounts/<alias>
  - Updated list(), set(), and remove() to handle aliased keychain accounts
  - Commands work seamlessly: heroku accounts:set production
  
  Security & Validation:
  - Fixed critical bug: passwords never written to keychain alias files (only email)
  - Prevents duplicate aliases for the same email address
  
  Code Quality:
  - Reduced duplication with helper methods (accountsDir(), convertRubySymbols(), writeAccountFile())
  - Simplified command logic (unified account lookup)
  - 65/65 tests passing
  
  Result: Feature parity with netrc mode. Both storage backends now support aliases. Backward compatible with existing non-aliased keychain accounts.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
<!-- Add any context/setup necessary for testing. -->

**Steps**:
1. Check out branch and run `npm i && npm run build`
2. Log in to first account using `./bin/run login`
3. Add the account to your cache using `./bin/run accounts:add first_account`
4. Check that the account has been added to your keychain
5. Check that there is a file in the ~/.config/heroku/accounts/ directory titled with the alias of your account that contains only the email address
6. Try to add the account again under a different alias by running `./bin/run accounts:add first_account_again` and confirm that you get an error message
7. Log in to a separate second account using `./bin/run login`
8. Add the account to your cache using `./bin/run accounts:add second_account`
9. Run `./bin/run accounts` and confirm that you see the aliases for both accounts listed
10. Run `./bin/run accounts:set first_account` and then run `./bin/run whoami` to confirm that the accounts were switched
11. Run `./bin/run accounts:remove second_account` and confirm that the account has been removed from your keychain and the file in the .config directory has been removed

## Screenshots (if applicable)

## Related Issues
GUS work items:
- [W-22822715](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bSgOTYA0/view)
- [W-22825354](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bT9Q0YAK/view)
- [W-20129179](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002OfpqWYAR/view)
