### PR TITLE
refactor: use @heroku/sdk for accounts:add command

### DIFF
--- a/src/commands/accounts/add.ts
+++ b/src/commands/accounts/add.ts
@@ -1,6 +1,6 @@
 import {Command} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 
 import AccountsModule from '../../lib/accounts/accounts.js'
@@ -13,6 +13,7 @@ export default class Add extends Command {
   static example = `${color.command('heroku accounts:add my-account')}`
 
   async run() {
+    const {platform} = new HerokuSDK()
     const {args} = await this.parse(Add)
     const {name} = args
     const accounts = await AccountsModule.list()
@@ -21,7 +22,7 @@ export default class Add extends Command {
       ux.error(`${name} already exists`)
     }
 
-    const {body: account} = await this.heroku.get<Heroku.Account>('/account')
+    const account = await platform.account.info()
     const email = account.email!
 
     const existingAlias = accounts.find(account => account.name && account.username === email)

--- a/test/unit/commands/accounts/add.unit.test.ts
+++ b/test/unit/commands/accounts/add.unit.test.ts
@@ -1,15 +1,25 @@
 import {APIClient} from '@heroku-cli/command'
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
 import {restore, SinonStub, stub} from 'sinon'
 
 import Cmd from '../../../../src/commands/accounts/add.js'
 import AccountsModule from '../../../../src/lib/accounts/accounts.js'
 import {stubCredentialManager} from '../../../helpers/credential-manager-stub.js'
 
+type FakePlatform = {
+  account: {info: SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    account: {info: stub()},
+  }
+}
+
 describe('accounts:add', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
   let addStub: SinonStub
   let listStub: SinonStub
   let originalApiKey: string | undefined
@@ -23,13 +33,13 @@ describe('accounts:add', function () {
 
     listStub = stub(AccountsModule, 'list').resolves([])
     addStub = stub(AccountsModule, 'add')
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
+    stub(APIClient.prototype, 'auth').get(() => 'testHerokuAPIKey')
   })
 
   afterEach(function () {
     restore()
-    api.done()
-    nock.cleanAll()
     if (originalApiKey !== undefined) process.env.HEROKU_API_KEY = originalApiKey
   })
 
@@ -39,8 +49,7 @@ describe('accounts:add', function () {
         getAuth: async () => ({account: 'testEmail', token: 'testHerokuAPIKey'}),
       })
 
-      api.get('/account')
-        .reply(200, {email: 'testEmail'})
+      fakePlatform.account.info.resolves({email: 'testEmail'})
 
       await runCommand(Cmd, ['testAccountName'])
       expect(addStub.calledOnce).to.equal(true)
@@ -56,8 +65,7 @@ describe('accounts:add', function () {
       const getStorageConfigStub = stub(AccountsModule, 'getStorageConfig')
       getStorageConfigStub.returns({credentialStore: 'keychain' as any, useNetrc: false})
 
-      api.get('/account')
-        .reply(200, {email: 'testEmail'})
+      fakePlatform.account.info.resolves({email: 'testEmail'})
 
       await runCommand(Cmd, ['testAccountName'])
 
@@ -75,8 +83,7 @@ describe('accounts:add', function () {
       const getStorageConfigStub = stub(AccountsModule, 'getStorageConfig')
       getStorageConfigStub.returns({credentialStore: null, useNetrc: true})
 
-      api.get('/account')
-        .reply(200, {email: 'testEmail'})
+      fakePlatform.account.info.resolves({email: 'testEmail'})
 
       await runCommand(Cmd, ['testAccountName'])
 
@@ -84,25 +91,6 @@ describe('accounts:add', function () {
       expect(addStub.args[0][0]).to.equal('testAccountName')
       expect(addStub.args[0][1]).to.equal('testEmail')
       expect(addStub.args[0][2]).to.equal('testHerokuAPIKey')
-    })
-
-    it('should prompt the user to log in if the user is not logged in', async function () {
-      stubCredentialManager({
-        getAuth: async () => ({account: undefined, token: undefined}),
-      })
-
-      const APIClientStub = stub(APIClient.prototype, 'login')
-      APIClientStub.resolves()
-
-      api.get('/account')
-        .reply(401, {id: 'unauthorized', message: 'Unauthorized'})
-
-      api.get('/account')
-        .reply(200, {email: 'testEmail'})
-
-      await runCommand(Cmd, ['testAccountName'])
-
-      expect(APIClientStub.calledOnce).to.equal(true)
     })
 
     it('should error if the account name already exists', async function () {
@@ -124,8 +112,7 @@ describe('accounts:add', function () {
         getAuth: async () => ({account: 'testEmail', token: 'testHerokuAPIKey'}),
       })
 
-      api.get('/account')
-        .reply(200, {email: 'testEmail'})
+      fakePlatform.account.info.resolves({email: 'testEmail'})
 
       listStub.resolves([{name: 'existingAlias', username: 'testEmail'}])
 

--- a/test/unit/commands/accounts/add.unit.test.ts
+++ b/test/unit/commands/accounts/add.unit.test.ts
@@ -101,5 +101,17 @@ describe('accounts:add', function () {
         expect((error as Error).message).to.contain('testEmail already has an alias: existingAlias')
       }
     })
+
+    it('should error if the user is not logged in', async function () {
+      fakePlatform.account.info.throws(new Error('Not logged in'))
+
+      try {
+        await runCommand(Cmd, ['testAccountName'])
+      }
+      catch (error: unknown) {
+        expect((error as Error).message).to.contain('Not logged in')
+        expect(addStub.called).to.equal(false)
+      }
+    })
   })
 })

--- a/test/unit/commands/accounts/add.unit.test.ts
+++ b/test/unit/commands/accounts/add.unit.test.ts
@@ -6,7 +6,6 @@ import {restore, SinonStub, stub} from 'sinon'
 
 import Cmd from '../../../../src/commands/accounts/add.js'
 import AccountsModule from '../../../../src/lib/accounts/accounts.js'
-import {stubCredentialManager} from '../../../helpers/credential-manager-stub.js'
 
 type FakePlatform = {
   account: {info: SinonStub}
@@ -25,7 +24,7 @@ describe('accounts:add', function () {
   let originalApiKey: string | undefined
 
   beforeEach(function () {
-    // Tests here rely on the stubbed credential manager for auth; HEROKU_API_KEY
+    // Tests here rely on the stubbed APIClient for auth; HEROKU_API_KEY
     // from test/helpers/init.mjs would otherwise take precedence in APIClient
     // and defeat the stubs.
     originalApiKey = process.env.HEROKU_API_KEY
@@ -45,10 +44,6 @@ describe('accounts:add', function () {
 
   describe('when the user is logged in', function () {
     it('should call the accounts.add function with the account name and user email', async function () {
-      stubCredentialManager({
-        getAuth: async () => ({account: 'testEmail', token: 'testHerokuAPIKey'}),
-      })
-
       fakePlatform.account.info.resolves({email: 'testEmail'})
 
       await runCommand(Cmd, ['testAccountName'])
@@ -58,10 +53,6 @@ describe('accounts:add', function () {
     })
 
     it('should not pass token to add() when credentialStore is active (keychain-mode)', async function () {
-      stubCredentialManager({
-        getAuth: async () => ({account: 'testEmail', token: 'testHerokuAPIKey'}),
-      })
-
       const getStorageConfigStub = stub(AccountsModule, 'getStorageConfig')
       getStorageConfigStub.returns({credentialStore: 'keychain' as any, useNetrc: false})
 
@@ -76,10 +67,6 @@ describe('accounts:add', function () {
     })
 
     it('should pass token to add() when credentialStore is not active (netrc-mode)', async function () {
-      stubCredentialManager({
-        getAuth: async () => ({account: 'testEmail', token: 'testHerokuAPIKey'}),
-      })
-
       const getStorageConfigStub = stub(AccountsModule, 'getStorageConfig')
       getStorageConfigStub.returns({credentialStore: null, useNetrc: true})
 
@@ -94,10 +81,6 @@ describe('accounts:add', function () {
     })
 
     it('should error if the account name already exists', async function () {
-      stubCredentialManager({
-        getAuth: async () => ({account: 'testEmail', token: 'testHerokuAPIKey'}),
-      })
-
       listStub.resolves([{name: 'testAccountName', username: 'testEmail'}])
 
       try {
@@ -108,10 +91,6 @@ describe('accounts:add', function () {
     })
 
     it('should error if the email already has an alias', async function () {
-      stubCredentialManager({
-        getAuth: async () => ({account: 'testEmail', token: 'testHerokuAPIKey'}),
-      })
-
       fakePlatform.account.info.resolves({email: 'testEmail'})
 
       listStub.resolves([{name: 'existingAlias', username: 'testEmail'}])

--- a/test/unit/commands/accounts/add.unit.test.ts
+++ b/test/unit/commands/accounts/add.unit.test.ts
@@ -107,8 +107,7 @@ describe('accounts:add', function () {
 
       try {
         await runCommand(Cmd, ['testAccountName'])
-      }
-      catch (error: unknown) {
+      } catch (error: unknown) {
         expect((error as Error).message).to.contain('Not logged in')
         expect(addStub.called).to.equal(false)
       }


### PR DESCRIPTION
## Summary
Migrates the `accounts:add` command to `@heroku/sdk`.

**Note:** The other accounts commands (`index`, `current`, `remove`, `set`) do not make Platform API calls - they only interact with local cache and credential management, so they do not require SDK migration.

## Changes
- Replaced `this.heroku.get<Heroku.Account>('/account')` with `platform.account.info()`
- Removed `@heroku-cli/schema` import (deprecated)
- Updated tests to stub `HerokuSDK.prototype.platform` instead of using nock
- Updated tests to stub `APIClient.prototype.auth` instead of using `stubCredentialManager()`. 
   - The command reads `this.heroku.auth` directly and does not call `getAuth()`/`getAuthEntry()`, so `stubCredentialManager()` is not exercised. Stubbing `APIClient.prototype.auth` aligns the test with actual behavior.

## Testing
**Notes:** 
The SDK uses heroku-fetch to make API calls, which looks for a netrc file. Therefore, we must login with `HEROKU_NETRC_WRITE=true`.

**Steps:**
1. Pull down this branch
2. `npm i && npm run build`

**Not logged in**
- `./bin/run logout`
- `./bin/run accounts:add first_account` — Errors "No authentication token found. Please set HEROKU_API_KEY or run: heroku login"

**Logged in, new account**
- `HEROKU_NETRC_WRITE=true ./bin/run login`
- `./bin/run accounts:add first_account`
- `./bin/run accounts:current` — Lists "first_account"

**Logged in, duplicate account name**
- `./bin/run accounts:add first_account` — Errors "${name} already exists"

**Logged in, duplicate account email**
- `./bin/run accounts:add duplicate_account` — Errors "Account ${email} already has an alias of first_account."

**Cleanup:**
- `./bin/run logout`

## Related Issues
GUS work item: [W-23387317](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eL7F3YAK/view)