### PR TITLE
feat: migrate run commands to @heroku/sdk

### DIFF
--- a/V12-CHANGES.md
+++ b/V12-CHANGES.md
@@ -5,3 +5,8 @@
 - `domains:wait` now shows a single spinner for multiple pending domains: `Waiting for all pending domains... done`
 - `domains:add --wait` no longer shows `Waiting for ${hostname)... done`
 
+## Run commands
+
+- `run`, `run:detached`, and `run:inside` now create dynos through `@heroku/sdk` (`platform.dyno.run`) instead of raw API calls.
+- Release-conflict (`409`) retries during one-off dyno creation are now handled by the SDK; the CLI no longer runs its own retry loop.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -3293,7 +3293,7 @@
     },
     "node_modules/@heroku/sdk": {
       "version": "0.5.1",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#f6f3a42370c099cc7024cedce461418be00e2ed8",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#26993a4607f1eabc01a974e63ac4b263ba28b354",
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku/heroku-fetch": "^0.1.1-beta",

--- a/src/commands/run/index.ts
+++ b/src/commands/run/index.ts
@@ -1,7 +1,7 @@
 import {Command, flags} from '@heroku-cli/command'
 import {DynoSizeCompletion, ProcessTypeCompletion} from '@heroku-cli/command/lib/completions.js'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {ux} from '@oclif/core/ux'
 import debugFactory from 'debug'
 
@@ -56,7 +56,7 @@ export default class Run extends Command {
       throw new Error('Usage: heroku run COMMAND\n\nExample: heroku run bash')
     }
 
-    await this.heroku.get<Heroku.Account>('/account')
+    await new HerokuSDK().platform.account.info()
     const dyno = new Dyno(opts)
     try {
       await dyno.start()

--- a/src/commands/run/index.ts
+++ b/src/commands/run/index.ts
@@ -2,6 +2,7 @@ import {Command, flags} from '@heroku-cli/command'
 import {DynoSizeCompletion, ProcessTypeCompletion} from '@heroku-cli/command/lib/completions.js'
 import * as color from '@heroku/heroku-cli-util/color'
 import {HerokuSDK} from '@heroku/sdk'
+import {dynoExtensions} from '@heroku/sdk/extensions/platform'
 import {ux} from '@oclif/core/ux'
 import debugFactory from 'debug'
 
@@ -38,6 +39,7 @@ export default class Run extends Command {
     const {argv, flags} = await this.parse(Run)
     const command = revertSortedArgs(process.argv, argv as string[])
     const builtCommand = await buildCommandWithLauncher(this.heroku, flags.app, command, flags['no-launcher'])
+    const sdk = new HerokuSDK({extensions: [dynoExtensions]})
     const opts = {
       app: flags.app,
       attach: true,
@@ -48,6 +50,7 @@ export default class Run extends Command {
       listen: flags.listen,
       'no-tty': flags['no-tty'],
       notify: !flags['no-notify'],
+      sdk,
       size: flags.size,
       type: flags.type,
     }
@@ -56,7 +59,7 @@ export default class Run extends Command {
       throw new Error('Usage: heroku run COMMAND\n\nExample: heroku run bash')
     }
 
-    await new HerokuSDK().platform.account.info()
+    await sdk.platform.account.info()
     const dyno = new Dyno(opts)
     try {
       await dyno.start()

--- a/src/lib/run/dyno.ts
+++ b/src/lib/run/dyno.ts
@@ -4,7 +4,6 @@ import {APIClient, type IOptions} from '@heroku-cli/command'
 import {type Notification, notify} from '@heroku-cli/notifications'
 import {Dyno as APIDyno} from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
-import {HTTP} from '@heroku/http-call'
 import {HerokuSDK} from '@heroku/sdk'
 import {dynoExtensions} from '@heroku/sdk/extensions/platform'
 import {ux} from '@oclif/core/ux'
@@ -52,6 +51,7 @@ export default class Dyno extends Duplex {
   p: any
   reject?: (reason?: any) => void
   resolve?: (value?: unknown) => void
+  sdk: HerokuSDK<readonly [typeof dynoExtensions]>
   unpipeStdin: any
   uri?: URL
   useSSH: any
@@ -63,6 +63,7 @@ export default class Dyno extends Duplex {
     this.cork()
     this.opts = opts
     this.heroku = opts.heroku
+    this.sdk = new HerokuSDK({extensions: [dynoExtensions]})
 
     if (this.opts.showStatus === undefined) {
       this.opts.showStatus = true
@@ -124,25 +125,18 @@ export default class Dyno extends Duplex {
     })
   }
 
-  async _doStart(retries = 2): Promise<HTTP<unknown> | undefined> {
-    const command = this.opts['exit-code'] ? `${this.opts.command}; echo "\uFFFF heroku-command-exit-status: $?"` : this.opts.command
-
+  async _doStart(): Promise<void> {
     try {
-      const dyno = await this.heroku.post(this.opts.dyno ? `/apps/${this.opts.app}/dynos/${this.opts.dyno}` : `/apps/${this.opts.app}/dynos`, {
-        body: {
-          attach: this.opts.attach,
-          command,
-          env: this._env(),
-          force_no_tty: this.opts['no-tty'],
-          size: this.opts.size,
-          type: this.opts.type,
-        },
-        headers: {
-          Accept: this.opts.dyno ? 'application/vnd.heroku+json; version=3.run-inside' : 'application/vnd.heroku+json; version=3',
-        },
+      const dyno = await this.sdk.platform.dyno.run(this.opts.app, this.opts.command, {
+        attach: this.opts.attach,
+        dyno: this.opts.dyno,
+        env: this._env(),
+        exitCode: this.opts['exit-code'],
+        forceNoTTY: this.opts['no-tty'],
+        size: this.opts.size,
+        type: this.opts.type,
       })
-      // @ts-ignore
-      this.dyno = dyno.body
+      this.dyno = dyno as APIDyno
 
       // Show status after dyno is created (after any 2FA prompt)
       if (this.opts.showStatus) {
@@ -150,9 +144,7 @@ export default class Dyno extends Duplex {
       }
 
       if (this.opts.attach || this.opts.dyno) {
-        // @ts-ignore
         if (this.dyno.name && this.opts.dyno === undefined) {
-          // @ts-ignore
           this.opts.dyno = this.dyno.name
         }
 
@@ -160,18 +152,6 @@ export default class Dyno extends Duplex {
       } else if (this.opts.showStatus) {
         ux.action.stop(this._status('done'))
       }
-    } catch (error: any) {
-      // Currently the runtime API sends back a 409 in the event the
-      // release isn't found yet. API just forwards this response back to
-      // the client, so we'll need to retry these. This usually
-      // happens when you create an app and immediately try to run a
-      // one-off dyno. No pause between attempts since this is
-      // typically a very short-lived condition.
-      if (error.statusCode === 409 && retries > 0) {
-        return this._doStart(retries - 1)
-      }
-
-      throw error
     } finally {
       ux.action.stop()
     }
@@ -449,7 +429,7 @@ export default class Dyno extends Duplex {
     // (`down` → `idle` → `starting`) was effectively uncapped. The
     // single shared budget here trades that for a hard ceiling;
     // 60s is comfortably above typical shielded-space provisioning.
-    const {platform} = new HerokuSDK({extensions: [dynoExtensions]})
+    const {platform} = this.sdk
     const dyno = await platform.dyno.waitForInfo(this.opts.app, this.opts.dyno!, {
       attempts: 60,
       onPoll: polled => {

--- a/src/lib/run/dyno.ts
+++ b/src/lib/run/dyno.ts
@@ -2,10 +2,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {APIClient, type IOptions} from '@heroku-cli/command'
 import {type Notification, notify} from '@heroku-cli/notifications'
-import {Dyno as APIDyno} from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
 import {HerokuSDK} from '@heroku/sdk'
 import {dynoExtensions} from '@heroku/sdk/extensions/platform'
+import {Dyno as SDKDyno} from '@heroku/types/3.sdk'
 import {ux} from '@oclif/core/ux'
 import debugFactory from 'debug'
 import {spawn} from 'node:child_process'
@@ -32,6 +32,7 @@ export interface DynoOpts {
   'no-tty'?: boolean
   notificationSubtitle?: string
   notify?: boolean
+  sdk?: HerokuSDK<readonly [typeof dynoExtensions]>
   showStatus?: boolean
   size?: string
   type?: string
@@ -44,7 +45,7 @@ interface HerokuApiClientRun extends APIClient {
 }
 
 export default class Dyno extends Duplex {
-  dyno?: APIDyno
+  dyno?: Partial<SDKDyno>
   heroku: HerokuApiClientRun
   input: any
   legacyUri?: {[key: string]: any}
@@ -63,7 +64,7 @@ export default class Dyno extends Duplex {
     this.cork()
     this.opts = opts
     this.heroku = opts.heroku
-    this.sdk = new HerokuSDK({extensions: [dynoExtensions]})
+    this.sdk = opts.sdk ?? new HerokuSDK({extensions: [dynoExtensions]})
 
     if (this.opts.showStatus === undefined) {
       this.opts.showStatus = true
@@ -136,7 +137,7 @@ export default class Dyno extends Duplex {
         size: this.opts.size,
         type: this.opts.type,
       })
-      this.dyno = dyno as APIDyno
+      this.dyno = dyno
 
       // Show status after dyno is created (after any 2FA prompt)
       if (this.opts.showStatus) {
@@ -433,13 +434,13 @@ export default class Dyno extends Duplex {
     const dyno = await platform.dyno.waitForInfo(this.opts.app, this.opts.dyno!, {
       attempts: 60,
       onPoll: polled => {
-        this.dyno = polled as APIDyno
+        this.dyno = polled
         if (this.opts.showStatus) {
           ux.action.status = this._status(polled.state)
         }
       },
       states: ['starting', 'up'],
-    }) as APIDyno
+    })
     // `this.dyno` was already updated by the final `onPoll` (the
     // helper fires onPoll before the state check returns), but the
     // helper's return value is the canonical reference; assign it

--- a/test/unit/commands/run/detached.unit.test.ts
+++ b/test/unit/commands/run/detached.unit.test.ts
@@ -1,18 +1,35 @@
 /* eslint-disable n/no-unsupported-features/node-builtins */
 
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
 import nock from 'nock'
+import * as sinon from 'sinon'
 
 import RunDetached from '../../../../src/commands/run/detached.js'
 
+type FakePlatform = {
+  dyno: {run: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    dyno: {run: sinon.stub()},
+  }
+}
+
 describe('run:detached', function () {
+  let fakePlatform: FakePlatform
+
   beforeEach(function () {
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
     nock.cleanAll()
     nock.disableNetConnect()
   })
 
   afterEach(function () {
+    sinon.restore()
     nock.enableNetConnect()
   })
 
@@ -32,21 +49,18 @@ describe('run:detached', function () {
     nock('https://api.heroku.com')
       .get('/apps/myapp')
       .reply(200, {name: 'myapp', stack: {name: 'heroku-20'}})
-      .post('/apps/myapp/dynos', body => {
-        expect(body.attach).to.equal(false)
-        return true
-      })
-      .reply(201, {
-        attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
-        command: 'echo test',
-        created_at: '2020-01-01T00:00:00Z',
-        id: '12345678-1234-1234-1234-123456789012',
-        name: 'run.1234',
-        size: 'basic',
-        state: 'starting',
-        type: 'run',
-        updated_at: '2020-01-01T00:00:00Z',
-      })
+
+    fakePlatform.dyno.run.resolves({
+      attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
+      command: 'echo test',
+      created_at: '2020-01-01T00:00:00Z',
+      id: '12345678-1234-1234-1234-123456789012',
+      name: 'run.1234',
+      size: 'basic',
+      state: 'starting',
+      type: 'run',
+      updated_at: '2020-01-01T00:00:00Z',
+    })
 
     const {stderr} = await runCommand(RunDetached, [
       '--app',
@@ -56,27 +70,16 @@ describe('run:detached', function () {
     ])
     // The command should output a message about viewing logs
     expect(stderr).to.match(/Run.*heroku logs|Running.*done/)
+
+    expect(fakePlatform.dyno.run.calledOnce).to.equal(true)
+    const options = fakePlatform.dyno.run.firstCall.args[2]
+    expect(options.attach).to.equal(false)
   })
 
   it('streams logs when --tail is specified', async function () {
     nock('https://api.heroku.com')
       .get('/apps/myapp')
       .reply(200, {name: 'myapp', stack: {name: 'heroku-20'}})
-      .post('/apps/myapp/dynos', body => {
-        expect(body.attach).to.equal(false)
-        return true
-      })
-      .reply(201, {
-        attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
-        command: 'echo test',
-        created_at: '2020-01-01T00:00:00Z',
-        id: '12345678-1234-1234-1234-123456789012',
-        name: 'run.1234',
-        size: 'basic',
-        state: 'starting',
-        type: 'run',
-        updated_at: '2020-01-01T00:00:00Z',
-      })
       .get('/apps/myapp')
       .reply(200, {name: 'myapp', stack: {name: 'heroku-20'}})
       .post('/apps/myapp/log-sessions', body => {
@@ -87,6 +90,18 @@ describe('run:detached', function () {
       .reply(200, {
         logplex_url: 'https://logs.example.com/logs',
       })
+
+    fakePlatform.dyno.run.resolves({
+      attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
+      command: 'echo test',
+      created_at: '2020-01-01T00:00:00Z',
+      id: '12345678-1234-1234-1234-123456789012',
+      name: 'run.1234',
+      size: 'basic',
+      state: 'starting',
+      type: 'run',
+      updated_at: '2020-01-01T00:00:00Z',
+    })
 
     // Mock EventSource for log streaming
     const originalEventSource = globalThis.EventSource
@@ -107,9 +122,12 @@ describe('run:detached', function () {
         'echo',
         'test',
       ])
-      // Expected to fail when trying to connect to logs
     } finally {
       globalThis.EventSource = originalEventSource
     }
+
+    expect(fakePlatform.dyno.run.calledOnce).to.equal(true)
+    const options = fakePlatform.dyno.run.firstCall.args[2]
+    expect(options.attach).to.equal(false)
   })
 })

--- a/test/unit/commands/run/detached.unit.test.ts
+++ b/test/unit/commands/run/detached.unit.test.ts
@@ -1,12 +1,12 @@
 /* eslint-disable n/no-unsupported-features/node-builtins */
 
 import {runCommand} from '@heroku-cli/test-utils'
-import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
 import nock from 'nock'
 import * as sinon from 'sinon'
 
 import RunDetached from '../../../../src/commands/run/detached.js'
+import {type MockSDK, mockSDKPlatform} from '../../../helpers/mock-sdk.js'
 
 type FakePlatform = {
   dyno: {run: sinon.SinonStub}
@@ -20,16 +20,17 @@ function buildFakePlatform(): FakePlatform {
 
 describe('run:detached', function () {
   let fakePlatform: FakePlatform
+  let sdkMock: MockSDK
 
   beforeEach(function () {
     fakePlatform = buildFakePlatform()
-    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
+    sdkMock = mockSDKPlatform(fakePlatform)
     nock.cleanAll()
     nock.disableNetConnect()
   })
 
   afterEach(function () {
-    sinon.restore()
+    sdkMock.restore()
     nock.enableNetConnect()
   })
 

--- a/test/unit/commands/run/index.unit.test.ts
+++ b/test/unit/commands/run/index.unit.test.ts
@@ -1,10 +1,10 @@
 import {runCommand} from '@heroku-cli/test-utils'
-import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
 import nock from 'nock'
 import * as sinon from 'sinon'
 
 import Run from '../../../../src/commands/run/index.js'
+import {type MockSDK, mockSDKPlatform} from '../../../helpers/mock-sdk.js'
 
 type FakePlatform = {
   account: {info: sinon.SinonStub}
@@ -21,7 +21,7 @@ function buildFakePlatform(): FakePlatform {
 describe('run', function () {
   const originalProcessArgv = [...process.argv]
   let fakePlatform: FakePlatform
-  let sandbox: sinon.SinonSandbox
+  let sdkMock: MockSDK
 
   const runWithCliArgv = async (args: string[]) => {
     process.argv = [
@@ -35,9 +35,8 @@ describe('run', function () {
   }
 
   beforeEach(function () {
-    sandbox = sinon.createSandbox()
     fakePlatform = buildFakePlatform()
-    sandbox.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform as unknown as HerokuSDK['platform'])
+    sdkMock = mockSDKPlatform(fakePlatform)
     nock.cleanAll()
     nock.disableNetConnect()
   })
@@ -45,7 +44,7 @@ describe('run', function () {
   afterEach(function () {
     nock.enableNetConnect()
     process.argv = [...originalProcessArgv]
-    sandbox.restore()
+    sdkMock.restore()
   })
 
   it('requires a command', async function () {
@@ -53,12 +52,11 @@ describe('run', function () {
       .get('/apps/myapp')
       .reply(200, {name: 'myapp', stack: {name: 'heroku-20'}})
 
-    await runCommand(Run, [
+    const {error} = await runCommand(Run, [
       '--app',
       'myapp',
-    ]).catch(error => {
-      expect(error.message).to.include('Usage: heroku run COMMAND')
-    })
+    ])
+    expect(error?.message).to.include('Usage: heroku run COMMAND')
   })
 
   it('creates and attaches to a dyno', async function () {
@@ -109,15 +107,14 @@ describe('run', function () {
       updated_at: '2020-01-01T00:00:00Z',
     })
 
-    await runWithCliArgv([
+    const {error} = await runWithCliArgv([
       '--app',
       'myapp',
       '--exit-code',
       'false',
-    ]).catch(error => {
-      // Expected to fail with exit code 1 or connection error
-      expect(error).to.exist
-    })
+    ])
+    // Expected to fail with exit code 1 or connection error
+    expect(error).to.exist
   })
 
   it('respects --no-launcher flag', async function () {

--- a/test/unit/commands/run/index.unit.test.ts
+++ b/test/unit/commands/run/index.unit.test.ts
@@ -1,13 +1,27 @@
-import {prompter} from '@heroku-cli/command'
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
 import nock from 'nock'
 import * as sinon from 'sinon'
 
 import Run from '../../../../src/commands/run/index.js'
 
+type FakePlatform = {
+  account: {info: sinon.SinonStub}
+  dyno: {run: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    account: {info: sinon.stub()},
+    dyno: {run: sinon.stub()},
+  }
+}
+
 describe('run', function () {
   const originalProcessArgv = [...process.argv]
+  let fakePlatform: FakePlatform
+  let sandbox: sinon.SinonSandbox
 
   const runWithCliArgv = async (args: string[]) => {
     process.argv = [
@@ -21,6 +35,9 @@ describe('run', function () {
   }
 
   beforeEach(function () {
+    sandbox = sinon.createSandbox()
+    fakePlatform = buildFakePlatform()
+    sandbox.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform as unknown as HerokuSDK['platform'])
     nock.cleanAll()
     nock.disableNetConnect()
   })
@@ -28,7 +45,7 @@ describe('run', function () {
   afterEach(function () {
     nock.enableNetConnect()
     process.argv = [...originalProcessArgv]
-    sinon.restore()
+    sandbox.restore()
   })
 
   it('requires a command', async function () {
@@ -46,58 +63,53 @@ describe('run', function () {
 
   it('creates and attaches to a dyno', async function () {
     nock('https://api.heroku.com')
-      .get('/account')
-      .reply(200, {email: 'test@example.com'})
       .get('/apps/myapp')
       .reply(200, {name: 'myapp', stack: {name: 'heroku-20'}})
-      .post('/apps/myapp/dynos', body => {
-        expect(body.attach).to.equal(true)
-        return true
-      })
-      .reply(201, {
-        attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
-        command: 'echo test',
-        created_at: '2020-01-01T00:00:00Z',
-        id: '12345678-1234-1234-1234-123456789012',
-        name: 'run.1234',
-        size: 'basic',
-        state: 'starting',
-        type: 'run',
-        updated_at: '2020-01-01T00:00:00Z',
-      })
 
-    // The command will try to connect to rendezvous, which will fail
-    // but we can verify the API calls were made correctly
-    await runCommand(Run, [
-      '--app',
-      'myapp',
-      'echo',
-      'test',
-    ]).catch(() => {
-      // Expected to fail when trying to connect
+    fakePlatform.account.info.resolves({email: 'test@example.com'})
+    fakePlatform.dyno.run.resolves({
+      attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
+      command: 'echo test',
+      created_at: '2020-01-01T00:00:00Z',
+      id: '12345678-1234-1234-1234-123456789012',
+      name: 'run.1234',
+      size: 'basic',
+      state: 'starting',
+      type: 'run',
+      updated_at: '2020-01-01T00:00:00Z',
     })
+
+    await runWithCliArgv(['--app', 'myapp', 'echo', 'test']).catch(() => {
+      // Expected to fail when trying to connect to rendezvous
+    })
+
+    expect(fakePlatform.account.info.calledOnce).to.equal(true)
+    expect(fakePlatform.dyno.run.calledOnce).to.equal(true)
+    const [appId, command, options] = fakePlatform.dyno.run.firstCall.args
+    expect(appId).to.equal('myapp')
+    expect(command).to.equal('echo test')
+    expect(options.attach).to.equal(true)
   })
 
   it('handles exit codes when --exit-code is specified', async function () {
     nock('https://api.heroku.com')
-      .get('/account')
-      .reply(200, {email: 'test@example.com'})
       .get('/apps/myapp')
       .reply(200, {name: 'myapp', stack: {name: 'heroku-20'}})
-      .post('/apps/myapp/dynos')
-      .reply(201, {
-        attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
-        command: 'false; echo "\uFFFF heroku-command-exit-status: 1"',
-        created_at: '2020-01-01T00:00:00Z',
-        id: '12345678-1234-1234-1234-123456789012',
-        name: 'run.1234',
-        size: 'basic',
-        state: 'starting',
-        type: 'run',
-        updated_at: '2020-01-01T00:00:00Z',
-      })
 
-    await runCommand(Run, [
+    fakePlatform.account.info.resolves({email: 'test@example.com'})
+    fakePlatform.dyno.run.resolves({
+      attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
+      command: 'false; echo "\uFFFF heroku-command-exit-status: 1"',
+      created_at: '2020-01-01T00:00:00Z',
+      id: '12345678-1234-1234-1234-123456789012',
+      name: 'run.1234',
+      size: 'basic',
+      state: 'starting',
+      type: 'run',
+      updated_at: '2020-01-01T00:00:00Z',
+    })
+
+    await runWithCliArgv([
       '--app',
       'myapp',
       '--exit-code',
@@ -110,24 +122,23 @@ describe('run', function () {
 
   it('respects --no-launcher flag', async function () {
     nock('https://api.heroku.com')
-      .get('/account')
-      .reply(200, {email: 'test@example.com'})
       .get('/apps/myapp')
       .reply(200, {name: 'myapp', stack: {name: 'cnb'}})
-      .post('/apps/myapp/dynos')
-      .reply(201, {
-        attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
-        command: 'echo test',
-        created_at: '2020-01-01T00:00:00Z',
-        id: '12345678-1234-1234-1234-123456789012',
-        name: 'run.1234',
-        size: 'basic',
-        state: 'starting',
-        type: 'run',
-        updated_at: '2020-01-01T00:00:00Z',
-      })
 
-    await runCommand(Run, [
+    fakePlatform.account.info.resolves({email: 'test@example.com'})
+    fakePlatform.dyno.run.resolves({
+      attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
+      command: 'echo test',
+      created_at: '2020-01-01T00:00:00Z',
+      id: '12345678-1234-1234-1234-123456789012',
+      name: 'run.1234',
+      size: 'basic',
+      state: 'starting',
+      type: 'run',
+      updated_at: '2020-01-01T00:00:00Z',
+    })
+
+    await runWithCliArgv([
       '--app',
       'myapp',
       '--no-launcher',
@@ -138,45 +149,9 @@ describe('run', function () {
     })
   })
 
-  it('prompts for 2FA via prompter and retries with Heroku-Two-Factor-Code header on 403 two_factor', async function () {
-    const promptStub = sinon.stub(prompter, 'prompt').resolves({factor: '123456'})
-
-    const api = nock('https://api.heroku.com')
-      .get('/apps/myapp')
-      .reply(200, {name: 'myapp', stack: {name: 'heroku-20'}})
-      .get('/account')
-      .reply(403, {id: 'two_factor', message: 'Two-factor code required'})
-      .get('/account', undefined, {reqheaders: {'heroku-two-factor-code': '123456'}})
-      .reply(200, {email: 'test@example.com'})
-      .post('/apps/myapp/dynos')
-      .reply(201, {
-        attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
-        command: 'echo test',
-        created_at: '2020-01-01T00:00:00Z',
-        id: '12345678-1234-1234-1234-123456789012',
-        name: 'run.1234',
-        size: 'basic',
-        state: 'starting',
-        type: 'run',
-        updated_at: '2020-01-01T00:00:00Z',
-      })
-
-    await runWithCliArgv([
-      '--app',
-      'myapp',
-      'echo',
-      'test',
-    ]).catch(() => {
-      // Expected to fail when trying to connect to rendezvous
-    })
-
-    expect(promptStub.calledOnce, 'prompter.prompt should be called exactly once').to.be.true
-    expect(promptStub.firstCall.args[0]).to.deep.equal([{
-      mask: '*',
-      message: 'Two-factor code',
-      name: 'factor',
-      type: 'password',
-    }])
-    expect(api.isDone(), 'all expected requests including the 2FA-retried /account should be made').to.be.true
-  })
+  // NOTE: Integration test needed for 2FA prompting behavior.
+  // The SDK stub is above the credentials layer, so unit tests can't verify
+  // that the prompter fires on 403 two_factor responses. The SDK's
+  // HerokuApiClient (via @heroku/heroku-fetch) does handle 2FA the same way
+  // as the legacy this.heroku client, but this requires integration coverage.
 })

--- a/test/unit/commands/run/inside.unit.test.ts
+++ b/test/unit/commands/run/inside.unit.test.ts
@@ -1,10 +1,23 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
 import nock from 'nock'
+import * as sinon from 'sinon'
 
 import RunInside from '../../../../src/commands/run/inside.js'
 
+type FakePlatform = {
+  dyno: {run: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    dyno: {run: sinon.stub()},
+  }
+}
+
 describe('run:inside', function () {
+  let fakePlatform: FakePlatform
   const originalProcessArgv = [...process.argv]
 
   const runWithCliArgv = async (args: string[]) => {
@@ -19,11 +32,14 @@ describe('run:inside', function () {
   }
 
   beforeEach(function () {
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
     nock.cleanAll()
     nock.disableNetConnect()
   })
 
   afterEach(function () {
+    sinon.restore()
     nock.enableNetConnect()
     process.argv = [...originalProcessArgv]
   })
@@ -46,21 +62,18 @@ describe('run:inside', function () {
     nock('https://api.heroku.com')
       .get('/apps/myapp')
       .reply(200, {name: 'myapp', stack: {name: 'heroku-20'}})
-      .post('/apps/myapp/dynos/web.1', body => {
-        expect(body.command).to.equal('bash')
-        return true
-      })
-      .reply(201, {
-        attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
-        command: 'bash',
-        created_at: '2020-01-01T00:00:00Z',
-        id: '12345678-1234-1234-1234-123456789012',
-        name: 'web.1',
-        size: 'basic',
-        state: 'starting',
-        type: 'web',
-        updated_at: '2020-01-01T00:00:00Z',
-      })
+
+    fakePlatform.dyno.run.resolves({
+      attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
+      command: 'bash',
+      created_at: '2020-01-01T00:00:00Z',
+      id: '12345678-1234-1234-1234-123456789012',
+      name: 'web.1',
+      size: 'basic',
+      state: 'starting',
+      type: 'web',
+      updated_at: '2020-01-01T00:00:00Z',
+    })
 
     await runWithCliArgv([
       'web.1',
@@ -70,24 +83,30 @@ describe('run:inside', function () {
     ]).catch(() => {
       // Expected to fail when trying to connect
     })
+
+    expect(fakePlatform.dyno.run.calledOnce).to.equal(true)
+    const [appId, command, options] = fakePlatform.dyno.run.firstCall.args
+    expect(appId).to.equal('myapp')
+    expect(command).to.equal('bash')
+    expect(options.dyno).to.equal('web.1')
   })
 
   it('handles exit codes when --exit-code is specified', async function () {
     nock('https://api.heroku.com')
       .get('/apps/myapp')
       .reply(200, {name: 'myapp', stack: {name: 'heroku-20'}})
-      .post('/apps/myapp/dynos/web.1')
-      .reply(201, {
-        attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
-        command: 'false; echo "\uFFFF heroku-command-exit-status: 1"',
-        created_at: '2020-01-01T00:00:00Z',
-        id: '12345678-1234-1234-1234-123456789012',
-        name: 'web.1',
-        size: 'basic',
-        state: 'starting',
-        type: 'web',
-        updated_at: '2020-01-01T00:00:00Z',
-      })
+
+    fakePlatform.dyno.run.resolves({
+      attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
+      command: 'false; echo "\uFFFF heroku-command-exit-status: 1"',
+      created_at: '2020-01-01T00:00:00Z',
+      id: '12345678-1234-1234-1234-123456789012',
+      name: 'web.1',
+      size: 'basic',
+      state: 'starting',
+      type: 'web',
+      updated_at: '2020-01-01T00:00:00Z',
+    })
 
     await runWithCliArgv([
       'web.1',
@@ -105,21 +124,18 @@ describe('run:inside', function () {
     nock('https://api.heroku.com')
       .get('/apps/myapp')
       .reply(200, {name: 'myapp', stack: {name: 'cnb'}})
-      .post('/apps/myapp/dynos/web.1', body => {
-        expect(body.command).to.equal('bash')
-        return true
-      })
-      .reply(201, {
-        attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
-        command: 'bash',
-        created_at: '2020-01-01T00:00:00Z',
-        id: '12345678-1234-1234-1234-123456789012',
-        name: 'web.1',
-        size: 'basic',
-        state: 'starting',
-        type: 'web',
-        updated_at: '2020-01-01T00:00:00Z',
-      })
+
+    fakePlatform.dyno.run.resolves({
+      attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
+      command: 'bash',
+      created_at: '2020-01-01T00:00:00Z',
+      id: '12345678-1234-1234-1234-123456789012',
+      name: 'web.1',
+      size: 'basic',
+      state: 'starting',
+      type: 'web',
+      updated_at: '2020-01-01T00:00:00Z',
+    })
 
     await runWithCliArgv([
       'web.1',
@@ -130,27 +146,28 @@ describe('run:inside', function () {
     ]).catch(() => {
       // Expected to fail when trying to connect
     })
+
+    expect(fakePlatform.dyno.run.calledOnce).to.equal(true)
+    const command = fakePlatform.dyno.run.firstCall.args[1]
+    expect(command).to.not.include('launcher')
   })
 
   it('prepends launcher by default on cnb apps', async function () {
     nock('https://api.heroku.com')
       .get('/apps/myapp')
       .reply(200, {name: 'myapp', stack: {name: 'cnb'}})
-      .post('/apps/myapp/dynos/web.1', body => {
-        expect(body.command).to.equal('launcher bash')
-        return true
-      })
-      .reply(201, {
-        attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
-        command: 'launcher bash',
-        created_at: '2020-01-01T00:00:00Z',
-        id: '12345678-1234-1234-1234-123456789012',
-        name: 'web.1',
-        size: 'basic',
-        state: 'starting',
-        type: 'web',
-        updated_at: '2020-01-01T00:00:00Z',
-      })
+
+    fakePlatform.dyno.run.resolves({
+      attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
+      command: 'launcher bash',
+      created_at: '2020-01-01T00:00:00Z',
+      id: '12345678-1234-1234-1234-123456789012',
+      name: 'web.1',
+      size: 'basic',
+      state: 'starting',
+      type: 'web',
+      updated_at: '2020-01-01T00:00:00Z',
+    })
 
     await runWithCliArgv([
       'web.1',
@@ -160,5 +177,10 @@ describe('run:inside', function () {
     ]).catch(() => {
       // Expected to fail when trying to connect
     })
+
+    expect(fakePlatform.dyno.run.calledOnce).to.equal(true)
+    const [appId, command] = fakePlatform.dyno.run.firstCall.args
+    expect(appId).to.equal('myapp')
+    expect(command).to.include('launcher')
   })
 })

--- a/test/unit/commands/run/inside.unit.test.ts
+++ b/test/unit/commands/run/inside.unit.test.ts
@@ -1,10 +1,10 @@
 import {runCommand} from '@heroku-cli/test-utils'
-import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
 import nock from 'nock'
 import * as sinon from 'sinon'
 
 import RunInside from '../../../../src/commands/run/inside.js'
+import {type MockSDK, mockSDKPlatform} from '../../../helpers/mock-sdk.js'
 
 type FakePlatform = {
   dyno: {run: sinon.SinonStub}
@@ -18,6 +18,7 @@ function buildFakePlatform(): FakePlatform {
 
 describe('run:inside', function () {
   let fakePlatform: FakePlatform
+  let sdkMock: MockSDK
   const originalProcessArgv = [...process.argv]
 
   const runWithCliArgv = async (args: string[]) => {
@@ -33,13 +34,13 @@ describe('run:inside', function () {
 
   beforeEach(function () {
     fakePlatform = buildFakePlatform()
-    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
+    sdkMock = mockSDKPlatform(fakePlatform)
     nock.cleanAll()
     nock.disableNetConnect()
   })
 
   afterEach(function () {
-    sinon.restore()
+    sdkMock.restore()
     nock.enableNetConnect()
     process.argv = [...originalProcessArgv]
   })
@@ -49,13 +50,12 @@ describe('run:inside', function () {
       .get('/apps/myapp')
       .reply(200, {name: 'myapp', stack: {name: 'heroku-20'}})
 
-    await runWithCliArgv([
+    const {error} = await runWithCliArgv([
       '--app',
       'myapp',
-    ]).catch(error => {
-      expect(error.message).to.include('Missing')
-      expect(error.message).to.include('dyno_name')
-    })
+    ])
+    expect(error?.message).to.include('Missing')
+    expect(error?.message).to.include('dyno_name')
   })
 
   it('runs a command inside an existing dyno', async function () {
@@ -108,16 +108,15 @@ describe('run:inside', function () {
       updated_at: '2020-01-01T00:00:00Z',
     })
 
-    await runWithCliArgv([
+    const {error} = await runWithCliArgv([
       'web.1',
       'false',
       '--app',
       'myapp',
       '--exit-code',
-    ]).catch(error => {
-      // Expected to fail with exit code 1 or connection error
-      expect(error).to.exist
-    })
+    ])
+    // Expected to fail with exit code 1 or connection error
+    expect(error).to.exist
   })
 
   it('respects --no-launcher flag', async function () {

--- a/test/unit/lib/run/dyno.unit.test.ts
+++ b/test/unit/lib/run/dyno.unit.test.ts
@@ -467,6 +467,27 @@ describe('Dyno', function () {
 
       expect(caught).to.equal(failure)
     })
+
+    it('propagates 409 errors without local retry (SDK owns the 409 retry loop)', async function () {
+      const failure = Object.assign(new Error('release not found yet'), {statusCode: 409})
+      runStub.rejects(failure)
+      const opts: DynoOpts = {
+        app: 'my-app',
+        command: 'bash',
+        heroku: mockHeroku,
+        showStatus: false,
+      }
+      const dyno = new Dyno(opts)
+      let caught: unknown
+      try {
+        await dyno._doStart()
+      } catch (error) {
+        caught = error
+      }
+
+      expect(caught).to.equal(failure)
+      expect(runStub.calledOnce).to.equal(true)
+    })
   })
 
   describe('_ssh', function () {

--- a/test/unit/lib/run/dyno.unit.test.ts
+++ b/test/unit/lib/run/dyno.unit.test.ts
@@ -5,6 +5,17 @@ import * as sinon from 'sinon'
 
 import Dyno, {DynoOpts} from '../../../../src/lib/run/dyno.js'
 
+function buildSshDyno(mockHeroku: APIClient): Dyno {
+  const opts: DynoOpts = {
+    app: 'my-app',
+    command: 'bash',
+    dyno: 'run.1234',
+    heroku: mockHeroku,
+    showStatus: false,
+  }
+  return new Dyno(opts)
+}
+
 describe('Dyno', function () {
   let sandbox: sinon.SinonSandbox
   let mockHeroku: APIClient
@@ -327,6 +338,137 @@ describe('Dyno', function () {
     })
   })
 
+  describe('_doStart', function () {
+    let runStub: sinon.SinonStub
+    let attachStub: sinon.SinonStub
+
+    beforeEach(function () {
+      runStub = sandbox.stub()
+      const fakePlatform = {
+        dyno: {run: runStub, waitForInfo: sandbox.stub()},
+      }
+      sandbox.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
+      // The attach path opens a real socket; stub it so the test never
+      // dials a network endpoint.
+      attachStub = sandbox.stub(Dyno.prototype, 'attach' as keyof Dyno).resolves()
+    })
+
+    it('calls platform.dyno.run with the app, command, and mapped options for a one-off dyno', async function () {
+      runStub.resolves({
+        attach_url: 'rendezvous://rendezvous.runtime.heroku.com:5000',
+        name: 'run.1234',
+        size: 'Standard-1X',
+        state: 'starting',
+      })
+      const opts: DynoOpts = {
+        app: 'my-app',
+        attach: true,
+        command: 'bash',
+        env: 'FOO=bar',
+        'exit-code': true,
+        heroku: mockHeroku,
+        'no-tty': true,
+        showStatus: false,
+        size: 'Standard-1X',
+        type: 'run',
+      }
+      const dyno = new Dyno(opts)
+      await dyno._doStart()
+
+      expect(runStub.calledOnce).to.equal(true)
+      const [appId, command, options] = runStub.firstCall.args
+      expect(appId).to.equal('my-app')
+      expect(command).to.equal('bash')
+      expect(options).to.include({
+        attach: true,
+        exitCode: true,
+        forceNoTTY: true,
+        size: 'Standard-1X',
+        type: 'run',
+      })
+      expect(options.env).to.have.property('FOO', 'bar')
+      expect(options.env).to.have.property('TERM')
+    })
+
+    it('passes options.dyno for the exec-inside variant', async function () {
+      runStub.resolves({name: 'web.1', size: 'Standard-1X', state: 'up'})
+      const opts: DynoOpts = {
+        app: 'my-app',
+        command: 'bash',
+        dyno: 'web.1',
+        heroku: mockHeroku,
+        showStatus: false,
+      }
+      const dyno = new Dyno(opts)
+      await dyno._doStart()
+
+      expect(runStub.calledOnce).to.equal(true)
+      const options = runStub.firstCall.args[2]
+      expect(options.dyno).to.equal('web.1')
+    })
+
+    it('stores the returned dyno on this.dyno and calls attach() when opts.attach is true', async function () {
+      const returned = {
+        attach_url: 'rendezvous://x:5000',
+        name: 'run.1234',
+        size: 'Standard-1X',
+        state: 'starting',
+      }
+      runStub.resolves(returned)
+      const opts: DynoOpts = {
+        app: 'my-app',
+        attach: true,
+        command: 'bash',
+        heroku: mockHeroku,
+        showStatus: false,
+      }
+      const dyno = new Dyno(opts)
+      await dyno._doStart()
+
+      expect(dyno.dyno).to.deep.equal(returned)
+      expect(attachStub.calledOnce).to.equal(true)
+    })
+
+    it('does not call attach() when opts.attach is false and opts.dyno is unset', async function () {
+      runStub.resolves({
+        name: 'run.1234',
+        size: 'Standard-1X',
+        state: 'starting',
+      })
+      const opts: DynoOpts = {
+        app: 'my-app',
+        attach: false,
+        command: 'bash',
+        heroku: mockHeroku,
+        showStatus: false,
+      }
+      const dyno = new Dyno(opts)
+      await dyno._doStart()
+
+      expect(attachStub.called).to.equal(false)
+    })
+
+    it('propagates non-409 errors from platform.dyno.run', async function () {
+      const failure = new Error('platform down')
+      runStub.rejects(failure)
+      const opts: DynoOpts = {
+        app: 'my-app',
+        command: 'bash',
+        heroku: mockHeroku,
+        showStatus: false,
+      }
+      const dyno = new Dyno(opts)
+      let caught: unknown
+      try {
+        await dyno._doStart()
+      } catch (error) {
+        caught = error
+      }
+
+      expect(caught).to.equal(failure)
+    })
+  })
+
   describe('_ssh', function () {
     let waitForInfoStub: sinon.SinonStub
     let connectStub: sinon.SinonStub
@@ -334,7 +476,7 @@ describe('Dyno', function () {
     beforeEach(function () {
       waitForInfoStub = sandbox.stub()
       const fakePlatform = {
-        dyno: {waitForInfo: waitForInfoStub},
+        dyno: {run: sandbox.stub(), waitForInfo: waitForInfoStub},
       }
       sandbox.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
       // _connect opens a TLS socket; stub it so the test never tries
@@ -342,21 +484,10 @@ describe('Dyno', function () {
       connectStub = sandbox.stub(Dyno.prototype, '_connect' as keyof Dyno).resolves('connected')
     })
 
-    function buildSshDyno(): Dyno {
-      const opts: DynoOpts = {
-        app: 'my-app',
-        command: 'bash',
-        dyno: 'run.1234',
-        heroku: mockHeroku,
-        showStatus: false,
-      }
-      return new Dyno(opts)
-    }
-
     it('calls waitForInfo with the runnable-state filter and forwards app+dyno args', async function () {
       waitForInfoStub.resolves({name: 'run.1234', size: 'Standard-1X', state: 'up'})
 
-      const dyno = buildSshDyno()
+      const dyno = buildSshDyno(mockHeroku)
       await dyno._ssh()
 
       expect(waitForInfoStub.calledOnce).to.equal(true)
@@ -376,7 +507,7 @@ describe('Dyno', function () {
         return finalDyno
       })
 
-      const dyno = buildSshDyno()
+      const dyno = buildSshDyno(mockHeroku)
       await dyno._ssh()
 
       expect(dyno.dyno).to.deep.equal(finalDyno)
@@ -385,7 +516,7 @@ describe('Dyno', function () {
     it('connects after the dyno reaches a runnable state', async function () {
       waitForInfoStub.resolves({name: 'run.1234', size: 'Standard-1X', state: 'starting'})
 
-      const dyno = buildSshDyno()
+      const dyno = buildSshDyno(mockHeroku)
       const result = await dyno._ssh()
 
       expect(connectStub.calledOnce).to.equal(true)
@@ -396,7 +527,7 @@ describe('Dyno', function () {
       const failure = new Error('platform unreachable')
       waitForInfoStub.rejects(failure)
 
-      const dyno = buildSshDyno()
+      const dyno = buildSshDyno(mockHeroku)
       let caught: unknown
       try {
         await dyno._ssh()


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
Migrates the `run`, `run:detached`, and `run:inside` command family off raw `this.heroku` API calls and onto `@heroku/sdk`.

Specifically:
1. Replaces the pre-flight account check with `account.info()` and one-off/exec-inside dyno creation with `platform.dyno.run`.
2. Drops the CLI's manual 409 release-conflict retry loop — the SDK now owns that behavior. A test locks in that `platform.dyno.run` is called exactly once when it rejects with 409, so the pre-SDK retry behavior cannot silently return.
3. Constructs one `HerokuSDK` in `run/index.ts` and passes it to `Dyno` via `opts.sdk` so `account.info()` and `dyno.run` share the same instance instead of instantiating the SDK twice per invocation.
4. Switches `this.dyno` from `@heroku-cli/schema`'s `APIDyno` to `@heroku/types/3.sdk`'s `Dyno` (typed as `Partial<SDKDyno>` to accommodate callers that assign partial shapes) and drops the leftover `as APIDyno` casts.
5. Adopts the shared `mockSDKPlatform` helper across the `run` test suites and switches assertions to `const {error} = await runCommand(...)`.

Note: the `run` unit test no longer exercises the 2FA prompt path because the SDK stub sits above the credentials layer. Integration coverage is needed to preserve that scenario.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [x] **test**: Add/update/remove tests

## Testing
**Notes**:
- Requires an app you can run one-off dynos against.
- The observable behavior (streaming output, exit codes, detached/inside modes) should be unchanged; verify no regressions vs. the pre-SDK path.
- The `run:inside` command requires a fir app with a dyno.

**Steps**:
1. `heroku run -a <app> -- echo hello` — confirm the command runs, streams output, and exits cleanly.
2. `heroku run:detached -a <app> -- sleep 5` — confirm a detached dyno is created and the CLI returns immediately with the dyno name.
3. `heroku run:inside <dyno-name> -a <fir-app-with-dyno> -- ls` — confirm exec-inside connects to a running dyno and streams output.
    - use `heroku ps -a <fir-app-with-dyno>` to get the dyno name

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-23374053](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eHvMxYAK/view)
