### PR TITLE
fix: pipelines:promote exits non-zero on partial failure

### DIFF
--- a/src/commands/pipelines/promote.ts
+++ b/src/commands/pipelines/promote.ts
@@ -117,6 +117,7 @@ export default class Promote extends Command {
       ux.stdout('\nPromotion successful')
     } else {
       ux.warn('\nPromotion to some apps failed')
+      process.exitCode = 1
     }
 
     hux.styledObject(styledTargets)

--- a/test/unit/commands/pipelines/promote.unit.test.ts
+++ b/test/unit/commands/pipelines/promote.unit.test.ts
@@ -71,6 +71,7 @@ describe('pipelines:promote', function () {
     api.done()
     nock.cleanAll()
     restore()
+    process.exitCode = 0
   })
 
   function mockPromotionTargets() {
@@ -129,6 +130,7 @@ describe('pipelines:promote', function () {
 
     expect(stdout).to.contain('failed')
     expect(stdout).to.contain('Because reasons')
+    expect(process.exitCode).to.equal(1)
   })
 
   context('passing a `to` flag', function () {


### PR DESCRIPTION
## Summary

- **File**: `src/commands/pipelines/promote.ts:119`
- In the `else` branch of the promotion result check, `ux.warn()` was called but `process.exitCode` was never set, causing the process to exit 0 even when promotion to some apps failed.
- Added `process.exitCode = 1` immediately after the `ux.warn()` call so CI scripts that run `heroku pipelines:promote` can detect partial failures.

## Changes

- `src/commands/pipelines/promote.ts` — add `process.exitCode = 1` in the partial-failure branch (line 119)
- `test/unit/commands/pipelines/promote.unit.test.ts` — add assertion `expect(process.exitCode).to.equal(1)` in the partial-failure test; reset `process.exitCode = 0` in `afterEach` to prevent state leak

## Test plan

- [ ] Existing test `promotes to all apps in the next stage` now explicitly asserts `process.exitCode === 1` on partial failure
- [ ] `afterEach` resets `process.exitCode` to 0 to avoid cross-test contamination
- [ ] All other tests are unaffected (success path still exits 0)
- [ ] CI runs full test suite

## References

- GUS work item: W-23597946
- GitHub issue: #1600

🤖 Generated with [Claude Code](https://claude.com/claude-code)