### PR TITLE
refactor: use @heroku/sdk for container commands

### DIFF
--- a/V12-CHANGES.md
+++ b/V12-CHANGES.md
@@ -9,6 +9,11 @@
 
 - `certs:add` no longer shows the `Waiting for stable domains to be created...` spinner while domains stabilize; the wait now happens silently before the certificate is associated
 - `certs:add` matches wildcard certificates against your app's domains more strictly: a `*.example.com` certificate now matches only direct subdomains (e.g. `www.example.com`), no longer matching deeper or trailing-suffix domains
+
+## Container commands
+
+- `container:rm` now shows a single spinner for batch removal (for example: `Removing container web, worker, clock and 2 more for example-app... done`)
+
 ## Run commands
 
 - `run`, `run:detached`, and `run:inside` now create dynos through `@heroku/sdk` (`platform.dyno.run`) instead of raw API calls.

--- a/V12-CHANGES.md
+++ b/V12-CHANGES.md
@@ -12,7 +12,7 @@
 
 ## Container commands
 
-- `container:rm` now shows a single spinner for batch removal (for example: `Removing container web, worker, clock and 2 more for example-app... done`)
+- `container:rm` now shows a single spinner for batch removal (for example: `Removing containers web, worker, clock from example-app... done`)
 
 ## Run commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3293,7 +3293,7 @@
     },
     "node_modules/@heroku/sdk": {
       "version": "0.5.1",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#7caff2882af34bff45d1c3bf3914cfad5994fac6",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#de9993dd90a7717db56ccfd2faddda3f4d0a0bb2",
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku/heroku-fetch": "^0.1.1-beta",
@@ -3302,15 +3302,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/@heroku/sdk/node_modules/@heroku/types": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@heroku/types/-/types-4.0.1.tgz",
-      "integrity": "sha512-NLl/ziXj8B/SHX0Q/1fN0U+GiUFhbPGyMqUcg1H/vQ6rGBtdGymj8gtHXWyIaVmH2anxgnC2FQxA7F226EKmNg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@heroku/socksv5": {

--- a/src/commands/container/pull.ts
+++ b/src/commands/container/pull.ts
@@ -1,6 +1,6 @@
 import {Command, flags, vars} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import {color, hux} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
 
 import {debug} from '../../lib/container/debug.js'
 import {DockerHelper} from '../../lib/container/docker-helper.js'
@@ -24,6 +24,7 @@ export default class Pull extends Command {
   dockerHelper = new DockerHelper()
 
   async run() {
+    const {platform} = new HerokuSDK()
     const {argv, flags} = await this.parse(Pull)
     const {app, verbose} = flags
 
@@ -31,7 +32,7 @@ export default class Pull extends Command {
       this.error(`Error: Requires one or more process types\n${Pull.examples.join('\n')}`)
     }
 
-    const {body: appBody} = await this.heroku.get<Heroku.App>(`/apps/${app}`)
+    const appBody = await platform.app.info(app)
     ensureContainerStack(appBody, 'pull')
 
     const registry = `registry.${vars.host}`

--- a/src/commands/container/pull.ts
+++ b/src/commands/container/pull.ts
@@ -1,6 +1,7 @@
 import {Command, flags, vars} from '@heroku-cli/command'
 import {color, hux} from '@heroku/heroku-cli-util'
 import {HerokuSDK} from '@heroku/sdk'
+import {containerExtensions} from '@heroku/sdk/extensions/platform'
 
 import {debug} from '../../lib/container/debug.js'
 import {DockerHelper} from '../../lib/container/docker-helper.js'
@@ -24,7 +25,7 @@ export default class Pull extends Command {
   dockerHelper = new DockerHelper()
 
   async run() {
-    const {platform} = new HerokuSDK()
+    const {platform} = new HerokuSDK({extensions: [containerExtensions]})
     const {argv, flags} = await this.parse(Pull)
     const {app, verbose} = flags
 
@@ -32,8 +33,7 @@ export default class Pull extends Command {
       this.error(`Error: Requires one or more process types\n${Pull.examples.join('\n')}`)
     }
 
-    const appBody = await platform.app.info(app)
-    ensureContainerStack(appBody, 'pull')
+    await ensureContainerStack(platform, app, 'pull')
 
     const registry = `registry.${vars.host}`
 

--- a/src/commands/container/push.ts
+++ b/src/commands/container/push.ts
@@ -1,6 +1,6 @@
 import {Command, flags, vars} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import {color, hux} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
 import {ux} from '@oclif/core/ux'
 
 import {debug} from '../../lib/container/debug.js'
@@ -30,6 +30,7 @@ export default class Push extends Command {
   dockerHelper = new DockerHelper()
 
   async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {argv: processTypes, flags} = await this.parse(Push)
     const {app, arg, 'context-path': contextPath, recursive, verbose} = flags
 
@@ -45,7 +46,7 @@ export default class Push extends Command {
       ux.error('Requires exactly one target process type, or --recursive option', {exit: 1})
     }
 
-    const {body: appBody} = await this.heroku.get<Heroku.App>(`/apps/${app}`)
+    const appBody = await platform.app.info(app)
     ensureContainerStack(appBody, 'push')
 
     const registry = `registry.${vars.host}`

--- a/src/commands/container/push.ts
+++ b/src/commands/container/push.ts
@@ -1,6 +1,7 @@
 import {Command, flags, vars} from '@heroku-cli/command'
 import {color, hux} from '@heroku/heroku-cli-util'
 import {HerokuSDK} from '@heroku/sdk'
+import {containerExtensions} from '@heroku/sdk/extensions/platform'
 import {ux} from '@oclif/core/ux'
 
 import {debug} from '../../lib/container/debug.js'
@@ -30,7 +31,7 @@ export default class Push extends Command {
   dockerHelper = new DockerHelper()
 
   async run(): Promise<void> {
-    const {platform} = new HerokuSDK()
+    const {platform} = new HerokuSDK({extensions: [containerExtensions]})
     const {argv: processTypes, flags} = await this.parse(Push)
     const {app, arg, 'context-path': contextPath, recursive, verbose} = flags
 
@@ -46,8 +47,7 @@ export default class Push extends Command {
       ux.error('Requires exactly one target process type, or --recursive option', {exit: 1})
     }
 
-    const appBody = await platform.app.info(app)
-    ensureContainerStack(appBody, 'push')
+    await ensureContainerStack(platform, app, 'push')
 
     const registry = `registry.${vars.host}`
     const dockerfiles = this.dockerHelper.getDockerfiles(process.cwd(), recursive)

--- a/src/commands/container/release.ts
+++ b/src/commands/container/release.ts
@@ -1,6 +1,7 @@
 import {Command, flags, vars} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
+import {containerExtensions} from '@heroku/sdk/extensions/platform'
 import {ux} from '@oclif/core/ux'
 
 import {debug} from '../../lib/container/debug.js'
@@ -29,6 +30,7 @@ export default class ContainerRelease extends Command {
   static usage = 'container:release'
 
   async run() {
+    const {platform} = new HerokuSDK({extensions: [containerExtensions]})
     const {argv, flags} = await this.parse(ContainerRelease)
     const {app, verbose} = flags
 
@@ -40,8 +42,7 @@ export default class ContainerRelease extends Command {
       debug.enabled = true
     }
 
-    const {body: appBody} = await this.heroku.get<Heroku.App>(`/apps/${app}`)
-    ensureContainerStack(appBody, 'release')
+    await ensureContainerStack(platform, app, 'release')
 
     const updateData: any[] = []
     for (const process of argv) {
@@ -77,25 +78,11 @@ export default class ContainerRelease extends Command {
       })
     }
 
-    const {body: oldReleases} = await this.heroku.get<Heroku.Release[]>(`/apps/${app}/releases`, {
-      headers: {Range: 'version ..; max=1, order=desc'}, partial: true,
-    })
-    const oldRelease = oldReleases[0]
-
     ux.action.start(`Releasing images ${argv.join(',')} to ${app}`)
-    await this.heroku.patch(`/apps/${app}/formation`, {
-      body: {updates: updateData}, headers: {
-        Accept: 'application/vnd.heroku+json; version=3.docker-releases',
-      },
-    })
+    const {newRelease: release, oldRelease} = await platform.container.releaseImages(app, updateData)
     ux.action.stop()
 
-    const {body: updatedReleases} = await this.heroku.get<Heroku.Release[]>(`/apps/${app}/releases`, {
-      headers: {Range: 'version ..; max=1, order=desc'}, partial: true,
-    })
-    const release = updatedReleases[0]
-
-    if ((!oldRelease && !release) || (oldRelease && (oldRelease.id === release.id))) {
+    if (!release || (oldRelease?.id === release.id)) {
       return
     }
 
@@ -104,7 +91,7 @@ export default class ContainerRelease extends Command {
     } else if ((release.status === 'pending') && release.output_stream_url) {
       ux.stdout('Running release command...')
       await streamer(release.output_stream_url, process.stdout)
-      const {body: finishedRelease} = await this.heroku.request<Heroku.Release>(`/apps/${app}/releases/${release.id}`)
+      const finishedRelease = await platform.release.info(app, release.id)
       if (finishedRelease.status === 'failed') {
         ux.error('Error: release command failed', {exit: 1})
       }

--- a/src/commands/container/rm.ts
+++ b/src/commands/container/rm.ts
@@ -32,7 +32,7 @@ export default class Rm extends Command {
     await ensureContainerStack(platform, app, 'rm')
 
     const processTypes = argv as string[]
-    ux.action.start(`Removing containers ${color.name(processTypes.join(', '))} from ${color.app(app)}`)
+    ux.action.start(`Removing containers ${processTypes.join(', ')} from ${color.app(app)}`)
     await platform.container.removeProcessTypes(app, processTypes)
     ux.action.stop()
   }

--- a/src/commands/container/rm.ts
+++ b/src/commands/container/rm.ts
@@ -1,6 +1,7 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
+import {containerExtensions} from '@heroku/sdk/extensions/platform'
 import {ux} from '@oclif/core/ux'
 
 import {ensureContainerStack} from '../../lib/container/helpers.js'
@@ -20,6 +21,7 @@ export default class Rm extends Command {
   static usage = 'container:rm -a APP [-v] PROCESS_TYPE...'
 
   async run() {
+    const {platform} = new HerokuSDK({extensions: [containerExtensions]})
     const {argv, flags} = await this.parse(Rm)
     const {app} = flags
 
@@ -27,18 +29,15 @@ export default class Rm extends Command {
       this.error(`Error: Requires one or more process types\n${Rm.examples.join('\n')}`)
     }
 
-    const {body: appBody} = await this.heroku.get<Heroku.App>(`/apps/${app}`)
-    ensureContainerStack(appBody, 'rm')
+    await ensureContainerStack(platform, app, 'rm')
 
-    for (const process of argv as string[]) {
-      ux.action.start(`Removing container ${process} for ${color.app(app)}`)
-      await this.heroku.patch(`/apps/${app}/formation/${process}`, {
-        body: {docker_image: null},
-        headers: {
-          Accept: 'application/vnd.heroku+json; version=3.docker-releases',
-        },
-      })
-      ux.action.stop()
-    }
+    const processTypes = argv as string[]
+    const processTypesDisplayList = processTypes.length > 3
+      ? `${processTypes.slice(0, 3).join(', ')} and ${processTypes.length - 3} more`
+      : processTypes.join(', ')
+
+    ux.action.start(`Removing container ${color.name(processTypesDisplayList)} for ${color.app(app)}`)
+    await platform.container.removeProcessTypes(app, processTypes)
+    ux.action.stop()
   }
 }

--- a/src/commands/container/rm.ts
+++ b/src/commands/container/rm.ts
@@ -32,11 +32,7 @@ export default class Rm extends Command {
     await ensureContainerStack(platform, app, 'rm')
 
     const processTypes = argv as string[]
-    const processTypesDisplayList = processTypes.length > 3
-      ? `${processTypes.slice(0, 3).join(', ')} and ${processTypes.length - 3} more`
-      : processTypes.join(', ')
-
-    ux.action.start(`Removing container ${color.name(processTypesDisplayList)} for ${color.app(app)}`)
+    ux.action.start(`Removing containers ${color.name(processTypes.join(', '))} from ${color.app(app)}`)
     await platform.container.removeProcessTypes(app, processTypes)
     ux.action.stop()
   }

--- a/src/commands/container/run.ts
+++ b/src/commands/container/run.ts
@@ -1,6 +1,6 @@
 import {Command, flags, vars} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import {color, hux} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
 import {ux} from '@oclif/core/ux'
 
 import {debug} from '../../lib/container/debug.js'
@@ -26,6 +26,7 @@ export default class Run extends Command {
   dockerHelper = new DockerHelper()
 
   async run() {
+    const {platform} = new HerokuSDK()
     const {argv, flags} = await this.parse(Run)
     const {app, port, verbose} = flags
 
@@ -37,7 +38,7 @@ export default class Run extends Command {
       debug.enabled = true
     }
 
-    const {body: appBody} = await this.heroku.get<Heroku.App>(`/apps/${app}`)
+    const appBody = await platform.app.info(app)
     ensureContainerStack(appBody, 'run')
 
     const processType = argv.shift() as string

--- a/src/commands/container/run.ts
+++ b/src/commands/container/run.ts
@@ -1,6 +1,7 @@
 import {Command, flags, vars} from '@heroku-cli/command'
 import {color, hux} from '@heroku/heroku-cli-util'
 import {HerokuSDK} from '@heroku/sdk'
+import {containerExtensions} from '@heroku/sdk/extensions/platform'
 import {ux} from '@oclif/core/ux'
 
 import {debug} from '../../lib/container/debug.js'
@@ -26,7 +27,7 @@ export default class Run extends Command {
   dockerHelper = new DockerHelper()
 
   async run() {
-    const {platform} = new HerokuSDK()
+    const {platform} = new HerokuSDK({extensions: [containerExtensions]})
     const {argv, flags} = await this.parse(Run)
     const {app, port, verbose} = flags
 
@@ -38,8 +39,7 @@ export default class Run extends Command {
       debug.enabled = true
     }
 
-    const appBody = await platform.app.info(app)
-    ensureContainerStack(appBody, 'run')
+    await ensureContainerStack(platform, app, 'run')
 
     const processType = argv.shift() as string
     const command: string = argv.join(' ')

--- a/src/lib/container/helpers.ts
+++ b/src/lib/container/helpers.ts
@@ -1,5 +1,5 @@
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {App} from '@heroku/types/3.sdk'
 import {ux} from '@oclif/core/ux'
 
 const stackLabelMap: {[key: string]: string} = {
@@ -8,11 +8,11 @@ const stackLabelMap: {[key: string]: string} = {
 
 /**
  * Ensure that the given app is a container app.
- * @param app {Heroku.App} heroku app
+ * @param app {App} heroku app
  * @param cmd {String} command name
  * @returns {null} null
  */
-export function ensureContainerStack(app: Heroku.App, cmd: string): void {
+export function ensureContainerStack(app: App, cmd: string): void {
   const buildStack = app.build_stack?.name
   const appStack = app.stack?.name
   const allowedStack = 'container'

--- a/src/lib/container/helpers.ts
+++ b/src/lib/container/helpers.ts
@@ -1,6 +1,9 @@
 import * as color from '@heroku/heroku-cli-util/color'
-import {App} from '@heroku/types/3.sdk'
+import {HerokuSDK} from '@heroku/sdk'
+import {containerExtensions, NotAContainerAppError} from '@heroku/sdk/extensions/platform'
 import {ux} from '@oclif/core/ux'
+
+type Platform = HerokuSDK<[typeof containerExtensions]>['platform']
 
 const stackLabelMap: {[key: string]: string} = {
   cnb: 'Cloud Native Buildpack',
@@ -8,22 +11,24 @@ const stackLabelMap: {[key: string]: string} = {
 
 /**
  * Ensure that the given app is a container app.
- * @param app {App} heroku app
+ * @param app {String} heroku app name
  * @param cmd {String} command name
  * @returns {null} null
  */
-export function ensureContainerStack(app: App, cmd: string): void {
-  const buildStack = app.build_stack?.name
-  const appStack = app.stack?.name
-  const allowedStack = 'container'
+export async function ensureContainerStack(platform: Platform, app: string, cmd: string): Promise<void> {
+  try {
+    await platform.container.ensureContainerStack(app)
+  } catch (error) {
+    if (error instanceof NotAContainerAppError) {
+      const {app} = error
+      let message = 'This command is for Docker apps only.'
+      if (['push', 'release'].includes(cmd)) {
+        message += ` Switch stacks by running ${color.code('heroku stack:set container')}. Or, to deploy ${color.app(app.name)} with ${color.name(app.stack.name)}, run ${color.code('git push heroku main')} instead.`
+      }
 
-  // either can be container stack and are allowed
-  if (buildStack !== allowedStack && appStack !== allowedStack) {
-    let message = 'This command is for Docker apps only.'
-    if (['push', 'release'].includes(cmd)) {
-      message += ` Switch stacks by running ${color.code('heroku stack:set container')}. Or, to deploy ${color.app(app.name ?? '')} with ${color.name(appStack ?? '')}, run ${color.code('git push heroku main')} instead.`
+      ux.error(message, {exit: 1})
     }
 
-    ux.error(message, {exit: 1})
+    throw error
   }
 }

--- a/test/unit/commands/container/pull.unit.test.ts
+++ b/test/unit/commands/container/pull.unit.test.ts
@@ -1,22 +1,34 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {Errors} from '@oclif/core'
 import {expect} from 'chai'
-import nock from 'nock'
 import * as sinon from 'sinon'
 
 import Cmd from '../../../../src/commands/container/pull.js'
 import {DockerHelper} from '../../../../src/lib/container/docker-helper.js'
 
+type FakePlatform = {
+  app: {info: sinon.SinonStub}
+}
+
+function buildFakePlatform(sandbox: sinon.SinonSandbox): FakePlatform {
+  return {
+    app: {info: sandbox.stub()},
+  }
+}
+
 describe('container pull', function () {
   let sandbox: sinon.SinonSandbox
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
     sandbox = sinon.createSandbox()
+    fakePlatform = buildFakePlatform(sandbox)
+    sandbox.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    nock.cleanAll()
-    return sandbox.restore()
+    sandbox.restore()
   })
 
   it('requires a process type', async function () {
@@ -30,9 +42,7 @@ describe('container pull', function () {
   })
 
   it('exits when the app stack is not container', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
+    fakePlatform.app.info.resolves({name: 'testapp', stack: {name: 'heroku-24'}})
     const {error, stdout} = await runCommand(Cmd, [
       '--app',
       'testapp',
@@ -44,13 +54,10 @@ describe('container pull', function () {
     expect(oclif.exit).to.equal(1)
 
     expect(stdout).to.equal('')
-    api.done()
   })
 
   it('pulls from the docker registry', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp', stack: {name: 'container'}})
+    fakePlatform.app.info.resolves({name: 'testapp', stack: {name: 'container'}})
     const pull = sandbox.stub(DockerHelper.prototype, 'pullImage')
       .withArgs('registry.heroku.com/testapp/web')
     const {stdout} = await runCommand(Cmd, [
@@ -60,7 +67,6 @@ describe('container pull', function () {
     ])
     expect(stdout).to.contain('Pulling web as registry.heroku.com/testapp/web')
     sandbox.assert.calledOnce(pull)
-    api.done()
   })
 
   context('when HEROKU_HOST is set to an invalid domain', function () {
@@ -80,9 +86,7 @@ describe('container pull', function () {
     })
 
     it('rejects invalid HEROKU_HOST and uses default registry', async function () {
-      const api = nock('https://api.heroku.com:443')
-        .get('/apps/testapp')
-        .reply(200, {name: 'testapp', stack: {name: 'container'}})
+      fakePlatform.app.info.resolves({name: 'testapp', stack: {name: 'container'}})
       const pull = sandbox.stub(DockerHelper.prototype, 'pullImage')
         .withArgs('registry.heroku.com/testapp/web')
 
@@ -94,7 +98,6 @@ describe('container pull', function () {
 
       expect(stderr).to.contain("Invalid HEROKU_HOST 'attacker.com'")
       sandbox.assert.calledOnce(pull)
-      api.done()
     })
   })
 })

--- a/test/unit/commands/container/pull.unit.test.ts
+++ b/test/unit/commands/container/pull.unit.test.ts
@@ -1,5 +1,6 @@
 import {runCommand} from '@heroku-cli/test-utils'
 import {HerokuSDK} from '@heroku/sdk'
+import {NotAContainerAppError} from '@heroku/sdk/extensions/platform'
 import {Errors} from '@oclif/core'
 import {expect} from 'chai'
 import * as sinon from 'sinon'
@@ -8,12 +9,12 @@ import Cmd from '../../../../src/commands/container/pull.js'
 import {DockerHelper} from '../../../../src/lib/container/docker-helper.js'
 
 type FakePlatform = {
-  app: {info: sinon.SinonStub}
+  container: {ensureContainerStack: sinon.SinonStub}
 }
 
 function buildFakePlatform(sandbox: sinon.SinonSandbox): FakePlatform {
   return {
-    app: {info: sandbox.stub()},
+    container: {ensureContainerStack: sandbox.stub()},
   }
 }
 
@@ -42,7 +43,12 @@ describe('container pull', function () {
   })
 
   it('exits when the app stack is not container', async function () {
-    fakePlatform.app.info.resolves({name: 'testapp', stack: {name: 'heroku-24'}})
+    fakePlatform.container.ensureContainerStack.rejects(new NotAContainerAppError({
+      build_stack: {name: 'heroku-24'},
+      id: 'test-id',
+      name: 'testapp',
+      stack: {id: 'test-id', name: 'heroku-24'},
+    }))
     const {error, stdout} = await runCommand(Cmd, [
       '--app',
       'testapp',
@@ -57,7 +63,7 @@ describe('container pull', function () {
   })
 
   it('pulls from the docker registry', async function () {
-    fakePlatform.app.info.resolves({name: 'testapp', stack: {name: 'container'}})
+    fakePlatform.container.ensureContainerStack.resolves()
     const pull = sandbox.stub(DockerHelper.prototype, 'pullImage')
       .withArgs('registry.heroku.com/testapp/web')
     const {stdout} = await runCommand(Cmd, [
@@ -86,7 +92,7 @@ describe('container pull', function () {
     })
 
     it('rejects invalid HEROKU_HOST and uses default registry', async function () {
-      fakePlatform.app.info.resolves({name: 'testapp', stack: {name: 'container'}})
+      fakePlatform.container.ensureContainerStack.resolves()
       const pull = sandbox.stub(DockerHelper.prototype, 'pullImage')
         .withArgs('registry.heroku.com/testapp/web')
 

--- a/test/unit/commands/container/push.unit.test.ts
+++ b/test/unit/commands/container/push.unit.test.ts
@@ -1,26 +1,35 @@
 import {runCommand} from '@heroku-cli/test-utils'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {Errors} from '@oclif/core'
 import {expect} from 'chai'
-import nock from 'nock'
 import * as sinon from 'sinon'
 
 import Cmd from '../../../../src/commands/container/push.js'
 import {DockerHelper} from '../../../../src/lib/container/docker-helper.js'
 
+type FakePlatform = {
+  app: {info: sinon.SinonStub}
+}
+
+function buildFakePlatform(sandbox: sinon.SinonSandbox): FakePlatform {
+  return {
+    app: {info: sandbox.stub()},
+  }
+}
+
 describe('container push', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
   let sandbox: sinon.SinonSandbox
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com:443')
     sandbox = sinon.createSandbox()
-    return nock.cleanAll()
+    fakePlatform = buildFakePlatform(sandbox)
+    sandbox.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    return sandbox.restore()
+    sandbox.restore()
   })
 
   context('when HEROKU_HOST is set to an invalid domain', function () {
@@ -29,9 +38,7 @@ describe('container push', function () {
     beforeEach(function () {
       originalHost = process.env.HEROKU_HOST
       process.env.HEROKU_HOST = 'attacker.com'
-      api
-        .get('/apps/testapp')
-        .reply(200, {name: 'testapp', stack: {name: 'container'}})
+      fakePlatform.app.info.resolves({name: 'testapp', stack: {name: 'container'}})
     })
 
     afterEach(function () {
@@ -64,9 +71,7 @@ describe('container push', function () {
 
   context('when the app stack is not "container"', function () {
     beforeEach(function () {
-      api
-        .get('/apps/testapp')
-        .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
+      fakePlatform.app.info.resolves({name: 'testapp', stack: {name: 'heroku-24'}})
     })
 
     it('exits', async function () {
@@ -83,9 +88,7 @@ describe('container push', function () {
 
   context('when the app build_stack is container', function () {
     beforeEach(function () {
-      api
-        .get('/apps/testapp')
-        .reply(200, {build_stack: {name: 'container'}, name: 'testapp', stack: {name: 'heroku-24'}})
+      fakePlatform.app.info.resolves({build_stack: {name: 'container'}, name: 'testapp', stack: {name: 'heroku-24'}})
     })
 
     it('allows push to the docker registry', async function () {
@@ -113,9 +116,7 @@ describe('container push', function () {
 
   context('when the app is a container app', function () {
     beforeEach(function () {
-      api
-        .get('/apps/testapp')
-        .reply(200, {name: 'testapp', stack: {name: 'container'}})
+      fakePlatform.app.info.resolves({name: 'testapp', stack: {name: 'container'}})
     })
 
     it('gets a build error', async function () {

--- a/test/unit/commands/container/push.unit.test.ts
+++ b/test/unit/commands/container/push.unit.test.ts
@@ -1,6 +1,7 @@
 import {runCommand} from '@heroku-cli/test-utils'
 import * as color from '@heroku/heroku-cli-util/color'
 import {HerokuSDK} from '@heroku/sdk'
+import {NotAContainerAppError} from '@heroku/sdk/extensions/platform'
 import {Errors} from '@oclif/core'
 import {expect} from 'chai'
 import * as sinon from 'sinon'
@@ -9,12 +10,12 @@ import Cmd from '../../../../src/commands/container/push.js'
 import {DockerHelper} from '../../../../src/lib/container/docker-helper.js'
 
 type FakePlatform = {
-  app: {info: sinon.SinonStub}
+  container: {ensureContainerStack: sinon.SinonStub}
 }
 
 function buildFakePlatform(sandbox: sinon.SinonSandbox): FakePlatform {
   return {
-    app: {info: sandbox.stub()},
+    container: {ensureContainerStack: sandbox.stub()},
   }
 }
 
@@ -38,7 +39,7 @@ describe('container push', function () {
     beforeEach(function () {
       originalHost = process.env.HEROKU_HOST
       process.env.HEROKU_HOST = 'attacker.com'
-      fakePlatform.app.info.resolves({name: 'testapp', stack: {name: 'container'}})
+      fakePlatform.container.ensureContainerStack.resolves()
     })
 
     afterEach(function () {
@@ -71,7 +72,12 @@ describe('container push', function () {
 
   context('when the app stack is not "container"', function () {
     beforeEach(function () {
-      fakePlatform.app.info.resolves({name: 'testapp', stack: {name: 'heroku-24'}})
+      fakePlatform.container.ensureContainerStack.rejects(new NotAContainerAppError({
+        build_stack: {name: 'heroku-24'},
+        id: 'test-id',
+        name: 'testapp',
+        stack: {id: 'test-id', name: 'heroku-24'},
+      }))
     })
 
     it('exits', async function () {
@@ -88,7 +94,7 @@ describe('container push', function () {
 
   context('when the app build_stack is container', function () {
     beforeEach(function () {
-      fakePlatform.app.info.resolves({build_stack: {name: 'container'}, name: 'testapp', stack: {name: 'heroku-24'}})
+      fakePlatform.container.ensureContainerStack.resolves()
     })
 
     it('allows push to the docker registry', async function () {
@@ -116,7 +122,7 @@ describe('container push', function () {
 
   context('when the app is a container app', function () {
     beforeEach(function () {
-      fakePlatform.app.info.resolves({name: 'testapp', stack: {name: 'container'}})
+      fakePlatform.container.ensureContainerStack.resolves()
     })
 
     it('gets a build error', async function () {

--- a/test/unit/commands/container/release.unit.test.ts
+++ b/test/unit/commands/container/release.unit.test.ts
@@ -1,24 +1,51 @@
 import {runCommand} from '@heroku-cli/test-utils'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
+import {NotAContainerAppError} from '@heroku/sdk/extensions/platform'
 import {Errors} from '@oclif/core'
 import {expect} from 'chai'
 import nock from 'nock'
-import {createSandbox, SinonSandbox} from 'sinon'
+import {createSandbox, SinonSandbox, SinonStub} from 'sinon'
 
 import Cmd from '../../../../src/commands/container/release.js'
 
+type FakePlatform = {
+  container: {
+    ensureContainerStack: SinonStub
+    releaseImages: SinonStub
+  }
+  release: {
+    info: SinonStub
+  }
+}
+
+function buildFakePlatform(sandbox: SinonSandbox): FakePlatform {
+  return {
+    container: {
+      ensureContainerStack: sandbox.stub().resolves(),
+      releaseImages: sandbox.stub().resolves({
+        newRelease: {id: 'new-release', status: 'succeeded'},
+        oldRelease: {id: 'old-release', status: 'succeeded'},
+      }),
+    },
+    release: {
+      info: sandbox.stub().resolves({status: 'succeeded'}),
+    },
+  }
+}
+
 describe('container release', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
   let sandbox: SinonSandbox
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com:443')
     sandbox = createSandbox()
+    fakePlatform = buildFakePlatform(sandbox)
+    sandbox.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    return sandbox.restore()
+    sandbox.restore()
   })
 
   it('has no process type specified', async function () {
@@ -32,9 +59,14 @@ describe('container release', function () {
   })
 
   it('exits when the app stack is not "container"', async function () {
-    api
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
+    fakePlatform.container.ensureContainerStack.rejects(new NotAContainerAppError({
+
+      build_stack: {id: 'heroku-24', name: 'heroku-24'},
+      id: 'app-id',
+      name: 'testapp',
+      stack: {id: 'heroku-24', name: 'heroku-24'},
+    }))
+
     const {error} = await runCommand(Cmd, [
       '--app',
       'testapp',
@@ -53,9 +85,6 @@ describe('container release', function () {
     beforeEach(function () {
       originalHost = process.env.HEROKU_HOST
       process.env.HEROKU_HOST = 'attacker.com'
-      api
-        .get('/apps/testapp')
-        .reply(200, {name: 'testapp', stack: {name: 'container'}})
       registry = nock('https://registry.heroku.com:443')
     })
 
@@ -70,17 +99,6 @@ describe('container release', function () {
     })
 
     it('rejects invalid host and sends request to registry.heroku.com', async function () {
-      api
-        .patch('/apps/testapp/formation', {
-          updates: [
-            {docker_image: 'image_id', type: 'web'},
-          ],
-        })
-        .reply(200, {})
-        .get('/apps/testapp/releases')
-        .reply(200, [])
-        .get('/apps/testapp/releases')
-        .reply(200, [{id: 'release_id'}])
       registry
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {config: {digest: 'image_id'}, schemaVersion: 2})
@@ -97,28 +115,24 @@ describe('container release', function () {
 
   context('when the app is a container app', function () {
     let registry: nock.Scope
+
     beforeEach(function () {
-      api
-        .get('/apps/testapp')
-        .reply(200, {name: 'testapp', stack: {name: 'container'}})
       registry = nock('https://registry.heroku.com:443')
     })
 
+    afterEach(function () {
+      registry.done()
+    })
+
     it('releases a single process type, no previous release', async function () {
-      api
-        .patch('/apps/testapp/formation', {
-          updates: [
-            {docker_image: 'image_id', type: 'web'},
-          ],
-        })
-        .reply(200, {})
-        .get('/apps/testapp/releases')
-        .reply(200, [])
-        .get('/apps/testapp/releases')
-        .reply(200, [{id: 'release_id'}])
+      fakePlatform.container.releaseImages.resolves({
+        newRelease: {id: 'release_id'},
+        oldRelease: undefined,
+      })
       registry
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {config: {digest: 'image_id'}, schemaVersion: 2})
+
       const {stderr, stdout} = await runCommand(Cmd, [
         '--app',
         'testapp',
@@ -126,23 +140,18 @@ describe('container release', function () {
       ])
       expect(stderr).to.contain('Releasing images web to testapp... done')
       expect(stdout).to.equal('')
+      expect(fakePlatform.container.releaseImages.calledOnce).to.equal(true)
     })
 
     it('releases a single process type, with a previous release', async function () {
-      api
-        .patch('/apps/testapp/formation', {
-          updates: [
-            {docker_image: 'image_id', type: 'web'},
-          ],
-        })
-        .reply(200, {})
-        .get('/apps/testapp/releases')
-        .reply(200, [{id: 'old_release_id'}])
-        .get('/apps/testapp/releases')
-        .reply(200, [{id: 'release_id'}])
+      fakePlatform.container.releaseImages.resolves({
+        newRelease: {id: 'release_id'},
+        oldRelease: {id: 'old_release_id'},
+      })
       registry
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {config: {digest: 'image_id'}, schemaVersion: 2})
+
       const {stderr, stdout} = await runCommand(Cmd, [
         '--app',
         'testapp',
@@ -150,23 +159,18 @@ describe('container release', function () {
       ])
       expect(stderr).to.contain('Releasing images web to testapp... done')
       expect(stdout).to.equal('')
+      expect(fakePlatform.container.releaseImages.calledOnce).to.equal(true)
     })
 
     it('retrieves data from a v1 schema version, no previous release', async function () {
-      api
-        .patch('/apps/testapp/formation', {
-          updates: [
-            {docker_image: 'image_id', type: 'web'},
-          ],
-        })
-        .reply(200, {})
-        .get('/apps/testapp/releases')
-        .reply(200, [])
-        .get('/apps/testapp/releases')
-        .reply(200, [{id: 'release_id', status: 'succeeded'}])
+      fakePlatform.container.releaseImages.resolves({
+        newRelease: {id: 'release_id', status: 'succeeded'},
+        oldRelease: undefined,
+      })
       registry
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {history: [{v1Compatibility: '{"id":"image_id"}'}], schemaVersion: 1})
+
       const {stderr, stdout} = await runCommand(Cmd, [
         '--app',
         'testapp',
@@ -174,23 +178,18 @@ describe('container release', function () {
       ])
       expect(stderr).to.contain('Releasing images web to testapp... done')
       expect(stdout).to.equal('')
+      expect(fakePlatform.container.releaseImages.firstCall.args[1][0].docker_image).to.equal('image_id')
     })
 
     it('retrieves data from a v1 schema version, with a previous release', async function () {
-      api
-        .patch('/apps/testapp/formation', {
-          updates: [
-            {docker_image: 'image_id', type: 'web'},
-          ],
-        })
-        .reply(200, {})
-        .get('/apps/testapp/releases')
-        .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
-        .get('/apps/testapp/releases')
-        .reply(200, [{id: 'release_id', status: 'succeeded'}])
+      fakePlatform.container.releaseImages.resolves({
+        newRelease: {id: 'release_id', status: 'succeeded'},
+        oldRelease: {id: 'old_release_id', status: 'succeeded'},
+      })
       registry
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {history: [{v1Compatibility: '{"id":"image_id"}'}], schemaVersion: 1})
+
       const {stderr, stdout} = await runCommand(Cmd, [
         '--app',
         'testapp',
@@ -198,25 +197,20 @@ describe('container release', function () {
       ])
       expect(stderr).to.contain('Releasing images web to testapp... done')
       expect(stdout).to.equal('')
+      expect(fakePlatform.container.releaseImages.firstCall.args[1][0].docker_image).to.equal('image_id')
     })
 
     it('releases multiple process types, no previous release', async function () {
-      api
-        .patch('/apps/testapp/formation', {
-          updates: [
-            {docker_image: 'web_image_id', type: 'web'}, {docker_image: 'worker_image_id', type: 'worker'},
-          ],
-        })
-        .reply(200, {})
-        .get('/apps/testapp/releases')
-        .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
-        .get('/apps/testapp/releases')
-        .reply(200, [{id: 'release_id', status: 'succeeded'}])
+      fakePlatform.container.releaseImages.resolves({
+        newRelease: {id: 'release_id', status: 'succeeded'},
+        oldRelease: undefined,
+      })
       registry
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {config: {digest: 'web_image_id'}, schemaVersion: 2})
         .get('/v2/testapp/worker/manifests/latest')
         .reply(200, {config: {digest: 'worker_image_id'}, schemaVersion: 2})
+
       const {stderr, stdout} = await runCommand(Cmd, [
         '--app',
         'testapp',
@@ -225,25 +219,23 @@ describe('container release', function () {
       ])
       expect(stderr).to.contain('Releasing images web,worker to testapp... done')
       expect(stdout).to.equal('')
+      expect(fakePlatform.container.releaseImages.firstCall.args[1]).to.deep.equal([
+        {docker_image: 'web_image_id', type: 'web'},
+        {docker_image: 'worker_image_id', type: 'worker'},
+      ])
     })
 
     it('releases multiple process types, with a previous release', async function () {
-      api
-        .patch('/apps/testapp/formation', {
-          updates: [
-            {docker_image: 'web_image_id', type: 'web'}, {docker_image: 'worker_image_id', type: 'worker'},
-          ],
-        })
-        .reply(200, {})
-        .get('/apps/testapp/releases')
-        .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
-        .get('/apps/testapp/releases')
-        .reply(200, [{id: 'release_id', status: 'succeeded'}])
+      fakePlatform.container.releaseImages.resolves({
+        newRelease: {id: 'release_id', status: 'succeeded'},
+        oldRelease: {id: 'old_release_id', status: 'succeeded'},
+      })
       registry
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {config: {digest: 'web_image_id'}, schemaVersion: 2})
         .get('/v2/testapp/worker/manifests/latest')
         .reply(200, {config: {digest: 'worker_image_id'}, schemaVersion: 2})
+
       const {stderr, stdout} = await runCommand(Cmd, [
         '--app',
         'testapp',
@@ -252,53 +244,43 @@ describe('container release', function () {
       ])
       expect(stderr).to.contain('Releasing images web,worker to testapp... done')
       expect(stdout).to.equal('')
+      expect(fakePlatform.container.releaseImages.firstCall.args[1]).to.deep.equal([
+        {docker_image: 'web_image_id', type: 'web'},
+        {docker_image: 'worker_image_id', type: 'worker'},
+      ])
     })
 
     it('releases with previous release and immediately successful release phase', async function () {
-      api
-        .patch('/apps/testapp/formation', {
-          updates: [
-            {docker_image: 'image_id', type: 'web'},
-          ],
-        })
-        .reply(200, {})
-        .get('/apps/testapp/releases')
-        .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
-        .get('/apps/testapp/releases')
-        .reply(200, [{id: 'release_id', status: 'succeeded'}])
+      fakePlatform.container.releaseImages.resolves({
+        newRelease: {id: 'release_id', status: 'succeeded'},
+        oldRelease: {id: 'old_release_id', status: 'succeeded'},
+      })
       registry
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {config: {digest: 'image_id'}, schemaVersion: 2})
+
       const {stderr, stdout} = await runCommand(Cmd, [
         '--app',
         'testapp',
         'web',
       ])
-      expect(stdout).to.equal('')
       expect(stderr).to.contain('Releasing images web to testapp... done')
+      expect(stdout).to.equal('')
     })
 
     it('releases with previous release and pending then successful release phase', async function () {
       const busl = nock('https://busl.test:443')
         .get('/streams/release.log')
         .reply(200, 'Release Output Content')
-      api
-        .patch('/apps/testapp/formation', {
-          updates: [
-            {docker_image: 'image_id', type: 'web'},
-          ],
-        })
-        .reply(200, {})
-        .get('/apps/testapp/releases')
-        .reply(200, [{id: 'old_release_id', status: 'failed'}])
-        .get('/apps/testapp/releases')
-        .reply(200, [{
+      fakePlatform.container.releaseImages.resolves({
+        newRelease: {
           id: 'release_id',
           output_stream_url: 'https://busl.test/streams/release.log',
           status: 'pending',
-        }])
-        .get('/apps/testapp/releases/release_id')
-        .reply(200, [{status: 'succeeded'}])
+        },
+        oldRelease: {id: 'old_release_id', status: 'failed'},
+      })
+      fakePlatform.release.info.resolves({status: 'succeeded'})
       registry
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {config: {digest: 'image_id'}, schemaVersion: 2})
@@ -312,22 +294,16 @@ describe('container release', function () {
       expect(stdout).to.contain('Running release command...')
       expect(stdout).to.contain('Release Output Content')
       expect(stderr).to.contain('Releasing images web to testapp...')
+      expect(fakePlatform.release.info.calledOnceWith('testapp', 'release_id')).to.equal(true)
 
       busl.done()
     })
 
     it('releases with previous release and immediately failed release phase', async function () {
-      api
-        .patch('/apps/testapp/formation', {
-          updates: [
-            {docker_image: 'image_id', type: 'web'},
-          ],
-        })
-        .reply(200, {})
-        .get('/apps/testapp/releases')
-        .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
-        .get('/apps/testapp/releases')
-        .reply(200, [{id: 'release_id', status: 'failed'}])
+      fakePlatform.container.releaseImages.resolves({
+        newRelease: {id: 'release_id', status: 'failed'},
+        oldRelease: {id: 'old_release_id', status: 'succeeded'},
+      })
       registry
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {config: {digest: 'image_id'}, schemaVersion: 2})
@@ -350,23 +326,15 @@ describe('container release', function () {
       const busl = nock('https://busl.test:443')
         .get('/streams/release.log')
         .reply(200, 'Release Output Content')
-      api
-        .patch('/apps/testapp/formation', {
-          updates: [
-            {docker_image: 'image_id', type: 'web'},
-          ],
-        })
-        .reply(200, {})
-        .get('/apps/testapp/releases')
-        .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
-        .get('/apps/testapp/releases')
-        .reply(200, [{
+      fakePlatform.container.releaseImages.resolves({
+        newRelease: {
           id: 'release_id',
           output_stream_url: 'https://busl.test/streams/release.log',
           status: 'pending',
-        }])
-        .get('/apps/testapp/releases/release_id')
-        .reply(200, {status: 'failed'})
+        },
+        oldRelease: {id: 'old_release_id', status: 'succeeded'},
+      })
+      fakePlatform.release.info.resolves({status: 'failed'})
       registry
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {config: {digest: 'image_id'}, schemaVersion: 2})
@@ -389,51 +357,36 @@ describe('container release', function () {
     })
 
     it('releases with no previous release and immediately successful release phase', async function () {
-      api
-        .patch('/apps/testapp/formation', {
-          updates: [
-            {docker_image: 'image_id', type: 'web'},
-          ],
-        })
-        .reply(200, {})
-        .get('/apps/testapp/releases')
-        .reply(200, [])
-        .get('/apps/testapp/releases')
-        .reply(200, [{status: 'succeeded'}])
+      fakePlatform.container.releaseImages.resolves({
+        newRelease: {id: 'release_id', status: 'succeeded'},
+        oldRelease: undefined,
+      })
       registry
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {config: {digest: 'image_id'}, schemaVersion: 2})
 
-      const {stderr} = await runCommand(Cmd, [
+      const {stderr, stdout} = await runCommand(Cmd, [
         '--app',
         'testapp',
         'web',
       ])
-
       expect(stderr).to.contain('Releasing images web to testapp... done')
+      expect(stdout).to.equal('')
     })
 
     it('releases with no previous release and pending then successful release phase', async function () {
       const busl = nock('https://busl.test:443')
         .get('/streams/release.log')
         .reply(200, 'Release Output Content')
-      api
-        .patch('/apps/testapp/formation', {
-          updates: [
-            {docker_image: 'image_id', type: 'web'},
-          ],
-        })
-        .reply(200, {})
-        .get('/apps/testapp/releases')
-        .reply(200, [])
-        .get('/apps/testapp/releases')
-        .reply(200, [{
+      fakePlatform.container.releaseImages.resolves({
+        newRelease: {
           id: 'release_id',
           output_stream_url: 'https://busl.test/streams/release.log',
           status: 'pending',
-        }])
-        .get('/apps/testapp/releases/release_id')
-        .reply(200, [{status: 'succeeded'}])
+        },
+        oldRelease: undefined,
+      })
+      fakePlatform.release.info.resolves({status: 'succeeded'})
       registry
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {config: {digest: 'image_id'}, schemaVersion: 2})
@@ -452,17 +405,10 @@ describe('container release', function () {
     })
 
     it('releases with no previous release and immediately failed release phase', async function () {
-      api
-        .patch('/apps/testapp/formation', {
-          updates: [
-            {docker_image: 'image_id', type: 'web'},
-          ],
-        })
-        .reply(200, {})
-        .get('/apps/testapp/releases')
-        .reply(200, [])
-        .get('/apps/testapp/releases')
-        .reply(200, [{status: 'failed'}])
+      fakePlatform.container.releaseImages.resolves({
+        newRelease: {id: 'release_id', status: 'failed'},
+        oldRelease: undefined,
+      })
       registry
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {config: {digest: 'image_id'}, schemaVersion: 2})
@@ -476,7 +422,6 @@ describe('container release', function () {
       const {message, oclif} = error as unknown as Errors.CLIError
       expect(message).to.equal('Error: release command failed')
       expect(oclif.exit).to.equal(1)
-
       expect(stderr).to.contain('Releasing images web to testapp... done')
     })
 
@@ -484,23 +429,15 @@ describe('container release', function () {
       const busl = nock('https://busl.test:443')
         .get('/streams/release.log')
         .reply(200, 'Release Output Content')
-      api
-        .patch('/apps/testapp/formation', {
-          updates: [
-            {docker_image: 'image_id', type: 'web'},
-          ],
-        })
-        .reply(200, {})
-        .get('/apps/testapp/releases')
-        .reply(200, [])
-        .get('/apps/testapp/releases')
-        .reply(200, [{
+      fakePlatform.container.releaseImages.resolves({
+        newRelease: {
           id: 'release_id',
           output_stream_url: 'https://busl.test/streams/release.log',
           status: 'pending',
-        }])
-        .get('/apps/testapp/releases/release_id')
-        .reply(200, {status: 'failed'})
+        },
+        oldRelease: undefined,
+      })
+      fakePlatform.release.info.resolves({status: 'failed'})
       registry
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {config: {digest: 'image_id'}, schemaVersion: 2})
@@ -514,7 +451,6 @@ describe('container release', function () {
       const {message, oclif} = error as unknown as Errors.CLIError
       expect(message).to.equal('Error: release command failed')
       expect(oclif.exit).to.equal(1)
-
       expect(stdout).to.contain('Running release command...')
       expect(stdout).to.contain('Release Output Content')
       expect(stderr).to.contain('Releasing images web to testapp...')
@@ -523,20 +459,14 @@ describe('container release', function () {
     })
 
     it('has release phase but no new release', async function () {
-      api
-        .patch('/apps/testapp/formation', {
-          updates: [
-            {docker_image: 'image_id', type: 'web'},
-          ],
-        })
-        .reply(200, {})
-        .get('/apps/testapp/releases')
-        .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
-        .get('/apps/testapp/releases')
-        .reply(200, [{id: 'old_release_id', status: 'succeeded'}])
+      fakePlatform.container.releaseImages.resolves({
+        newRelease: {id: 'old_release_id', status: 'succeeded'},
+        oldRelease: {id: 'old_release_id', status: 'succeeded'},
+      })
       registry
         .get('/v2/testapp/web/manifests/latest')
         .reply(200, {config: {digest: 'image_id'}, schemaVersion: 2})
+
       const {stderr, stdout} = await runCommand(Cmd, [
         '--app',
         'testapp',
@@ -544,6 +474,7 @@ describe('container release', function () {
       ])
       expect(stderr).to.not.contain('Running release command...')
       expect(stdout).to.equal('')
+      expect(fakePlatform.release.info.called).to.equal(false)
     })
   })
 })

--- a/test/unit/commands/container/rm.unit.test.ts
+++ b/test/unit/commands/container/rm.unit.test.ts
@@ -77,7 +77,7 @@ describe('container removal', function () {
         'web',
       ])
       expectOutput(stdout, '')
-      expect(stderr).to.contain('Removing container web for ⬢ testapp... done')
+      expect(stderr).to.contain('Removing containers web from ⬢ testapp... done')
       expect(fakePlatform.container.removeProcessTypes.calledOnceWith('testapp', ['web'])).to.equal(true)
     })
 
@@ -89,7 +89,7 @@ describe('container removal', function () {
         'worker',
       ])
       expectOutput(stdout, '')
-      expect(stderr).to.contain('Removing container web, worker for ⬢ testapp... done')
+      expect(stderr).to.contain('Removing containers web, worker from ⬢ testapp... done')
       expect(fakePlatform.container.removeProcessTypes.calledOnceWith('testapp', ['web', 'worker'])).to.equal(true)
     })
   })

--- a/test/unit/commands/container/rm.unit.test.ts
+++ b/test/unit/commands/container/rm.unit.test.ts
@@ -1,19 +1,38 @@
 import {expectOutput, runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
+import {NotAContainerAppError} from '@heroku/sdk/extensions/platform'
 import {Errors} from '@oclif/core'
 import {expect} from 'chai'
-import nock from 'nock'
+import {restore, SinonStub, stub} from 'sinon'
 
 import Cmd from '../../../../src/commands/container/rm.js'
 
+type FakePlatform = {
+  container: {
+    ensureContainerStack: SinonStub
+    removeProcessTypes: SinonStub
+  }
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    container: {
+      ensureContainerStack: stub(),
+      removeProcessTypes: stub(),
+    },
+  }
+}
+
 describe('container removal', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com:443')
+    fakePlatform = buildFakePlatform()
+    stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
+    restore()
   })
 
   it('requires a container to be specified', async function () {
@@ -27,9 +46,14 @@ describe('container removal', function () {
   })
 
   it('exits when the app stack is not "container"', async function () {
-    api
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
+    fakePlatform.container.ensureContainerStack.rejects(new NotAContainerAppError({
+
+      build_stack: {id: 'heroku-24', name: 'heroku-24'},
+      id: 'app-id',
+      name: 'testapp',
+      stack: {id: 'heroku-24', name: 'heroku-24'},
+    }))
+
     const {error, stdout} = await runCommand(Cmd, [
       '--app',
       'testapp',
@@ -42,22 +66,11 @@ describe('container removal', function () {
   })
 
   context('when the app is a container app', function () {
-    let apiV3DockerRelease: nock.Scope
-
     beforeEach(function () {
-      api
-        .get('/apps/testapp')
-        .reply(200, {name: 'testapp', stack: {name: 'container'}})
-      apiV3DockerRelease = nock('https://api.heroku.com', {reqheaders: {Accept: 'application/vnd.heroku+json; version=3.docker-releases'}})
-    })
-    afterEach(function () {
-      apiV3DockerRelease.done()
+      fakePlatform.container.ensureContainerStack.resolves()
     })
 
     it('removes one container', async function () {
-      apiV3DockerRelease
-        .patch('/apps/testapp/formation/web')
-        .reply(200, {})
       const {stderr, stdout} = await runCommand(Cmd, [
         '--app',
         'testapp',
@@ -65,14 +78,10 @@ describe('container removal', function () {
       ])
       expectOutput(stdout, '')
       expect(stderr).to.contain('Removing container web for ⬢ testapp... done')
+      expect(fakePlatform.container.removeProcessTypes.calledOnceWith('testapp', ['web'])).to.equal(true)
     })
 
     it('removes two containers', async function () {
-      apiV3DockerRelease
-        .patch('/apps/testapp/formation/web')
-        .reply(200, {})
-        .patch('/apps/testapp/formation/worker')
-        .reply(200, {})
       const {stderr, stdout} = await runCommand(Cmd, [
         '--app',
         'testapp',
@@ -80,8 +89,8 @@ describe('container removal', function () {
         'worker',
       ])
       expectOutput(stdout, '')
-      expect(stderr).to.contain('Removing container web for ⬢ testapp... done')
-      expect(stderr).to.contain('Removing container worker for ⬢ testapp... done')
+      expect(stderr).to.contain('Removing container web, worker for ⬢ testapp... done')
+      expect(fakePlatform.container.removeProcessTypes.calledOnceWith('testapp', ['web', 'worker'])).to.equal(true)
     })
   })
 })

--- a/test/unit/commands/container/run.unit.test.ts
+++ b/test/unit/commands/container/run.unit.test.ts
@@ -1,25 +1,35 @@
 import {expectOutput, runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {Errors} from '@oclif/core'
 import {expect} from 'chai'
-import nock from 'nock'
-import {createSandbox, SinonSandbox} from 'sinon'
+import {createSandbox, SinonSandbox, SinonStub} from 'sinon'
 
 import Cmd from '../../../../src/commands/container/run.js'
 import {DockerHelper} from '../../../../src/lib/container/docker-helper.js'
 
+type FakePlatform = {
+  app: {info: SinonStub}
+}
+
+function buildFakePlatform(sandbox: SinonSandbox): FakePlatform {
+  return {
+    app: {info: sandbox.stub()},
+  }
+}
+
 describe('container run', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
   let sandbox: SinonSandbox
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com:443')
     process.env.HEROKU_API_KEY = 'heroku_token'
     sandbox = createSandbox()
+    fakePlatform = buildFakePlatform(sandbox)
+    sandbox.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    return sandbox.restore()
+    sandbox.restore()
   })
 
   context('when HEROKU_HOST is set to an invalid domain', function () {
@@ -28,9 +38,7 @@ describe('container run', function () {
     beforeEach(function () {
       originalHost = process.env.HEROKU_HOST
       process.env.HEROKU_HOST = 'attacker.com'
-      api
-        .get('/apps/testapp')
-        .reply(200, {name: 'testapp', stack: {name: 'container'}})
+      fakePlatform.app.info.resolves({name: 'testapp', stack: {name: 'container'}})
     })
 
     afterEach(function () {
@@ -70,9 +78,7 @@ describe('container run', function () {
   })
 
   it('exits when the app stack is not "container"', async function () {
-    api
-      .get('/apps/testapp')
-      .reply(200, {name: 'testapp', stack: {name: 'heroku-24'}})
+    fakePlatform.app.info.resolves({name: 'testapp', stack: {name: 'heroku-24'}})
     const {error, stdout} = await runCommand(Cmd, [
       '--app',
       'testapp',
@@ -86,9 +92,7 @@ describe('container run', function () {
 
   context('when the app is a container app', function () {
     beforeEach(function () {
-      api
-        .get('/apps/testapp')
-        .reply(200, {name: 'testapp', stack: {name: 'container'}})
+      fakePlatform.app.info.resolves({name: 'testapp', stack: {name: 'container'}})
     })
 
     it('runs a container', async function () {

--- a/test/unit/commands/container/run.unit.test.ts
+++ b/test/unit/commands/container/run.unit.test.ts
@@ -1,5 +1,6 @@
 import {expectOutput, runCommand} from '@heroku-cli/test-utils'
 import {HerokuSDK} from '@heroku/sdk'
+import {NotAContainerAppError} from '@heroku/sdk/extensions/platform'
 import {Errors} from '@oclif/core'
 import {expect} from 'chai'
 import {createSandbox, SinonSandbox, SinonStub} from 'sinon'
@@ -8,12 +9,12 @@ import Cmd from '../../../../src/commands/container/run.js'
 import {DockerHelper} from '../../../../src/lib/container/docker-helper.js'
 
 type FakePlatform = {
-  app: {info: SinonStub}
+  container: {ensureContainerStack: SinonStub}
 }
 
 function buildFakePlatform(sandbox: SinonSandbox): FakePlatform {
   return {
-    app: {info: sandbox.stub()},
+    container: {ensureContainerStack: sandbox.stub()},
   }
 }
 
@@ -38,7 +39,7 @@ describe('container run', function () {
     beforeEach(function () {
       originalHost = process.env.HEROKU_HOST
       process.env.HEROKU_HOST = 'attacker.com'
-      fakePlatform.app.info.resolves({name: 'testapp', stack: {name: 'container'}})
+      fakePlatform.container.ensureContainerStack.resolves()
     })
 
     afterEach(function () {
@@ -78,7 +79,12 @@ describe('container run', function () {
   })
 
   it('exits when the app stack is not "container"', async function () {
-    fakePlatform.app.info.resolves({name: 'testapp', stack: {name: 'heroku-24'}})
+    fakePlatform.container.ensureContainerStack.rejects(new NotAContainerAppError({
+      build_stack: {name: 'heroku-24'},
+      id: 'test-id',
+      name: 'testapp',
+      stack: {id: 'test-id', name: 'heroku-24'},
+    }))
     const {error, stdout} = await runCommand(Cmd, [
       '--app',
       'testapp',
@@ -92,7 +98,7 @@ describe('container run', function () {
 
   context('when the app is a container app', function () {
     beforeEach(function () {
-      fakePlatform.app.info.resolves({name: 'testapp', stack: {name: 'container'}})
+      fakePlatform.container.ensureContainerStack.resolves()
     })
 
     it('runs a container', async function () {


### PR DESCRIPTION
## Summary
Migrates the following `container` commands to `@heroku/sdk`:
- `container:pull`
- `container:push`
- `container:release`
- `container:rm`
- `container:run`

**Shared helper (`src/lib/container/helpers.ts`)**
- `ensureContainerStack` delegates app lookup + stack validation to the SDK. Catches `NotAContainerAppError` and re-surfaces it with a custom message. All other errors are re-thrown.

**`pull` / `push` / `run`**
- Builds a `platform` with `containerExtensions` and passes it to the updated `ensureContainerStack` helper.

**`release`**
- Replaces the release sequence with `platform.container.releaseImages`.
- Replaces `this.heroku.request<Heroku.Release>` with `platform.release.info`.
- Simplifies the no-op guard to `!release || (oldRelease?.id === release.id)`, which avoids a potential dereference when there is no new release.

**`rm`**
- Replaces the per-process `PATCH /formation/{process}` calls with a single `platform.container.removeProcessTypes` call.
- **User-facing change:** the spinner is now a single batch message with truncation after 3 process types (documented in `V12-CHANGES.md`).

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [x] **test**: Add/update/remove tests

## Testing
**Notes**:
<!-- Add any context/setup necessary for testing. -->
The SDK uses `heroku-fetch` to make API calls, which looks for a netrc file. Therefore, we must log in with `HEROKU_NETRC_WRITE=true`.

Requires a container-based app that is used for testing. The following steps include destructive actions.

**Setup**:
- Pull down this branch
- `npm i && npm run build`
- `heroku logout`
- `HEROKU_NETRC_WRITE=true ./bin/run login`

**Steps**:
- Start Docker Desktop
- `./bin/run container:login`

**With container app**
- `./bin/run container:push web --app CONTAINER_APP`
   - Expect: build output, push output, then `Your image has been successfully pushed. You can now release it with the 'container:release' command.`
- `./bin/run container:push worker --app CONTAINER_APP`
   - Expect: same as above
- `./bin/run container:release web worker --app CONTAINER_APP`
   - Expect: `Releasing images web,worker to APP... done`
   - `./bin/run releases --app APP` shows a new release
- `./bin/run container:pull web --app CONTAINER_APP`
   - Expect: the web image pulls from `registry.heroku.com/<APP>/web`
- `./bin/run container:run web --app CONTAINER_APP -- bash`
   - Expect: an interactive shell inside the container. Run `which heroku` to confirm the image has a working Heroku CLI install, then `exit` to stop the container.
- `./bin/run container:rm web worker --app CONTAINER_APP`
   - Expect: a single spinner — `Removing containers web, worker from ⬢ APP... done`

**With non-container app**
- `./bin/run container:push web --app NON_CONTAINER_APP`
   - Expect: `This command is for Docker apps only. Switch stacks by running 'heroku stack:set container'. Or, to deploy APP with APP_STACK_NAME, run 'git push heroku main' instead.`
- `./bin/run container:release web --app NON_CONTAINER_APP`
   - Expect: `This command is for Docker apps only. Switch stacks by running 'heroku stack:set container'. Or, to deploy APP with APP_STACK_NAME, run 'git push heroku main' instead.`
- `./bin/run container:pull web --app NON_CONTAINER_APP`
   - Expect: `This command is for Docker apps only.`
- `./bin/run container:run web --app NON_CONTAINER_APP`
   - Expect: `This command is for Docker apps only.`
- `./bin/run container:rm web --app NON_CONTAINER_APP` 
   - Expect: `This command is for Docker apps only.`
 
**Cleanup**:
- `./bin/run container:logout`
- `./bin/run logout`

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-23383781](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eLm3hYAC/view)
