### PR TITLE
fix: pg:copy confirmation prompt shows addon name not app name

### DIFF
--- a/src/commands/pg/copy.ts
+++ b/src/commands/pg/copy.ts
@@ -30,14 +30,16 @@ const getAttachmentInfo = async function (heroku: APIClient, db: string, app: st
   const {body: config} = await heroku.get<Heroku.ConfigVars>(`/apps/${attachment.app.name}/config-vars`)
   const formattedConfig = Object.fromEntries(Object.entries(config).map(([k, v]) => [k.toUpperCase(), v]))
 
+  const addonName = attachment.name
+    .replace(/^HEROKU_POSTGRESQL_/, '')
+    .replace(/_URL$/, '')
   return {
     attachment: {
       ...attachment,
       addon,
     },
-    confirm: app,
-    name: attachment.name.replace(/^HEROKU_POSTGRESQL_/, '')
-      .replace(/_URL$/, ''),
+    confirm: addonName,
+    name: addonName,
     url: formattedConfig[attachment.name.toUpperCase() + '_URL'],
   }
 }

--- a/test/unit/commands/pg/copy.unit.test.ts
+++ b/test/unit/commands/pg/copy.unit.test.ts
@@ -79,7 +79,7 @@ describe('pg:copy', function () {
         '--app',
         'myapp',
         '--confirm',
-        'myapp',
+        'RED',
         'postgres://foo.com/bar',
         'HEROKU_POSTGRESQL_RED_URL',
       ])
@@ -92,7 +92,7 @@ describe('pg:copy', function () {
         '--app',
         'myapp',
         '--confirm',
-        'myapp',
+        'RED',
         'postgres://boop.com:5678/bar',
         'HEROKU_POSTGRESQL_RED_URL',
       ])
@@ -133,7 +133,7 @@ describe('pg:copy', function () {
         '--app',
         'myapp',
         '--confirm',
-        'myapp',
+        'BLUE',
         'HEROKU_POSTGRESQL_RED_URL',
         'myotherapp::DATABASE_URL',
       ])
@@ -179,7 +179,7 @@ describe('pg:copy', function () {
         '--app',
         'myapp',
         '--confirm',
-        'myapp',
+        'ATTACHED_BLUE',
         'HEROKU_POSTGRESQL_RED_URL',
         'ATTACHED_BLUE',
       ])
@@ -220,13 +220,37 @@ describe('pg:copy', function () {
         '--app',
         'mylowercaseapp',
         '--confirm',
-        'mylowercaseapp',
+        'BLUE',
         'lowercase_database_URL',
         'myotherapp::DATABASE_URL',
       ])
       expect(stdout).to.equal('')
       expect(stderr).to.include('Starting copy of lowercase_database to BLUE... done\n')
       expect(stderr).to.include(copyingText)
+    })
+  })
+  context('confirmation uses addon name not app name', function () {
+    beforeEach(function () {
+      api.get('/addons/postgres-1')
+        .reply(200, addon)
+      api.post('/actions/addon-attachments/resolve', {
+        addon_attachment: 'HEROKU_POSTGRESQL_RED_URL', app: 'myapp',
+      })
+        .reply(200, [attachment])
+      api.get('/apps/myapp/config-vars')
+        .reply(200, myappConfig)
+    })
+    it('rejects confirmation when app name is given instead of addon name', async function () {
+      const {error} = await runCommand(Cmd, [
+        '--app',
+        'myapp',
+        '--confirm',
+        'myapp',
+        'postgres://foo.com/bar',
+        'HEROKU_POSTGRESQL_RED_URL',
+      ])
+      expect(error?.message).to.include('Confirmation')
+      expect(error?.message).to.include('did not match')
     })
   })
   context('fails', function () {
@@ -256,7 +280,7 @@ describe('pg:copy', function () {
         '--app',
         'myapp',
         '--confirm',
-        'myapp',
+        'RED',
         'postgres://foo.com/bar',
         'HEROKU_POSTGRESQL_RED_URL',
       ])


### PR DESCRIPTION
## Summary

- **Bug**: `pg:copy` destructive-action confirmation prompt asked users to type the **app name** to confirm, even when the target was a named Heroku PostgreSQL attachment. A user copying to the wrong database on the same app would see an identical prompt for both, providing no safety signal.
- **Data-loss risk**: Because the `confirm` value was always the app name, not the specific database, a mistaken `heroku pg:copy SOURCE TARGET` against the wrong database on the same app would clear and overwrite data with no distinguishing warning. This is a real data-safety gap.
- **Fix**: Extract the human-readable addon name (e.g. `JADE`, `CRIMSON`) from the config-var attachment name and use it for both `name` and `confirm`, mirroring the existing behavior of the `postgres://` URL branch which already correctly uses `conn.database || conn.host`.

Fixes: W-23597886
Related: https://github.com/heroku/cli/issues/1545

## Before / After

**Before** — both prompts for two databases on the same app look identical:
```
WARNING: Destructive action
This command will remove all data from JADE
Type my-app to confirm: _
```

**After** — each prompt names the specific database:
```
WARNING: Destructive action
This command will remove all data from JADE
Type JADE to confirm: _
```

## Test plan

- [ ] `heroku pg:copy SOURCE TARGET --app my-app` where target is a named attachment: prompt asks you to type the addon name (e.g. `JADE`), not the app name.
- [ ] `heroku pg:copy postgres://... TARGET --app my-app`: existing behavior unchanged — prompt still uses `conn.database || conn.host`.
- [ ] Providing the wrong confirmation string still aborts without copying.
- [ ] `--confirm JADE` flag bypasses the prompt correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)