### PR TITLE
docs: add SDK command migration guide

### DIFF
--- a/.claude/skills/sdk-command-migration/GUIDE.md
+++ b/.claude/skills/sdk-command-migration/GUIDE.md
@@ -14,11 +14,30 @@ If you just want the exact commands and the commit/PR mechanics, [`SKILL.md`](./
 
 These rules keep each migration reviewable and easy to unwind if something slips through. [`SKILL.md`](./SKILL.md) is written to follow them.
 
-- One command per PR. Don't bundle multiple command migrations. One command at a time keeps the review small and keeps a later bisect useful when a regression turns up.
-- Two commits per command, the source migration first and then the test rewrite. Commit messages:
+- Batch by complexity, not by count alone. A PR can hold:
+  - **Up to 5 commands** when every command in the batch is simple (see [What counts as complex](#what-counts-as-complex) below).
+  - **2-3 commands** when the batch mixes simple commands with one complex command. Put the complex command's commits last so a reviewer scanning the diff top-to-bottom hits the mechanical work first.
+  - **1 command** when the command is complex, or when you're unsure. Bias toward a solo PR when in doubt.
+
+  The bisect story stays workable because a mixed PR is still small and a complex PR is always alone.
+- Two commits per command in the PR, source migration first then the test rewrite. In a multi-command batch, keep each command's pair contiguous. Commit messages:
   - `refactor: use @heroku/sdk for <command> command`
   - `test(<command>): stub @heroku/sdk directly, drop nock`
 - Open PRs against `v12.0.0`, not `main`. This work is part of the v12 release, so nothing merges to `main` yet.
+
+### What counts as complex
+
+A command is complex if any of the following applies. Everything else is simple.
+
+- The codemod left a `// TODO(sdk-migration):` marker: ambiguous route, dynamic path, unrecognized body shape, extra options arg, or no matching SDK route. See [Where you need to step in](#where-you-need-to-step-in).
+- The migration touches helper-threaded APIClient calls (the codemod reported "no change" and you rewrote helpers by hand). See [Helper-threaded APIClient calls](#helper-threaded-apiclient-calls).
+- The command uses a composite extension method (`platform.app.describe`, `addOn.create` with the rich options shape, `pipelineCoupling.infoByApp`, etc.). Extensions need `{extensions: [...]}` registration, a parameterized `Platform` alias, and usually a camelCase→snake_case rename at the output boundary. See [SDK method selection](#3-sdk-method-selection).
+- The command uses the `HerokuApiClient` escape hatch. See [CLI-only escape hatch](#cli-only-escape-hatch-see-skillmdstep-12b-cli-only-escape-hatches-via-herokuapiclient).
+- The PR requires a `@heroku/types` or `package-lock.json` bump (metadata-gap workaround or a new direct dependency). See [Metadata-gap workarounds](#metadata-gap-workarounds).
+- The command backfills a `void` return, or a strict-null finding widens a helper's parameter/return type upstream of `run()`. See [run() return value](#5-run-return-value) and [Backwards-compatibility rules](#7-backwards-compatibility-rules).
+- The change touches `src/lib/`, or the diff on the command file is more than ~50 lines. Shared-helper edits ripple to sibling commands, so isolate them.
+
+Simple, restated positively: the codemod ran clean, every replacement is a 1:1 route-derived method, types come only from `@heroku/types/3.sdk`, no helpers changed, no lockfile bump, and `run()` already returns a value (or matches a documented carve-out).
 
 ---
 
@@ -308,4 +327,5 @@ One gap against this guide: `apps:info`'s `run()` still returns void. Per [run()
 - [ ] Namespace convention followed: `data.*` for data-plane, `platform.*` for platform-plane.
 - [ ] Backwards-compat preserved: identical stdout/stderr/exit-codes/JSON keys; no silent null coalescing; no new truthiness gates.
 - [ ] Tests rewritten: `nock` removed, SDK stubbed via `HerokuSDK.prototype.platform`; escape hatch (if any) stubs `HerokuApiClient.prototype.get` with a duck-typed `{json}` return.
-- [ ] tsc clean vs. baseline; eslint clean on changed files; two commits; PR against `v12.0.0`.
+- [ ] tsc clean vs. baseline; eslint clean on changed files; two commits per command in the PR; PR against `v12.0.0`.
+- [ ] Batch respects the cap: ≤5 simple, 2-3 mixed with one complex, or 1 complex alone. See [What counts as complex](#what-counts-as-complex).

--- a/.claude/skills/sdk-command-migration/GUIDE.md
+++ b/.claude/skills/sdk-command-migration/GUIDE.md
@@ -1,0 +1,311 @@
+# SDK Command Migration Process
+
+This is the manual guide to migrating a command to `@heroku/sdk`. It covers the whole process end to end, so you can run a migration entirely by hand. Its focus is the parts that need a human, the decisions the [codemod](../../../scripts/codemods/sdk-migration) can't make and the places where the automation hands the problem back to you.
+
+Most of the migration is mechanical. An agent running the [`SKILL.md`](./SKILL.md) playbook can do the routine steps, and the [codemod](../../../scripts/codemods/sdk-migration) rewrites the raw `this.heroku.<verb>(path)` calls. Neither can choose the right SDK method, decide where business logic belongs, work out what `run()` should return, or judge whether the output still matches what users expect. Each section below marks where you have to step in.
+
+You'll return to two spots most: [Where you need to step in](#where-you-need-to-step-in) and [run() return value](#5-run-return-value). Those are the parts the automation can't finish for you.
+
+If you just want the exact commands and the commit/PR mechanics, [`SKILL.md`](./SKILL.md) is the executable version of this same process. The two are meant to agree.
+
+---
+
+## 1. Guidelines
+
+These rules keep each migration reviewable and easy to unwind if something slips through. [`SKILL.md`](./SKILL.md) is written to follow them.
+
+- One command per PR. Don't bundle multiple command migrations. One command at a time keeps the review small and keeps a later bisect useful when a regression turns up.
+- Two commits per command, the source migration first and then the test rewrite. Commit messages:
+  - `refactor: use @heroku/sdk for <command> command`
+  - `test(<command>): stub @heroku/sdk directly, drop nock`
+- Open PRs against `v12.0.0`, not `main`. This work is part of the v12 release, so nothing merges to `main` yet.
+
+---
+
+## 2. The codemod
+
+### What the codemod handles
+
+The [codemod](../../../scripts/codemods/sdk-migration) does the repetitive work so you can spend your attention on the decisions that need judgment. Dry-run first, read the diff, then write:
+
+```bash
+npx tsx scripts/codemods/sdk-migration/migrate-command.ts --dry-run src/commands/<path>.ts
+npx tsx scripts/codemods/sdk-migration/migrate-command.ts         src/commands/<path>.ts
+```
+
+It handles the deterministic ~80%:
+- reverse-looks-up each `this.heroku.<verb>(path)` against the SDK route table and replaces it with `<service>.<resource>.<method>(...)`,
+- unwraps `{body: ...}` at call sites (the SDK returns the body directly),
+- drops the `{hostname}` option, adds `import {HerokuSDK} from '@heroku/sdk'`, and inserts a single `const {<services>} = new HerokuSDK()` at the top of `run()`,
+- removes the deprecated `@heroku-cli/schema` import when nothing else references it.
+
+When it leaves a `// TODO(sdk-migration): ...` marker it exits non-zero. Read that as a pointer to a spot that needs your judgment, not as a failure.
+
+The rest of the toolkit lives alongside it in `scripts/codemods/sdk-migration/`: `preflight.sh` (working-tree, SDK, and baseline checks), `tsc-delta.sh` (new-error filter against the baseline), `check-route.sh` (route-metadata diagnostics), `routes-index.ts` (the `(verb, path)` -> resource/method lookup), `transform.ts` (the AST engine), and `README.md`.
+
+### Where you need to step in
+
+These are the cases the codemod flags but leaves for you. Each one needs a decision it can't make. This is the section you'll come back to most.
+
+#### Helper-threaded APIClient calls
+
+Some commands pass `this.heroku` into private helpers that call `heroku.<verb>(path)`. The codemod reports "no change" for those, because it only matches the `this.heroku.<verb>` shape. To finish them by hand, change each helper's `heroku: APIClient` parameter to `platform: Platform` (or `data: HerokuSDK['data']`), rewrite the calls, construct the SDK once in `run()`, and pass `platform` in. For the reasoning, see [Business-logic placement](#4-business-logic-placement) and [Test pattern for SDK stubbing](#6-test-pattern-for-sdk-stubbing).
+
+#### Metadata-gap workarounds
+
+The SDK's dispatcher only forwards a request body when the route metadata has `hasRequestBody: true`. When `@heroku/types` is missing that flag, the generated method won't accept a body, and it silently drops anything you cast through, so you'll see "request body did not match" or an empty payload. Confirm it with `bash scripts/codemods/sdk-migration/check-route.sh PATCH /apps/example/config-vars`. The fix belongs upstream, in a `@heroku/types` bump. An escape hatch around it quietly undoes what the migration is for, so take the slower path. Include the lockfile bump in the source commit and explain it in the body.
+
+#### Multi-instance HerokuSDK refactors
+
+Aim for one `new HerokuSDK()` per `run()`, threaded into helpers as a parameter. It keeps the command's test setup clean and the "one SDK, threaded through" model intact. [Test pattern for SDK stubbing](#6-test-pattern-for-sdk-stubbing) covers what extra instances cost you.
+
+#### Return-value backfill on already-migrated commands
+
+A few commands migrated on this branch still return void. When you're in one of them, take the chance to bring it up to the return-value contract. See [run() return value](#5-run-return-value).
+
+#### Ambiguous routes, dynamic paths, and schema types
+
+When several methods share a `(verb, path)`, pick the one that matches the request-body intent. When the path is a variable, trace it and replace it by hand. Swap every `Heroku.<Type>` for its canonical replacement: entity types from `@heroku/types/3.sdk` (`App`, `AddOn`, `Collaborator`, `Dyno`, ...), composite return types from `@heroku/sdk/resources/<service>/<resource>/<file>` (`AppInfo`, ...), and CLI-only field gaps from `src/lib/types/` (for example `ExtendedApp` in `src/lib/types/app.d.ts`).
+
+---
+
+## 3. SDK method selection
+
+After the codemod's pass, the first real decision is which SDK method to use.
+
+Reach for a composite method before hand-rolling a `Promise.all`. When a command fans out to several endpoints, there's often a composite that already wraps up the parallelism and soft-fail logic: `platform.app.describe` (fans out addons, app, dynos, collaborators, and pipeline coupling), `addOn.create` (the rich user-facing options shape), or `pipelineCoupling.infoByApp`. Composites live as separate files under `node_modules/@heroku/sdk/dist/resources/<service>/<resource>/` (anything other than `index.{js,d.ts}`), so look there before you build the fan-out yourself.
+
+Composites are extension methods, so register them. They only exist at runtime when you pass the matching extension to the constructor:
+
+```ts
+import {HerokuSDK} from '@heroku/sdk'
+import {appExtensions} from '@heroku/sdk/extensions/platform'
+
+const {platform} = new HerokuSDK({extensions: [appExtensions]})
+await platform.app.describe('myapp')   // undefined at runtime without the extension
+```
+
+The catch worth watching for: test stubs mask a missing registration, because a stubbed `describe` looks structurally fine even when the production wiring isn't there. Check the registration against a sibling command's wiring and smoke-test against a real app before you trust it. For helpers, parameterize the type alias so the extended method shows up statically: `type Platform = HerokuSDK<readonly [typeof appExtensions]>['platform']`.
+
+When there's no composite, take the codemod's 1:1 route-derived method. This is the most common case, and it's a good result.
+
+When adding to the SDK, follow the namespace convention. Data-plane services live under `data.*` (for example `data.database.*`, `data.redis.*`, `data.pgBackup.*`, `data.maintenance.*`), and platform-plane services live under `platform.*`. When you're not sure where something belongs, check `src/services/` (in the [heroku/heroku-sdk repo](https://github.com/heroku/heroku-sdk)) and `src/resources/` for the current namespace layout.
+
+---
+
+## 4. Business-logic placement
+
+As you migrate, logic tends to move around. Think in three tiers and ask which one each piece belongs to.
+
+- The SDK handles cross-endpoint orchestration, retries, soft-fail, and hostname resolution. If a command is fanning out several calls with its own error handling, the work wants to live in a composite method rather than the command. Push it down instead of reimplementing it in the CLI.
+- A shared CLI helper (`src/lib/...`) is for logic reused across commands. A helper takes `platform`/`data` as a parameter and leaves the SDK construction to its caller; [Test pattern for SDK stubbing](#6-test-pattern-for-sdk-stubbing) explains why that matters for tests. Type its parameter `type Platform = HerokuSDK['platform']`, or the extension-parameterized form when it calls a composite.
+- The command class `run()` owns flag parsing, the single `new HerokuSDK()`, and output rendering via `hux`/`ux`. It's also where the two naming worlds meet. The CLI's snake_case output is a contract the CLI owns, and the SDK's camelCase return shapes are a separate bounded context. Translate between them right at the output boundary (the JSON/shell serialization sites) rather than threading renamed fields back through the helpers:
+
+  ```ts
+  // Good: rename at the JSON serialization boundary.
+  } else if (flags.json) {
+    const {pipelineCoupling, ...rest} = info
+    hux.styledJSON({...rest, pipeline_coupling: pipelineCoupling})
+  }
+  ```
+
+In the same spirit, derive composite-shaped helper types from the SDK instead of restating them by hand. `type Info = Omit<AppInfo, 'app'> & {app: ExtendedApp}` keeps your type in sync with the SDK and sidesteps a subtle trap: a restated `pipeline_coupling: described.pipelineCoupling` still type-checks after an upstream rename, then quietly returns `undefined` at runtime.
+
+---
+
+## 5. run() return value
+
+The contract is that `run()` should return the SDK-shaped data it fetched or produced. When it does, the command becomes composable, so other commands and tests can call it and assert on its behavior without scraping stdout. Prefer returning the SDK result (or a small object built from it) over `void`.
+
+These commands on this branch still return void and need updating to match the contract (there are work items tracking the work):
+- `src/commands/addons/detach.ts` (`Promise<void>`, line 17). A natural return is `{attachment, releases}`; both are already fetched and today only used for their side effects.
+- `src/commands/pipelines/info.ts` (implicit void, line 32). A natural return is `{pipeline, apps}`.
+- `src/commands/apps/create.ts` (void). A natural return is the created app.
+
+Some commands genuinely can't produce a payload, and that's fine. Don't force one:
+- Streaming commands like `logs --tail` return void or a short summary. Under `--tail` the stream never ends, so there's nothing serializable to hand back.
+- Interactive TTY commands like `run:inside` and `redis:cli` call `process.exit()` / `ux.exit()`, which oclif catches as `EEXIT`. Control never returns normally, so there's no value to produce.
+- Progressive-stdout commands, such as a backup download that prints progress as it goes, return a summary of the finished operation rather than the streaming progress itself.
+
+---
+
+## 6. Test pattern for SDK stubbing
+
+Once the source is migrated, the tests change too. We drop `nock` here, since it no longer intercepts the SDK's `undici`-based fetch on Node 20+, and stub the SDK directly instead. For a full example to read alongside this, `test/unit/commands/apps/info.unit.test.ts` and `test/unit/commands/apps/index.unit.test.ts` are the reference implementations.
+
+Build a `FakePlatform` with just the resources and methods the command actually uses:
+
+```ts
+type FakePlatform = {
+  app: {describe: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {app: {describe: sinon.stub()}}
+}
+```
+
+Stub the prototype getter in `beforeEach` and restore it in `afterEach`:
+
+```ts
+let fakePlatform: FakePlatform
+
+beforeEach(function () {
+  fakePlatform = buildFakePlatform()
+  sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
+})
+
+afterEach(function () {
+  sinon.restore()
+})
+```
+
+This works because `HerokuSDK.platform` is a configurable class-prototype getter, so `sinon.stub(...).get(...)` can swap it out for the duration of the test. If your command uses the `HerokuApiClient` escape hatch (see [Backwards-compatibility rules](#7-backwards-compatibility-rules)), stub `HerokuApiClient.prototype.get` as well and return a duck-typed `{json: async () => fixture}` rather than a real `Response`:
+
+```ts
+apiGet = sinon.stub(HerokuApiClient.prototype, 'get')
+apiGet.withArgs('/apps/myapp?extended=true').resolves({json: async () => appExtended})
+```
+
+Wire each test's behavior with `.resolves(...)`, and assert routing with `.calledOnceWithExactly(...)` where the flag-to-method mapping is the thing you're testing. On tests that only check output formatting, the routing assertion is just noise, so leave it off:
+
+```ts
+fakePlatform.app.describe.resolves({addons, app: appAcm, collaborators, dynos, pipelineCoupling: null})
+const {stdout} = await runCommand(Info, ['-a', 'myapp'])
+expect(fakePlatform.app.describe.calledOnceWithExactly('myapp')).to.equal(true)
+```
+
+### The one assumption everything rests on, a single HerokuSDK per run()
+
+This pattern reads cleanest when one thing is true: the command creates `new HerokuSDK()` once per `run()` and reads `.platform` after `beforeEach` has installed the stub. Two things can go wrong when it isn't:
+- The dangerous case is a `platform` / `ctx.platform` reference captured before the stub is installed. It holds a real, unstubbed client, the stub never applies to it, and the test quietly stops testing what you think it does.
+- The stub replaces the getter on `HerokuSDK.prototype`, so every instance built at any time resolves through it, but building the SDK more than once trips up `calledOnce` assertions (more on that below).
+
+Here's the shape you want. `src/commands/apps/create.ts` builds the SDK once at the top of `run()` (line 201) and passes `platform` into its helpers as a parameter:
+
+  ```ts
+  // apps/create.ts:22
+  type Platform = HerokuSDK['platform']
+
+  // apps/create.ts:33 helper accepts platform, never instantiates its own SDK
+  async function createApp(context, platform: Platform, name, stack) {
+    const app = (params.space || params.team)
+      ? await platform.teamApp.create(params as TeamAppCreateOpts) as App
+      : await platform.app.create(params as AppCreateOpts)
+    return app
+  }
+
+  // apps/create.ts:201 single instance, threaded to createApp / addAddons / addConfigVars
+  const {platform} = new HerokuSDK()
+  ```
+
+And here's the shape to avoid. `src/commands/addons/upgrade.ts` builds the SDK twice, once inside `getPlans()` (line 89) and again in `run()` (line 102):
+
+  ```ts
+  // addons/upgrade.ts:89 second instance, inside a helper
+  const {platform} = new HerokuSDK({extensions: [addOnExtensions]})
+  // addons/upgrade.ts:102 first instance, in run()
+  const {platform} = new HerokuSDK({extensions: [addOnExtensions]})
+  ```
+
+A single `sinon.stub(HerokuSDK.prototype, 'platform').get(...)` still works here, since `platform` is a getter on `HerokuSDK.prototype` and the stub replaces it for every instance no matter how many you build. The cost of two instances shows up in the assertions. When both instances call the same stubbed method, a `calledOnceWithExactly(...)` check fails with "called twice," so you end up loosening routing assertions to paper over a structural problem.
+
+The fix is the same every time. When a helper needs the SDK, give it a `platform: Platform` parameter and build the SDK once in `run()`. For `addons/upgrade.ts`, that means `getPlans()` takes `platform` from the single instance `run()` created, instead of spinning up its own.
+
+---
+
+## 7. Backwards-compatibility rules
+
+The migration should be invisible from the outside.
+
+Same bytes out. stdout, stderr, exit codes, and JSON keys all stay identical. The JSON and shell contract is snake_case, so preserve it exactly and do the rename at the output boundary (see [Business-logic placement](#4-business-logic-placement)).
+
+Handle strict-null types without touching output. `@heroku/types/3.sdk` is stricter than the old `@heroku-cli/schema`; `web_url` is now `string | null`, for instance. The tempting fix is to coalesce (`?? ''`, `?? 0`), but that quietly changes what prints: `web_url=null` would become `web_url=`. Don't. Reach for an `as` cast at a call site the runtime already guards (`filesize(info.app.repo_size as number, ...)`), or loosen a local consumer's signature (`function print(k: string, v: unknown)`).
+
+Don't add truthiness gates the old code didn't have. A type fix that skips a field the original always printed isn't a type fix, it's a behavior change in disguise.
+
+### CLI-only escape hatch (see [SKILL.md](./SKILL.md#step-12b-cli-only-escape-hatches-via-herokuapiclient))
+
+Sometimes a variant exists on the platform but the SDK doesn't expose it. The canonical case is `GET /apps/{id}?extended=true`, which the route table collapses down to plain `app.info`. When something really is a CLI-only concern, drop straight to `HerokuApiClient` instead of keeping a lone `this.heroku.<verb>` call threaded through the command:
+
+```ts
+import {HerokuApiClient} from '@heroku/heroku-fetch'
+
+const client = new HerokuApiClient()
+const response = await client.get(`/apps/${app}?extended=true`)
+const appExtended = await response.json() as ExtendedApp
+```
+
+To test, stub `HerokuApiClient.prototype.get` (see [Test pattern for SDK stubbing](#6-test-pattern-for-sdk-stubbing)).
+
+---
+
+## 8. Worked example, apps:info end to end
+
+`src/commands/apps/info.ts` is a good example. It hits most of this guide in one small command.
+
+Imports and type aliases (lines 1-18). The composite return type from the SDK resource file, the SDK itself, the extension, and a platform alias parameterized by that extension:
+
+```ts
+import type {AppInfo} from '@heroku/sdk/resources/platform/app/info'
+import {HerokuApiClient} from '@heroku/heroku-fetch'
+import {HerokuSDK} from '@heroku/sdk'
+import {appExtensions} from '@heroku/sdk/extensions/platform'
+import {ExtendedApp} from '../../lib/types/app.js'
+
+type Platform = HerokuSDK<readonly [typeof appExtensions]>['platform']
+type Info = Omit<AppInfo, 'app'> & {app: ExtendedApp}
+```
+
+Single SDK instance in `run()` (line 57), passed to the helper:
+
+```ts
+const {platform} = new HerokuSDK({extensions: [appExtensions]})
+const info = await getInfo(app, platform, flags.extended)
+```
+
+Helper takes `platform`, uses the composite, and applies the escape hatch for `--extended` (lines 106-118):
+
+```ts
+async function getInfo(app: string, platform: Platform, extended: boolean): Promise<Info> {
+  const data: Info = await platform.app.describe(app)   // composite: fans out several endpoints
+  if (extended) {
+    const client = new HerokuApiClient()
+    const response = await client.get(`/apps/${app}?extended=true`)
+    const appExtended = await response.json() as ExtendedApp
+    appExtended.acm = data.app.acm
+    data.app = appExtended
+  }
+
+  return data
+}
+```
+
+snake_case rename at the JSON output boundary (lines 93-95):
+
+```ts
+} else if (flags.json) {
+  const {pipelineCoupling, ...rest} = info
+  hux.styledJSON({...rest, pipeline_coupling: pipelineCoupling})
+}
+```
+
+The test (`test/unit/commands/apps/info.unit.test.ts`) puts the pattern together. It builds a minimal `FakePlatform` (`{app: {describe: sinon.stub()}}`), stubs both the prototype getter and `HerokuApiClient.prototype.get` in `beforeEach` (lines 117-121), and wires each case with `fakePlatform.app.describe.resolves(...)`. The escape-hatch response is duck-typed, `apiGet.withArgs('/apps/myapp?extended=true').resolves({json: async () => appExtended})` (line 151), and routing is checked with `fakePlatform.app.describe.calledOnceWithExactly('myapp')` (line 140). No `nock` anywhere.
+
+One gap against this guide: `apps:info`'s `run()` still returns void. Per [run() return value](#5-run-return-value), the natural backfill is to return `info`, the `Info` object it already has in hand.
+
+---
+
+## 9. Self-review checklist
+
+- [ ] Codemod runs first; every `// TODO(sdk-migration):` marker resolved.
+- [ ] No `this.heroku.<verb>` calls and no bare helper `heroku.<verb>` calls remain.
+- [ ] Composite methods used where a `Promise.all` fan-out existed; their extensions are registered via `{extensions: [...]}` (verified against a sibling command or smoke test).
+- [ ] `@heroku-cli/schema` gone; types come from `@heroku/types/3.sdk`, SDK resource files, or `src/lib/types/`.
+- [ ] Business logic sits in the right tier; snake_case renames happen at the output boundary, not threaded through helpers.
+- [ ] Exactly one `new HerokuSDK()` per `run()`; helpers accept `platform`/`data` as a parameter and never instantiate their own SDK.
+- [ ] `run()` returns the SDK-shaped data, or the case is a documented carve-out (streaming, interactive-TTY, or progressive-stdout).
+- [ ] Namespace convention followed: `data.*` for data-plane, `platform.*` for platform-plane.
+- [ ] Backwards-compat preserved: identical stdout/stderr/exit-codes/JSON keys; no silent null coalescing; no new truthiness gates.
+- [ ] Tests rewritten: `nock` removed, SDK stubbed via `HerokuSDK.prototype.platform`; escape hatch (if any) stubs `HerokuApiClient.prototype.get` with a duck-typed `{json}` return.
+- [ ] tsc clean vs. baseline; eslint clean on changed files; two commits; PR against `v12.0.0`.

--- a/.claude/skills/sdk-command-migration/GUIDE.md
+++ b/.claude/skills/sdk-command-migration/GUIDE.md
@@ -39,6 +39,16 @@ A command is complex if any of the following applies. Everything else is simple.
 
 Simple, restated positively: the codemod ran clean, every replacement is a 1:1 route-derived method, types come only from `@heroku/types/3.sdk`, no helpers changed, no lockfile bump, and `run()` already returns a value (or matches a documented carve-out).
 
+### Reading the topic work item
+
+A topic WI covers many commands and turns into several PRs. When you pick up one command, the WI tells you two things worth checking first: how complex the command is, and whether an SDK extension needs to land before you can migrate.
+
+Each command in the WI has a line like `<file> (<tag>) → <SDK target>`. Read the tag for intent, not for exact wording:
+- "mechanical swap to existing route method" (or similar) means **simple**.
+- "new SDK extension needed" (or similar) means **complex**, and the WI names the extension.
+
+If the tag doesn't clearly fit one of those, stop and ask. If it's complex, confirm the extension is installed before running the codemod. [`SKILL.md` Step P0](./SKILL.md#step-p0-read-the-work-item) has the exact commands.
+
 ---
 
 ## 2. The codemod

--- a/.claude/skills/sdk-command-migration/SKILL.md
+++ b/.claude/skills/sdk-command-migration/SKILL.md
@@ -64,6 +64,30 @@ Each step is required. Do not skip.
 
 Run these once per command, before any code change. They prevent the most common surprises.
 
+### Step P0: Read the work item
+
+If the invocation cites a work item, read it before touching code. Topic WIs cover many commands, so find the line for yours and check whether it names a prerequisite. If there's no WI, skip this step.
+
+**Find your command's line.** Each command in the WI has a line shaped like `<file> (<tag>) → <SDK target>. Currently: ... SDK owns: ... CLI owns: ...`. Find the one whose `<file>` matches your target (e.g., `add.ts` for `domains/add`).
+
+**Read the tag for intent, not exact wording.** The vocabulary is still settling — match on meaning:
+- Mechanical / 1:1 swap / call-site swap / existing route method → **simple**. The codemod handles it.
+- New SDK extension needed / new composite / needs extension → **complex**. An extension in `@heroku/sdk` has to land first; the WI names it in its "SDK-side design work" section.
+- Already migrated → **skip**. Confirm the file already imports `@heroku/sdk` and stop.
+- Anything you can't confidently place → stop and ask.
+
+**Complex commands: verify the extension exists before running the codemod.**
+
+```bash
+ls node_modules/@heroku/sdk/dist/resources/platform/<resource>/ 2>/dev/null
+```
+
+Files other than `index.{js,d.ts}` are extensions. If the one the WI named is missing, stop and confirm with the user — don't migrate against a method that doesn't exist yet. Cross-topic prerequisites (a paragraph like "Coordination with the <other> topic") count the same as first-party ones.
+
+Mechanical commands don't need this check — the codemod fails loudly if a route-derived method is missing.
+
+Remember the tier you extracted here — you'll use it at [Step V3](#step-v3-push-and-open-pr) to decide the PR's scope against the batching rules in [`GUIDE.md` §1](./GUIDE.md#what-counts-as-complex).
+
 ### Steps P1+P2: Working tree, SDK probe, and baselines
 
 ```bash

--- a/.claude/skills/sdk-command-migration/SKILL.md
+++ b/.claude/skills/sdk-command-migration/SKILL.md
@@ -12,6 +12,8 @@ description: >
 
 Apply once per command in `src/commands/`. Each application produces one PR-ready unit of work containing two commits: the source migration and the test rewrite.
 
+> For the conceptual guide and decision rules — SDK method selection, business-logic placement, the return-value contract and its carve-outs, and backwards-compat rules — see [`GUIDE.md`](./GUIDE.md).
+
 ## When to Use
 
 **Invoke when:**
@@ -28,10 +30,24 @@ Apply once per command in `src/commands/`. Each application produces one PR-read
 
 - TypeScript with NodeNext ESM, `module: "NodeNext"`, target `ES2022`.
 - oclif 4 command framework.
-- `@heroku/sdk` published beta (currently `^0.1.0-beta`); the bare entry exports `HerokuSDK` and `HerokuSDKOptions`. `@heroku/types` (the route metadata package) is `^3.0.0-beta`.
+- `@heroku/sdk` published beta (currently `^0.5.0-beta`); the bare entry exports `HerokuSDK` and `HerokuSDKOptions`. `@heroku/types` (the route metadata package) is `^3.0.0-beta`.
 - `@heroku/heroku-fetch` is a direct dependency exporting `HerokuApiClient`. The SDK uses it internally; commands also use it directly for CLI-only escape hatches (see "CLI-only escape hatches" below).
 - **`@heroku-cli/schema` is deprecated.** Replace `import * as Heroku from '@heroku-cli/schema'` with imports from `@heroku/types/3.sdk` (entity types: `App`, `AddOn`, `Collaborator`, `Dyno`, etc.) and from the SDK composite resource files (`AppInfo`, `PipelineCouplingDetail`, etc., from `@heroku/sdk/resources/<service>/<resource>/<file>`). See "Replacing @heroku-cli/schema" below.
 - Tests use `mocha` + `chai` + `chai-as-promised` + `sinon`. Existing tests use `nock` to intercept HTTP; the rewrite drops `nock` in favor of direct SDK stubbing.
+
+## Design Principles
+
+Three rules shape every migration. They come up throughout the process below and are worth internalizing before starting. See [`GUIDE.md`](./GUIDE.md) sections 4-6 for the fuller reasoning behind each.
+
+
+**Business logic sits in three tiers.** The SDK owns cross-endpoint orchestration, retries, soft-fail, and hostname resolution — push fan-outs down into a composite method rather than reimplementing them in the CLI. Shared CLI helpers (`src/lib/...`) take `platform`/`data` as a parameter and leave SDK construction to their caller. The command class `run()` owns flag parsing, the single `new HerokuSDK()`, and output rendering via `hux`/`ux`. The `run()` boundary is also where CLI snake_case output meets SDK camelCase — translate at the output sites, not inside helpers.
+
+**Exactly one `new HerokuSDK()` per `run()`.** Helpers accept `platform: Platform` (or `data: HerokuSDK['data']`) as a parameter and never instantiate their own SDK. A second instance still test-stubs correctly (the stub is on `HerokuSDK.prototype`), but both instances' calls hit the same stub — so `calledOnceWithExactly(...)` assertions fail with "called twice," and the usual response is to loosen routing assertions to paper over a structural problem. If the codemod's insertion or a helper's `new HerokuSDK()` puts you at two instances, thread `platform` through as a parameter instead. See Step 1.2a for the conversion pattern.
+
+**`run()` returns the SDK-shaped data it fetched or produced.** This keeps commands composable — other commands and tests can call `run()` and assert on its behavior without scraping stdout. Prefer returning the SDK result (or a small object built from it) over `void`. When you migrate a command that currently returns `void`, backfill the return value as part of the same PR unless the command is one of the documented carve-outs:
+- **Streaming commands** (e.g., `logs --tail`) — under tail, the stream never ends; there's nothing serializable to return.
+- **Interactive TTY commands** (e.g., `run:inside`, `redis:cli`) — call `process.exit()` / `ux.exit()`, which oclif catches as `EEXIT`; control never returns normally.
+- **Progressive-stdout commands** (e.g., a backup download printing progress) — return a summary of the finished operation rather than the streaming progress itself.
 
 ## Process
 
@@ -471,11 +487,11 @@ Expected: empty. New errors mean the migration introduced a regression.
 
 ### Step V3: Push and open PR
 
-**Base branch is `feat/heroku-sdk-integration`, not `main`.** All SDK-migration work stacks onto the integration branch until that branch lands. Opening against `main` would surface ~120 files of integration-branch noise to reviewers; opening against `feat/heroku-sdk-integration` shows only the per-command diff (~4 files). When the integration branch eventually merges, GitHub automatically updates the open child PRs to target `main` with the same minimal diff.
+**Base branch is `v12.0.0`, not `main`.** All SDK-migration work stacks onto the v12 branch until that branch lands. Opening against `main` would surface the whole integration diff to reviewers; opening against `v12.0.0` shows only the per-command diff (~4 files). When the v12 branch eventually merges, GitHub automatically updates the open child PRs to target `main` with the same minimal diff.
 
 ```bash
 git push -u origin <branch>
-gh pr create --draft --base feat/heroku-sdk-integration \
+gh pr create --draft --base v12.0.0 \
   --title "refactor: use @heroku/sdk for <command> command" \
   --body "$(cat <<'EOF'
 ## Summary
@@ -504,6 +520,9 @@ Each PR migrates exactly one command. Don't bundle multiple command migrations �
 
 Before opening the PR:
 
+- [ ] Exactly one `new HerokuSDK()` per `run()`. Helpers accept `platform`/`data` as a parameter; no helper instantiates its own SDK. (See Design Principles.)
+- [ ] `run()` returns the SDK-shaped data it fetched or produced, or the command matches a documented carve-out (streaming, interactive-TTY, progressive-stdout). Backfill the return value if the command previously returned `void`.
+- [ ] Business logic sits in the right tier: cross-endpoint orchestration in the SDK (composite methods), reused logic in `src/lib/...` helpers, flag parsing / SDK construction / output rendering in `run()`. Snake_case renames happen at the output boundary, not threaded through helpers.
 - [ ] No `this.heroku.<verb>` calls remain in the migrated file. (Escape-hatch calls go through `HerokuApiClient` per Step 1.2b — never via `this.heroku`.)
 - [ ] No bare `heroku.<verb>(...)` calls remain in helper functions (helper-threading shape — see Step 1.2a).
 - [ ] No `// TODO(sdk-migration):` markers remain.
@@ -521,7 +540,7 @@ Before opening the PR:
 - [ ] Lint clean on changed files.
 - [ ] One source file changed per source commit; commit messages follow the convention. A `package.json`/`package-lock.json` bump (route-metadata gap from Step 1.2, or a new direct dep like `@heroku/heroku-fetch` for the escape hatch from Step 1.2b) is allowed in the source commit and should be called out in the commit body.
 - [ ] No incidental edits to other unrelated files (type defs, sibling commands).
-- [ ] PR opened with `--base feat/heroku-sdk-integration`, not `main` (Step V3).
+- [ ] PR opened with `--base v12.0.0`, not `main` (Step V3).
 
 ---
 
@@ -535,4 +554,4 @@ Before opening the PR:
 - **Escape hatch:** a direct `HerokuApiClient` call from `@heroku/heroku-fetch` for endpoints/variants the SDK doesn't expose. Sanctioned for CLI-only concerns like `?extended=true` query variants — see Step 1.2b.
 - **Pre-flight baseline:** the snapshot of `tsc`/test state captured before any migration work, used to filter pre-existing noise out of post-migration verification.
 - **Codemod:** `scripts/codemods/sdk-migration/migrate-command.ts` — the deterministic transform run in Task 1, Step 1.1.
-- **Integration branch:** `feat/heroku-sdk-integration` — the base branch for all per-command migration PRs until the integration lands. See Step V3.
+- **Integration branch:** `v12.0.0` — the base branch for all per-command migration PRs until the integration lands. See Step V3.

--- a/.claude/skills/sdk-command-migration/SKILL.md
+++ b/.claude/skills/sdk-command-migration/SKILL.md
@@ -10,7 +10,7 @@ description: >
 
 # SDK Command Migration
 
-Apply once per command in `src/commands/`. Each application produces one PR-ready unit of work containing two commits: the source migration and the test rewrite.
+Apply once per command in `src/commands/`. Each application produces two commits — the source migration and the test rewrite — which land in a PR alongside other commands' commits according to the batching rules below.
 
 > For the conceptual guide and decision rules — SDK method selection, business-logic placement, the return-value contract and its carve-outs, and backwards-compat rules — see [`GUIDE.md`](./GUIDE.md).
 
@@ -22,9 +22,10 @@ Apply once per command in `src/commands/`. Each application produces one PR-read
 - The user invokes `/sdk-command-migration` directly.
 
 **Do NOT invoke for:**
-- Multi-command refactors — each command gets its own application.
 - Commands that import from `@heroku/sdk/compositions/*` (the subpath was removed in 0.4 — needs separate migration).
 - Helpers/libraries shared by multiple commands — migrate the helper in its own commit and link from the command commits.
+
+**Batching:** apply the skill once per command; then bundle up to 5 simple commands, or 2-3 commands including one complex one, into a single PR. A complex command ships alone. See [`GUIDE.md` §1](./GUIDE.md#1-guidelines) for the full definition and [Step V3](#step-v3-push-and-open-pr) for the PR mechanics.
 
 ## Tech Stack
 
@@ -487,32 +488,42 @@ Expected: empty. New errors mean the migration introduced a regression.
 
 ### Step V3: Push and open PR
 
-**Base branch is `v12.0.0`, not `main`.** All SDK-migration work stacks onto the v12 branch until that branch lands. Opening against `main` would surface the whole integration diff to reviewers; opening against `v12.0.0` shows only the per-command diff (~4 files). When the v12 branch eventually merges, GitHub automatically updates the open child PRs to target `main` with the same minimal diff.
+**Base branch is `v12.0.0`, not `main`.** All SDK-migration work stacks onto the v12 branch until that branch lands. Opening against `main` would surface the whole integration diff to reviewers; opening against `v12.0.0` shows only the per-command diff. When the v12 branch eventually merges, GitHub automatically updates the open child PRs to target `main` with the same minimal diff.
+
+**Batch scope.** A PR may include:
+- up to 5 commands when every command is simple,
+- 2-3 commands when the batch includes one complex command (put its two commits last),
+- 1 command when the command is complex or when you're unsure.
+
+See [`GUIDE.md` §1](./GUIDE.md#what-counts-as-complex) for the definition of complex. If any command in the batch trips a complexity criterion after you've already committed, split it out before opening the PR.
 
 ```bash
 git push -u origin <branch>
 gh pr create --draft --base v12.0.0 \
-  --title "refactor: use @heroku/sdk for <command> command" \
+  --title "refactor: use @heroku/sdk for <commands>" \
   --body "$(cat <<'EOF'
 ## Summary
-...
+Migrates the following commands to @heroku/sdk:
+- <command-a>
+- <command-b>
+
 ## Test plan
 - [x] tsc clean vs. baseline
 - [x] eslint clean
-- [x] mocha for the migrated test file passes
+- [x] mocha for each migrated test file passes
 - [x] mocha for sibling tests in the same dir passes
-- [ ] Manual smoke test against a real app (list the flag combinations to exercise)
+- [ ] Manual smoke test against a real app (list the flag combinations to exercise, per command)
 EOF
 )"
 ```
 
-The PR contains exactly two commits per command:
+The PR contains exactly two commits per migrated command, contiguous per command:
 - `refactor: use @heroku/sdk for <command> command`
 - `test(<command>): stub @heroku/sdk directly, drop nock`
 
-If the source migration uses the `HerokuApiClient` escape hatch (Step 1.2b), append `and @heroku/heroku-fetch` to the test commit subject: `test(<command>): stub @heroku/sdk and @heroku/heroku-fetch directly, drop nock`.
+If a source migration uses the `HerokuApiClient` escape hatch (Step 1.2b), append `and @heroku/heroku-fetch` to that command's test commit subject: `test(<command>): stub @heroku/sdk and @heroku/heroku-fetch directly, drop nock`.
 
-Each PR migrates exactly one command. Don't bundle multiple command migrations — review surface stays small and bisect remains useful if a regression slips through.
+For a single-command PR, keep the title in the `refactor: use @heroku/sdk for <command> command` form. For a multi-command batch, use `refactor: use @heroku/sdk for <commands>` (or list the two or three commands explicitly if they fit).
 
 ---
 
@@ -540,6 +551,7 @@ Before opening the PR:
 - [ ] Lint clean on changed files.
 - [ ] One source file changed per source commit; commit messages follow the convention. A `package.json`/`package-lock.json` bump (route-metadata gap from Step 1.2, or a new direct dep like `@heroku/heroku-fetch` for the escape hatch from Step 1.2b) is allowed in the source commit and should be called out in the commit body.
 - [ ] No incidental edits to other unrelated files (type defs, sibling commands).
+- [ ] Batch scope respected: ≤5 simple commands, 2-3 mixed with one complex, or 1 complex alone. See [`GUIDE.md` §1](./GUIDE.md#what-counts-as-complex).
 - [ ] PR opened with `--base v12.0.0`, not `main` (Step V3).
 
 ---

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -92,6 +92,7 @@ dynosize
 ECCN
 echoerr
 Edmonds
+EEXIT
 elif
 EOFCOMMENT
 EOFTABLE
@@ -408,6 +409,7 @@ unref
 unschedules
 unscheduling
 unsetting
+unstubbed
 usename
 userid
 usesysid

--- a/package-lock.json
+++ b/package-lock.json
@@ -1873,6 +1873,40 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.50.2",
       "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.50.2.tgz",
@@ -3825,6 +3859,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
     "node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -5060,6 +5107,25 @@
         "node": ">=14"
       }
     },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
@@ -5155,6 +5221,41 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -5330,24 +5431,59 @@
       }
     },
     "node_modules/@sentry/node/node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.219.0.tgz",
-      "integrity": "sha512-9t6SvBXXBEjOBcIzgozvBbd3jWrv3Gt3ngGhl1fhdZ/zRc7oZDVOFEqbi2zlBpW9BXhgDMKv422J0DL/3iQWfw==",
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.220.0.tgz",
+      "integrity": "sha512-/+ExB3lRkf+erv4PnoywyL7RHKITidxtUpUTS55k7OQ0dB42S7gEF1gry7swb9MSm1hYLUhJg4QQh9W8SpwwqA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/otlp-exporter-base": "0.219.0",
-        "@opentelemetry/otlp-transformer": "0.219.0",
-        "@opentelemetry/resources": "2.8.0",
-        "@opentelemetry/sdk-trace-base": "2.8.0"
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/otlp-exporter-base": "0.220.0",
+        "@opentelemetry/otlp-transformer": "0.220.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation": {
@@ -5368,15 +5504,15 @@
       }
     },
     "node_modules/@sentry/node/node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.219.0.tgz",
-      "integrity": "sha512-zvIxQX/AZUVKDU+hCuYx+7UkiP7GRdnk1ZbFQRYzHvYp47cAWR4j3IhoPhV9KaeXEv2xdGq3IA6PnpzDmLcmSA==",
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.220.0.tgz",
+      "integrity": "sha512-CXYo8UD5Mn9YbgebO2EL4wejtA+gxLmLiu6HCk2KH2BR7XhFN6/6p1UlCb23DYCjeYkndevLHuejCCN1yx4+OQ==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/otlp-transformer": "0.219.0"
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/otlp-transformer": "0.220.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -5385,20 +5521,37 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@sentry/node/node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.219.0.tgz",
-      "integrity": "sha512-aaYKAyXhw9VchKZVGOopD3Gw/kPsyrX2c6IQ0AW32mTjqmZOh5Y6Gf5OYqTNqVktAeBjmFinhyFaCwW6GYK9YQ==",
+    "node_modules/@sentry/node/node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@opentelemetry/api-logs": "0.219.0",
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/resources": "2.8.0",
-        "@opentelemetry/sdk-logs": "0.219.0",
-        "@opentelemetry/sdk-metrics": "2.8.0",
-        "@opentelemetry/sdk-trace-base": "2.8.0"
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.220.0.tgz",
+      "integrity": "sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-logs": "0.220.0",
+        "@opentelemetry/sdk-metrics": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -5408,9 +5561,9 @@
       }
     },
     "node_modules/@sentry/node/node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.219.0.tgz",
-      "integrity": "sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==",
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -5419,6 +5572,41 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@sentry/node/node_modules/@opentelemetry/resources": {
@@ -5438,16 +5626,16 @@
       }
     },
     "node_modules/@sentry/node/node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.219.0.tgz",
-      "integrity": "sha512-s6lTKRakaPClvKoWHRChxnXjDMkM/TQ30ff78jN6EBGf7MI7VzANE5PU3f4z9qDUudWjvZjOLHG0rBnBKYvoXA==",
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.220.0.tgz",
+      "integrity": "sha512-WywcTkQtv2iNmt+6y5Kcd4rzvx9bLVsBa2Nwcmg01IUaBTkTow3W4d9KE5vNBpEDtb9tp21WcRBY/lANRrApYA==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@opentelemetry/api-logs": "0.219.0",
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/api-logs": "0.220.0",
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -5458,9 +5646,9 @@
       }
     },
     "node_modules/@sentry/node/node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/api-logs": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.219.0.tgz",
-      "integrity": "sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg==",
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
@@ -5471,22 +5659,92 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@sentry/node/node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.8.0.tgz",
-      "integrity": "sha512-UDBGaj6W0Rgy5rTTaoxs8gVGF/aGkAKyjurJv7se6wjRxJu7FoquTLT/vt54DZfo4crbprYfhX/SOK9+BPw1qg==",
+    "node_modules/@sentry/node/node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/resources": "2.8.0"
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
+      "integrity": "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@sentry/node/node_modules/@opentelemetry/sdk-trace-base": {
@@ -6615,6 +6873,17 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "license": "MIT"
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@types/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -7361,6 +7630,34 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
@@ -7373,6 +7670,233 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@xmldom/xmldom": {


### PR DESCRIPTION
## Summary
Adds a companion `GUIDE.md` to the `sdk-command-migration` skill that documents the
end-to-end process for migrating a CLI command to `@heroku/sdk`, including where a
human has to step in vs. what the codemod handles. Also refreshes `SKILL.md` to link to
the guide and updates the package lockfile.

- Adds `.claude/skills/sdk-command-migration/GUIDE.md` — human-facing walkthrough of
the migration process
- Updates `.claude/skills/sdk-command-migration/SKILL.md` to reference the new guide
- Adds two entries to `cspell-dictionary.txt` for new terms introduced by the guide
- Refreshes `package-lock.json`

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [x] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
Passing CI suffices — this PR only adds/updates documentation under `.claude/skills/`
and refreshes the lockfile. No runtime behavior changes.

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-23373079](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07
EE00002eHSXvYAO/view)