### PR TITLE
refactor: first pass at adding pg commands from pg-extras plugin to cli PR 1 of 3

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -18,7 +18,11 @@ armel
 armhf
 armv
 atleti
+attname
+attnum
+attrelid
 atts
+atttypid
 auths
 authtoken
 autodeploy
@@ -33,6 +37,7 @@ barsize
 baseport
 bindkey
 binrun
+blks
 blocklisted
 boop
 Bpcy
@@ -93,9 +98,11 @@ eventsource
 execa
 expialidocious
 extnamespace
+extwlist
 favorited
 favoriteid
 favoriting
+fdwsql
 filebase
 filesize
 FIRPRIVATESPACES
@@ -276,6 +283,7 @@ pico
 pinentry
 pipefail
 pjson
+plpgsql
 printenv
 pooler
 portfinder
@@ -311,6 +319,7 @@ rediss
 regionize
 rejairieja
 relid
+relkind
 reloptions
 relopts
 relname
@@ -357,6 +366,7 @@ splunkhec
 sshdir
 sslmode
 stampy
+statio
 strftime
 stubber
 supersecretkey
@@ -379,6 +389,7 @@ transactionid
 trimline
 tsheredoc
 twofactor
+typname
 uncolorized
 undefinedcommand
 undeployed

--- a/src/commands/pg/cache-hit.ts
+++ b/src/commands/pg/cache-hit.ts
@@ -1,0 +1,37 @@
+import {Command, flags} from '@heroku-cli/command'
+import {utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+
+export const generateCacheHitQuery = (): string => `
+SELECT
+  'index hit rate' AS name,
+  (sum(idx_blks_hit)) / nullif(sum(idx_blks_hit + idx_blks_read),0) AS ratio
+FROM pg_statio_user_indexes
+UNION ALL
+SELECT
+ 'table hit rate' AS name,
+  sum(heap_blks_hit) / nullif(sum(heap_blks_hit) + sum(heap_blks_read),0) AS ratio
+FROM pg_statio_user_tables;
+`.trim()
+
+export default class PgCacheHit extends Command {
+  static args = {
+    database: Args.string({description: 'database name', required: false}),
+  }
+  static description = 'show index and table hit rate'
+  static flags = {
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+  }
+  static hiddenAliases = ['pg:cache_hit']
+  static topic = 'pg'
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(PgCacheHit)
+    const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
+    const db = await dbResolver.getDatabase(flags.app, args.database)
+    const psqlService = new utils.pg.PsqlService(db)
+    const output = await psqlService.execQuery(generateCacheHitQuery())
+    ux.stdout(output)
+  }
+}

--- a/src/commands/pg/cache-hit.ts
+++ b/src/commands/pg/cache-hit.ts
@@ -1,6 +1,9 @@
 import {Command, flags} from '@heroku-cli/command'
-import {utils} from '@heroku/heroku-cli-util'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
+import tsheredoc from 'tsheredoc'
+
+const heredoc = tsheredoc.default
 
 export const generateCacheHitQuery = (): string => `
 SELECT
@@ -19,6 +22,9 @@ export default class PgCacheHit extends Command {
     database: Args.string({description: 'database name', required: false}),
   }
   static description = 'show index and table hit rate'
+  static examples = [heredoc`
+    ${color.command('heroku pg:cache-hit --app example-app')}
+  `]
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),

--- a/src/commands/pg/cache-hit.ts
+++ b/src/commands/pg/cache-hit.ts
@@ -3,6 +3,8 @@ import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
+import {nls} from '../../nls.js'
+
 const heredoc = tsheredoc.default
 
 export const generateCacheHitQuery = (): string => `
@@ -19,7 +21,7 @@ FROM pg_statio_user_tables;
 
 export default class PgCacheHit extends Command {
   static args = {
-    database: Args.string({description: 'database name', required: false}),
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`, required: false}),
   }
   static description = 'show index and table hit rate'
   static examples = [heredoc`

--- a/src/commands/pg/calls.ts
+++ b/src/commands/pg/calls.ts
@@ -4,6 +4,7 @@ import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
 import {ensurePGStatStatement, newBlkTimeFields, newTotalExecTimeField} from '../../lib/pg/extras.js'
+import {nls} from '../../nls.js'
 
 const heredoc = tsheredoc.default
 
@@ -35,7 +36,7 @@ LIMIT 10
 
 export default class PgCalls extends Command {
   static args = {
-    database: Args.string({description: 'database name', required: false}),
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`, required: false}),
   }
   static description = 'show 10 queries that have highest frequency of execution'
   static examples = [heredoc`

--- a/src/commands/pg/calls.ts
+++ b/src/commands/pg/calls.ts
@@ -1,0 +1,55 @@
+import {Command, flags} from '@heroku-cli/command'
+import {pg, utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+
+import {ensurePGStatStatement, newBlkTimeFields, newTotalExecTimeField} from '../../lib/pg/extras.js'
+
+export async function generateCallsQuery(db: pg.ConnectionDetails, flags: {truncate?: boolean}): Promise<string> {
+  await ensurePGStatStatement(db)
+
+  const truncatedQueryString = flags.truncate
+    ? 'CASE WHEN length(query) <= 40 THEN query ELSE substr(query, 0, 39) || \'…\' END'
+    : 'query'
+
+  const newTotalExecTime = await newTotalExecTimeField(db)
+  const totalExecTimeField = newTotalExecTime ? 'total_exec_time' : 'total_time'
+
+  const newBlkTime = await newBlkTimeFields(db)
+  const blkReadField = newBlkTime ? 'shared_blk_read_time' : 'blk_read_time'
+  const blkWriteField = newBlkTime ? 'shared_blk_write_time' : 'blk_write_time'
+
+  return `
+SELECT interval '1 millisecond' * ${totalExecTimeField} AS total_exec_time,
+to_char((${totalExecTimeField}/sum(${totalExecTimeField}) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
+to_char(calls, 'FM999G999G999G990') AS ncalls,
+interval '1 millisecond' * (${blkReadField} + ${blkWriteField}) AS sync_io_time,
+${truncatedQueryString} AS query
+FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
+ORDER BY calls DESC
+LIMIT 10
+`.trim()
+}
+
+export default class PgCalls extends Command {
+  static args = {
+    database: Args.string({description: 'database name', required: false}),
+  }
+  static description = 'show 10 queries that have highest frequency of execution'
+  static flags = {
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+    truncate: flags.boolean({char: 't', description: 'truncate queries to 40 characters'}),
+  }
+  static topic = 'pg'
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(PgCalls)
+    const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
+    const db = await dbResolver.getDatabase(flags.app, args.database)
+    const psqlService = new utils.pg.PsqlService(db)
+
+    const query = await generateCallsQuery(db, flags)
+    const output = await psqlService.execQuery(query)
+    ux.stdout(output)
+  }
+}

--- a/src/commands/pg/calls.ts
+++ b/src/commands/pg/calls.ts
@@ -1,8 +1,11 @@
 import {Command, flags} from '@heroku-cli/command'
-import {pg, utils} from '@heroku/heroku-cli-util'
+import {color, pg, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
+import tsheredoc from 'tsheredoc'
 
 import {ensurePGStatStatement, newBlkTimeFields, newTotalExecTimeField} from '../../lib/pg/extras.js'
+
+const heredoc = tsheredoc.default
 
 export async function generateCallsQuery(db: pg.ConnectionDetails, flags: {truncate?: boolean}): Promise<string> {
   await ensurePGStatStatement(db)
@@ -35,6 +38,12 @@ export default class PgCalls extends Command {
     database: Args.string({description: 'database name', required: false}),
   }
   static description = 'show 10 queries that have highest frequency of execution'
+  static examples = [heredoc`
+    ${color.command('heroku pg:calls --app example-app')}
+  `, heredoc`
+    # truncate queries to 40 characters
+    ${color.command('heroku pg:calls --truncate --app example-app')}
+  `]
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),

--- a/src/commands/pg/extensions.ts
+++ b/src/commands/pg/extensions.ts
@@ -4,6 +4,7 @@ import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
 import {essentialNumPlan} from '../../lib/pg/extras.js'
+import {nls} from '../../nls.js'
 
 const heredoc = tsheredoc.default
 
@@ -19,7 +20,7 @@ export function generateExtensionsQuery(db: pg.ConnectionDetails): string {
 
 export default class PgExtensions extends Command {
   static args = {
-    database: Args.string({description: 'database name', required: false}),
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`, required: false}),
   }
   static description = 'list available and installed extensions'
   static examples = [heredoc`

--- a/src/commands/pg/extensions.ts
+++ b/src/commands/pg/extensions.ts
@@ -1,8 +1,11 @@
 import {Command, flags} from '@heroku-cli/command'
-import {pg, utils} from '@heroku/heroku-cli-util'
+import {color, pg, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
+import tsheredoc from 'tsheredoc'
 
 import {essentialNumPlan} from '../../lib/pg/extras.js'
+
+const heredoc = tsheredoc.default
 
 export function generateExtensionsQuery(db: pg.ConnectionDetails): string {
   return essentialNumPlan(db.attachment!.addon)
@@ -19,6 +22,9 @@ export default class PgExtensions extends Command {
     database: Args.string({description: 'database name', required: false}),
   }
   static description = 'list available and installed extensions'
+  static examples = [heredoc`
+    ${color.command('heroku pg:extensions --app example-app')}
+  `]
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),

--- a/src/commands/pg/extensions.ts
+++ b/src/commands/pg/extensions.ts
@@ -1,0 +1,37 @@
+import {Command, flags} from '@heroku-cli/command'
+import {pg, utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+
+import {essentialNumPlan} from '../../lib/pg/extras.js'
+
+export function generateExtensionsQuery(db: pg.ConnectionDetails): string {
+  return essentialNumPlan(db.attachment!.addon)
+    ? `SELECT *
+                     FROM pg_available_extensions
+                     WHERE name IN (SELECT unnest(string_to_array(current_setting('rds.allowed_extensions'), ',')))`
+    : `SELECT *
+                     FROM pg_available_extensions
+                     WHERE name IN (SELECT unnest(string_to_array(current_setting('extwlist.extensions'), ',')))`
+}
+
+export default class PgExtensions extends Command {
+  static args = {
+    database: Args.string({description: 'database name', required: false}),
+  }
+  static description = 'list available and installed extensions'
+  static flags = {
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+  }
+  static topic = 'pg'
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(PgExtensions)
+    const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
+    const db = await dbResolver.getDatabase(flags.app, args.database)
+    const psqlService = new utils.pg.PsqlService(db)
+    const query = generateExtensionsQuery(db)
+    const output = await psqlService.execQuery(query)
+    ux.stdout(output)
+  }
+}

--- a/src/commands/pg/fdwsql.ts
+++ b/src/commands/pg/fdwsql.ts
@@ -1,0 +1,69 @@
+import {Command, flags} from '@heroku-cli/command'
+import {utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+
+import {ensureEssentialTierPlan} from '../../lib/pg/extras.js'
+
+export const generateFdwsqlQuery = (prefix: string): string => `
+SELECT
+  'CREATE FOREIGN TABLE '
+  || quote_ident('${prefix}_' || c.relname)
+  || '(' || array_to_string(array_agg(quote_ident(a.attname) || ' ' || t.typname), ', ') || ') '
+  || ' SERVER ${prefix}_db OPTIONS'
+  || ' (schema_name ''' || quote_ident(n.nspname) || ''', table_name ''' || quote_ident(c.relname) || ''');'
+FROM
+  pg_class     c,
+  pg_attribute a,
+  pg_type      t,
+  pg_namespace n
+WHERE
+  a.attnum > 0
+  AND a.attrelid = c.oid
+  AND a.atttypid = t.oid
+  AND n.oid = c.relnamespace
+  AND c.relkind in ('r', 'v')
+  AND n.nspname <> 'pg_catalog'
+  AND n.nspname <> 'information_schema'
+  AND n.nspname !~ '^pg_toast'
+  AND pg_catalog.pg_table_is_visible(c.oid)
+GROUP BY c.relname, n.nspname
+ORDER BY c.relname;
+`.trim()
+
+export default class PgFdwsql extends Command {
+  /* eslint-disable perfectionist/sort-objects */
+  static args = {
+    prefix: Args.string({description: 'prefix for foreign data wrapper', required: true}),
+    database: Args.string({description: 'database name', required: false}),
+  }
+  /* eslint-enable perfectionist/sort-objects */
+  static description = 'generate fdw install sql for database'
+  static flags = {
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+  }
+  static topic = 'pg'
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(PgFdwsql)
+    const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
+    const db = await dbResolver.getDatabase(flags.app, args.database)
+
+    await ensureEssentialTierPlan(db)
+
+    const psqlService = new utils.pg.PsqlService(db)
+
+    ux.stdout('CREATE EXTENSION IF NOT EXISTS postgres_fdw;')
+    ux.stdout(`DROP SERVER IF EXISTS ${args.prefix}_db;`)
+    ux.stdout(`CREATE SERVER ${args.prefix}_db
+  FOREIGN DATA WRAPPER postgres_fdw
+  OPTIONS (dbname '${db.database}', host '${db.host}');`)
+    ux.stdout(`CREATE USER MAPPING FOR CURRENT_USER
+  SERVER ${args.prefix}_db
+  OPTIONS (user '${db.user}', password '${db.password}');`)
+
+    let output = await psqlService.execQuery(generateFdwsqlQuery(args.prefix))
+    output = output.split('\n').filter((l: string) => /CREATE/.test(l)).join('\n')
+    ux.stdout(output)
+  }
+}

--- a/src/commands/pg/fdwsql.ts
+++ b/src/commands/pg/fdwsql.ts
@@ -1,8 +1,11 @@
 import {Command, flags} from '@heroku-cli/command'
-import {utils} from '@heroku/heroku-cli-util'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
+import tsheredoc from 'tsheredoc'
 
 import {ensureEssentialTierPlan} from '../../lib/pg/extras.js'
+
+const heredoc = tsheredoc.default
 
 export const generateFdwsqlQuery = (prefix: string): string => `
 SELECT
@@ -38,6 +41,9 @@ export default class PgFdwsql extends Command {
   }
   /* eslint-enable perfectionist/sort-objects */
   static description = 'generate fdw install sql for database'
+  static examples = [heredoc`
+    ${color.command('heroku pg:fdwsql example_prefix --app example-app')}
+  `]
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),

--- a/src/commands/pg/fdwsql.ts
+++ b/src/commands/pg/fdwsql.ts
@@ -4,6 +4,7 @@ import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
 import {ensureEssentialTierPlan} from '../../lib/pg/extras.js'
+import {nls} from '../../nls.js'
 
 const heredoc = tsheredoc.default
 
@@ -37,7 +38,7 @@ export default class PgFdwsql extends Command {
   /* eslint-disable perfectionist/sort-objects */
   static args = {
     prefix: Args.string({description: 'prefix for foreign data wrapper', required: true}),
-    database: Args.string({description: 'database name', required: false}),
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`, required: false}),
   }
   /* eslint-enable perfectionist/sort-objects */
   static description = 'generate fdw install sql for database'
@@ -52,6 +53,10 @@ export default class PgFdwsql extends Command {
 
   public async run(): Promise<void> {
     const {args, flags} = await this.parse(PgFdwsql)
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(args.prefix)) {
+      ux.error('prefix must start with a letter or underscore and contain only letters, numbers, and underscores', {exit: 1})
+    }
+
     const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
     const db = await dbResolver.getDatabase(flags.app, args.database)
 

--- a/src/commands/pg/index-size.ts
+++ b/src/commands/pg/index-size.ts
@@ -1,0 +1,37 @@
+import {Command, flags} from '@heroku-cli/command'
+import {utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+
+export const generateIndexSizeQuery = (): string => `
+SELECT c.relname AS name,
+  pg_size_pretty(sum(c.relpages::bigint*8192)::bigint) AS size
+FROM pg_class c
+LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+AND n.nspname !~ '^pg_toast'
+AND c.relkind='i'
+GROUP BY c.relname
+ORDER BY sum(c.relpages) DESC;
+`.trim()
+
+export default class PgIndexSize extends Command {
+  static args = {
+    database: Args.string({description: 'database name', required: false}),
+  }
+  static description = 'show the size of indexes, descending by size'
+  static flags = {
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+  }
+  static hiddenAliases = ['pg:index_size']
+  static topic = 'pg'
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(PgIndexSize)
+    const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
+    const db = await dbResolver.getDatabase(flags.app, args.database)
+    const psqlService = new utils.pg.PsqlService(db)
+    const output = await psqlService.execQuery(generateIndexSizeQuery())
+    ux.stdout(output)
+  }
+}

--- a/src/commands/pg/index-size.ts
+++ b/src/commands/pg/index-size.ts
@@ -3,6 +3,8 @@ import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
+import {nls} from '../../nls.js'
+
 const heredoc = tsheredoc.default
 
 export const generateIndexSizeQuery = (): string => `
@@ -19,7 +21,7 @@ ORDER BY sum(c.relpages) DESC;
 
 export default class PgIndexSize extends Command {
   static args = {
-    database: Args.string({description: 'database name', required: false}),
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`, required: false}),
   }
   static description = 'show the size of indexes, descending by size'
   static examples = [heredoc`

--- a/src/commands/pg/index-size.ts
+++ b/src/commands/pg/index-size.ts
@@ -1,6 +1,9 @@
 import {Command, flags} from '@heroku-cli/command'
-import {utils} from '@heroku/heroku-cli-util'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
+import tsheredoc from 'tsheredoc'
+
+const heredoc = tsheredoc.default
 
 export const generateIndexSizeQuery = (): string => `
 SELECT c.relname AS name,
@@ -19,6 +22,9 @@ export default class PgIndexSize extends Command {
     database: Args.string({description: 'database name', required: false}),
   }
   static description = 'show the size of indexes, descending by size'
+  static examples = [heredoc`
+    ${color.command('heroku pg:index-size --app example-app')}
+  `]
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),

--- a/src/commands/pg/index-usage.ts
+++ b/src/commands/pg/index-usage.ts
@@ -1,6 +1,9 @@
 import {Command, flags} from '@heroku-cli/command'
-import {utils} from '@heroku/heroku-cli-util'
+import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
+import tsheredoc from 'tsheredoc'
+
+const heredoc = tsheredoc.default
 
 export const generateIndexUsageQuery = (): string => `
 SELECT relname,
@@ -19,7 +22,10 @@ export default class PgIndexUsage extends Command {
   static args = {
     database: Args.string({description: 'database name', required: false}),
   }
-  static description = 'calculates your index hit rate (effective databases are at 99% and up)'
+  static description = 'show percentage of times an index was used for each table'
+  static examples = [heredoc`
+    ${color.command('heroku pg:index-usage --app example-app')}
+  `]
   static flags = {
     app: flags.app({required: true}),
     remote: flags.remote(),

--- a/src/commands/pg/index-usage.ts
+++ b/src/commands/pg/index-usage.ts
@@ -3,6 +3,8 @@ import {color, utils} from '@heroku/heroku-cli-util'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
+import {nls} from '../../nls.js'
+
 const heredoc = tsheredoc.default
 
 export const generateIndexUsageQuery = (): string => `
@@ -20,7 +22,7 @@ SELECT relname,
 
 export default class PgIndexUsage extends Command {
   static args = {
-    database: Args.string({description: 'database name', required: false}),
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`, required: false}),
   }
   static description = 'calculates your index hit rate (effective databases are at 99% and up)'
   static examples = [heredoc`

--- a/src/commands/pg/index-usage.ts
+++ b/src/commands/pg/index-usage.ts
@@ -1,0 +1,38 @@
+import {Command, flags} from '@heroku-cli/command'
+import {utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+
+export const generateIndexUsageQuery = (): string => `
+SELECT relname,
+   CASE idx_scan
+     WHEN 0 THEN 'Insufficient data'
+     ELSE (100 * idx_scan / (seq_scan + idx_scan))::text
+   END percent_of_times_index_used,
+   n_live_tup rows_in_table
+ FROM
+   pg_stat_user_tables
+ ORDER BY
+   n_live_tup DESC;
+`.trim()
+
+export default class PgIndexUsage extends Command {
+  static args = {
+    database: Args.string({description: 'database name', required: false}),
+  }
+  static description = 'calculates your index hit rate (effective databases are at 99% and up)'
+  static flags = {
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+  }
+  static hiddenAliases = ['pg:index_usage']
+  static topic = 'pg'
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(PgIndexUsage)
+    const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
+    const db = await dbResolver.getDatabase(flags.app, args.database)
+    const psqlService = new utils.pg.PsqlService(db)
+    const output = await psqlService.execQuery(generateIndexUsageQuery())
+    ux.stdout(output)
+  }
+}

--- a/src/commands/pg/index-usage.ts
+++ b/src/commands/pg/index-usage.ts
@@ -22,7 +22,7 @@ export default class PgIndexUsage extends Command {
   static args = {
     database: Args.string({description: 'database name', required: false}),
   }
-  static description = 'show percentage of times an index was used for each table'
+  static description = 'calculates your index hit rate (effective databases are at 99% and up)'
   static examples = [heredoc`
     ${color.command('heroku pg:index-usage --app example-app')}
   `]

--- a/src/lib/pg/extras.ts
+++ b/src/lib/pg/extras.ts
@@ -1,0 +1,88 @@
+import * as Heroku from '@heroku-cli/schema'
+import {pg, utils} from '@heroku/heroku-cli-util'
+import {ux} from '@oclif/core/ux'
+
+interface Plan {
+  plan: Heroku.AddOn['plan']
+}
+
+export async function ensurePGStatStatement(db: pg.ConnectionDetails): Promise<void> {
+  try {
+    const query = `
+SELECT exists(
+  SELECT 1 FROM pg_extension e LEFT JOIN pg_namespace n ON n.oid = e.extnamespace
+  WHERE e.extname='pg_stat_statements' AND n.nspname = 'public'
+) AS available`
+    const psqlService = new utils.pg.PsqlService(db)
+    const output = await psqlService.execQuery(query)
+
+    if (!output.includes('t')) {
+      ux.error(`pg_stat_statements extension need to be installed in the public schema first.
+You can install it by running:
+
+    CREATE EXTENSION pg_stat_statements;`, {exit: 1})
+    }
+  } catch {
+    ux.error('Failed to check pg_stat_statements extension availability', {exit: 1})
+  }
+}
+
+export async function ensureEssentialTierPlan(db: pg.ConnectionDetails): Promise<void> {
+  const planName = db.attachment?.addon?.plan?.name
+
+  if (!planName) {
+    ux.error('Unable to determine database plan type', {exit: 1})
+    return
+  }
+
+  if (/(dev|basic|essential-\d+)$/.test(planName)) {
+    ux.error('This operation is not supported by Essential-tier databases.', {exit: 1})
+  }
+}
+
+export function essentialNumPlan(a: Plan): boolean {
+  if (!a.plan?.name) return false
+  const parts = a.plan.name.split(':')
+  if (parts.length < 2) return false
+  return Boolean(parts[1].startsWith('essential'))
+}
+
+export async function newTotalExecTimeField(db: pg.ConnectionDetails): Promise<boolean> {
+  try {
+    const newTotalExecTimeFieldQuery = 'SELECT current_setting(\'server_version_num\')::numeric >= 130000'
+    const psqlService = new utils.pg.PsqlService(db)
+    const newTotalExecTimeFieldRaw = await psqlService.execQuery(newTotalExecTimeFieldQuery, ['-t', '-q'])
+
+    // error checks
+    const newTotalExecTimeField = newTotalExecTimeFieldRaw.split('\n')[0].trim()
+
+    if (newTotalExecTimeField !== 't' && newTotalExecTimeField !== 'f') {
+      ux.error(`Unable to determine database version, expected "t" or "f", got: "${newTotalExecTimeField}"`, {exit: 1})
+    }
+
+    return newTotalExecTimeField === 't'
+  } catch {
+    ux.error('Failed to determine database version for total execution time field', {exit: 1})
+    return false // This will never be reached due to ux.error exit
+  }
+}
+
+export async function newBlkTimeFields(db: pg.ConnectionDetails): Promise<boolean> {
+  try {
+    const newBlkTimeFieldsQuery = 'SELECT current_setting(\'server_version_num\')::numeric >= 170000'
+    const psqlService = new utils.pg.PsqlService(db)
+    const newBlkTimeFieldsRaw = await psqlService.execQuery(newBlkTimeFieldsQuery, ['-t', '-q'])
+
+    // error checks
+    const newBlkTimeField = newBlkTimeFieldsRaw.split('\n')[0].trim()
+
+    if (newBlkTimeField !== 't' && newBlkTimeField !== 'f') {
+      ux.error(`Unable to determine database version, expected "t" or "f", got: "${newBlkTimeField}"`, {exit: 1})
+    }
+
+    return newBlkTimeField === 't'
+  } catch {
+    ux.error('Failed to determine database version for block time fields', {exit: 1})
+    return false // This will never be reached due to ux.error exit
+  }
+}

--- a/src/lib/pg/extras.ts
+++ b/src/lib/pg/extras.ts
@@ -11,7 +11,7 @@ export async function ensurePGStatStatement(db: pg.ConnectionDetails): Promise<v
     const query = `
 SELECT exists(
   SELECT 1 FROM pg_extension e LEFT JOIN pg_namespace n ON n.oid = e.extnamespace
-  WHERE e.extname='pg_stat_statements' AND n.nspname = 'public'
+  WHERE e.extname='pg_stat_statements' AND n.nspname IN ('public', 'heroku_ext')
 ) AS available`
     const psqlService = new utils.pg.PsqlService(db)
     const output = await psqlService.execQuery(query)

--- a/src/lib/pg/extras.ts
+++ b/src/lib/pg/extras.ts
@@ -7,23 +7,19 @@ interface Plan {
 }
 
 export async function ensurePGStatStatement(db: pg.ConnectionDetails): Promise<void> {
-  try {
-    const query = `
+  const query = `
 SELECT exists(
   SELECT 1 FROM pg_extension e LEFT JOIN pg_namespace n ON n.oid = e.extnamespace
   WHERE e.extname='pg_stat_statements' AND n.nspname IN ('public', 'heroku_ext')
 ) AS available`
-    const psqlService = new utils.pg.PsqlService(db)
-    const output = await psqlService.execQuery(query)
+  const psqlService = new utils.pg.PsqlService(db)
+  const output = await psqlService.execQuery(query)
 
-    if (!output.includes('t')) {
-      ux.error(`pg_stat_statements extension need to be installed in the public schema first.
+  if (!output.includes('t')) {
+    ux.error(`pg_stat_statements extension need to be installed in the public schema first.
 You can install it by running:
 
     CREATE EXTENSION pg_stat_statements;`, {exit: 1})
-    }
-  } catch {
-    ux.error('Failed to check pg_stat_statements extension availability', {exit: 1})
   }
 }
 
@@ -48,41 +44,31 @@ export function essentialNumPlan(a: Plan): boolean {
 }
 
 export async function newTotalExecTimeField(db: pg.ConnectionDetails): Promise<boolean> {
-  try {
-    const newTotalExecTimeFieldQuery = 'SELECT current_setting(\'server_version_num\')::numeric >= 130000'
-    const psqlService = new utils.pg.PsqlService(db)
-    const newTotalExecTimeFieldRaw = await psqlService.execQuery(newTotalExecTimeFieldQuery, ['-t', '-q'])
+  const newTotalExecTimeFieldQuery = 'SELECT current_setting(\'server_version_num\')::numeric >= 130000'
+  const psqlService = new utils.pg.PsqlService(db)
+  const newTotalExecTimeFieldRaw = await psqlService.execQuery(newTotalExecTimeFieldQuery, ['-t', '-q'])
 
-    // error checks
-    const newTotalExecTimeField = newTotalExecTimeFieldRaw.split('\n')[0].trim()
+  // error checks
+  const newTotalExecTimeField = newTotalExecTimeFieldRaw.split('\n')[0].trim()
 
-    if (newTotalExecTimeField !== 't' && newTotalExecTimeField !== 'f') {
-      ux.error(`Unable to determine database version, expected "t" or "f", got: "${newTotalExecTimeField}"`, {exit: 1})
-    }
-
-    return newTotalExecTimeField === 't'
-  } catch {
-    ux.error('Failed to determine database version for total execution time field', {exit: 1})
-    return false // This will never be reached due to ux.error exit
+  if (newTotalExecTimeField !== 't' && newTotalExecTimeField !== 'f') {
+    ux.error(`Unable to determine database version, expected "t" or "f", got: "${newTotalExecTimeField}"`, {exit: 1})
   }
+
+  return newTotalExecTimeField === 't'
 }
 
 export async function newBlkTimeFields(db: pg.ConnectionDetails): Promise<boolean> {
-  try {
-    const newBlkTimeFieldsQuery = 'SELECT current_setting(\'server_version_num\')::numeric >= 170000'
-    const psqlService = new utils.pg.PsqlService(db)
-    const newBlkTimeFieldsRaw = await psqlService.execQuery(newBlkTimeFieldsQuery, ['-t', '-q'])
+  const newBlkTimeFieldsQuery = 'SELECT current_setting(\'server_version_num\')::numeric >= 170000'
+  const psqlService = new utils.pg.PsqlService(db)
+  const newBlkTimeFieldsRaw = await psqlService.execQuery(newBlkTimeFieldsQuery, ['-t', '-q'])
 
-    // error checks
-    const newBlkTimeField = newBlkTimeFieldsRaw.split('\n')[0].trim()
+  // error checks
+  const newBlkTimeField = newBlkTimeFieldsRaw.split('\n')[0].trim()
 
-    if (newBlkTimeField !== 't' && newBlkTimeField !== 'f') {
-      ux.error(`Unable to determine database version, expected "t" or "f", got: "${newBlkTimeField}"`, {exit: 1})
-    }
-
-    return newBlkTimeField === 't'
-  } catch {
-    ux.error('Failed to determine database version for block time fields', {exit: 1})
-    return false // This will never be reached due to ux.error exit
+  if (newBlkTimeField !== 't' && newBlkTimeField !== 'f') {
+    ux.error(`Unable to determine database version, expected "t" or "f", got: "${newBlkTimeField}"`, {exit: 1})
   }
+
+  return newBlkTimeField === 't'
 }

--- a/test/unit/commands/pg/cache-hit.unit.test.ts
+++ b/test/unit/commands/pg/cache-hit.unit.test.ts
@@ -1,0 +1,98 @@
+import {runCommand} from '@heroku-cli/test-utils'
+import {pg, utils} from '@heroku/heroku-cli-util'
+import {expect} from 'chai'
+import * as sinon from 'sinon'
+
+import Cmd, {generateCacheHitQuery} from '../../../../src/commands/pg/cache-hit.js'
+
+const mockDb = {
+  attachment: {
+    addon: {
+      plan: {name: 'heroku-postgresql:premium-0'},
+    },
+    name: 'DATABASE',
+  },
+  database: 'testdb',
+  host: 'localhost',
+  password: 'testpass',
+  pathname: '/testdb',
+  port: '5432',
+  url: 'postgres://localhost:5432/testdb',
+  user: 'testuser',
+} as unknown as pg.ConnectionDetails
+
+describe('pg:cache-hit', function () {
+  let sandbox: sinon.SinonSandbox
+  let getDatabaseStub: sinon.SinonStub
+  let execQueryStub: sinon.SinonStub
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox()
+    getDatabaseStub = sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockDb)
+    execQueryStub = sandbox.stub(utils.pg.PsqlService.prototype, 'execQuery')
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('generateCacheHitQuery', function () {
+    it('generates the exact expected SQL query', function () {
+      const expectedQuery = `SELECT
+  'index hit rate' AS name,
+  (sum(idx_blks_hit)) / nullif(sum(idx_blks_hit + idx_blks_read),0) AS ratio
+FROM pg_statio_user_indexes
+UNION ALL
+SELECT
+ 'table hit rate' AS name,
+  sum(heap_blks_hit) / nullif(sum(heap_blks_hit) + sum(heap_blks_read),0) AS ratio
+FROM pg_statio_user_tables;`
+
+      expect(generateCacheHitQuery()).to.equal(expectedQuery)
+    })
+
+    it('uses safe division for null handling', function () {
+      const query = generateCacheHitQuery()
+      expect(query).to.contain('nullif(')
+      expect(query).to.contain('sum(idx_blks_hit + idx_blks_read)')
+      expect(query).to.contain('sum(heap_blks_hit) + sum(heap_blks_read)')
+    })
+  })
+
+  describe('command behavior', function () {
+    it('displays cache hit rate information', async function () {
+      const mockOutput = `name            | ratio
+----------------|-------
+index hit rate  | 0.95
+table hit rate  | 0.87`
+      execQueryStub.resolves(mockOutput)
+
+      const {stderr, stdout} = await runCommand(Cmd, ['--app', 'my-app'])
+
+      expect(getDatabaseStub.calledOnceWith('my-app')).to.be.true
+      expect(execQueryStub.calledOnceWith(generateCacheHitQuery())).to.be.true
+      expect(stdout).to.contain(mockOutput)
+      expect(stderr).to.eq('')
+    })
+
+    it('resolves the named database when provided', async function () {
+      execQueryStub.resolves('')
+      await runCommand(Cmd, ['custom-db', '--app', 'my-app'])
+      expect(getDatabaseStub.calledOnceWith('my-app', 'custom-db')).to.be.true
+    })
+  })
+
+  describe('error handling', function () {
+    it('surfaces database connection failures', async function () {
+      getDatabaseStub.rejects(new Error('Database connection failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'my-app'])
+      expect(error?.message).to.contain('Database connection failed')
+    })
+
+    it('surfaces SQL execution failures', async function () {
+      execQueryStub.rejects(new Error('SQL execution failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'my-app'])
+      expect(error?.message).to.contain('SQL execution failed')
+    })
+  })
+})

--- a/test/unit/commands/pg/calls.unit.test.ts
+++ b/test/unit/commands/pg/calls.unit.test.ts
@@ -144,13 +144,13 @@ SELECT * FROM users | 1.23 | 0.15 | 100 | 0.05`
     })
 
     it('errors when pg_stat_statements is not available', async function () {
-      // ensurePGStatStatement raises the "need to be installed" error inside its own
-      // try/catch, which then re-raises the generic availability-check failure.
+      // ensurePGStatStatement surfaces its real "need to be installed" error directly;
+      // the helpful install instructions propagate to the user instead of being swallowed.
       execQueryStub.onCall(0).resolves('f')
 
       const {error} = await runCommand(Cmd, ['--app', 'my-app'])
 
-      expect(error?.message).to.contain('Failed to check pg_stat_statements extension availability')
+      expect(error?.message).to.contain('pg_stat_statements extension need to be installed in the public schema first.')
     })
   })
 })

--- a/test/unit/commands/pg/calls.unit.test.ts
+++ b/test/unit/commands/pg/calls.unit.test.ts
@@ -1,0 +1,156 @@
+import {runCommand} from '@heroku-cli/test-utils'
+import {pg, utils} from '@heroku/heroku-cli-util'
+import {expect} from 'chai'
+import * as sinon from 'sinon'
+
+import Cmd, {generateCallsQuery} from '../../../../src/commands/pg/calls.js'
+
+const mockDb = {
+  attachment: {
+    addon: {
+      plan: {name: 'heroku-postgresql:premium-0'},
+    },
+    name: 'DATABASE',
+  },
+  database: 'testdb',
+  host: 'localhost',
+  password: 'testpass',
+  pathname: '/testdb',
+  port: '5432',
+  url: 'postgres://localhost:5432/testdb',
+  user: 'testuser',
+} as unknown as pg.ConnectionDetails
+
+describe('pg:calls', function () {
+  let sandbox: sinon.SinonSandbox
+  let getDatabaseStub: sinon.SinonStub
+  let execQueryStub: sinon.SinonStub
+
+  // Drives the helper queries in generateCallsQuery:
+  //   call 0: ensurePGStatStatement -> availability ('t')
+  //   call 1: newTotalExecTimeField -> server_version_num >= 130000
+  //   call 2: newBlkTimeFields      -> server_version_num >= 170000
+  function setupHelperStubs({newBlkTime, newTotalExecTime}: {newBlkTime: boolean; newTotalExecTime: boolean}) {
+    execQueryStub.onCall(0).resolves('t')
+    execQueryStub.onCall(1).resolves(newTotalExecTime ? 't' : 'f')
+    execQueryStub.onCall(2).resolves(newBlkTime ? 't' : 'f')
+  }
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox()
+    getDatabaseStub = sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockDb)
+    execQueryStub = sandbox.stub(utils.pg.PsqlService.prototype, 'execQuery')
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('generateCallsQuery', function () {
+    it('generates the expected SQL for PostgreSQL 13+/17+ with truncate', async function () {
+      setupHelperStubs({newBlkTime: true, newTotalExecTime: true})
+
+      const expectedQuery = `SELECT interval '1 millisecond' * total_exec_time AS total_exec_time,
+to_char((total_exec_time/sum(total_exec_time) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
+to_char(calls, 'FM999G999G999G990') AS ncalls,
+interval '1 millisecond' * (shared_blk_read_time + shared_blk_write_time) AS sync_io_time,
+CASE WHEN length(query) <= 40 THEN query ELSE substr(query, 0, 39) || '…' END AS query
+FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
+ORDER BY calls DESC
+LIMIT 10`
+
+      const actual = await generateCallsQuery(mockDb, {truncate: true})
+      expect(actual).to.equal(expectedQuery)
+    })
+
+    it('generates the expected SQL for PostgreSQL 13+/17+ without truncate', async function () {
+      setupHelperStubs({newBlkTime: true, newTotalExecTime: true})
+
+      const expectedQuery = `SELECT interval '1 millisecond' * total_exec_time AS total_exec_time,
+to_char((total_exec_time/sum(total_exec_time) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
+to_char(calls, 'FM999G999G999G990') AS ncalls,
+interval '1 millisecond' * (shared_blk_read_time + shared_blk_write_time) AS sync_io_time,
+query AS query
+FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
+ORDER BY calls DESC
+LIMIT 10`
+
+      const actual = await generateCallsQuery(mockDb, {truncate: false})
+      expect(actual).to.equal(expectedQuery)
+    })
+
+    it('generates the expected SQL for older PostgreSQL versions', async function () {
+      setupHelperStubs({newBlkTime: false, newTotalExecTime: false})
+
+      const expectedQuery = `SELECT interval '1 millisecond' * total_time AS total_exec_time,
+to_char((total_time/sum(total_time) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
+to_char(calls, 'FM999G999G999G990') AS ncalls,
+interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time,
+CASE WHEN length(query) <= 40 THEN query ELSE substr(query, 0, 39) || '…' END AS query
+FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
+ORDER BY calls DESC
+LIMIT 10`
+
+      const actual = await generateCallsQuery(mockDb, {truncate: true})
+      expect(actual).to.equal(expectedQuery)
+    })
+
+    it('handles the truncate flag correctly', async function () {
+      setupHelperStubs({newBlkTime: true, newTotalExecTime: true})
+      const truncated = await generateCallsQuery(mockDb, {truncate: true})
+      expect(truncated).to.contain('CASE WHEN length(query) <= 40')
+
+      sandbox.restore()
+      sandbox = sinon.createSandbox()
+      sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockDb)
+      execQueryStub = sandbox.stub(utils.pg.PsqlService.prototype, 'execQuery')
+      setupHelperStubs({newBlkTime: true, newTotalExecTime: true})
+      const full = await generateCallsQuery(mockDb, {truncate: false})
+      expect(full).to.contain('query AS query')
+      expect(full).not.to.contain('CASE WHEN length(query)')
+    })
+  })
+
+  describe('command behavior', function () {
+    it('displays database calls information', async function () {
+      const mockOutput = `query | exec_time | prop_exec_time | ncalls | sync_io_time
+------|-----------|----------------|--------|-------------
+SELECT * FROM users | 1.23 | 0.15 | 100 | 0.05`
+      setupHelperStubs({newBlkTime: true, newTotalExecTime: true})
+      execQueryStub.onCall(3).resolves(mockOutput)
+
+      const {stderr, stdout} = await runCommand(Cmd, ['--app', 'my-app'])
+
+      expect(getDatabaseStub.calledOnceWith('my-app')).to.be.true
+      expect(stdout).to.contain(mockOutput)
+      expect(stderr).to.eq('')
+    })
+
+    it('passes the truncate flag through to the query', async function () {
+      setupHelperStubs({newBlkTime: true, newTotalExecTime: true})
+      execQueryStub.onCall(3).resolves('out')
+
+      await runCommand(Cmd, ['--app', 'my-app', '--truncate'])
+
+      expect(execQueryStub.getCall(3).args[0]).to.contain('CASE WHEN length(query) <= 40')
+    })
+  })
+
+  describe('error handling', function () {
+    it('surfaces database connection failures', async function () {
+      getDatabaseStub.rejects(new Error('Database connection failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'my-app'])
+      expect(error?.message).to.contain('Database connection failed')
+    })
+
+    it('errors when pg_stat_statements is not available', async function () {
+      // ensurePGStatStatement raises the "need to be installed" error inside its own
+      // try/catch, which then re-raises the generic availability-check failure.
+      execQueryStub.onCall(0).resolves('f')
+
+      const {error} = await runCommand(Cmd, ['--app', 'my-app'])
+
+      expect(error?.message).to.contain('Failed to check pg_stat_statements extension availability')
+    })
+  })
+})

--- a/test/unit/commands/pg/extensions.unit.test.ts
+++ b/test/unit/commands/pg/extensions.unit.test.ts
@@ -1,0 +1,99 @@
+import {runCommand} from '@heroku-cli/test-utils'
+import {pg, utils} from '@heroku/heroku-cli-util'
+import {expect} from 'chai'
+import * as sinon from 'sinon'
+
+import Cmd, {generateExtensionsQuery} from '../../../../src/commands/pg/extensions.js'
+
+function mockDb(planName: string): pg.ConnectionDetails {
+  return {
+    attachment: {
+      addon: {
+        plan: {name: planName},
+      },
+      name: 'DATABASE',
+    },
+    database: 'testdb',
+    host: 'localhost',
+    password: 'testpass',
+    pathname: '/testdb',
+    port: '5432',
+    url: 'postgres://localhost:5432/testdb',
+    user: 'testuser',
+  } as unknown as pg.ConnectionDetails
+}
+
+describe('pg:extensions', function () {
+  let sandbox: sinon.SinonSandbox
+  let getDatabaseStub: sinon.SinonStub
+  let execQueryStub: sinon.SinonStub
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox()
+    getDatabaseStub = sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockDb('heroku-postgresql:premium-0'))
+    execQueryStub = sandbox.stub(utils.pg.PsqlService.prototype, 'execQuery')
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('generateExtensionsQuery', function () {
+    it('restricts extensions for essential plans', function () {
+      const expectedQuery = `SELECT *
+                     FROM pg_available_extensions
+                     WHERE name IN (SELECT unnest(string_to_array(current_setting('rds.allowed_extensions'), ',')))`
+      const query = generateExtensionsQuery(mockDb('heroku-postgresql:essential-0'))
+      expect(query).to.equal(expectedQuery)
+      expect(query).to.contain('rds.allowed_extensions')
+    })
+
+    it('shows all whitelisted extensions for standard plans', function () {
+      const expectedQuery = `SELECT *
+                     FROM pg_available_extensions
+                     WHERE name IN (SELECT unnest(string_to_array(current_setting('extwlist.extensions'), ',')))`
+      const query = generateExtensionsQuery(mockDb('heroku-postgresql:premium-0'))
+      expect(query).to.equal(expectedQuery)
+      expect(query).to.contain('extwlist.extensions')
+    })
+  })
+
+  describe('command behavior', function () {
+    it('displays extensions information', async function () {
+      const mockOutput = `name | version | schema | description
+-----|---------|--------|-------------
+plpgsql | 1.0 | pg_catalog | PL/pgSQL procedural language`
+      execQueryStub.resolves(mockOutput)
+
+      const {stderr, stdout} = await runCommand(Cmd, ['--app', 'my-app'])
+
+      expect(getDatabaseStub.calledOnceWith('my-app')).to.be.true
+      expect(execQueryStub.calledOnce).to.be.true
+      expect(stdout).to.contain(mockOutput)
+      expect(stderr).to.eq('')
+    })
+
+    it('uses the essential-tier query when the db is on an essential plan', async function () {
+      getDatabaseStub.resolves(mockDb('heroku-postgresql:essential-0'))
+      execQueryStub.resolves('')
+
+      await runCommand(Cmd, ['--app', 'my-app'])
+
+      expect(execQueryStub.getCall(0).args[0]).to.contain('rds.allowed_extensions')
+    })
+  })
+
+  describe('error handling', function () {
+    it('surfaces database connection failures', async function () {
+      getDatabaseStub.rejects(new Error('Database connection failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'my-app'])
+      expect(error?.message).to.contain('Database connection failed')
+    })
+
+    it('surfaces SQL execution failures', async function () {
+      execQueryStub.rejects(new Error('SQL execution failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'my-app'])
+      expect(error?.message).to.contain('SQL execution failed')
+    })
+  })
+})

--- a/test/unit/commands/pg/fdwsql.unit.test.ts
+++ b/test/unit/commands/pg/fdwsql.unit.test.ts
@@ -91,6 +91,21 @@ ORDER BY c.relname;`
       expect(stderr).to.eq('')
     })
 
+    it('filters out non-CREATE lines from the query output', async function () {
+      execQueryStub.resolves(`                              ?column?
+-------------------------------------------------------
+ CREATE FOREIGN TABLE test_prefix_table1(col1 int) SERVER test_prefix_db OPTIONS (schema_name 'public', table_name 'table1');
+NOTICE:  some psql noise
+(1 row)`)
+
+      const {stdout} = await runCommand(Cmd, ['test_prefix', '--app', 'my-app'])
+
+      expect(stdout).to.contain('CREATE FOREIGN TABLE test_prefix_table1')
+      expect(stdout).to.not.contain('?column?')
+      expect(stdout).to.not.contain('NOTICE:')
+      expect(stdout).to.not.contain('(1 row)')
+    })
+
     it('shows setup SQL even when no foreign tables are returned', async function () {
       execQueryStub.resolves('')
 

--- a/test/unit/commands/pg/fdwsql.unit.test.ts
+++ b/test/unit/commands/pg/fdwsql.unit.test.ts
@@ -1,0 +1,132 @@
+import {runCommand} from '@heroku-cli/test-utils'
+import {pg, utils} from '@heroku/heroku-cli-util'
+import {expect} from 'chai'
+import * as sinon from 'sinon'
+
+import Cmd, {generateFdwsqlQuery} from '../../../../src/commands/pg/fdwsql.js'
+
+function mockDb(planName = 'heroku-postgresql:premium-0'): pg.ConnectionDetails {
+  return {
+    attachment: {
+      addon: {
+        plan: {name: planName},
+      },
+      name: 'DATABASE',
+    },
+    database: 'testdb',
+    host: 'localhost',
+    password: 'testpass',
+    pathname: '/testdb',
+    port: '5432',
+    url: 'postgres://localhost:5432/testdb',
+    user: 'testuser',
+  } as unknown as pg.ConnectionDetails
+}
+
+describe('pg:fdwsql', function () {
+  let sandbox: sinon.SinonSandbox
+  let getDatabaseStub: sinon.SinonStub
+  let execQueryStub: sinon.SinonStub
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox()
+    getDatabaseStub = sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockDb())
+    execQueryStub = sandbox.stub(utils.pg.PsqlService.prototype, 'execQuery')
+    execQueryStub.resolves(`CREATE FOREIGN TABLE test_prefix_table1(col1 int, col2 text) SERVER test_prefix_db OPTIONS (schema_name 'public', table_name 'table1');
+CREATE FOREIGN TABLE test_prefix_table2(col3 varchar) SERVER test_prefix_db OPTIONS (schema_name 'public', table_name 'table2');`)
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('generateFdwsqlQuery', function () {
+    it('generates the exact expected SQL query', function () {
+      const prefix = 'test_prefix'
+      const expectedQuery = `SELECT
+  'CREATE FOREIGN TABLE '
+  || quote_ident('${prefix}_' || c.relname)
+  || '(' || array_to_string(array_agg(quote_ident(a.attname) || ' ' || t.typname), ', ') || ') '
+  || ' SERVER ${prefix}_db OPTIONS'
+  || ' (schema_name ''' || quote_ident(n.nspname) || ''', table_name ''' || quote_ident(c.relname) || ''');'
+FROM
+  pg_class     c,
+  pg_attribute a,
+  pg_type      t,
+  pg_namespace n
+WHERE
+  a.attnum > 0
+  AND a.attrelid = c.oid
+  AND a.atttypid = t.oid
+  AND n.oid = c.relnamespace
+  AND c.relkind in ('r', 'v')
+  AND n.nspname <> 'pg_catalog'
+  AND n.nspname <> 'information_schema'
+  AND n.nspname !~ '^pg_toast'
+  AND pg_catalog.pg_table_is_visible(c.oid)
+GROUP BY c.relname, n.nspname
+ORDER BY c.relname;`
+
+      expect(generateFdwsqlQuery(prefix)).to.equal(expectedQuery)
+    })
+
+    it('excludes system schemas and includes only tables and views', function () {
+      const query = generateFdwsqlQuery('test_prefix')
+      expect(query).to.contain("n.nspname <> 'pg_catalog'")
+      expect(query).to.contain("n.nspname <> 'information_schema'")
+      expect(query).to.contain("n.nspname !~ '^pg_toast'")
+      expect(query).to.contain("c.relkind in ('r', 'v')")
+    })
+  })
+
+  describe('command behavior', function () {
+    it('displays foreign data wrapper setup SQL and filtered output', async function () {
+      const {stderr, stdout} = await runCommand(Cmd, ['test_prefix', '--app', 'my-app'])
+
+      expect(stdout).to.contain('CREATE EXTENSION IF NOT EXISTS postgres_fdw;')
+      expect(stdout).to.contain('DROP SERVER IF EXISTS test_prefix_db;')
+      expect(stdout).to.contain('CREATE SERVER test_prefix_db')
+      expect(stdout).to.contain('CREATE USER MAPPING FOR CURRENT_USER')
+      expect(stdout).to.contain('CREATE FOREIGN TABLE test_prefix_table1')
+      expect(stderr).to.eq('')
+    })
+
+    it('shows setup SQL even when no foreign tables are returned', async function () {
+      execQueryStub.resolves('')
+
+      const {stdout} = await runCommand(Cmd, ['test_prefix', '--app', 'my-app'])
+
+      expect(stdout).to.contain('CREATE EXTENSION IF NOT EXISTS postgres_fdw;')
+      expect(stdout).to.contain('DROP SERVER IF EXISTS test_prefix_db;')
+      expect(stdout).to.contain('CREATE SERVER test_prefix_db')
+      expect(stdout).to.contain('CREATE USER MAPPING FOR CURRENT_USER')
+    })
+
+    it('resolves the named database when provided', async function () {
+      await runCommand(Cmd, ['test_prefix', 'custom-db', '--app', 'my-app'])
+      expect(getDatabaseStub.calledOnceWith('my-app', 'custom-db')).to.be.true
+    })
+
+    it('errors on essential-tier databases', async function () {
+      getDatabaseStub.resolves(mockDb('heroku-postgresql:essential-0'))
+
+      const {error} = await runCommand(Cmd, ['test_prefix', '--app', 'my-app'])
+
+      expect(error?.message).to.contain('This operation is not supported by Essential-tier databases.')
+    })
+  })
+
+  describe('error handling', function () {
+    it('surfaces database connection failures', async function () {
+      getDatabaseStub.rejects(new Error('Database connection failed'))
+      const {error} = await runCommand(Cmd, ['test_prefix', '--app', 'my-app'])
+      expect(error?.message).to.contain('Database connection failed')
+    })
+
+    it('surfaces SQL execution failures', async function () {
+      execQueryStub.rejects(new Error('SQL execution failed'))
+      const {error} = await runCommand(Cmd, ['test_prefix', '--app', 'my-app'])
+      expect(error?.message).to.contain('SQL execution failed')
+    })
+  })
+})

--- a/test/unit/commands/pg/fdwsql.unit.test.ts
+++ b/test/unit/commands/pg/fdwsql.unit.test.ts
@@ -122,6 +122,14 @@ NOTICE:  some psql noise
       expect(getDatabaseStub.calledOnceWith('my-app', 'custom-db')).to.be.true
     })
 
+    it('rejects a malicious prefix and emits no SQL', async function () {
+      const {error, stdout} = await runCommand(Cmd, ['foo; DROP TABLE users', '--app', 'my-app'])
+
+      expect(error?.message).to.contain('prefix must start with a letter or underscore')
+      expect(execQueryStub.called).to.be.false
+      expect(stdout).to.eq('')
+    })
+
     it('errors on essential-tier databases', async function () {
       getDatabaseStub.resolves(mockDb('heroku-postgresql:essential-0'))
 

--- a/test/unit/commands/pg/index-size.unit.test.ts
+++ b/test/unit/commands/pg/index-size.unit.test.ts
@@ -1,0 +1,94 @@
+import {runCommand} from '@heroku-cli/test-utils'
+import {pg, utils} from '@heroku/heroku-cli-util'
+import {expect} from 'chai'
+import * as sinon from 'sinon'
+
+import Cmd, {generateIndexSizeQuery} from '../../../../src/commands/pg/index-size.js'
+
+const mockDb = {
+  attachment: {
+    addon: {
+      plan: {name: 'heroku-postgresql:premium-0'},
+    },
+    name: 'DATABASE',
+  },
+  database: 'testdb',
+  host: 'localhost',
+  password: 'testpass',
+  pathname: '/testdb',
+  port: '5432',
+  url: 'postgres://localhost:5432/testdb',
+  user: 'testuser',
+} as unknown as pg.ConnectionDetails
+
+describe('pg:index-size', function () {
+  let sandbox: sinon.SinonSandbox
+  let getDatabaseStub: sinon.SinonStub
+  let execQueryStub: sinon.SinonStub
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox()
+    getDatabaseStub = sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockDb)
+    execQueryStub = sandbox.stub(utils.pg.PsqlService.prototype, 'execQuery')
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('generateIndexSizeQuery', function () {
+    it('generates the exact expected SQL query', function () {
+      const expectedQuery = `SELECT c.relname AS name,
+  pg_size_pretty(sum(c.relpages::bigint*8192)::bigint) AS size
+FROM pg_class c
+LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+AND n.nspname !~ '^pg_toast'
+AND c.relkind='i'
+GROUP BY c.relname
+ORDER BY sum(c.relpages) DESC;`
+
+      expect(generateIndexSizeQuery()).to.equal(expectedQuery)
+    })
+
+    it('excludes system schemas and includes only indexes', function () {
+      const query = generateIndexSizeQuery()
+      expect(query).to.contain("n.nspname NOT IN ('pg_catalog', 'information_schema')")
+      expect(query).to.contain("n.nspname !~ '^pg_toast'")
+      expect(query).to.contain("c.relkind='i'")
+      expect(query).to.contain('sum(c.relpages::bigint*8192)')
+      expect(query).to.contain('pg_size_pretty')
+    })
+  })
+
+  describe('command behavior', function () {
+    it('displays index size information', async function () {
+      const mockOutput = `name | size
+-----|-----
+idx_users_email | 2.1 MB
+idx_posts_title | 1.8 MB`
+      execQueryStub.resolves(mockOutput)
+
+      const {stderr, stdout} = await runCommand(Cmd, ['--app', 'my-app'])
+
+      expect(getDatabaseStub.calledOnceWith('my-app')).to.be.true
+      expect(execQueryStub.calledOnceWith(generateIndexSizeQuery())).to.be.true
+      expect(stdout).to.contain(mockOutput)
+      expect(stderr).to.eq('')
+    })
+  })
+
+  describe('error handling', function () {
+    it('surfaces database connection failures', async function () {
+      getDatabaseStub.rejects(new Error('Database connection failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'my-app'])
+      expect(error?.message).to.contain('Database connection failed')
+    })
+
+    it('surfaces SQL execution failures', async function () {
+      execQueryStub.rejects(new Error('SQL execution failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'my-app'])
+      expect(error?.message).to.contain('SQL execution failed')
+    })
+  })
+})

--- a/test/unit/commands/pg/index-usage.unit.test.ts
+++ b/test/unit/commands/pg/index-usage.unit.test.ts
@@ -1,0 +1,93 @@
+import {runCommand} from '@heroku-cli/test-utils'
+import {pg, utils} from '@heroku/heroku-cli-util'
+import {expect} from 'chai'
+import * as sinon from 'sinon'
+
+import Cmd, {generateIndexUsageQuery} from '../../../../src/commands/pg/index-usage.js'
+
+const mockDb = {
+  attachment: {
+    addon: {
+      plan: {name: 'heroku-postgresql:premium-0'},
+    },
+    name: 'DATABASE',
+  },
+  database: 'testdb',
+  host: 'localhost',
+  password: 'testpass',
+  pathname: '/testdb',
+  port: '5432',
+  url: 'postgres://localhost:5432/testdb',
+  user: 'testuser',
+} as unknown as pg.ConnectionDetails
+
+describe('pg:index-usage', function () {
+  let sandbox: sinon.SinonSandbox
+  let getDatabaseStub: sinon.SinonStub
+  let execQueryStub: sinon.SinonStub
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox()
+    getDatabaseStub = sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockDb)
+    execQueryStub = sandbox.stub(utils.pg.PsqlService.prototype, 'execQuery')
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('generateIndexUsageQuery', function () {
+    it('generates the exact expected SQL query', function () {
+      const expectedQuery = `SELECT relname,
+   CASE idx_scan
+     WHEN 0 THEN 'Insufficient data'
+     ELSE (100 * idx_scan / (seq_scan + idx_scan))::text
+   END percent_of_times_index_used,
+   n_live_tup rows_in_table
+ FROM
+   pg_stat_user_tables
+ ORDER BY
+   n_live_tup DESC;`
+
+      expect(generateIndexUsageQuery()).to.equal(expectedQuery)
+    })
+
+    it('calculates index usage percentage and orders by table size', function () {
+      const query = generateIndexUsageQuery()
+      expect(query).to.contain('100 * idx_scan / (seq_scan + idx_scan)')
+      expect(query).to.contain('CASE idx_scan')
+      expect(query).to.contain('Insufficient data')
+      expect(query).to.contain('n_live_tup DESC')
+    })
+  })
+
+  describe('command behavior', function () {
+    it('displays index usage statistics', async function () {
+      const mockOutput = `relname | percent_of_times_index_used | rows_in_table
+---------|------------------------------|---------------
+users    | 95                          | 10000`
+      execQueryStub.resolves(mockOutput)
+
+      const {stderr, stdout} = await runCommand(Cmd, ['--app', 'my-app'])
+
+      expect(getDatabaseStub.calledOnceWith('my-app')).to.be.true
+      expect(execQueryStub.calledOnceWith(generateIndexUsageQuery())).to.be.true
+      expect(stdout).to.contain(mockOutput)
+      expect(stderr).to.eq('')
+    })
+  })
+
+  describe('error handling', function () {
+    it('surfaces database connection failures', async function () {
+      getDatabaseStub.rejects(new Error('Database connection failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'my-app'])
+      expect(error?.message).to.contain('Database connection failed')
+    })
+
+    it('surfaces SQL execution failures', async function () {
+      execQueryStub.rejects(new Error('SQL execution failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'my-app'])
+      expect(error?.message).to.contain('SQL execution failed')
+    })
+  })
+})

--- a/test/unit/lib/pg/extras.unit.test.ts
+++ b/test/unit/lib/pg/extras.unit.test.ts
@@ -77,13 +77,10 @@ describe('lib/pg/extras', function () {
       expect(uxErrorStub.called).to.be.false
     })
 
-    it('calls ux.error when psql exec fails', async function () {
+    it('propagates the error when psql exec fails', async function () {
       execQueryStub.rejects(new Error('boom'))
 
-      await ensurePGStatStatement(mockDb())
-
-      expect(uxErrorStub.calledOnce).to.be.true
-      expect(uxErrorStub.firstCall.args[1]).to.deep.equal({exit: 1})
+      await expect(ensurePGStatStatement(mockDb())).to.be.rejectedWith('boom')
     })
 
     it('calls ux.error when pg_stat_statements is not available', async function () {
@@ -169,11 +166,9 @@ describe('lib/pg/extras', function () {
       expect(uxErrorStub.firstCall.args[1]).to.deep.equal({exit: 1})
     })
 
-    it('calls ux.error when the query fails', async function () {
+    it('propagates the error when the query fails', async function () {
       execQueryStub.rejects(new Error('boom'))
-      await newTotalExecTimeField(mockDb())
-      expect(uxErrorStub.calledOnce).to.be.true
-      expect(uxErrorStub.firstCall.args[1]).to.deep.equal({exit: 1})
+      await expect(newTotalExecTimeField(mockDb())).to.be.rejectedWith('boom')
     })
   })
 
@@ -196,11 +191,27 @@ describe('lib/pg/extras', function () {
       expect(uxErrorStub.firstCall.args[1]).to.deep.equal({exit: 1})
     })
 
-    it('calls ux.error when the query fails', async function () {
+    it('propagates the error when the query fails', async function () {
       execQueryStub.rejects(new Error('boom'))
-      await newBlkTimeFields(mockDb())
-      expect(uxErrorStub.calledOnce).to.be.true
-      expect(uxErrorStub.firstCall.args[1]).to.deep.equal({exit: 1})
+      await expect(newBlkTimeFields(mockDb())).to.be.rejectedWith('boom')
+    })
+  })
+
+  describe('error propagation', function () {
+    beforeEach(function () {
+      // Let ux.error throw as it does in production (instead of the no-op stub),
+      // so we can assert the real, user-visible message propagates uncaught.
+      uxErrorStub.restore()
+    })
+
+    it('newTotalExecTimeField surfaces the real version error on an unexpected response', async function () {
+      execQueryStub.resolves('garbage\n')
+      await expect(newTotalExecTimeField(mockDb())).to.be.rejectedWith('Unable to determine database version')
+    })
+
+    it('newBlkTimeFields surfaces the real version error on an unexpected response', async function () {
+      execQueryStub.resolves('garbage\n')
+      await expect(newBlkTimeFields(mockDb())).to.be.rejectedWith('Unable to determine database version')
     })
   })
 })

--- a/test/unit/lib/pg/extras.unit.test.ts
+++ b/test/unit/lib/pg/extras.unit.test.ts
@@ -55,6 +55,30 @@ describe('lib/pg/extras', function () {
       expect(uxErrorStub.called).to.be.false
     })
 
+    it('checks both public and heroku_ext schemas for pg_stat_statements', async function () {
+      execQueryStub.resolves('t')
+
+      await ensurePGStatStatement(mockDb())
+
+      const querySql = execQueryStub.firstCall.args[0]
+      expect(querySql).to.include('pg_stat_statements')
+      expect(querySql).to.include("'public'")
+      expect(querySql).to.include("'heroku_ext'")
+    })
+
+    it('detects pg_stat_statements when it is installed in the heroku_ext schema', async function () {
+      // Simulate a database where the extension lives in heroku_ext (standard for
+      // modern Heroku Postgres) and NOT in public. The check only succeeds if the
+      // query actually looks in heroku_ext, so this fails on the public-only bug.
+      execQueryStub.callsFake((query: string) =>
+        Promise.resolve(query.includes("'heroku_ext'") ? 't' : 'f'),
+      )
+
+      await ensurePGStatStatement(mockDb())
+
+      expect(uxErrorStub.called).to.be.false
+    })
+
     it('calls ux.error when psql exec fails', async function () {
       execQueryStub.rejects(new Error('boom'))
 

--- a/test/unit/lib/pg/extras.unit.test.ts
+++ b/test/unit/lib/pg/extras.unit.test.ts
@@ -1,0 +1,184 @@
+import {pg, utils} from '@heroku/heroku-cli-util'
+import {ux} from '@oclif/core/ux'
+import {expect} from 'chai'
+import * as sinon from 'sinon'
+
+import {
+  ensureEssentialTierPlan,
+  ensurePGStatStatement,
+  essentialNumPlan,
+  newBlkTimeFields,
+  newTotalExecTimeField,
+} from '../../../../src/lib/pg/extras.js'
+
+function mockDb(planName = 'heroku-postgresql:premium-0'): pg.ConnectionDetails {
+  return {
+    attachment: {
+      addon: {
+        plan: {name: planName},
+      },
+      name: 'DATABASE',
+    },
+    database: 'testdb',
+    host: 'localhost',
+    password: 'testpass',
+    pathname: '/testdb',
+    port: '5432',
+    url: 'postgres://localhost:5432/testdb',
+    user: 'testuser',
+  } as unknown as pg.ConnectionDetails
+}
+
+describe('lib/pg/extras', function () {
+  let sandbox: sinon.SinonSandbox
+  let execQueryStub: sinon.SinonStub
+  let uxErrorStub: sinon.SinonStub
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox()
+    execQueryStub = sandbox.stub(utils.pg.PsqlService.prototype, 'execQuery')
+    uxErrorStub = sandbox.stub(ux, 'error')
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('ensurePGStatStatement', function () {
+    it('succeeds when pg_stat_statements is available', async function () {
+      execQueryStub.resolves('t')
+
+      await ensurePGStatStatement(mockDb())
+
+      expect(execQueryStub.calledOnce).to.be.true
+      expect(execQueryStub.firstCall.args[0]).to.include('pg_stat_statements')
+      expect(uxErrorStub.called).to.be.false
+    })
+
+    it('calls ux.error when psql exec fails', async function () {
+      execQueryStub.rejects(new Error('boom'))
+
+      await ensurePGStatStatement(mockDb())
+
+      expect(uxErrorStub.calledOnce).to.be.true
+      expect(uxErrorStub.firstCall.args[1]).to.deep.equal({exit: 1})
+    })
+
+    it('calls ux.error when pg_stat_statements is not available', async function () {
+      execQueryStub.resolves('f')
+
+      await ensurePGStatStatement(mockDb())
+
+      expect(uxErrorStub.calledOnce).to.be.true
+      expect(uxErrorStub.firstCall.args[1]).to.deep.equal({exit: 1})
+    })
+  })
+
+  describe('ensureEssentialTierPlan', function () {
+    it('succeeds for non-essential tier plans', async function () {
+      await ensureEssentialTierPlan(mockDb('heroku-postgresql:premium-0'))
+      expect(uxErrorStub.called).to.be.false
+    })
+
+    it('calls ux.error for dev tier plans', async function () {
+      await ensureEssentialTierPlan(mockDb('heroku-postgresql:dev'))
+      expect(uxErrorStub.calledOnce).to.be.true
+      expect(uxErrorStub.firstCall.args[1]).to.deep.equal({exit: 1})
+    })
+
+    it('calls ux.error for basic tier plans', async function () {
+      await ensureEssentialTierPlan(mockDb('heroku-postgresql:basic'))
+      expect(uxErrorStub.calledOnce).to.be.true
+      expect(uxErrorStub.firstCall.args[1]).to.deep.equal({exit: 1})
+    })
+
+    it('calls ux.error for essential tier plans', async function () {
+      await ensureEssentialTierPlan(mockDb('heroku-postgresql:essential-0'))
+      expect(uxErrorStub.calledOnce).to.be.true
+      expect(uxErrorStub.firstCall.args[1]).to.deep.equal({exit: 1})
+    })
+
+    it('calls ux.error when plan name is missing', async function () {
+      const db = mockDb()
+      // @ts-expect-error - intentionally clearing the plan name for the test
+      db.attachment.addon.plan.name = undefined
+
+      await ensureEssentialTierPlan(db)
+
+      expect(uxErrorStub.calledOnce).to.be.true
+      expect(uxErrorStub.firstCall.args[1]).to.deep.equal({exit: 1})
+    })
+  })
+
+  describe('essentialNumPlan', function () {
+    it('returns true for essential-numbered plans', function () {
+      expect(essentialNumPlan({plan: {name: 'heroku-postgresql:essential-0'}})).to.be.true
+    })
+
+    it('returns false for non-essential plans', function () {
+      expect(essentialNumPlan({plan: {name: 'heroku-postgresql:premium-0'}})).to.be.false
+    })
+
+    it('returns false when plan name is missing', function () {
+      expect(essentialNumPlan({plan: {}})).to.be.false
+    })
+
+    it('returns false when plan name has no tier segment', function () {
+      expect(essentialNumPlan({plan: {name: 'heroku-postgresql'}})).to.be.false
+    })
+  })
+
+  describe('newTotalExecTimeField', function () {
+    it('returns true when server reports t', async function () {
+      execQueryStub.resolves('t\n')
+      expect(await newTotalExecTimeField(mockDb())).to.be.true
+      expect(execQueryStub.firstCall.args[1]).to.deep.equal(['-t', '-q'])
+    })
+
+    it('returns false when server reports f', async function () {
+      execQueryStub.resolves('f\n')
+      expect(await newTotalExecTimeField(mockDb())).to.be.false
+    })
+
+    it('calls ux.error for an unexpected response', async function () {
+      execQueryStub.resolves('garbage\n')
+      await newTotalExecTimeField(mockDb())
+      expect(uxErrorStub.calledOnce).to.be.true
+      expect(uxErrorStub.firstCall.args[1]).to.deep.equal({exit: 1})
+    })
+
+    it('calls ux.error when the query fails', async function () {
+      execQueryStub.rejects(new Error('boom'))
+      await newTotalExecTimeField(mockDb())
+      expect(uxErrorStub.calledOnce).to.be.true
+      expect(uxErrorStub.firstCall.args[1]).to.deep.equal({exit: 1})
+    })
+  })
+
+  describe('newBlkTimeFields', function () {
+    it('returns true when server reports t', async function () {
+      execQueryStub.resolves('t\n')
+      expect(await newBlkTimeFields(mockDb())).to.be.true
+      expect(execQueryStub.firstCall.args[1]).to.deep.equal(['-t', '-q'])
+    })
+
+    it('returns false when server reports f', async function () {
+      execQueryStub.resolves('f\n')
+      expect(await newBlkTimeFields(mockDb())).to.be.false
+    })
+
+    it('calls ux.error for an unexpected response', async function () {
+      execQueryStub.resolves('garbage\n')
+      await newBlkTimeFields(mockDb())
+      expect(uxErrorStub.calledOnce).to.be.true
+      expect(uxErrorStub.firstCall.args[1]).to.deep.equal({exit: 1})
+    })
+
+    it('calls ux.error when the query fails', async function () {
+      execQueryStub.rejects(new Error('boom'))
+      await newBlkTimeFields(mockDb())
+      expect(uxErrorStub.calledOnce).to.be.true
+      expect(uxErrorStub.firstCall.args[1]).to.deep.equal({exit: 1})
+    })
+  })
+})

--- a/test/unit/lib/pg/extras.unit.test.ts
+++ b/test/unit/lib/pg/extras.unit.test.ts
@@ -70,9 +70,7 @@ describe('lib/pg/extras', function () {
       // Simulate a database where the extension lives in heroku_ext (standard for
       // modern Heroku Postgres) and NOT in public. The check only succeeds if the
       // query actually looks in heroku_ext, so this fails on the public-only bug.
-      execQueryStub.callsFake((query: string) =>
-        Promise.resolve(query.includes("'heroku_ext'") ? 't' : 'f'),
-      )
+      execQueryStub.callsFake((query: string) => Promise.resolve(query.includes("'heroku_ext'") ? 't' : 'f'))
 
       await ensurePGStatStatement(mockDb())
 


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary

We need to move the commands from the [pg-extras plugin](https://github.com/heroku/heroku-pg-extras) to the core CLI, which will require us to update the commands to use oclif/core v4 and heroku-cli-command v12.

This is PR 1 of 3 to accomplish this task and we will be merging these PRs in feature/migrate_pg_extras_to_cli

Things done:

- Add postgres words to cspell dictionary

This work item covers migrating the following 6 pg-extras commands to the core CLI:

- pg/cache-hit.ts
- pg/calls.ts
- pg/extensions.ts
- pg/fdwsql.ts
- pg/index-size.ts
- pg/index-usage.ts

ALSO did:

- AGENTS.md requires usage examples to the migrated pg-extras commands so I added those
- Fixed a bug in pg:call so that it now works 😄 

What I'm not doing and why
- There is some code overlap with the commands we are moving into CLI.  Whereas we could refactor it all, it seems like a fair amount of work and I'd rather keep this series of PR's small and more time constrained.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [x] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [x] **test**: Add/update/remove tests

## Testing
**Notes**:

The --help changes (should be limited to --prompt and GLOBAL FLAGS additions that came with cli upgrades) ALSO examples as the cli requires:

diff <(./bin/run pg:cache-hit --help) <(heroku pg:cache-hit --help)
diff <(./bin/run pg:calls --help) <(heroku pg:calls --help)
diff <(./bin/run pg:extensions --help) <(heroku pg:extensions --help)
diff <(./bin/run pg:fdwsql --help) <(heroku pg:fdwsql --help)
diff <(./bin/run pg:index-size --help) <(heroku pg:index-size --help)
diff <(./bin/run pg:index-usage --help) <(heroku pg:index-usage --help)

New Command Testing Steps:

1. Show index and table hit rate (two rows: index hit rate and table hit rate, each with a
  ratio)

./bin/run pg:cache-hit -a $APP

2. Confirm the hidden underscore alias produces identical output to step 1

./bin/run pg:cache_hit -a $APP

3. Show index usage (relname | percent_of_times_index_used | rows_in_table, ordered by rows
  descending; tables with no scans show Insufficient data)

./bin/run pg:index-usage -a $APP

4. Confirm the hidden underscore alias produces identical output to step 3

./bin/run pg:index_usage -a $APP

5. Show index sizes (name | size for each index, descending by size, e.g. 5196 MB)

./bin/run pg:index-size -a $APP

6. Confirm the hidden underscore alias produces identical output to step 5

./bin/run pg:index_size -a $APP

7. List available and installed extensions (name | version | schema | description, e.g. a
  plpgsql row)

./bin/run pg:extensions -a $APP

8. Show the 10 highest-frequency queries (total_exec_time | prop_exec_time | ncalls | sync_io_time | query, ordered by calls DESC; requires pg_stat_statements)

./bin/run pg:calls -a $APP

9. Same as step 8 but with the query column truncated to 40 characters (look for … at the cut point)

./bin/run pg:calls --truncate -a $APP

10. Generate foreign data wrapper SQL (output starts with CREATE EXTENSION IF NOT EXISTS postgres_fdw;, DROP SERVER IF EXISTS example_prefix_db;, CREATE SERVER example_prefix_db…, CREATE USER MAPPING…, then one CREATE FOREIGN TABLE… line per table/view; psql noise like (N rows) is filtered out)

./bin/run pg:fdwsql example_prefix -a $APP

11. Confirm the optional database arg resolves a specific database instead of the default

./bin/run pg:cache-hit DATABASE_URL -a $APP
./bin/run pg:fdwsql example_prefix DATABASE_URL -a $APP

## Screenshots (if applicable)

## Related Issues

GUS work item: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Yzk1lYAB/view
