### PR TITLE
refactor: use @heroku/sdk for apps:rename and apps:stacks:set commands

### DIFF
--- a/src/commands/apps/rename.ts
+++ b/src/commands/apps/rename.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 
 import * as git from '../../lib/ci/git.js'
@@ -22,13 +22,13 @@ export default class AppsRename extends Command {
   static topic = 'apps'
 
   async run() {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(AppsRename)
     const oldApp = flags.app
     const newApp = args.newname
 
     ux.action.start(`Renaming ${color.app(oldApp)} to ${color.info(newApp)}`)
-    const appResponse = await this.heroku.patch<Heroku.App>(`/apps/${oldApp}`, {body: {name: newApp}})
-    const app = appResponse.body
+    const app = await platform.app.update(oldApp, {name: newApp})
     ux.action.stop()
 
     const gitUrl = git.gitUrl(app.name)

--- a/src/commands/apps/stacks/set.ts
+++ b/src/commands/apps/stacks/set.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 
 import push from '../../../lib/git/push.js'
@@ -21,13 +21,12 @@ Run git push heroku main to trigger a new build on myapp.`
   static hiddenAliases = ['stack:set']
 
   async run() {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Set)
     const stack = map(args.stack)
 
     ux.action.start(`Setting stack to ${color.name(stack)}`)
-    const {body: app} = await this.heroku.patch<Heroku.App>(`/apps/${flags.app}`, {
-      body: {build_stack: stack},
-    })
+    const app = await platform.app.update(flags.app, {build_stack: stack})
 
     // A redeployment is not required for apps that have never been deployed, since
     // API updates the app's `stack` to match `build_stack` immediately.

--- a/test/unit/commands/apps/rename.unit.test.ts
+++ b/test/unit/commands/apps/rename.unit.test.ts
@@ -1,9 +1,20 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Rename from '../../../../src/commands/apps/rename.js'
 import {unwrap} from '../../../helpers/utils/unwrap.js'
+
+type FakePlatform = {
+  app: {update: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    app: {update: sinon.stub()},
+  }
+}
 
 describe('apps:rename', function () {
   const newApp = {
@@ -17,32 +28,29 @@ describe('apps:rename', function () {
   const oldApp = {
     name: 'myapp',
   }
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('renames an app', async function () {
-    api
-      .patch(`/apps/${oldApp.name}`, {name: newApp.name})
-      .reply(200, newApp)
+    fakePlatform.app.update.resolves(newApp)
 
     const {stderr, stdout} = await runCommand(Rename, ['-a', oldApp.name, newApp.name])
 
     expect(stdout).to.equal('https://newname.com | https://git.heroku.com/newname.git\n')
     expect(unwrap(stderr)).to.contains('Renaming ⬢ myapp to newname... doneWarning: Don\'t forget to update git remotes for all other local checkouts of the app.\n')
+    expect(fakePlatform.app.update.calledOnceWithExactly(oldApp.name, {name: newApp.name})).to.equal(true)
   })
 
   it('gives a message if the web_url is still http', async function () {
-    api
-      .patch(`/apps/${oldApp.name}`, {name: newApp.name})
-      .reply(200, newAppSillUsingHttp)
+    fakePlatform.app.update.resolves(newAppSillUsingHttp)
 
     const {stderr, stdout} = await runCommand(Rename, ['-a', oldApp.name, newApp.name])
 

--- a/test/unit/commands/apps/stacks/set.unit.test.ts
+++ b/test/unit/commands/apps/stacks/set.unit.test.ts
@@ -1,6 +1,7 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Set from '../../../../../src/commands/apps/stacks/set.js'
 
@@ -29,34 +30,41 @@ const completedUpgradeApp = {
   },
 }
 
+type FakePlatform = {
+  app: {update: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    app: {update: sinon.stub()},
+  }
+}
+
 describe('stack:set', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('sets the stack', async function () {
-    api
-      .patch(`/apps/${APP}`, {build_stack: TO_STACK})
-      .reply(200, pendingUpgradeApp)
+    fakePlatform.app.update.resolves(pendingUpgradeApp)
 
     const {stderr, stdout} = await runCommand(Set, [`--app=${APP}`, TO_STACK])
 
     expect(stderr).to.contain(`Setting stack to ${TO_STACK}`)
     expect(stderr).to.contain('... done')
     expect(stdout).to.equal(`You will need to redeploy ⬢ ${APP} for the change to take effect.\nRun git push heroku ${MAIN_REMOTE} to trigger a new build on ⬢ ${APP}.\n`)
+    expect(fakePlatform.app.update.calledOnceWithExactly(APP, {build_stack: TO_STACK})).to.equal(true)
   })
 
   it('sets the stack on a different remote', async function () {
-    api
-      .patch(`/apps/${APP}`, {build_stack: TO_STACK})
-      .reply(200, pendingUpgradeApp)
+    fakePlatform.app.update.resolves(pendingUpgradeApp)
 
     const {stderr, stdout} = await runCommand(Set, [`--app=${APP}`, '--remote=staging', TO_STACK])
 
@@ -66,9 +74,7 @@ describe('stack:set', function () {
   })
 
   it('does not show the redeploy message if the stack was immediately updated by API', async function () {
-    api
-      .patch(`/apps/${APP}`, {build_stack: TO_STACK})
-      .reply(200, completedUpgradeApp)
+    fakePlatform.app.update.resolves(completedUpgradeApp)
 
     const {stderr, stdout} = await runCommand(Set, [`--app=${APP}`, TO_STACK])
 


### PR DESCRIPTION
## Summary
- Migrate `src/commands/apps/rename.ts` from raw `this.heroku.patch` to `platform.app.update` via `@heroku/sdk`.
- Migrate `src/commands/apps/stacks/set.ts` from raw `this.heroku.patch` to `platform.app.update` via `@heroku/sdk`.
- Drop the deprecated `@heroku-cli/schema` imports in both files; SDK method return types are inferred from `@heroku/types/3.sdk`.
- Rewrite both unit test files to stub `HerokuSDK.prototype.platform`, dropping `nock`. Test counts and observable output unchanged.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
- [x] tsc clean vs. baseline (`scripts/codemods/sdk-migration/tsc-delta.sh` empty)
- [x] eslint clean on changed files
- [x] mocha for `test/unit/commands/apps/rename.unit.test.ts` passes (2/2)
- [x] mocha for `test/unit/commands/apps/stacks/set.unit.test.ts` passes (3/3)
- [x] mocha for sibling `test/unit/commands/apps/**/*.unit.test.ts` passes (89/89)
- [ ] Manual smoke against a real app: `heroku apps:rename --app <old> <new>` (verify URL output and git-remote rewrite)
- [ ] Manual smoke against a real app: `heroku apps:stacks:set heroku-24 -a <app>` (verify pending vs. immediate-update message paths)

## Related Issues
GUS work item: [W-22264732](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Z03bAYAR/view)