### PR TITLE
fix: pg:backups:capture -v null guard on undefined logs

### DIFF
--- a/src/lib/pg/backups.ts
+++ b/src/lib/pg/backups.ts
@@ -18,8 +18,8 @@ class Backups {
     this.heroku = heroku
   }
 
-  protected displayLogs(logs: BackupTransfer['logs']) {
-    for (const log of logs) {
+  protected displayLogs(logs: BackupTransfer['logs'] | undefined) {
+    for (const log of (logs ?? [])) {
       if (this.logsAlreadyShown.has(log.created_at + log.message)) {
         continue
       }


### PR DESCRIPTION
## Summary

- Fixes a `TypeError: undefined is not iterable` crash in `heroku pg:backups:capture -v` when the Postgres API returns a permission error during verbose polling
- `backup.logs` can be `undefined` when a permission error is returned, but `displayLogs` iterated it unconditionally
- Widened the `displayLogs` parameter type from `BackupTransfer['logs']` to `BackupTransfer['logs'] | undefined` and added a `?? []` null-coalescing guard so the method is safely a no-op when `logs` is absent

**File**: `src/lib/pg/backups.ts:22`

Fixes #1294
Ref: W-23597889

## Test plan

- [ ] Run `heroku pg:backups:capture -v` against an app where the Postgres add-on does not have backup permissions — confirm no `TypeError` is thrown and the command exits cleanly
- [ ] Run `heroku pg:backups:capture -v` against an app with a healthy Postgres add-on — confirm verbose log lines are still printed as before (happy path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)