### PR TITLE
chore: pass PR title via env in pr-title-check workflow

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title follows Conventional Commits
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
           echo "Checking PR title: $PR_TITLE"
 
           # Define allowed types


### PR DESCRIPTION
## Summary
- Read the PR title from an environment variable in `.github/workflows/pr-title-check.yml` instead of inlining `${{ github.event.pull_request.title }}` into the shell `run:` block.
- Follows GitHub Actions guidance for handling untrusted input from PR metadata.

## Type of Change
### Patch Updates (patch semver update)
- [x] **chore**: Change that does not affect production code

## Testing
**Steps**:
1. Open this PR and confirm the `pr-title-check` workflow runs and passes against the conventional-commit title.
2. (Optional) Push a follow-up commit that temporarily renames the PR to a non-conforming title (e.g. `bad title`) and verify the check fails as before, then restore the title.

## Related Issues
n/a