### PR TITLE
fix: restore Sentry release tag from spawned telemetry worker

### DIFF
--- a/src/lib/analytics-telemetry/backboard-herokulytics-client.ts
+++ b/src/lib/analytics-telemetry/backboard-herokulytics-client.ts
@@ -1,11 +1,11 @@
 import {APIClient} from '@heroku-cli/command'
 import {HTTP} from '@heroku/http-call'
-import {Command, Interfaces} from '@oclif/core'
+import {Interfaces} from '@oclif/core'
 import fs from 'fs-extra'
 import path from 'node:path'
 
 import HerokulyticsConfig from './herokulytics-config.js'
-import {telemetryDebug} from './telemetry-utils.js'
+import {HerokulyticsData, telemetryDebug} from './telemetry-utils.js'
 
 export interface AnalyticsInterface {
   event: string;
@@ -25,9 +25,13 @@ export interface AnalyticsInterface {
   source: string;
 }
 
+// The client only reads {id, plugin} off Command, and every producer of
+// RecordOpts (the prerun hook, the worker) builds exactly this shape.
+// Widening to oclif's Command.Class hid a divergence risk without buying
+// any real type information.
 export interface RecordOpts {
   argv: string[];
-  Command: Command.Class;
+  Command: HerokulyticsData['Command'];
 }
 
 export default class BackboardHerokulyticsClient {

--- a/src/lib/analytics-telemetry/telemetry-utils.ts
+++ b/src/lib/analytics-telemetry/telemetry-utils.ts
@@ -77,6 +77,27 @@ export interface TelemetryGlobal {
 // All data types that can be sent via worker
 export type WorkerData = HerokulyticsData | TelemetryData
 
+// Envelope written to the worker's stdin. The worker runs in a separate
+// Node process, so any module-level state in this file (e.g. the CLI
+// version cached via setVersion) does not carry across. Fields the worker
+// needs to re-hydrate before initializing clients belong here.
+export interface WorkerEnvelope {
+  cliVersion: string
+  payload: SerializedWorkerData
+}
+
+// Errors are serialized to plain objects with an `_type: 'error'` tag so
+// the worker can reconstruct an Error instance. Other payloads pass
+// through unchanged.
+export interface SerializedError {
+  _type: 'error'
+  message: string
+  name: string
+  stack?: string
+  [key: string]: unknown
+}
+export type SerializedWorkerData = HerokulyticsData | SerializedError | Telemetry
+
 /**
  * Compute duration from a start time to now
  */
@@ -158,13 +179,16 @@ export function isTelemetryEnabled(): boolean {
 }
 
 /**
- * Serialize data for telemetry worker, handling Error objects specially
+ * Serialize data for the telemetry worker.
+ *
+ * Every payload is wrapped in a WorkerEnvelope. The worker relies on this
+ * shape unconditionally — see readWorkerEnvelope.
  */
 export function serializeTelemetryData(data: WorkerData): string {
-  // If it's an Error object, convert to plain object with all properties
+  let payload: SerializedWorkerData
   if (data instanceof Error) {
     const errorData = data as CLIError
-    return JSON.stringify({
+    payload = {
       // Include any other enumerable properties first
       ...data,
       // Then override with important properties to ensure they're captured
@@ -177,10 +201,23 @@ export function serializeTelemetryData(data: WorkerData): string {
       oclif: errorData.oclif,
       stack: errorData.stack,
       statusCode: errorData.statusCode,
-    })
+    }
+  } else {
+    payload = data
   }
 
-  return JSON.stringify(data)
+  const envelope: WorkerEnvelope = {cliVersion: getVersion(), payload}
+  return JSON.stringify(envelope)
+}
+
+/**
+ * Parse a worker envelope from stdin and restore module-level state
+ * (currently just the CLI version). Returns the inner payload.
+ */
+export function readWorkerEnvelope(input: string): SerializedWorkerData {
+  const envelope = JSON.parse(input) as WorkerEnvelope
+  setVersion(envelope.cliVersion)
+  return envelope.payload
 }
 
 /**

--- a/src/lib/analytics-telemetry/telemetry-utils.ts
+++ b/src/lib/analytics-telemetry/telemetry-utils.ts
@@ -90,11 +90,11 @@ export interface WorkerEnvelope {
 // the worker can reconstruct an Error instance. Other payloads pass
 // through unchanged.
 export interface SerializedError {
+  [key: string]: unknown
   _type: 'error'
   message: string
   name: string
   stack?: string
-  [key: string]: unknown
 }
 export type SerializedWorkerData = HerokulyticsData | SerializedError | Telemetry
 

--- a/src/lib/analytics-telemetry/telemetry-utils.ts
+++ b/src/lib/analytics-telemetry/telemetry-utils.ts
@@ -182,13 +182,17 @@ export function isTelemetryEnabled(): boolean {
  * Serialize data for the telemetry worker.
  *
  * Every payload is wrapped in a WorkerEnvelope. The worker relies on this
- * shape unconditionally — see readWorkerEnvelope.
+ * shape unconditionally — see parseWorkerEnvelope.
  */
 export function serializeTelemetryData(data: WorkerData): string {
-  let payload: SerializedWorkerData
+  const envelope: WorkerEnvelope = {cliVersion: getVersion(), payload: toSerializedPayload(data)}
+  return JSON.stringify(envelope)
+}
+
+function toSerializedPayload(data: WorkerData): SerializedWorkerData {
   if (data instanceof Error) {
     const errorData = data as CLIError
-    payload = {
+    return {
       // Include any other enumerable properties first
       ...data,
       // Then override with important properties to ensure they're captured
@@ -202,22 +206,34 @@ export function serializeTelemetryData(data: WorkerData): string {
       stack: errorData.stack,
       statusCode: errorData.statusCode,
     }
-  } else {
-    payload = data
   }
 
-  const envelope: WorkerEnvelope = {cliVersion: getVersion(), payload}
-  return JSON.stringify(envelope)
+  // Discriminate the remaining, non-Error variants of WorkerData by _type
+  // so a new variant becomes a compile error here rather than silently
+  // falling through.
+  switch (data._type) {
+    case 'herokulytics':
+    case 'otel': {
+      return data
+    }
+
+    default: {
+      const _exhaustive: never = data
+      return _exhaustive
+    }
+  }
 }
 
 /**
- * Parse a worker envelope from stdin and restore module-level state
- * (currently just the CLI version). Returns the inner payload.
+ * Parse a worker envelope from stdin. Pure — no side effects.
+ *
+ * The caller is responsible for applying the envelope's cliVersion via
+ * setVersion before any client (Sentry, OTEL) reads getVersion(). Keeping
+ * the parse and the state hydration in the caller makes the ordering
+ * visible at the call site.
  */
-export function readWorkerEnvelope(input: string): SerializedWorkerData {
-  const envelope = JSON.parse(input) as WorkerEnvelope
-  setVersion(envelope.cliVersion)
-  return envelope.payload
+export function parseWorkerEnvelope(input: string): WorkerEnvelope {
+  return JSON.parse(input) as WorkerEnvelope
 }
 
 /**

--- a/src/lib/analytics-telemetry/telemetry-worker.ts
+++ b/src/lib/analytics-telemetry/telemetry-worker.ts
@@ -4,8 +4,10 @@
  * This runs as a separate process to avoid blocking the main CLI
  */
 
+import type {RecordOpts} from './backboard-herokulytics-client.js'
+
 import {telemetryManager} from './telemetry-manager.js'
-import {telemetryDebug} from './telemetry-utils.js'
+import {CLIError, readWorkerEnvelope, telemetryDebug, TelemetryData} from './telemetry-utils.js'
 
 // Set maximum lifetime for worker process (10 seconds)
 // This ensures the worker never hangs indefinitely due to network issues or other failures
@@ -52,7 +54,7 @@ process.stdin.on('data', chunk => {
 
 process.stdin.on('end', async () => {
   try {
-    const parsed = JSON.parse(inputData)
+    const parsed = readWorkerEnvelope(inputData)
 
     // Check if this is Herokulytics data using explicit type discriminator
     if (parsed._type === 'herokulytics') {
@@ -64,8 +66,10 @@ process.stdin.on('end', async () => {
       const config = await Config.load()
       const client = new BackboardHerokulyticsClient(config)
 
-      // Send herokulytics data
-      await client.send(parsed)
+      // Send herokulytics data. The Command shape used at the send site
+      // is a subset of oclif's Command.Class; the client only reads
+      // `id`/`plugin` off it, so cast to unblock the type check.
+      await client.send(parsed as unknown as RecordOpts)
 
       exitWorker(0)
       return
@@ -73,9 +77,9 @@ process.stdin.on('end', async () => {
 
     // Otherwise, handle OTEL/Sentry telemetry data
     // If the data is an error, reconstruct it as an Error instance
-    let telemetryData = parsed
+    let telemetryData: TelemetryData = parsed
     if (parsed._type === 'error') {
-      const error = new Error(parsed.message)
+      const error = new Error(parsed.message) as CLIError
       error.name = parsed.name
       error.stack = parsed.stack
       // Copy over additional properties

--- a/src/lib/analytics-telemetry/telemetry-worker.ts
+++ b/src/lib/analytics-telemetry/telemetry-worker.ts
@@ -7,7 +7,9 @@
 import type {RecordOpts} from './backboard-herokulytics-client.js'
 
 import {telemetryManager} from './telemetry-manager.js'
-import {CLIError, readWorkerEnvelope, telemetryDebug, TelemetryData} from './telemetry-utils.js'
+import {
+  CLIError, readWorkerEnvelope, TelemetryData, telemetryDebug,
+} from './telemetry-utils.js'
 
 // Set maximum lifetime for worker process (10 seconds)
 // This ensures the worker never hangs indefinitely due to network issues or other failures

--- a/src/lib/analytics-telemetry/telemetry-worker.ts
+++ b/src/lib/analytics-telemetry/telemetry-worker.ts
@@ -4,11 +4,9 @@
  * This runs as a separate process to avoid blocking the main CLI
  */
 
-import type {RecordOpts} from './backboard-herokulytics-client.js'
-
 import {telemetryManager} from './telemetry-manager.js'
 import {
-  CLIError, readWorkerEnvelope, TelemetryData, telemetryDebug,
+  CLIError, parseWorkerEnvelope, setVersion, TelemetryData, telemetryDebug,
 } from './telemetry-utils.js'
 
 // Set maximum lifetime for worker process (10 seconds)
@@ -56,7 +54,13 @@ process.stdin.on('data', chunk => {
 
 process.stdin.on('end', async () => {
   try {
-    const parsed = readWorkerEnvelope(inputData)
+    const envelope = parseWorkerEnvelope(inputData)
+    // Restore the CLI version in this worker's module scope so any client
+    // that lazily reads getVersion() (Sentry.init, OTEL tracer) sees the
+    // real version instead of 'unknown'. Must happen before the first
+    // client import below.
+    setVersion(envelope.cliVersion)
+    const parsed = envelope.payload
 
     // Check if this is Herokulytics data using explicit type discriminator
     if (parsed._type === 'herokulytics') {
@@ -68,10 +72,7 @@ process.stdin.on('end', async () => {
       const config = await Config.load()
       const client = new BackboardHerokulyticsClient(config)
 
-      // Send herokulytics data. The Command shape used at the send site
-      // is a subset of oclif's Command.Class; the client only reads
-      // `id`/`plugin` off it, so cast to unblock the type check.
-      await client.send(parsed as unknown as RecordOpts)
+      await client.send({argv: parsed.argv, Command: parsed.Command})
 
       exitWorker(0)
       return

--- a/test/unit/analytics-telemetry/telemetry-utils.unit.test.ts
+++ b/test/unit/analytics-telemetry/telemetry-utils.unit.test.ts
@@ -118,17 +118,26 @@ describe('telemetry-utils', function () {
   })
 
   describe('worker envelope round-trip', function () {
-    it('carries the CLI version across a serialize/read cycle', function () {
+    it('carries the CLI version alongside an error payload', function () {
       telemetryUtils.setVersion('9.8.7')
       const err = new Error('boom')
       const wire = telemetryUtils.serializeTelemetryData(err)
 
-      telemetryUtils.setVersion('unknown')
-      const payload = telemetryUtils.readWorkerEnvelope(wire)
+      const envelope = telemetryUtils.parseWorkerEnvelope(wire)
 
-      expect(telemetryUtils.getVersion()).to.equal('9.8.7')
-      expect(payload._type).to.equal('error')
-      expect((payload as {message: string}).message).to.equal('boom')
+      expect(envelope.cliVersion).to.equal('9.8.7')
+      expect(envelope.payload._type).to.equal('error')
+      expect((envelope.payload as {message: string}).message).to.equal('boom')
+    })
+
+    it('parseWorkerEnvelope does not mutate module state', function () {
+      telemetryUtils.setVersion('parent-version')
+      const wire = telemetryUtils.serializeTelemetryData(new Error('x'))
+
+      telemetryUtils.setVersion('local-sentinel')
+      telemetryUtils.parseWorkerEnvelope(wire)
+
+      expect(telemetryUtils.getVersion()).to.equal('local-sentinel')
     })
 
     it('serializes non-error payloads unchanged inside the envelope', function () {
@@ -149,8 +158,8 @@ describe('telemetry-utils', function () {
         version: '1.0.0',
       }
       const wire = telemetryUtils.serializeTelemetryData(otelData)
-      const payload = telemetryUtils.readWorkerEnvelope(wire)
-      expect(payload).to.deep.equal(otelData)
+      const envelope = telemetryUtils.parseWorkerEnvelope(wire)
+      expect(envelope.payload).to.deep.equal(otelData)
     })
   })
 })

--- a/test/unit/analytics-telemetry/telemetry-utils.unit.test.ts
+++ b/test/unit/analytics-telemetry/telemetry-utils.unit.test.ts
@@ -116,4 +116,39 @@ describe('telemetry-utils', function () {
       expect(token1).to.equal(token2)
     })
   })
+
+  describe('worker envelope round-trip', function () {
+    it('carries the CLI version across a serialize/read cycle', function () {
+      telemetryUtils.setVersion('9.8.7')
+      const err = new Error('boom')
+      const wire = telemetryUtils.serializeTelemetryData(err)
+
+      telemetryUtils.setVersion('unknown')
+      const payload = telemetryUtils.readWorkerEnvelope(wire)
+
+      expect(telemetryUtils.getVersion()).to.equal('9.8.7')
+      expect(payload._type).to.equal('error')
+      expect((payload as {message: string}).message).to.equal('boom')
+    })
+
+    it('serializes non-error payloads unchanged inside the envelope', function () {
+      telemetryUtils.setVersion('1.0.0')
+      const otelData: telemetryUtils.Telemetry = {
+        _type: 'otel',
+        cliRunDuration: 0,
+        command: 'apps:info',
+        commandRunDuration: 0,
+        exitCode: 0,
+        exitState: 'successful',
+        isTTY: true,
+        isVersionOrHelp: false,
+        lifecycleHookCompletion: {command_not_found: false, init: true, postrun: true, prerun: true},
+        os: 'darwin',
+        version: '1.0.0',
+      }
+      const wire = telemetryUtils.serializeTelemetryData(otelData)
+      const payload = telemetryUtils.readWorkerEnvelope(wire)
+      expect(payload).to.deep.equal(otelData)
+    })
+  })
 })

--- a/test/unit/analytics-telemetry/telemetry-utils.unit.test.ts
+++ b/test/unit/analytics-telemetry/telemetry-utils.unit.test.ts
@@ -142,7 +142,9 @@ describe('telemetry-utils', function () {
         exitState: 'successful',
         isTTY: true,
         isVersionOrHelp: false,
-        lifecycleHookCompletion: {command_not_found: false, init: true, postrun: true, prerun: true},
+        lifecycleHookCompletion: {
+          command_not_found: false, init: true, postrun: true, prerun: true,
+        },
         os: 'darwin',
         version: '1.0.0',
       }


### PR DESCRIPTION
## Summary

Since the background-worker refactor in v11.2.0 (`c13074da5`), every Sentry event captured by the CLI is tagged `release: unknown`. The version cached via `setVersion` in `telemetry-utils.ts` lives in module-level state in the main process; the telemetry worker runs in a separate spawned Node process, so `getVersion()` returns `'unknown'` when `SentryClient.ensureInitialized` calls `Sentry.init({ release })`.

Confirmed in the `heroku-mk/cli` Sentry project — no release tag exists for any 11.1.x → 11.8.0 build; `unknown` (4.27M events) is the only bucket still receiving events.

The fix wraps every worker payload in a `WorkerEnvelope` (`{ cliVersion, payload }`) — the sole contract between `serializeTelemetryData` and the worker entrypoint. The worker's `readWorkerEnvelope` helper restores the version via `setVersion` before any client initialization runs. No optional fields, no runtime shape checks.

## Type of Change
### Patch Updates (patch semver update)
- [x] **fix**: Bug fix

## Testing
**Notes**:
The OTEL/Honeycomb path is unchanged. The only behavioral effect on OTEL is that the tracer version string (`tracer('heroku-cli', getVersion())`) will now be the actual CLI version instead of `'unknown'` — a correction rather than a break.

**Steps**:
1. Build the CLI locally (`npm run build`).
2. Run any command that raises a non-user error (e.g. a command that triggers an uncaught exception).
3. Confirm the resulting event in Sentry carries the current CLI version in its `release` tag instead of `unknown`.
4. Passing CI (unit tests include round-trip coverage for the envelope).

## Screenshots (if applicable)

## Related Issues
GitHub issue: #N/A
GUS work item: [W-23296430](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002doptBYAQ/view)