### PR TITLE
feat: skip caching token in keychain mode for accounts cache

### DIFF
--- a/src/commands/accounts/add.ts
+++ b/src/commands/accounts/add.ts
@@ -30,7 +30,14 @@ export default class Add extends Command {
     }
 
     const token = this.heroku.auth!
+    const config = AccountsModule.getStorageConfig()
 
-    AccountsModule.add(name, email, token)
+    if (config.credentialStore) {
+      // Keychain-mode: don't save token to cache file
+      AccountsModule.add(name, email)
+    } else {
+      // Netrc-mode: save token to cache file
+      AccountsModule.add(name, email, token)
+    }
   }
 }

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -16,7 +16,7 @@ export interface AccountEntry {
 }
 
 export interface IAccountsWrapper {
-  add(name: string, username: string, password: string): void
+  add(name: string, username: string, password?: string): void
   current(heroku: APIClient): Promise<null | string>
   currentNetrc(): Promise<null | string>
   getStorageConfig(): ReturnType<typeof getStorageConfig>
@@ -29,11 +29,14 @@ export interface IAccountsWrapper {
 export class AccountsWrapper implements IAccountsWrapper {
   private netrc: any
 
-  add(name: string, username: string, password: string): void {
+  add(name: string, username: string, password?: string): void {
     fs.mkdirSync(this.accountsDir(), {recursive: true})
 
-    // eslint-disable-next-line perfectionist/sort-objects
-    this.writeAccountFile(name, {username, password})
+    const content: Record<string, string> = {username}
+    if (password !== undefined) {
+      content.password = password
+    }
+    this.writeAccountFile(name, content)
   }
 
   async current(heroku: APIClient): Promise<null | string> {

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -101,6 +101,7 @@ export class AccountsWrapper implements IAccountsWrapper {
         if (!email) {
           throw new Error(`We can't find the alias file for ${account.name}.`)
         }
+
         await this.writeLoginState(dataDir, email)
         return
       }

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -32,10 +32,9 @@ export class AccountsWrapper implements IAccountsWrapper {
   add(name: string, username: string, password?: string): void {
     fs.mkdirSync(this.accountsDir(), {recursive: true})
 
-    const content: Record<string, string> = {username}
-    if (password !== undefined) {
-      content.password = password
-    }
+    const content: Record<string, string> = password === undefined
+      ? {username}
+      : {username, password} // eslint-disable-line perfectionist/sort-objects
 
     this.writeAccountFile(name, content)
   }

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -96,12 +96,16 @@ export class AccountsWrapper implements IAccountsWrapper {
 
     if (account.name) {
       if (config.credentialStore) {
+        // Keychain mode: only update login state, skip netrc
         const email = this.getAliasEmail(account.name)
-        if (email) {
-          await this.writeLoginState(dataDir, email)
+        if (!email) {
+          throw new Error(`We can't find the alias file for ${account.name}.`)
         }
+        await this.writeLoginState(dataDir, email)
+        return
       }
 
+      // Netrc mode: update both login state and netrc files
       const netrcInstance = await this.initNetrc()
       let current
       try {

--- a/src/lib/accounts/accounts.ts
+++ b/src/lib/accounts/accounts.ts
@@ -36,6 +36,7 @@ export class AccountsWrapper implements IAccountsWrapper {
     if (password !== undefined) {
       content.password = password
     }
+
     this.writeAccountFile(name, content)
   }
 

--- a/test/unit/commands/accounts/add.unit.test.ts
+++ b/test/unit/commands/accounts/add.unit.test.ts
@@ -31,10 +31,51 @@ describe('accounts:add', function () {
         getAuth: async () => ({account: 'testEmail', token: 'testHerokuAPIKey'}),
       })
 
+      const getStorageConfigStub = stub(AccountsModule, 'getStorageConfig')
+      getStorageConfigStub.returns({credentialStore: null, useNetrc: true})
+
       api.get('/account')
         .reply(200, {email: 'testEmail'})
 
       await runCommand(Cmd, ['testAccountName'])
+      expect(addStub.calledOnce).to.equal(true)
+      expect(addStub.args[0][0]).to.equal('testAccountName')
+      expect(addStub.args[0][1]).to.equal('testEmail')
+      expect(addStub.args[0][2]).to.equal('testHerokuAPIKey')
+    })
+
+    it('should not pass token to add() when credentialStore is active (keychain-mode)', async function () {
+      stubCredentialManager({
+        getAuth: async () => ({account: 'testEmail', token: 'testHerokuAPIKey'}),
+      })
+
+      const getStorageConfigStub = stub(AccountsModule, 'getStorageConfig')
+      getStorageConfigStub.returns({credentialStore: 'keychain' as any, useNetrc: false})
+
+      api.get('/account')
+        .reply(200, {email: 'testEmail'})
+
+      await runCommand(Cmd, ['testAccountName'])
+
+      expect(addStub.calledOnce).to.equal(true)
+      expect(addStub.args[0][0]).to.equal('testAccountName')
+      expect(addStub.args[0][1]).to.equal('testEmail')
+      expect(addStub.args[0][2]).to.be.undefined
+    })
+
+    it('should pass token to add() when credentialStore is not active (netrc-mode)', async function () {
+      stubCredentialManager({
+        getAuth: async () => ({account: 'testEmail', token: 'testHerokuAPIKey'}),
+      })
+
+      const getStorageConfigStub = stub(AccountsModule, 'getStorageConfig')
+      getStorageConfigStub.returns({credentialStore: null, useNetrc: true})
+
+      api.get('/account')
+        .reply(200, {email: 'testEmail'})
+
+      await runCommand(Cmd, ['testAccountName'])
+
       expect(addStub.calledOnce).to.equal(true)
       expect(addStub.args[0][0]).to.equal('testAccountName')
       expect(addStub.args[0][1]).to.equal('testEmail')

--- a/test/unit/commands/accounts/add.unit.test.ts
+++ b/test/unit/commands/accounts/add.unit.test.ts
@@ -26,13 +26,10 @@ describe('accounts:add', function () {
   })
 
   describe('when the user is logged in', function () {
-    it('should call the accounts.add function with the account name, user email, and auth token', async function () {
+    it('should call the accounts.add function with the account name and user email', async function () {
       stubCredentialManager({
         getAuth: async () => ({account: 'testEmail', token: 'testHerokuAPIKey'}),
       })
-
-      const getStorageConfigStub = stub(AccountsModule, 'getStorageConfig')
-      getStorageConfigStub.returns({credentialStore: null, useNetrc: true})
 
       api.get('/account')
         .reply(200, {email: 'testEmail'})
@@ -41,7 +38,6 @@ describe('accounts:add', function () {
       expect(addStub.calledOnce).to.equal(true)
       expect(addStub.args[0][0]).to.equal('testAccountName')
       expect(addStub.args[0][1]).to.equal('testEmail')
-      expect(addStub.args[0][2]).to.equal('testHerokuAPIKey')
     })
 
     it('should not pass token to add() when credentialStore is active (keychain-mode)', async function () {

--- a/test/unit/lib/accounts/accounts.unit.test.ts
+++ b/test/unit/lib/accounts/accounts.unit.test.ts
@@ -161,7 +161,7 @@ describe('accounts', function () {
         setNetrc(null as unknown as typeof fakeNetrc)
       })
 
-      it('calls writeLoginState with email from alias file and writes to netrc', async function () {
+      it('calls writeLoginState with email from alias file but does not write to netrc', async function () {
         const account = {name: 'production', username: 'prod@example.com'}
         existsSyncStub.withArgs('/user/home/.config/heroku').returns(false)
         existsSyncStub.withArgs(match(/production$/)).returns(true)
@@ -173,9 +173,9 @@ describe('accounts', function () {
         expect(writeLoginStateStub.calledOnce).to.be.true
         expect(writeLoginStateStub.firstCall.args[0]).to.equal('/data/heroku')
         expect(writeLoginStateStub.firstCall.args[1]).to.equal('prod@example.com')
-        expect(fakeNetrc.machines['api.heroku.com']).to.deep.equal({login: 'prod@example.com', password: 'secret'})
-        expect(fakeNetrc.machines['git.heroku.com']).to.deep.equal({login: 'prod@example.com', password: 'secret'})
-        expect(fakeNetrc.save.calledOnce).to.be.true
+        expect(fakeNetrc.machines['api.heroku.com']).to.be.undefined
+        expect(fakeNetrc.machines['git.heroku.com']).to.be.undefined
+        expect(fakeNetrc.save.called).to.be.false
       })
 
       it('throws error when alias file does not exist', async function () {

--- a/test/unit/lib/accounts/accounts.unit.test.ts
+++ b/test/unit/lib/accounts/accounts.unit.test.ts
@@ -119,6 +119,22 @@ describe('accounts', function () {
 
       expect(() => AccountsModule.add('test-user', 'username123', 'password123')).to.throw()
     })
+
+    it('should write only username when password is undefined (keychain-mode)', function () {
+      AccountsModule.add('test-user', 'username123')
+
+      expect(writeFileSyncStub.calledOnce).to.be.true
+      expect(writeFileSyncStub.firstCall.args[1]).to.equal('username: username123\n')
+      expect(writeFileSyncStub.firstCall.args[2]).to.equal('utf8')
+    })
+
+    it('should write username and password when password is provided (netrc-mode)', function () {
+      AccountsModule.add('test-user', 'username123', 'password123')
+
+      expect(writeFileSyncStub.calledOnce).to.be.true
+      expect(writeFileSyncStub.firstCall.args[1]).to.equal('username: username123\npassword: password123\n')
+      expect(writeFileSyncStub.firstCall.args[2]).to.equal('utf8')
+    })
   })
 
   describe('set()', function () {


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
Adds keychain-mode awareness to the accounts cache system to prevent token persistence to disk when keychain storage is active.

When `credentialStore` (keychain) is configured, the CLI now:
1. Skips saving tokens to account cache files in `accounts:add` command
2. Skips netrc file updates in `AccountsWrapper.set()` method

This ensures tokens are only stored in the system keychain when keychain-mode is active, avoiding duplicate token storage in cache files.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
Requires testing in both keychain-mode and netrc-mode configurations.

Setup:
1. Check out this branch and run `npm i && npm run build`
2. Logout using `heroku logout`

**Steps**:
Test keychain-mode
1. Run `./bin/run accounts:add test-account`
2. Verify the account cache file at `~/.config/heroku/accounts/test-account` contains only `username:` (no `password:` field)
3. Run `./bin/run accounts:remove test-account` to remove the account cache

Test netrc-mode
1. Run `HEROKU_NETRC_WRITE=true ./bin/run accounts:add test-account`
2. Verify the account cache file contains both `username:` and `password:` fields
3. Run `./bin/run accounts:remove test-account` to remove the account cache

## Screenshots (if applicable)
N/A

## Related Issues
GUS work item: [W-23123793](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002colxqYAA/view)
