### PR TITLE
fix: pg:backups:download respects HTTPS_PROXY env var

### DIFF
--- a/src/lib/pg/download.ts
+++ b/src/lib/pg/download.ts
@@ -2,6 +2,7 @@ import cliProgress from 'cli-progress'
 import fs from 'fs-extra'
 import https from 'node:https'
 import Path from 'node:path'
+import {HttpsProxyAgent} from 'https-proxy-agent'
 
 type downloadOptions = {
   progress: boolean
@@ -30,7 +31,9 @@ export default function download(url: string, path: string, opts: downloadOption
   return new Promise((resolve, reject) => {
     fs.mkdirSync(Path.dirname(path), {recursive: true})
     const file = fs.createWriteStream(path)
-    https.get(url, (rsp: any) => {
+    const proxy = process.env.https_proxy || process.env.HTTPS_PROXY
+    const options: https.RequestOptions = proxy ? {agent: new HttpsProxyAgent(proxy)} : {}
+    https.get(url, options, (rsp: any) => {
       if (tty && opts.progress) showProgress(rsp)
       rsp.pipe(file)
         .on('error', reject)

--- a/src/lib/pg/download.ts
+++ b/src/lib/pg/download.ts
@@ -1,8 +1,8 @@
 import cliProgress from 'cli-progress'
 import fs from 'fs-extra'
+import {HttpsProxyAgent} from 'https-proxy-agent'
 import https from 'node:https'
 import Path from 'node:path'
-import {HttpsProxyAgent} from 'https-proxy-agent'
 
 type downloadOptions = {
   progress: boolean


### PR DESCRIPTION
## Summary

- `pg:backups:download` used bare `https.get(url, callback)` with no proxy agent, silently bypassing any configured corporate proxy
- Adds proxy detection (`https_proxy` / `HTTPS_PROXY`) and wires in `HttpsProxyAgent` — exactly the pattern already used in `src/lib/run/log-displayer.ts`
- `https-proxy-agent` is already a declared production dependency (`^7.0.6` in `package.json`), so no new deps are needed
- When no proxy env var is set, behavior is unchanged (empty options object is passed)

Fixes #1531 | W-23597944

## Test plan

- [ ] Set `HTTPS_PROXY=http://your-proxy:8080` and run `heroku pg:backups:download` — confirm traffic routes through the proxy
- [ ] Unset `HTTPS_PROXY` and confirm download still works normally
- [ ] No unit test file exists for `src/lib/pg/download.ts`; a follow-up test can be added if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)