### PR TITLE
fix: remove GitHub org/repo in error messages

### DIFF
--- a/src/lib/pipelines/setup/get-repo.ts
+++ b/src/lib/pipelines/setup/get-repo.ts
@@ -1,7 +1,7 @@
 export default function getRepo(github: any, name: any) {
-  return github.getRepo(name).catch((err: any) => {
-    const error: any = new Error('Couldn\'t access that repo')
-    error.statusCode = err.statusCode || err.http?.statusCode
-    throw error
+  return github.getRepo(name).catch((error: any) => {
+    const err: any = new Error('Couldn\'t access that repo')
+    err.statusCode = error.statusCode || error.http?.statusCode
+    throw err
   })
 }

--- a/src/lib/pipelines/setup/get-repo.ts
+++ b/src/lib/pipelines/setup/get-repo.ts
@@ -1,5 +1,7 @@
 export default function getRepo(github: any, name: any) {
-  return github.getRepo(name).catch(() => {
-    throw new Error('Couldn\'t access that repo')
+  return github.getRepo(name).catch((err: any) => {
+    const error: any = new Error('Couldn\'t access that repo')
+    error.statusCode = err.statusCode || err.http?.statusCode
+    throw error
   })
 }

--- a/src/lib/pipelines/setup/get-repo.ts
+++ b/src/lib/pipelines/setup/get-repo.ts
@@ -1,5 +1,5 @@
 export default function getRepo(github: any, name: any) {
   return github.getRepo(name).catch(() => {
-    throw new Error(`Could not access the ${name} repo`)
+    throw new Error('Couldn\'t access that repo')
   })
 }

--- a/test/unit/commands/pipelines/connect.unit.test.ts
+++ b/test/unit/commands/pipelines/connect.unit.test.ts
@@ -100,7 +100,9 @@ describe('pipelines:connect', function () {
 
       const {error} = await runCommand(PipelinesConnect, ['my-pipeline', '--repo=my-org/my-repo'])
 
-      expect(error?.message).to.contain('Could not access the my-org/my-repo repo')
+      expect(error?.message).to.contain('Couldn\'t access that repo')
+      expect(error?.message).not.to.contain(repo.name)
+      expect((error as any)?.statusCode).to.equal(401)
     })
   })
 })


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
This PR updates `getRepo()` error handling to avoid exposing GitHub org/repo names in thrown error messages. Also, it preserves HTTP status codes on the new error so existing telemetry filters treat 4xx as user errors.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
<!-- Add any context/setup necessary for testing. -->
Requires a Heroku pipeline for testing.

**Steps**:
1. Pull down this branch
2. `npm i && npm run build`
3. `./bin/run pipelines:connect PIPELINE -r fake-repo/xyz` - should not contain Github org/repo name

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-20503496](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Qz40MYAR/view)
