### PR TITLE
fix: use HEROKU_CLI_CHANNEL in Direwolf test trigger

### DIFF
--- a/.github/workflows/direwolf.yml
+++ b/.github/workflows/direwolf.yml
@@ -35,6 +35,6 @@ jobs:
     - name: run direwolf suite
       run: ./scripts/direwolf-test-run
       env:
-        HEROKU_CLI_VERSION: ${{ inputs.releaseChannel }}
+        HEROKU_CLI_CHANNEL: ${{ inputs.releaseChannel }}
         DIREWOLF_TOKEN: ${{ secrets.DEV_TOOLING_DIREWOLF_TOKEN }}
         DIREWOLF_CLOUD_UUID: ${{ secrets.DIREWOLF_CLOUD_UUID_PRODUCTION }}

--- a/scripts/direwolf-test-run
+++ b/scripts/direwolf-test-run
@@ -4,16 +4,16 @@ set -euo pipefail
 
 DIREWOLF_SUITE="cli"
 
-# default CLI version is stable
-HEROKU_CLI_VERSION=${HEROKU_CLI_VERSION:="stable"}
+# default CLI channel is stable
+HEROKU_CLI_CHANNEL=${HEROKU_CLI_CHANNEL:="stable"}
 
 DIREWOLF_URL="https://$DIREWOLF_TOKEN@direwolf-api.herokai.com"
 
 POST_BODY=$(jq --null-input \
   --arg cloud "$DIREWOLF_CLOUD_UUID" \
   --arg suite "$DIREWOLF_SUITE" \
-  --arg env "$HEROKU_CLI_VERSION" \
-  '{"cloud": { "id": $cloud }, "suite": { "label": $suite }, "env": { "HEROKU_CLI_VERSION": $env }}')
+  --arg channel "$HEROKU_CLI_CHANNEL" \
+  '{"cloud": { "id": $cloud }, "suite": { "label": $suite }, "env": { "HEROKU_CLI_CHANNEL": $channel }}')
 
 echo "Enqueuing: $POST_BODY"
  


### PR DESCRIPTION
## Summary

Fix the Direwolf test trigger to pass the release channel via `HEROKU_CLI_CHANNEL` instead of `HEROKU_CLI_VERSION`. The workflow has always passed a channel name (e.g. `alpha`), but the env var name `HEROKU_CLI_VERSION` caused the Direwolf test helper to treat it as a semver and run `heroku update --version `alpha`, which fails and skips all tests.

- Replace `HEROKU_CLI_VERSION` with `HEROKU_CLI_CHANNEL` in the workflow env and runner script
- Update the Direwolf API payload JSON key from `HEROKU_CLI_VERSION` to `HEROKU_CLI_CHANNEL`

## Type of Change

- [x] **fix**: Bug fix or issue (patch semvar update)
- [ ] **feat**: Introduces a new feature to the codebase (minor semvar update)
- [ ] **perf**: Performance improvement
- [ ] **docs**: Documentation only changes
- [ ] **tests**: Adding missing tests or correcting existing tests
- [ ] **chore**: Code cleanup tasks, dependency updates, or other changes

## Verification

CI Passes

## Additional Context

- **Breaking:** none
- **Risk:** low; variable-name alignment only
- **Follow-up:** verify the downstream Direwolf suite expects `HEROKU_CLI_CHANNEL` (and not the old key) in production runs

## Related Issue

GUS work item: [W-22934969](https://gus.lightning.force.com/a07EE00002bxjetYAA)