### PR TITLE
refactor: use @heroku/sdk for auth commands

### DIFF
--- a/src/commands/auth/2fa/index.ts
+++ b/src/commands/auth/2fa/index.ts
@@ -1,18 +1,23 @@
+import type {Account} from '@heroku/types/3.sdk'
+
 import {Command} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {ux} from '@oclif/core/ux'
 
 export default class TwoFactor extends Command {
   static aliases = ['2fa', 'twofactor']
   static description = 'check 2fa status'
 
-  async run() {
-    const {body: account} = await this.heroku.get<Heroku.Account>('/account')
+  async run(): Promise<Account> {
+    const {platform} = new HerokuSDK()
+    const account = await platform.account.info()
     if (account.two_factor_authentication) {
       ux.stdout(`Two-factor authentication is ${color.success('enabled')}`)
     } else {
       ux.stdout(`Two-factor authentication is ${color.failure('not enabled')}`)
     }
+
+    return account
   }
 }

--- a/src/commands/auth/2fa/index.ts
+++ b/src/commands/auth/2fa/index.ts
@@ -9,7 +9,7 @@ export default class TwoFactor extends Command {
   static aliases = ['2fa', 'twofactor']
   static description = 'check 2fa status'
 
-  async run(): Promise<Account> {
+  async run(): Promise<boolean> {
     const {platform} = new HerokuSDK()
     const account = await platform.account.info()
     if (account.two_factor_authentication) {
@@ -18,6 +18,6 @@ export default class TwoFactor extends Command {
       ux.stdout(`Two-factor authentication is ${color.failure('not enabled')}`)
     }
 
-    return account
+    return account.two_factor_authentication
   }
 }

--- a/src/commands/auth/2fa/index.ts
+++ b/src/commands/auth/2fa/index.ts
@@ -1,3 +1,5 @@
+import type {Account} from '@heroku/types/3.sdk'
+
 import {Command} from '@heroku-cli/command'
 import * as color from '@heroku/heroku-cli-util/color'
 import {HerokuSDK} from '@heroku/sdk'
@@ -7,7 +9,7 @@ export default class TwoFactor extends Command {
   static aliases = ['2fa', 'twofactor']
   static description = 'check 2fa status'
 
-  async run() {
+  async run(): Promise<Account> {
     const {platform} = new HerokuSDK()
     const account = await platform.account.info()
     if (account.two_factor_authentication) {
@@ -15,5 +17,7 @@ export default class TwoFactor extends Command {
     } else {
       ux.stdout(`Two-factor authentication is ${color.failure('not enabled')}`)
     }
+
+    return account
   }
 }

--- a/src/commands/auth/2fa/index.ts
+++ b/src/commands/auth/2fa/index.ts
@@ -1,5 +1,3 @@
-import type {Account} from '@heroku/types/3.sdk'
-
 import {Command} from '@heroku-cli/command'
 import * as color from '@heroku/heroku-cli-util/color'
 import {HerokuSDK} from '@heroku/sdk'
@@ -9,7 +7,7 @@ export default class TwoFactor extends Command {
   static aliases = ['2fa', 'twofactor']
   static description = 'check 2fa status'
 
-  async run(): Promise<Account> {
+  async run() {
     const {platform} = new HerokuSDK()
     const account = await platform.account.info()
     if (account.two_factor_authentication) {
@@ -17,7 +15,5 @@ export default class TwoFactor extends Command {
     } else {
       ux.stdout(`Two-factor authentication is ${color.failure('not enabled')}`)
     }
-
-    return account
   }
 }

--- a/src/commands/auth/2fa/index.ts
+++ b/src/commands/auth/2fa/index.ts
@@ -1,5 +1,3 @@
-import type {Account} from '@heroku/types/3.sdk'
-
 import {Command} from '@heroku-cli/command'
 import * as color from '@heroku/heroku-cli-util/color'
 import {HerokuSDK} from '@heroku/sdk'

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -1,6 +1,8 @@
+import type {Account} from '@heroku/types/3.sdk'
+
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 
 import Git from '../../lib/git/git.js'
 
@@ -14,12 +16,13 @@ export default class Login extends Command {
     sso: flags.boolean({char: 's', description: 'login for enterprise users under SSO', hidden: true}),
   }
 
-  async run() {
+  async run(): Promise<Account> {
+    const {platform} = new HerokuSDK()
     const {flags} = await this.parse(Login)
     let method: 'interactive' | undefined
     if (flags.interactive) method = 'interactive'
     await this.heroku.login({browser: flags.browser, expiresIn: flags['expires-in'], method})
-    const {body: account} = await this.heroku.get<Heroku.Account>('/account', {retryAuth: false})
+    const account = await platform.account.info()
     this.log(`Logged in as ${color.user(account.email!)}`)
 
     const git = new Git()
@@ -31,5 +34,6 @@ export default class Login extends Command {
     }
 
     await this.config.runHook('recache', {type: 'login'})
+    return account
   }
 }

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -1,5 +1,3 @@
-import type {Account} from '@heroku/types/3.sdk'
-
 import {Command, flags} from '@heroku-cli/command'
 import * as color from '@heroku/heroku-cli-util/color'
 import {HerokuSDK} from '@heroku/sdk'
@@ -16,7 +14,7 @@ export default class Login extends Command {
     sso: flags.boolean({char: 's', description: 'login for enterprise users under SSO', hidden: true}),
   }
 
-  async run(): Promise<Account> {
+  async run() {
     const {platform} = new HerokuSDK()
     const {flags} = await this.parse(Login)
     let method: 'interactive' | undefined
@@ -34,6 +32,5 @@ export default class Login extends Command {
     }
 
     await this.config.runHook('recache', {type: 'login'})
-    return account
   }
 }

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -1,3 +1,5 @@
+import type {Account} from '@heroku/types/3.sdk'
+
 import {Command, flags} from '@heroku-cli/command'
 import * as color from '@heroku/heroku-cli-util/color'
 import {HerokuSDK} from '@heroku/sdk'
@@ -14,7 +16,7 @@ export default class Login extends Command {
     sso: flags.boolean({char: 's', description: 'login for enterprise users under SSO', hidden: true}),
   }
 
-  async run() {
+  async run(): Promise<Account> {
     const {platform} = new HerokuSDK()
     const {flags} = await this.parse(Login)
     let method: 'interactive' | undefined
@@ -32,5 +34,6 @@ export default class Login extends Command {
     }
 
     await this.config.runHook('recache', {type: 'login'})
+    return account
   }
 }

--- a/src/commands/auth/token.ts
+++ b/src/commands/auth/token.ts
@@ -11,7 +11,7 @@ export default class AuthToken extends Command {
 By default, the CLI auth token is only valid for 1 year. To generate a long-lived token, use heroku authorizations:create`
   static promptFlagActive = false
 
-  async run(): Promise<string> {
+  async run() {
     const {platform} = new HerokuSDK()
     const {formatRelative} = await lazyModuleLoader.loadDateFns()
 
@@ -33,6 +33,5 @@ By default, the CLI auth token is only valid for 1 year. To generate a long-live
     }
 
     ux.stdout(this.heroku.auth)
-    return this.heroku.auth
   }
 }

--- a/src/commands/auth/token.ts
+++ b/src/commands/auth/token.ts
@@ -1,6 +1,6 @@
 import {Command} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {ux} from '@oclif/core/ux'
 
 import {lazyModuleLoader} from '../../lib/lazy-module-loader.js'
@@ -11,26 +11,28 @@ export default class AuthToken extends Command {
 By default, the CLI auth token is only valid for 1 year. To generate a long-lived token, use heroku authorizations:create`
   static promptFlagActive = false
 
-  async run() {
+  async run(): Promise<string> {
+    const {platform} = new HerokuSDK()
     const {formatRelative} = await lazyModuleLoader.loadDateFns()
 
     this.parse(AuthToken)
     if (!this.heroku.auth) this.error('not logged in')
     try {
-      const {body: tokens} = await this.heroku.get<Heroku.OAuthAuthorization>('/oauth/authorizations', {retryAuth: false})
-      const token = tokens.find((t: any) => t.access_token && t.access_token.token === this.heroku.auth)
+      const tokens = await platform.oauthAuthorization.list()
+      const token = tokens.find(t => t.access_token && t.access_token.token === this.heroku.auth)
       const isInternal = token ? token.user.email.includes('@heroku.com') : false
-      if (token && token.access_token.expires_in) {
+      if (token?.access_token?.expires_in) {
         const d = new Date()
         d.setSeconds(d.getSeconds() + token.access_token.expires_in)
         this.warn(`token will expire ${formatRelative(d, new Date())}\n${isInternal
           ? 'All tokens expire one year after we generate it.'
           : `To generate a token that expires in one year, use ${color.code('heroku authorizations:create')}.`}`)
       }
-    } catch (error: any) {
-      this.warn(error)
+    } catch (error: unknown) {
+      this.warn(error as Error)
     }
 
     ux.stdout(this.heroku.auth)
+    return this.heroku.auth
   }
 }

--- a/src/commands/auth/token.ts
+++ b/src/commands/auth/token.ts
@@ -11,7 +11,7 @@ export default class AuthToken extends Command {
 By default, the CLI auth token is only valid for 1 year. To generate a long-lived token, use heroku authorizations:create`
   static promptFlagActive = false
 
-  async run() {
+  async run(): Promise<string> {
     const {platform} = new HerokuSDK()
     const {formatRelative} = await lazyModuleLoader.loadDateFns()
 
@@ -33,5 +33,6 @@ By default, the CLI auth token is only valid for 1 year. To generate a long-live
     }
 
     ux.stdout(this.heroku.auth)
+    return this.heroku.auth
   }
 }

--- a/src/commands/auth/whoami.ts
+++ b/src/commands/auth/whoami.ts
@@ -1,5 +1,7 @@
+import type {Account} from '@heroku/types/3.sdk'
+
 import {Command} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
+import {HerokuSDK} from '@heroku/sdk'
 
 export default class AuthWhoami extends Command {
   static aliases = ['whoami']
@@ -11,14 +13,17 @@ export default class AuthWhoami extends Command {
     this.error('not logged in', {exit: 100})
   }
 
-  async run() {
+  async run(): Promise<Account> {
+    const {platform} = new HerokuSDK()
+
     if (process.env.HEROKU_API_KEY) this.warn('HEROKU_API_KEY is set')
     if (!this.heroku.auth) this.notloggedin()
     try {
-      const {body: account} = await this.heroku.get<Heroku.Account>('/account', {retryAuth: false})
+      const account = await platform.account.info()
       this.log(account.email)
-    } catch (error: any) {
-      if (error.statusCode === 401) this.notloggedin()
+      return account
+    } catch (error: unknown) {
+      if ((error as {statusCode?: number}).statusCode === 401) this.notloggedin()
       throw error
     }
   }

--- a/src/commands/auth/whoami.ts
+++ b/src/commands/auth/whoami.ts
@@ -1,5 +1,3 @@
-import type {Account} from '@heroku/types/3.sdk'
-
 import {Command} from '@heroku-cli/command'
 import {HerokuSDK} from '@heroku/sdk'
 
@@ -13,7 +11,7 @@ export default class AuthWhoami extends Command {
     this.error('not logged in', {exit: 100})
   }
 
-  async run(): Promise<Account> {
+  async run() {
     const {platform} = new HerokuSDK()
 
     if (process.env.HEROKU_API_KEY) this.warn('HEROKU_API_KEY is set')
@@ -21,7 +19,6 @@ export default class AuthWhoami extends Command {
     try {
       const account = await platform.account.info()
       this.log(account.email)
-      return account
     } catch (error: unknown) {
       if ((error as {statusCode?: number}).statusCode === 401) this.notloggedin()
       throw error

--- a/src/commands/auth/whoami.ts
+++ b/src/commands/auth/whoami.ts
@@ -1,3 +1,5 @@
+import type {Account} from '@heroku/types/3.sdk'
+
 import {Command} from '@heroku-cli/command'
 import {HerokuSDK} from '@heroku/sdk'
 
@@ -11,7 +13,7 @@ export default class AuthWhoami extends Command {
     this.error('not logged in', {exit: 100})
   }
 
-  async run() {
+  async run(): Promise<Account> {
     const {platform} = new HerokuSDK()
 
     if (process.env.HEROKU_API_KEY) this.warn('HEROKU_API_KEY is set')
@@ -19,6 +21,7 @@ export default class AuthWhoami extends Command {
     try {
       const account = await platform.account.info()
       this.log(account.email)
+      return account
     } catch (error: unknown) {
       if ((error as {statusCode?: number}).statusCode === 401) this.notloggedin()
       throw error

--- a/test/unit/commands/auth/login.unit.test.ts
+++ b/test/unit/commands/auth/login.unit.test.ts
@@ -1,21 +1,32 @@
 import {APIClient} from '@heroku-cli/command'
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
-import {SinonStub, stub} from 'sinon'
+import {restore, SinonStub, stub} from 'sinon'
 
 import Login from '../../../../src/commands/auth/login.js'
 import Git from '../../../../src/lib/git/git.js'
 
+type FakePlatform = {
+  account: {info: SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    account: {info: stub()},
+  }
+}
+
 describe('auth:login', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
   let configureCredentialHelperStub: SinonStub
   let eraseCredentialsStub: SinonStub
   let loginStub: SinonStub
   let savedApiKey: string | undefined
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
 
     savedApiKey = process.env.HEROKU_API_KEY
     delete process.env.HEROKU_API_KEY
@@ -26,22 +37,15 @@ describe('auth:login', function () {
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
-
     if (savedApiKey !== undefined) {
       process.env.HEROKU_API_KEY = savedApiKey
     }
 
-    configureCredentialHelperStub.restore()
-    eraseCredentialsStub.restore()
-    loginStub.restore()
+    restore()
   })
 
   it('displays the logged in user', async function () {
-    api
-      .get('/account')
-      .reply(200, {email: 'user@example.com'})
+    fakePlatform.account.info.resolves({email: 'user@example.com'})
 
     const {stdout} = await runCommand(Login, [])
 
@@ -49,11 +53,9 @@ describe('auth:login', function () {
   })
 
   it('configures git credential helper after successful login', async function () {
-    api
-      .get('/account')
-      .reply(200, {
-        email: 'user@example.com',
-      })
+    fakePlatform.account.info.resolves({
+      email: 'user@example.com',
+    })
 
     await runCommand(Login, [])
 
@@ -61,11 +63,9 @@ describe('auth:login', function () {
   })
 
   it('rejects stale git credentials after successful login', async function () {
-    api
-      .get('/account')
-      .reply(200, {
-        email: 'user@example.com',
-      })
+    fakePlatform.account.info.resolves({
+      email: 'user@example.com',
+    })
 
     await runCommand(Login, [])
 
@@ -84,11 +84,9 @@ describe('auth:login', function () {
   it('does not fail login if git credential helper configuration fails', async function () {
     configureCredentialHelperStub.rejects(new Error('Git not found'))
 
-    api
-      .get('/account')
-      .reply(200, {
-        email: 'user@example.com',
-      })
+    fakePlatform.account.info.resolves({
+      email: 'user@example.com',
+    })
 
     const {error} = await runCommand(Login, [])
 
@@ -99,11 +97,9 @@ describe('auth:login', function () {
   it('does not fail login if git credential deletion fails', async function () {
     eraseCredentialsStub.rejects(new Error('Git not found'))
 
-    api
-      .get('/account')
-      .reply(200, {
-        email: 'user@example.com',
-      })
+    fakePlatform.account.info.resolves({
+      email: 'user@example.com',
+    })
 
     const {error} = await runCommand(Login, [])
 

--- a/test/unit/commands/auth/token.unit.test.ts
+++ b/test/unit/commands/auth/token.unit.test.ts
@@ -1,33 +1,40 @@
 import {APIClient} from '@heroku-cli/command'
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
-import {restore, stub} from 'sinon'
+import {restore, SinonStub, stub} from 'sinon'
 
 import Token from '../../../../src/commands/auth/token.js'
 
+type FakePlatform = {
+  oauthAuthorization: {list: SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    oauthAuthorization: {list: stub()},
+  }
+}
+
 describe('auth:token', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
     stub(APIClient.prototype, 'auth').get(() => 'foobar')
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
     restore()
   })
 
   it('shows auth token', async function () {
-    api
-      .get('/oauth/authorizations')
-      .reply(200, [
-        {access_token: {token: 'somethingelse'}},
-        {access_token: {expires_in: 60, token: 'foobar'}, user: {email: 'foo@bar.com'}},
-        {},
-      ])
+    fakePlatform.oauthAuthorization.list.resolves([
+      {access_token: {token: 'somethingelse'}},
+      {access_token: {expires_in: 60, token: 'foobar'}, user: {email: 'foo@bar.com'}},
+      {},
+    ])
 
     const {stderr, stdout} = await runCommand(Token, [])
 
@@ -36,13 +43,11 @@ describe('auth:token', function () {
   })
 
   it('shows "long-term" token generation warning for non-internal users', async function () {
-    api
-      .get('/oauth/authorizations')
-      .reply(200, [
-        {access_token: {token: 'somethingelse'}},
-        {access_token: {expires_in: 60, token: 'foobar'}, user: {email: 'foo@bar.com'}},
-        {},
-      ])
+    fakePlatform.oauthAuthorization.list.resolves([
+      {access_token: {token: 'somethingelse'}},
+      {access_token: {expires_in: 60, token: 'foobar'}, user: {email: 'foo@bar.com'}},
+      {},
+    ])
 
     const {stderr, stdout} = await runCommand(Token, [])
 
@@ -53,13 +58,11 @@ describe('auth:token', function () {
   })
 
   it('shows AT2 token generation warning for internal users', async function () {
-    api
-      .get('/oauth/authorizations')
-      .reply(200, [
-        {access_token: {token: 'somethingelse'}},
-        {access_token: {expires_in: 60, token: 'foobar'}, user: {email: 'foo@heroku.com'}},
-        {},
-      ])
+    fakePlatform.oauthAuthorization.list.resolves([
+      {access_token: {token: 'somethingelse'}},
+      {access_token: {expires_in: 60, token: 'foobar'}, user: {email: 'foo@heroku.com'}},
+      {},
+    ])
 
     const {stderr, stdout} = await runCommand(Token, [])
 

--- a/test/unit/commands/auth/whoami.unit.test.ts
+++ b/test/unit/commands/auth/whoami.unit.test.ts
@@ -1,51 +1,56 @@
 import {APIClient} from '@heroku-cli/command'
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
-import {restore, stub} from 'sinon'
+import {restore, SinonStub, stub} from 'sinon'
 
 import Whoami from '../../../../src/commands/auth/whoami.js'
 
+type FakePlatform = {
+  account: {info: SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    account: {info: stub()},
+  }
+}
+
 describe('auth:whoami', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
     stub(APIClient.prototype, 'auth').get(() => 'foobar')
   })
 
   afterEach(function () {
     delete process.env.HEROKU_API_KEY
-    api.done()
-    nock.cleanAll()
     restore()
   })
 
   it('shows user email when logged in', async function () {
-    api
-      .get('/account')
-      .reply(200, {email: 'gandalf@example.com'})
+    fakePlatform.account.info.resolves({email: 'gandalf@example.com'})
 
     const {stdout} = await runCommand(Whoami, [])
 
     expect(stdout).to.equal('gandalf@example.com\n')
+    expect(fakePlatform.account.info.calledOnce).to.equal(true)
   })
 
   it('exits with status 100 when not logged in', async function () {
-    api
-      .get('/account')
-      .reply(401)
+    const error = Object.assign(new Error('Unauthorized'), {statusCode: 401})
+    fakePlatform.account.info.rejects(error)
 
-    const {error} = await runCommand(Whoami, [])
+    const {error: cmdError} = await runCommand(Whoami, [])
 
-    expect(error?.oclif?.exit).to.equal(100)
+    expect(cmdError?.oclif?.exit).to.equal(100)
   })
 
   it('shows a warning when the HEROKU_API_KEY env var is set', async function () {
     process.env.HEROKU_API_KEY = 'foobar'
-    api
-      .get('/account')
-      .reply(200, {email: 'gandalf@example.com'})
+    fakePlatform.account.info.resolves({email: 'gandalf@example.com'})
 
     const {stderr, stdout} = await runCommand(Whoami, [])
 


### PR DESCRIPTION
## Summary
Migrates the following `auth` commands to `@heroku/sdk`:
- `auth/whoami`
- `auth/token`
- `auth/2fa`
- `auth/login`

## Details
- **auth/whoami**: Migrated `GET /account` call to `platform.account.info()`
- **auth/token**: Migrated `GET /oauth/authorizations` call to `platform.oauthAuthorization.list()`
- **auth/2fa**: Migrated `GET /account` call to `platform.account.info()`
- **auth/login**: Migrated `GET /account` call to `platform.account.info()` (login flow itself remains with `APIClient.login()`)

## Not migrated
- **auth/logout**: No HTTP API calls to migrate (only uses `APIClient.logout()` and local credential management)
- **auth/2fa/disable**: Command just errors out; no API calls

## Testing
**Notes:**
The SDK uses heroku-fetch to make API calls, which looks for a netrc file. Therefore, we must login with `HEROKU_NETRC_WRITE=true`.

**Steps:**
1. Pull down this branch
2. `npm i && npm run build`
3. `./bin/run logout`
4. `HEROKU_NETRC_WRITE=true ./bin/run login` — Outputs "logged in as email"
5. `./bin/run whoami` — Outputs "email"
6. `./bin/run auth:token` — Outputs "token"
7. `./bin/run auth:2fa` — Outputs "two-factor authentication is enabled/not enabled"

**Cleanup:**
- `./bin/run logout`

## Related Issues
GUS work item: [W-23373474](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eHI94YAG/view)