### PR TITLE
fix: config:get --shell does not double-escape backslashes in single-quoted output

### DIFF
--- a/src/lib/config/quote.ts
+++ b/src/lib/config/quote.ts
@@ -9,7 +9,7 @@ export function quote(s: string): string {
         .replaceAll(/(["\\$`!])/g, String.raw`\$1`)
         .replaceAll('\n', String.raw`\n`)
       + '"'
-    return "'" + s.replaceAll(/(['\\])/g, String.raw`\$1`) + "'"
+    return "'" + s + "'"
   }
 
   return s
@@ -19,7 +19,7 @@ export function parse(a: string): string {
   if (a.startsWith('"')) {
     a = a.replaceAll(String.raw`\n`, '\n')
   } else if (a.startsWith("'")) {
-    a = a.replaceAll('\\\\', '\\')
+    // single-quoted strings are literal in POSIX sh — no unescaping needed
   }
 
   const parsed = shell.parse(a)

--- a/test/unit/lib/config/quote.test.ts
+++ b/test/unit/lib/config/quote.test.ts
@@ -8,7 +8,7 @@ describe('quote', function () {
     ['ab$c', "'ab$c'"],
     ['a\'bc', '"a\'bc"'],
     ['a\nb\nc', String.raw`"a\nb\nc"`],
-    [String.raw`foo\nb:ar\bz`, String.raw`'foo\\nb:ar\\bz'`],
+    [String.raw`foo\nb:ar\bz`, String.raw`'foo\nb:ar\bz'`],
   ]) {
     it(`${a}===${b}`, function () {
       expect(quote(a)).to.eq(b)


### PR DESCRIPTION
## Summary

- **Bug**: `heroku config:get --shell` double-escapes backslashes inside single-quoted output. A config value like `foo\nbar` (one literal backslash) was emitted as `'foo\\nbar'`, which the shell interprets as two backslashes, corrupting the value when the output is `eval`'d.

- **Root cause**: `src/lib/config/quote.ts:12` ran `s.replaceAll(/(['\\])/g, String.raw\`\$1\`)` before wrapping the string in single quotes. POSIX single-quoted strings are fully literal — backslashes have no special meaning and must not be escaped. The single-quote branch is only reached when the string contains no single quotes and no newlines, so there are nothing to escape at all.

- **Fix**: Remove the `replaceAll` from the `quote()` single-quote branch (`src/lib/config/quote.ts:12`) and remove the compensating `replaceAll('\\\\', '\\')` from the `parse()` single-quote branch (`src/lib/config/quote.ts:22`) that was undoing the double-escaping on read-back.

- **Test**: Updated `test/unit/lib/config/quote.test.ts:11` to assert the correct (un-escaped) single-quoted output. Roundtrip tests continue to pass.

Fixes #1384
Fixes W-23597884

## Changes

| File | Line | Change |
|---|---|---|
| `src/lib/config/quote.ts` | 12 | Remove `replaceAll` from single-quote branch in `quote()` |
| `src/lib/config/quote.ts` | 22 | Remove `replaceAll('\\\\', '\\')` from single-quote branch in `parse()` |
| `test/unit/lib/config/quote.test.ts` | 11 | Update expected output for backslash-containing input to use un-escaped single quotes |

## Test plan

- [ ] `npm test -- --grep quote` passes (quote/parse unit tests including roundtrip)
- [ ] `heroku config:set FOO='foo\nbar'` then `eval $(heroku config:get FOO --shell)` yields a single backslash in `$FOO`

🤖 Generated with [Claude Code](https://claude.com/claude-code)