### PR TITLE
fix: migration method selection navigation bug (W-23306091)

### DIFF
--- a/src/commands/data/pg/migrate.ts
+++ b/src/commands/data/pg/migrate.ts
@@ -41,6 +41,7 @@ export default class DataPgMigrate extends BaseCommand {
   private appName: string | undefined
   private classicDatabases: Array<pg.ExtendedAddonAttachment['addon'] & {attachment_names?: string[]}> = []
   private extendedLevelsInfo: ExtendedPostgresLevelInfo[] | undefined
+  private methodProvidedViaFlag = false
   private migrationTargets: Array<MigrationResponse> = []
   private selectedMigrationMethod?: MigrationMethod
 
@@ -56,8 +57,10 @@ export default class DataPgMigrate extends BaseCommand {
     const {flags} = await this.parse(DataPgMigrate)
     const {app, method} = flags
     this.appName = app
-    // If --method flag is provided, convert and store
+    // If --method flag is provided, convert and store, and record that the method
+    // came from the flag so the interactive selection step is skipped throughout.
     if (method !== undefined) {
+      this.methodProvidedViaFlag = true
       this.selectedMigrationMethod = method === 'streaming' ? MigrationMethod.CDC : MigrationMethod.FULL_LOAD
     }
 
@@ -177,6 +180,13 @@ export default class DataPgMigrate extends BaseCommand {
   }
 
   private async configureMigration(): Promise<void> {
+    // When the method wasn't provided via the --method flag, clear any method
+    // selected during a previous migration in this session so a stale value can
+    // never reach the migration request if the interactive step is ever skipped.
+    if (!this.methodProvidedViaFlag) {
+      this.selectedMigrationMethod = undefined
+    }
+
     let currentStep = '__select_source'
     let sourceDatabaseId: string | undefined
     let targetDatabaseId: string | undefined
@@ -310,7 +320,7 @@ export default class DataPgMigrate extends BaseCommand {
         case '__confirm_migration': {
           const action = await confirmMigration()
           if (action === '__go_back') {
-            currentStep = '__select_target'
+            currentStep = this.methodProvidedViaFlag ? '__select_target' : '__select_method'
           } else if (action === '__confirm') {
             ux.stdout('')
             ux.action.start('Configuring migration')
@@ -355,12 +365,12 @@ export default class DataPgMigrate extends BaseCommand {
             if (addon) {
               targetDatabaseId = addon.id!
               targetDatabaseName = addon.name
-              currentStep = this.selectedMigrationMethod === undefined ? '__select_method' : '__confirm_migration'
+              currentStep = this.methodProvidedViaFlag ? '__confirm_migration' : '__select_method'
             } else {
               currentStep = '__select_target'
             }
           } else {
-            currentStep = this.selectedMigrationMethod === undefined ? '__select_method' : '__confirm_migration'
+            currentStep = this.methodProvidedViaFlag ? '__confirm_migration' : '__select_method'
           }
 
           break

--- a/test/unit/commands/data/pg/migrate.unit.test.ts
+++ b/test/unit/commands/data/pg/migrate.unit.test.ts
@@ -996,7 +996,7 @@ describe('data:pg:migrate', function () {
       expect(stdout).to.match(/Select the migration method: Snapshot/)
     })
 
-    it('allows user to select snapshot migration method', async function () {
+    it('allows user to select cdc streaming migration method', async function () {
       dataApi = nock('https://api.data.heroku.com')
         .get(`/data/postgres/v1/${nonTargetAdvancedDbAttachment.addon.id}/migrations`)
         .reply(404, {
@@ -1063,6 +1063,49 @@ describe('data:pg:migrate', function () {
       dataApi.done()
       expect(stderr).to.equal('')
       expect(stdout).to.match(/Select the migration method: Go back/)
+    })
+
+    it('prompts for the migration method again after going back from confirmation', async function () {
+      dataApi = nock('https://api.data.heroku.com')
+        .get(`/data/postgres/v1/${nonTargetAdvancedDbAttachment.addon.id}/migrations`)
+        .reply(404, {
+          id: 'not_found',
+          message: 'Add-on not found',
+        })
+        .get(`/data/postgres/v1/${nonTargetAdvancedDbAttachment.addon.id}/info`)
+        .reply(200, nonTargetAdvancedDbInfo)
+        .post(`/data/postgres/v1/${nonTargetAdvancedDbAttachment.addon.id}/migrations`, {
+          method: 'full-load',
+          source_id: premiumDbAttachment.addon.id,
+        })
+        .reply(200, createdMigrationResponse)
+        .get(`/data/postgres/v1/${nonTargetAdvancedDbAttachment.addon.id}/migrations`)
+        .reply(200, createdMigrationResponse)
+        .get(`/data/postgres/v1/${nonTargetAdvancedDbAttachment.addon.id}/info`)
+        .reply(200, nonTargetAdvancedDbInfo)
+
+      mockedStdinInput = [
+        '\n',          // Select configure migration
+        '\n',          // Select source database
+        '\n',          // Select target database
+        '\u001B[B\n',  // Select streaming method (first selection)
+        '\u001B[A\n',  // Confirm migration configuration: > Go back
+        '\n',          // Select snapshot method (second selection, default)
+        '\n',          // Confirm migration
+        '\n',          // Main menu: > Exit
+      ]
+
+      const {stderr, stdout} = await runCommand(DataPgMigrate, ['--app=myapp'])
+
+      herokuApi.done()
+      dataApi.done()
+      expect(stderr).to.equal('Configuring migration... done\n')
+      // The method prompt must be presented twice (once per pass), not skipped on
+      // the second pass. The "(Use arrow keys)" hint renders only on a prompt's
+      // first paint, so counting it yields one match per distinct prompt display.
+      expect(stdout.match(/Select the migration method: \(Use arrow keys\)/g)?.length).to.equal(2)
+      // The second selection (snapshot -> full-load) must be what gets submitted,
+      // which is asserted by the nock POST body matcher above requiring method=full-load
     })
 
     it('skips method selection prompt when --method=snapshot flag is provided', async function () {


### PR DESCRIPTION
## Summary

The issue was caused because `selectedMigrationMethod` was overloaded as both the data value (POST body) and the control gate deciding whether to show the method prompt. Once set —interactively or via flag— it stayed truthy, so the prompt was skipped on the next pass (after "Go back", or for a second migration in the same session).

The fix was to introduce a new attribute to record if the method was provided via flag and ensure the `selectedMigrationMethod` gets reset each time a new migration is configured.

Added one unit test that selects one of the methods and then goes back to select the other one and verifies the POST is done with the correct method (the last one selected) and that the prompt appears two times as expected.

## Type of Change
### Patch Updates (patch semver update)
- [X] **fix**: Bug fix

## Testing
**Notes**:
You'll need to have at least a classic Postgres database on your app (and recommended, optionally an available and empty Advanced one).

**Steps**:
1. Checkout this branch and run
    ```bash
    npm install && npm run build
    ```
2. Run
    ```bash
    heroku data:pg:migrate --app example-app
    ```
    Follow the interactive steps to configure a migration from the classic DB to the Advanced one with any migration method. On the confirmation step select `Go back` and observe you're redirected to the destination database selection step instead of the migration method selection and you cannot change the migration method. Cancel the migration configuration with CTRL+C.
3. Repeat the test with the fixed command
    ```bash
    ./bin/run data:pg:migrate --app example-app
    ```
    Verify that now you're allowed to go back to the migration method selection step and change the migration method before confirmation.

## Screenshots (if applicable)
<img width="1248" height="961" alt="Captura de pantalla 2026-07-03 a la(s) 13 46 10" src="https://github.com/user-attachments/assets/bc275471-87de-4d5f-9f0e-128612b54713" />

## Related Issues
GUS work item: [W-23306091](https://gus.lightning.force.com/a07EE00002dt6gbYAA)
