### PR TITLE
fix: remove keychain accounts cache on logout

### DIFF
--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -14,7 +14,7 @@ export default class Logout extends Command {
     await this.parse(Logout)
 
     ux.action.start('Logging out')
-    const cachedNetrcAccount = await AccountsModule.currentNetrc()
+    const cachedAccount = await AccountsModule.current(this.heroku)
     await this.heroku.logout()
 
     const git = new Git()
@@ -25,8 +25,8 @@ export default class Logout extends Command {
       // ignore
     }
 
-    if (cachedNetrcAccount) {
-      await AccountsModule.remove(cachedNetrcAccount)
+    if (cachedAccount) {
+      await AccountsModule.remove(cachedAccount)
     }
 
     await this.config.runHook('recache', {type: 'logout'})

--- a/test/unit/commands/auth/logout.unit.test.ts
+++ b/test/unit/commands/auth/logout.unit.test.ts
@@ -9,13 +9,13 @@ import Git from '../../../../src/lib/git/git.js'
 describe('auth:logout', function () {
   let eraseCredentialsStub: sinon.SinonStub
   let removeCredentialHelperStub: sinon.SinonStub
-  let currentNetrcStub: sinon.SinonStub
+  let currentAccountStub: sinon.SinonStub
   let removeStub: sinon.SinonStub
 
   beforeEach(function () {
     eraseCredentialsStub = sinon.stub(Git.prototype, 'eraseCredentials').resolves()
     removeCredentialHelperStub = sinon.stub(Git.prototype, 'removeCredentialHelper').resolves()
-    currentNetrcStub = sinon.stub(AccountsModule, 'currentNetrc').resolves(null)
+    currentAccountStub = sinon.stub(AccountsModule, 'current').resolves(null)
     removeStub = sinon.stub(AccountsModule, 'remove').resolves()
   })
 
@@ -48,14 +48,14 @@ describe('auth:logout', function () {
     expect(error).to.be.undefined
   })
 
-  it('checks for cached netrc account', async function () {
+  it('checks for cached accounts', async function () {
     await runCommand(Logout, [])
 
-    expect(currentNetrcStub.calledOnce).to.be.true
+    expect(currentAccountStub.calledOnce).to.be.true
   })
 
-  it('removes cached netrc account when present', async function () {
-    currentNetrcStub.resolves('my-account')
+  it('removes cached account when present', async function () {
+    currentAccountStub.resolves('my-account')
 
     await runCommand(Logout, [])
 
@@ -63,8 +63,8 @@ describe('auth:logout', function () {
     expect(removeStub.firstCall.args[0]).to.equal('my-account')
   })
 
-  it('does not remove account when no cached netrc account', async function () {
-    currentNetrcStub.resolves(null)
+  it('does not remove account when no cached account', async function () {
+    currentAccountStub.resolves(null)
 
     await runCommand(Logout, [])
 


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
This PR updates the logout command to remove keychain and netrc account cache files on `heroku logout`.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
<!-- Add any context/setup necessary for testing. -->

**Steps**:
1. `npm install && npm run build`
2. `heroku logout`
3. `./bin/run login` — logs in without error
4. `./bin/run accounts` — lists accounts if you have other accounts, otherwise, "Error: You don't have any accounts in your cache."
5. `./bin/run accounts:add first_account` — adds first_account without error
6. `./bin/run accounts` — contains *first_account in the accounts list
7. `cat ~/.local/share/heroku/login.json` — outputs email
8. `[ -f ~/.config/heroku/accounts/first_account ] && echo "Exists" || echo "Not found"` — outputs "Exists"
9. `./bin/run accounts:current` — outputs "first_account"
10. `./bin/run accounts:remove first_account` — Errors "Error: first_account is the current account. To log out, run  $ heroku logout"
11. `./bin/run logout` — logs out without error
12. `./bin/run whoami` — Errors "Error: not logged in"
13. `cat ~/.local/share/heroku/login.json` — missing file
14. `[ -f ~/.config/heroku/accounts/first_account ] && echo "Exists" || echo "Not found"` — outputs "Not found"

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-23257242](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dYyn9YAC/view)
