### PR TITLE
feat!: exclude backups from long running queries

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -418,6 +418,7 @@ urijs
 uxxxxxxxxx
 vcpu
 VERSINFO
+walsender
 webfactory
 withfig
 wrapline

--- a/src/commands/pg/long-running-queries.ts
+++ b/src/commands/pg/long-running-queries.ts
@@ -18,6 +18,11 @@ WHERE
   pg_stat_activity.query <> ''::text
   AND state <> 'idle'
   AND now() - pg_stat_activity.query_start > interval '5 minutes'
+  AND NOT (
+    state = 'idle in transaction'
+    AND usename = 'postgres'
+    AND query LIKE '%pg_backup_start%'
+  )
 ORDER BY
   now() - pg_stat_activity.query_start DESC;
 `.trim()

--- a/src/commands/pg/long-running-queries.ts
+++ b/src/commands/pg/long-running-queries.ts
@@ -18,6 +18,7 @@ WHERE
   pg_stat_activity.query <> ''::text
   AND state <> 'idle'
   AND now() - pg_stat_activity.query_start > interval '5 minutes'
+  AND backend_type <> 'walsender'
   AND NOT (
     usename = 'postgres'
     AND query LIKE '%pg_backup_start%'

--- a/src/commands/pg/long-running-queries.ts
+++ b/src/commands/pg/long-running-queries.ts
@@ -19,8 +19,7 @@ WHERE
   AND state <> 'idle'
   AND now() - pg_stat_activity.query_start > interval '5 minutes'
   AND NOT (
-    state = 'idle in transaction'
-    AND usename = 'postgres'
+    usename = 'postgres'
     AND query LIKE '%pg_backup_start%'
   )
 ORDER BY

--- a/test/unit/commands/pg/long-running-queries.unit.test.ts
+++ b/test/unit/commands/pg/long-running-queries.unit.test.ts
@@ -45,6 +45,11 @@ WHERE
   pg_stat_activity.query <> ''::text
   AND state <> 'idle'
   AND now() - pg_stat_activity.query_start > interval '5 minutes'
+  AND NOT (
+    state = 'idle in transaction'
+    AND usename = 'postgres'
+    AND query LIKE '%pg_backup_start%'
+  )
 ORDER BY
   now() - pg_stat_activity.query_start DESC;`
 
@@ -57,6 +62,13 @@ ORDER BY
       expect(query).to.contain('now() - pg_stat_activity.query_start')
       expect(query).to.contain("state <> 'idle'")
       expect(query).to.contain("interval '5 minutes'")
+    })
+
+    it('excludes the internal physical backup query from results', function () {
+      const query = generateLongRunningQueriesQuery()
+      expect(query).to.contain("state = 'idle in transaction'")
+      expect(query).to.contain("usename = 'postgres'")
+      expect(query).to.contain("query LIKE '%pg_backup_start%'")
     })
   })
 

--- a/test/unit/commands/pg/long-running-queries.unit.test.ts
+++ b/test/unit/commands/pg/long-running-queries.unit.test.ts
@@ -66,7 +66,6 @@ ORDER BY
 
     it('excludes the internal physical backup query from results', function () {
       const query = generateLongRunningQueriesQuery()
-      expect(query).to.contain("state = 'idle in transaction'")
       expect(query).to.contain("usename = 'postgres'")
       expect(query).to.contain("query LIKE '%pg_backup_start%'")
     })

--- a/test/unit/commands/pg/long-running-queries.unit.test.ts
+++ b/test/unit/commands/pg/long-running-queries.unit.test.ts
@@ -45,6 +45,7 @@ WHERE
   pg_stat_activity.query <> ''::text
   AND state <> 'idle'
   AND now() - pg_stat_activity.query_start > interval '5 minutes'
+  AND backend_type <> 'walsender'
   AND NOT (
     usename = 'postgres'
     AND query LIKE '%pg_backup_start%'
@@ -67,6 +68,11 @@ ORDER BY
       const query = generateLongRunningQueriesQuery()
       expect(query).to.contain("usename = 'postgres'")
       expect(query).to.contain("query LIKE '%pg_backup_start%'")
+    })
+
+    it('excludes walsender backends from results', function () {
+      const query = generateLongRunningQueriesQuery()
+      expect(query).to.contain("backend_type <> 'walsender'")
     })
   })
 

--- a/test/unit/commands/pg/long-running-queries.unit.test.ts
+++ b/test/unit/commands/pg/long-running-queries.unit.test.ts
@@ -46,8 +46,7 @@ WHERE
   AND state <> 'idle'
   AND now() - pg_stat_activity.query_start > interval '5 minutes'
   AND NOT (
-    state = 'idle in transaction'
-    AND usename = 'postgres'
+    usename = 'postgres'
     AND query LIKE '%pg_backup_start%'
   )
 ORDER BY


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->

This pr adds a `where` clause to `pg:long-running-queries` to filter out backups that are expected, low impact, and not actionable for customers. This command is meant to provide clarity for debugging, so the existence of this query leads to customer confusion. The`pg:ps` command will continue to show _all_ active queries.

We'd like to ship this change in the v12 cli release.

Slack discussion for additional context: https://salesforce.enterprise.slack.com/archives/C1RU5S0G2/p1782485686544529.

## Type of Change
### Breaking Changes (major semver update)
- [x] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
<!-- Add any context/setup necessary for testing. -->
**Standard db Testing**

ps shows all running queries. Below we see follower replication, backup, and user queries:

```
% ./bin/dev.js pg:ps postgresql-trapezoidal-38184 --app ekozil-dev
  pid   |        state        |      source      |    username    |   running_for   |       transaction_start       | waiting |                                                                               query                                                                                
--------+---------------------+------------------+----------------+-----------------+-------------------------------+---------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
 557810 | active              | psql interactive | ub7m0qjpm7g4mi | 00:08:16.344795 | 2026-06-26 14:03:10.928145+00 | t       | SELECT pg_sleep(36000);
 557739 | idle in transaction |                  | postgres       | 00:15:10.941238 | 2026-06-26 13:56:16.331702+00 | t       | SELECT file_name,   lpad(file_offset::text, 8, '0') AS file_offset FROM pg_walfile_name_offset(  pg_backup_start('freeze_start_2026-06-26T13:56:16.331605+00:00'))
 557712 | active              | follower         | postgres       |                 |                               | t       | START_REPLICATION 0/61000000 TIMELINE 1
(3 rows)

```



long-running-queries pre-implementation, we see the backup and follower queries:
```
% ./bin/dev.js pg:long-running-queries postgresql-trapezoidal-38184  --app ekozil-dev
  pid   |    duration     |                                                                               query                                                                                
--------+-----------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
 557712 | 00:17:05.834817 | START_REPLICATION 0/61000000 TIMELINE 1
 557739 | 00:16:03.32151  | SELECT file_name,   lpad(file_offset::text, 8, '0') AS file_offset FROM pg_walfile_name_offset(  pg_backup_start('freeze_start_2026-06-26T13:56:16.331605+00:00'))
 557810 | 00:09:08.725209 | SELECT pg_sleep(36000);
(3 rows)

```

Post-implementation we only see the user query, filtering out the backup and follower queries:
```
% ./bin/dev.js pg:long-running-queries postgresql-trapezoidal-38184  --app ekozil-dev
  pid   |    duration     |         query          
--------+-----------------+------------------------
 557810 | 00:08:47.514534 | SELECT pg_sleep(36000);
(1 row)


```

Post-implementation smoke tests for essential and advanced show the command runs without error:
```
% ./bin/dev.js pg:long-running-queries postgresql-pointy-19471 --app ekozil-dev   
(node:54131) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)
 pid | duration | query 
-----+----------+-------
(0 rows)


./bin/dev.js pg:long-running-queries postgresql-octagonal-04440 --app ekozil-dev          
(node:50829) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)
 pid | duration | query 
-----+----------+-------
(0 rows)
```





## Screenshots (if applicable)

## Related Issues
GUS work item: [W-22101694](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002YM48QYAT/view)
