### PR TITLE
refactor: final pass at adding pg commands from pg-extras plugin to cli PR 3 of 3

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -134,6 +134,8 @@ Icann
 infile
 iname
 indexrelid
+indexrelname
+indisunique
 indrelid
 inreplace
 iotta

--- a/src/commands/pg/table-size.ts
+++ b/src/commands/pg/table-size.ts
@@ -1,0 +1,44 @@
+import {Command, flags} from '@heroku-cli/command'
+import {color, utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+import tsheredoc from 'tsheredoc'
+
+import {nls} from '../../nls.js'
+
+const heredoc = tsheredoc.default
+
+export const generateTableSizeQuery = (): string => `
+SELECT c.relname AS name,
+  pg_size_pretty(pg_table_size(c.oid)) AS size
+FROM pg_class c
+LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+AND n.nspname !~ '^pg_toast'
+AND c.relkind='r'
+ORDER BY pg_table_size(c.oid) DESC;
+`.trim()
+
+export default class PgTableSize extends Command {
+  static aliases = ['pg:table_size']
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`, required: false}),
+  }
+  static description = 'show the size of the tables (excluding indexes), descending by size'
+  static examples = [heredoc`
+    ${color.command('heroku pg:table-size --app example-app')}
+  `]
+  static flags = {
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+  }
+  static topic = 'pg'
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(PgTableSize)
+    const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
+    const db = await dbResolver.getDatabase(flags.app, args.database)
+    const psqlService = new utils.pg.PsqlService(db)
+    const output = await psqlService.execQuery(generateTableSizeQuery())
+    ux.stdout(output)
+  }
+}

--- a/src/commands/pg/total-index-size.ts
+++ b/src/commands/pg/total-index-size.ts
@@ -1,0 +1,42 @@
+import {Command, flags} from '@heroku-cli/command'
+import {color, utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+import tsheredoc from 'tsheredoc'
+
+import {nls} from '../../nls.js'
+
+const heredoc = tsheredoc.default
+
+export const generateTotalIndexSizeQuery = (): string => `
+SELECT pg_size_pretty(sum(c.relpages::bigint*8192)::bigint) AS size
+FROM pg_class c
+LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+AND n.nspname !~ '^pg_toast'
+AND c.relkind='i';
+`.trim()
+
+export default class PgTotalIndexSize extends Command {
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`, required: false}),
+  }
+  static description = 'show the total size of all indexes in MB'
+  static examples = [heredoc`
+    ${color.command('heroku pg:total-index-size --app example-app')}
+  `]
+  static flags = {
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+  }
+  static hiddenAliases = ['pg:total_index_size']
+  static topic = 'pg'
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(PgTotalIndexSize)
+    const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
+    const db = await dbResolver.getDatabase(flags.app, args.database)
+    const psqlService = new utils.pg.PsqlService(db)
+    const output = await psqlService.execQuery(generateTotalIndexSizeQuery())
+    ux.stdout(output)
+  }
+}

--- a/src/commands/pg/total-table-size.ts
+++ b/src/commands/pg/total-table-size.ts
@@ -1,0 +1,44 @@
+import {Command, flags} from '@heroku-cli/command'
+import {color, utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+import tsheredoc from 'tsheredoc'
+
+import {nls} from '../../nls.js'
+
+const heredoc = tsheredoc.default
+
+export const generateTotalTableSizeQuery = (): string => `
+SELECT c.relname AS name,
+  pg_size_pretty(pg_total_relation_size(c.oid)) AS size
+FROM pg_class c
+LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+AND n.nspname !~ '^pg_toast'
+AND c.relkind='r'
+ORDER BY pg_total_relation_size(c.oid) DESC;
+`.trim()
+
+export default class PgTotalTableSize extends Command {
+  static aliases = ['pg:total_table_size']
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`, required: false}),
+  }
+  static description = 'show the size of the tables (including indexes), descending by size'
+  static examples = [heredoc`
+    ${color.command('heroku pg:total-table-size --app example-app')}
+  `]
+  static flags = {
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+  }
+  static topic = 'pg'
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(PgTotalTableSize)
+    const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
+    const db = await dbResolver.getDatabase(flags.app, args.database)
+    const psqlService = new utils.pg.PsqlService(db)
+    const output = await psqlService.execQuery(generateTotalTableSizeQuery())
+    ux.stdout(output)
+  }
+}

--- a/src/commands/pg/unused-indexes.ts
+++ b/src/commands/pg/unused-indexes.ts
@@ -1,0 +1,46 @@
+import {Command, flags} from '@heroku-cli/command'
+import {color, utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+import tsheredoc from 'tsheredoc'
+
+import {nls} from '../../nls.js'
+
+const heredoc = tsheredoc.default
+
+export const generateUnusedIndexesQuery = (): string => `
+SELECT
+  schemaname || '.' || relname AS table,
+  indexrelname AS index,
+  pg_size_pretty(pg_relation_size(i.indexrelid)) AS index_size,
+  idx_scan as index_scans
+FROM pg_stat_user_indexes ui
+JOIN pg_index i ON ui.indexrelid = i.indexrelid
+WHERE NOT indisunique AND idx_scan < 50 AND pg_relation_size(relid) > 5 * 8192
+ORDER BY pg_relation_size(i.indexrelid) / nullif(idx_scan, 0) DESC NULLS FIRST,
+pg_relation_size(i.indexrelid) DESC;
+`.trim()
+
+export default class PgUnusedIndexes extends Command {
+  static aliases = ['pg:unused_indexes']
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`, required: false}),
+  }
+  static description = 'show unused and almost unused indexes'
+  static examples = [heredoc`
+    ${color.command('heroku pg:unused-indexes --app example-app')}
+  `]
+  static flags = {
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+  }
+  static topic = 'pg'
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(PgUnusedIndexes)
+    const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
+    const db = await dbResolver.getDatabase(flags.app, args.database)
+    const psqlService = new utils.pg.PsqlService(db)
+    const output = await psqlService.execQuery(generateUnusedIndexesQuery())
+    ux.stdout(output)
+  }
+}

--- a/src/commands/pg/user-connections.ts
+++ b/src/commands/pg/user-connections.ts
@@ -1,0 +1,43 @@
+import {Command, flags} from '@heroku-cli/command'
+import {color, utils} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+import tsheredoc from 'tsheredoc'
+
+import {nls} from '../../nls.js'
+
+const heredoc = tsheredoc.default
+
+export const generateUserConnectionsQuery = (): string => `
+SELECT
+  usename AS credential,
+  count(*) AS connections
+FROM pg_stat_activity
+WHERE state = 'active'
+GROUP BY usename
+ORDER BY connections DESC;
+`.trim()
+
+export default class PgUserConnections extends Command {
+  static args = {
+    database: Args.string({description: `${nls('pg:database:arg:description')} ${nls('pg:database:arg:description:default:suffix')}`, required: false}),
+  }
+  static description = 'returns the number of connections per credential'
+  static examples = [heredoc`
+    ${color.command('heroku pg:user-connections --app example-app')}
+  `]
+  static flags = {
+    app: flags.app({required: true}),
+    remote: flags.remote(),
+  }
+  static hiddenAliases = ['pg:user_connections']
+  static topic = 'pg'
+
+  public async run(): Promise<void> {
+    const {args, flags} = await this.parse(PgUserConnections)
+    const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
+    const db = await dbResolver.getDatabase(flags.app, args.database)
+    const psqlService = new utils.pg.PsqlService(db)
+    const output = await psqlService.execQuery(generateUserConnectionsQuery())
+    ux.stdout(output)
+  }
+}

--- a/test/unit/commands/pg/table-size.unit.test.ts
+++ b/test/unit/commands/pg/table-size.unit.test.ts
@@ -1,0 +1,97 @@
+import {runCommand} from '@heroku-cli/test-utils'
+import {pg, utils} from '@heroku/heroku-cli-util'
+import {expect} from 'chai'
+import {
+  createSandbox, SinonSandbox, SinonStub,
+} from 'sinon'
+
+import Cmd, {generateTableSizeQuery} from '../../../../src/commands/pg/table-size.js'
+
+describe('pg:table-size', function () {
+  let sandbox: SinonSandbox
+  let getDatabaseStub: SinonStub
+  let execQueryStub: SinonStub
+  const expectedOutput = 'name | size\n---+---\nusers | 50 MB'
+
+  const mockDb: pg.ConnectionDetails = {
+    database: 'testdb',
+    host: 'localhost',
+    password: 'testpass',
+    pathname: '/testdb',
+    port: '5432',
+    url: 'postgres://localhost:5432/testdb',
+    user: 'testuser',
+  }
+
+  beforeEach(function () {
+    sandbox = createSandbox()
+    getDatabaseStub = sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockDb)
+    execQueryStub = sandbox.stub(utils.pg.PsqlService.prototype, 'execQuery').resolves(expectedOutput)
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('generateTableSizeQuery', function () {
+    it('generates SQL with the expected clauses', function () {
+      const query = generateTableSizeQuery()
+      expect(query).to.contain('pg_table_size')
+      expect(query).to.contain('pg_class')
+      expect(query).to.contain('information_schema')
+    })
+
+    it('generates the exact expected SQL query', function () {
+      const expectedQuery = `SELECT c.relname AS name,
+  pg_size_pretty(pg_table_size(c.oid)) AS size
+FROM pg_class c
+LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+AND n.nspname !~ '^pg_toast'
+AND c.relkind='r'
+ORDER BY pg_table_size(c.oid) DESC;`
+
+      expect(generateTableSizeQuery()).to.equal(expectedQuery)
+    })
+  })
+
+  describe('command behavior', function () {
+    it('displays the size of the tables', async function () {
+      const {stderr, stdout} = await runCommand(Cmd, [
+        '--app',
+        'myapp',
+      ])
+
+      expect(getDatabaseStub.calledOnceWith('myapp')).to.be.true
+      expect(execQueryStub.calledOnce).to.be.true
+      expect(execQueryStub.getCall(0).args[0]).to.eq(generateTableSizeQuery())
+      expect(stdout).to.contain(expectedOutput)
+      expect(stderr).to.eq('')
+    })
+
+    it('accepts a database argument', async function () {
+      await runCommand(Cmd, [
+        '--app',
+        'myapp',
+        'postgres-123',
+      ])
+
+      expect(getDatabaseStub.calledOnce).to.be.true
+      expect(getDatabaseStub.getCall(0).args[1]).to.eq('postgres-123')
+    })
+  })
+
+  describe('error handling', function () {
+    it('surfaces database connection failures', async function () {
+      getDatabaseStub.rejects(new Error('Database connection failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'myapp'])
+      expect(error?.message).to.contain('Database connection failed')
+    })
+
+    it('surfaces SQL execution failures', async function () {
+      execQueryStub.rejects(new Error('SQL execution failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'myapp'])
+      expect(error?.message).to.contain('SQL execution failed')
+    })
+  })
+})

--- a/test/unit/commands/pg/total-index-size.unit.test.ts
+++ b/test/unit/commands/pg/total-index-size.unit.test.ts
@@ -1,0 +1,96 @@
+import {runCommand} from '@heroku-cli/test-utils'
+import {pg, utils} from '@heroku/heroku-cli-util'
+import {expect} from 'chai'
+import {
+  createSandbox, SinonSandbox, SinonStub,
+} from 'sinon'
+
+import Cmd, {generateTotalIndexSizeQuery} from '../../../../src/commands/pg/total-index-size.js'
+
+describe('pg:total-index-size', function () {
+  let sandbox: SinonSandbox
+  let getDatabaseStub: SinonStub
+  let execQueryStub: SinonStub
+  const expectedOutput = 'size\n---\n15.2 MB'
+
+  const mockDb: pg.ConnectionDetails = {
+    database: 'testdb',
+    host: 'localhost',
+    password: 'testpass',
+    pathname: '/testdb',
+    port: '5432',
+    url: 'postgres://localhost:5432/testdb',
+    user: 'testuser',
+  }
+
+  beforeEach(function () {
+    sandbox = createSandbox()
+    getDatabaseStub = sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockDb)
+    execQueryStub = sandbox.stub(utils.pg.PsqlService.prototype, 'execQuery').resolves(expectedOutput)
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('generateTotalIndexSizeQuery', function () {
+    it('generates SQL with the expected clauses', function () {
+      const query = generateTotalIndexSizeQuery()
+      expect(query).to.contain('sum(c.relpages')
+      expect(query).to.contain('pg_size_pretty')
+      expect(query).to.contain("c.relkind='i'")
+      expect(query).to.contain('information_schema')
+    })
+
+    it('generates the exact expected SQL query', function () {
+      const expectedQuery = `SELECT pg_size_pretty(sum(c.relpages::bigint*8192)::bigint) AS size
+FROM pg_class c
+LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+AND n.nspname !~ '^pg_toast'
+AND c.relkind='i';`
+
+      expect(generateTotalIndexSizeQuery()).to.equal(expectedQuery)
+    })
+  })
+
+  describe('command behavior', function () {
+    it('displays the total size of all indexes', async function () {
+      const {stderr, stdout} = await runCommand(Cmd, [
+        '--app',
+        'myapp',
+      ])
+
+      expect(getDatabaseStub.calledOnceWith('myapp')).to.be.true
+      expect(execQueryStub.calledOnce).to.be.true
+      expect(execQueryStub.getCall(0).args[0]).to.eq(generateTotalIndexSizeQuery())
+      expect(stdout).to.contain(expectedOutput)
+      expect(stderr).to.eq('')
+    })
+
+    it('accepts a database argument', async function () {
+      await runCommand(Cmd, [
+        '--app',
+        'myapp',
+        'postgres-123',
+      ])
+
+      expect(getDatabaseStub.calledOnce).to.be.true
+      expect(getDatabaseStub.getCall(0).args[1]).to.eq('postgres-123')
+    })
+  })
+
+  describe('error handling', function () {
+    it('surfaces database connection failures', async function () {
+      getDatabaseStub.rejects(new Error('Database connection failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'myapp'])
+      expect(error?.message).to.contain('Database connection failed')
+    })
+
+    it('surfaces SQL execution failures', async function () {
+      execQueryStub.rejects(new Error('SQL execution failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'myapp'])
+      expect(error?.message).to.contain('SQL execution failed')
+    })
+  })
+})

--- a/test/unit/commands/pg/total-table-size.unit.test.ts
+++ b/test/unit/commands/pg/total-table-size.unit.test.ts
@@ -1,0 +1,98 @@
+import {runCommand} from '@heroku-cli/test-utils'
+import {pg, utils} from '@heroku/heroku-cli-util'
+import {expect} from 'chai'
+import {
+  createSandbox, SinonSandbox, SinonStub,
+} from 'sinon'
+
+import Cmd, {generateTotalTableSizeQuery} from '../../../../src/commands/pg/total-table-size.js'
+
+describe('pg:total-table-size', function () {
+  let sandbox: SinonSandbox
+  let getDatabaseStub: SinonStub
+  let execQueryStub: SinonStub
+  const expectedOutput = 'name | size\n---+---\nusers | 75 MB'
+
+  const mockDb: pg.ConnectionDetails = {
+    database: 'testdb',
+    host: 'localhost',
+    password: 'testpass',
+    pathname: '/testdb',
+    port: '5432',
+    url: 'postgres://localhost:5432/testdb',
+    user: 'testuser',
+  }
+
+  beforeEach(function () {
+    sandbox = createSandbox()
+    getDatabaseStub = sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockDb)
+    execQueryStub = sandbox.stub(utils.pg.PsqlService.prototype, 'execQuery').resolves(expectedOutput)
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('generateTotalTableSizeQuery', function () {
+    it('generates SQL with the expected clauses', function () {
+      const query = generateTotalTableSizeQuery()
+      expect(query).to.contain('pg_total_relation_size')
+      expect(query).to.contain('pg_class')
+      expect(query).to.contain('information_schema')
+      expect(query).to.contain("c.relkind='r'")
+    })
+
+    it('generates the exact expected SQL query', function () {
+      const expectedQuery = `SELECT c.relname AS name,
+  pg_size_pretty(pg_total_relation_size(c.oid)) AS size
+FROM pg_class c
+LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
+WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+AND n.nspname !~ '^pg_toast'
+AND c.relkind='r'
+ORDER BY pg_total_relation_size(c.oid) DESC;`
+
+      expect(generateTotalTableSizeQuery()).to.equal(expectedQuery)
+    })
+  })
+
+  describe('command behavior', function () {
+    it('displays the size of the tables (including indexes)', async function () {
+      const {stderr, stdout} = await runCommand(Cmd, [
+        '--app',
+        'myapp',
+      ])
+
+      expect(getDatabaseStub.calledOnceWith('myapp')).to.be.true
+      expect(execQueryStub.calledOnce).to.be.true
+      expect(execQueryStub.getCall(0).args[0]).to.eq(generateTotalTableSizeQuery())
+      expect(stdout).to.contain(expectedOutput)
+      expect(stderr).to.eq('')
+    })
+
+    it('accepts a database argument', async function () {
+      await runCommand(Cmd, [
+        '--app',
+        'myapp',
+        'postgres-123',
+      ])
+
+      expect(getDatabaseStub.calledOnce).to.be.true
+      expect(getDatabaseStub.getCall(0).args[1]).to.eq('postgres-123')
+    })
+  })
+
+  describe('error handling', function () {
+    it('surfaces database connection failures', async function () {
+      getDatabaseStub.rejects(new Error('Database connection failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'myapp'])
+      expect(error?.message).to.contain('Database connection failed')
+    })
+
+    it('surfaces SQL execution failures', async function () {
+      execQueryStub.rejects(new Error('SQL execution failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'myapp'])
+      expect(error?.message).to.contain('SQL execution failed')
+    })
+  })
+})

--- a/test/unit/commands/pg/unused-indexes.unit.test.ts
+++ b/test/unit/commands/pg/unused-indexes.unit.test.ts
@@ -1,0 +1,112 @@
+import {runCommand} from '@heroku-cli/test-utils'
+import {pg, utils} from '@heroku/heroku-cli-util'
+import {expect} from 'chai'
+import {
+  createSandbox, SinonSandbox, SinonStub,
+} from 'sinon'
+
+import Cmd, {generateUnusedIndexesQuery} from '../../../../src/commands/pg/unused-indexes.js'
+
+describe('pg:unused-indexes', function () {
+  let sandbox: SinonSandbox
+  let getDatabaseStub: SinonStub
+  let execQueryStub: SinonStub
+  const expectedOutput = 'table | index | index_size | index_scans\n---+---\npublic.users | idx_users_email | 2.1 MB | 12'
+
+  const mockDb: pg.ConnectionDetails = {
+    database: 'testdb',
+    host: 'localhost',
+    password: 'testpass',
+    pathname: '/testdb',
+    port: '5432',
+    url: 'postgres://localhost:5432/testdb',
+    user: 'testuser',
+  }
+
+  beforeEach(function () {
+    sandbox = createSandbox()
+    getDatabaseStub = sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockDb)
+    execQueryStub = sandbox.stub(utils.pg.PsqlService.prototype, 'execQuery').resolves(expectedOutput)
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('generateUnusedIndexesQuery', function () {
+    it('generates SQL with idx_scan < 50 filter', function () {
+      const query = generateUnusedIndexesQuery()
+      expect(query).to.contain('idx_scan < 50')
+    })
+
+    it('generates SQL with NOT indisunique filter', function () {
+      const query = generateUnusedIndexesQuery()
+      expect(query).to.contain('NOT indisunique')
+    })
+
+    it('generates SQL with pg_relation_size filter', function () {
+      const query = generateUnusedIndexesQuery()
+      expect(query).to.contain('pg_relation_size(relid) > 5 * 8192')
+    })
+
+    it('generates SQL with correct ORDER BY clause', function () {
+      const query = generateUnusedIndexesQuery()
+      expect(query).to.contain('ORDER BY pg_relation_size(i.indexrelid) / nullif(idx_scan, 0) DESC NULLS FIRST')
+    })
+
+    it('generates the exact expected SQL query', function () {
+      const expectedQuery = `SELECT
+  schemaname || '.' || relname AS table,
+  indexrelname AS index,
+  pg_size_pretty(pg_relation_size(i.indexrelid)) AS index_size,
+  idx_scan as index_scans
+FROM pg_stat_user_indexes ui
+JOIN pg_index i ON ui.indexrelid = i.indexrelid
+WHERE NOT indisunique AND idx_scan < 50 AND pg_relation_size(relid) > 5 * 8192
+ORDER BY pg_relation_size(i.indexrelid) / nullif(idx_scan, 0) DESC NULLS FIRST,
+pg_relation_size(i.indexrelid) DESC;`
+
+      expect(generateUnusedIndexesQuery()).to.equal(expectedQuery)
+    })
+  })
+
+  describe('command behavior', function () {
+    it('displays unused and almost unused indexes', async function () {
+      const {stderr, stdout} = await runCommand(Cmd, [
+        '--app',
+        'myapp',
+      ])
+
+      expect(getDatabaseStub.calledOnceWith('myapp')).to.be.true
+      expect(execQueryStub.calledOnce).to.be.true
+      expect(execQueryStub.getCall(0).args[0]).to.eq(generateUnusedIndexesQuery())
+      expect(stdout).to.contain(expectedOutput)
+      expect(stderr).to.eq('')
+    })
+
+    it('accepts a database argument', async function () {
+      await runCommand(Cmd, [
+        '--app',
+        'myapp',
+        'postgres-123',
+      ])
+
+      expect(getDatabaseStub.calledOnce).to.be.true
+      expect(getDatabaseStub.getCall(0).args[1]).to.eq('postgres-123')
+    })
+  })
+
+  describe('error handling', function () {
+    it('surfaces database connection failures', async function () {
+      getDatabaseStub.rejects(new Error('Database connection failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'myapp'])
+      expect(error?.message).to.contain('Database connection failed')
+    })
+
+    it('surfaces SQL execution failures', async function () {
+      execQueryStub.rejects(new Error('SQL execution failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'myapp'])
+      expect(error?.message).to.contain('SQL execution failed')
+    })
+  })
+})

--- a/test/unit/commands/pg/user-connections.unit.test.ts
+++ b/test/unit/commands/pg/user-connections.unit.test.ts
@@ -1,0 +1,97 @@
+import {runCommand} from '@heroku-cli/test-utils'
+import {pg, utils} from '@heroku/heroku-cli-util'
+import {expect} from 'chai'
+import {
+  createSandbox, SinonSandbox, SinonStub,
+} from 'sinon'
+
+import Cmd, {generateUserConnectionsQuery} from '../../../../src/commands/pg/user-connections.js'
+
+describe('pg:user-connections', function () {
+  let sandbox: SinonSandbox
+  let getDatabaseStub: SinonStub
+  let execQueryStub: SinonStub
+  const expectedOutput = 'credential | connections\n---+---\npostgres | 5'
+
+  const mockDb: pg.ConnectionDetails = {
+    database: 'testdb',
+    host: 'localhost',
+    password: 'testpass',
+    pathname: '/testdb',
+    port: '5432',
+    url: 'postgres://localhost:5432/testdb',
+    user: 'testuser',
+  }
+
+  beforeEach(function () {
+    sandbox = createSandbox()
+    getDatabaseStub = sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockDb)
+    execQueryStub = sandbox.stub(utils.pg.PsqlService.prototype, 'execQuery').resolves(expectedOutput)
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('generateUserConnectionsQuery', function () {
+    it('generates SQL with the expected clauses', function () {
+      const query = generateUserConnectionsQuery()
+      expect(query).to.contain('WHERE state = \'active\'')
+      expect(query).to.contain('GROUP BY usename')
+      expect(query).to.contain('ORDER BY connections DESC')
+      expect(query).to.contain('count(*) AS connections')
+    })
+
+    it('generates the exact expected SQL query', function () {
+      const expectedQuery = `SELECT
+  usename AS credential,
+  count(*) AS connections
+FROM pg_stat_activity
+WHERE state = 'active'
+GROUP BY usename
+ORDER BY connections DESC;`
+
+      expect(generateUserConnectionsQuery()).to.equal(expectedQuery)
+    })
+  })
+
+  describe('command behavior', function () {
+    it('displays the number of connections per credential', async function () {
+      const {stderr, stdout} = await runCommand(Cmd, [
+        '--app',
+        'myapp',
+      ])
+
+      expect(getDatabaseStub.calledOnceWith('myapp')).to.be.true
+      expect(execQueryStub.calledOnce).to.be.true
+      expect(execQueryStub.getCall(0).args[0]).to.eq(generateUserConnectionsQuery())
+      expect(stdout).to.contain(expectedOutput)
+      expect(stderr).to.eq('')
+    })
+
+    it('accepts a database argument', async function () {
+      await runCommand(Cmd, [
+        '--app',
+        'myapp',
+        'postgres-123',
+      ])
+
+      expect(getDatabaseStub.calledOnce).to.be.true
+      expect(getDatabaseStub.getCall(0).args[1]).to.eq('postgres-123')
+    })
+  })
+
+  describe('error handling', function () {
+    it('surfaces database connection failures', async function () {
+      getDatabaseStub.rejects(new Error('Database connection failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'myapp'])
+      expect(error?.message).to.contain('Database connection failed')
+    })
+
+    it('surfaces SQL execution failures', async function () {
+      execQueryStub.rejects(new Error('SQL execution failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'myapp'])
+      expect(error?.message).to.contain('SQL execution failed')
+    })
+  })
+})

--- a/test/unit/commands/pg/vacuum-stats.unit.test.ts
+++ b/test/unit/commands/pg/vacuum-stats.unit.test.ts
@@ -1,0 +1,86 @@
+import {runCommand} from '@heroku-cli/test-utils'
+import {pg, utils} from '@heroku/heroku-cli-util'
+import {expect} from 'chai'
+import {
+  createSandbox, SinonSandbox, SinonStub,
+} from 'sinon'
+
+import Cmd from '../../../../src/commands/pg/vacuum-stats.js'
+
+describe('pg:vacuum-stats', function () {
+  let sandbox: SinonSandbox
+  let getDatabaseStub: SinonStub
+  let execQueryStub: SinonStub
+  const expectedOutput = 'schema | table | last_vacuum\n---+---\npublic | users | 2024-01-01 12:00'
+
+  const mockDb: pg.ConnectionDetails = {
+    database: 'testdb',
+    host: 'localhost',
+    password: 'testpass',
+    pathname: '/testdb',
+    port: '5432',
+    url: 'postgres://localhost:5432/testdb',
+    user: 'testuser',
+  }
+
+  beforeEach(function () {
+    sandbox = createSandbox()
+    getDatabaseStub = sandbox.stub(utils.pg.DatabaseResolver.prototype, 'getDatabase').resolves(mockDb)
+    execQueryStub = sandbox.stub(utils.pg.PsqlService.prototype, 'execQuery').resolves(expectedOutput)
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+  })
+
+  describe('command behavior', function () {
+    it('displays dead rows and whether an automatic vacuum is expected', async function () {
+      const {stderr, stdout} = await runCommand(Cmd, [
+        '--app',
+        'myapp',
+      ])
+
+      expect(getDatabaseStub.calledOnceWith('myapp')).to.be.true
+      expect(execQueryStub.calledOnce).to.be.true
+      expect(stdout).to.contain(expectedOutput)
+      expect(stderr).to.eq('')
+    })
+
+    it('executes the vacuum-stats query with expected clauses', async function () {
+      await runCommand(Cmd, [
+        '--app',
+        'myapp',
+      ])
+
+      const executedQuery = execQueryStub.getCall(0).args[0]
+      expect(executedQuery).to.contain('autovacuum_vacuum_threshold')
+      expect(executedQuery).to.contain('pg_stat_user_tables')
+      expect(executedQuery).to.contain('expect_autovacuum')
+    })
+
+    it('accepts a database argument', async function () {
+      await runCommand(Cmd, [
+        '--app',
+        'myapp',
+        'postgres-123',
+      ])
+
+      expect(getDatabaseStub.calledOnce).to.be.true
+      expect(getDatabaseStub.getCall(0).args[1]).to.eq('postgres-123')
+    })
+  })
+
+  describe('error handling', function () {
+    it('surfaces database connection failures', async function () {
+      getDatabaseStub.rejects(new Error('Database connection failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'myapp'])
+      expect(error?.message).to.contain('Database connection failed')
+    })
+
+    it('surfaces SQL execution failures', async function () {
+      execQueryStub.rejects(new Error('SQL execution failed'))
+      const {error} = await runCommand(Cmd, ['--app', 'myapp'])
+      expect(error?.message).to.contain('SQL execution failed')
+    })
+  })
+})


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary

We need to move the commands from the [pg-extras plugin](https://github.com/heroku/heroku-pg-extras) to the core CLI, which will require us to update the commands to use oclif/core v4 and heroku-cli-command v12.

This is PR 3 of 3 and final to accomplish this task and we will be merging these PRs in feature/migrate_pg_extras_to_cli

Commands migrated:

- pg:table-size
- pg:total-index-size
- pg:total-table-size
- pg:unused-indexes
- pg:user-connections
- pg:vacuum-stats

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [x] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [x] **test**: Add/update/remove tests

## Testing

The --help changes (should be limited to --prompt and GLOBAL FLAGS additions that came with cli upgrades) ALSO examples as the cli requires:

diff <(./bin/run pg:table-size --help) <(heroku pg:table-size --help)
diff <(./bin/run pg:total-index-size --help) <(heroku pg:total-index-size --help)
diff <(./bin/run pg:total-table-size --help) <(heroku pg:total-table-size --help)
diff <(./bin/run pg:unused-indexes --help) <(heroku pg:unused-indexes --help)
diff <(./bin/run pg:user-connections --help) <(heroku pg:user-connections --help)
diff <(./bin/run pg:vacuum-stats --help) <(heroku pg:vacuum-stats --help)

New Command Testing Steps:

1. Show the size of the tables excluding indexes (name | size for each table, descending by size, e.g. 50 MB)

./bin/run pg:table-size -a $APP

2. Confirm the underscore alias (visible) produces identical output to step 1

./bin/run pg:table_size -a $APP

3. Show the total size of all indexes in the database (single size row, e.g. 15 MB)

./bin/run pg:total-index-size -a $APP

4. Confirm the hidden underscore alias produces identical output to step 3

./bin/run pg:total_index_size -a $APP

5. Show the size of the tables including indexes (name | size for each table, descending by size, e.g. 75 MB; values should be >= the matching row from step 1)

./bin/run pg:total-table-size -a $APP

6. Confirm the underscore alias (visible) produces identical output to step 5

./bin/run pg:total_table_size -a $APP

7. Show unused and almost unused indexes (table | index | index_size | index_scans, ordered by size-to-scan ratio descending; excludes unique indexes and tables under ~40 kB; a small or well-used database may return no rows)

./bin/run pg:unused-indexes -a $APP

8. Confirm the underscore alias (visible) produces identical output to step 7

./bin/run pg:unused_indexes -a $APP

9. Show the number of active connections per credential (credential | connections, ordered by connections descending)

./bin/run pg:user-connections -a $APP

10. Confirm the hidden underscore alias produces identical output to step 9

./bin/run pg:user_connections -a $APP

11. Show dead rows and whether an automatic vacuum is expected (schema | table | last_vacuum | last_autovacuum | rowcount | dead_rowcount | autovacuum_threshold | expect_autovacuum; expect_autovacuum shows yes only when dead rows exceed the threshold. Note: this command has no underscore alias)

./bin/run pg:vacuum-stats -a $APP

## Screenshots (if applicable)

## Related Issues
GUS work item: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002YzlNjYAJ/view

