### PR TITLE
fix: replace jQuery CDN dependency in addons:open SSO template with vanilla JS

### DIFF
--- a/src/commands/addons/open.ts
+++ b/src/commands/addons/open.ts
@@ -139,7 +139,7 @@ export default class Open extends Command {
 
   private async writeSudoTemplate(app: string, addon: string, sso:AddonSso): Promise<string> {
     const ssoPath = path.join(os.tmpdir(), 'heroku-sso.html')
-    const html = `<!DOCTYPE HTML>\n<html lang="en">\n  <head>\n    <meta charset="utf-8">\n    <title>Heroku Add-ons SSO</title>\n    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js"></script>\n  </head>\n\n  <body>\n    <h3>Opening ${addon}${app ? ` on ${app}` : ''}...</h3>\n    <form method="POST" action="${sso.action}">\n    </form>\n\n    <script>\n      var params = ${JSON.stringify(sso.params)}\n      var form = document.forms[0]\n      $(document).ready(function() {\n        $.each(params, function(key, value) {\n          $('<input>').attr({ type: 'hidden', name: key, value: value })\n            .appendTo(form)\n        })\n        form.submit()\n      })\n    </script>\n  </body>\n</html>`
+    const html = `<!DOCTYPE HTML>\n<html lang="en">\n  <head>\n    <meta charset="utf-8">\n    <title>Heroku Add-ons SSO</title>\n  </head>\n\n  <body>\n    <h3>Opening ${addon}${app ? ` on ${app}` : ''}...</h3>\n    <form method="POST" action="${sso.action}">\n    </form>\n\n    <script>\n      document.addEventListener('DOMContentLoaded', function() {\n        var params = ${JSON.stringify(sso.params)}\n        var form = document.forms[0]\n        Object.keys(params).forEach(function(key) {\n          var input = document.createElement('input')\n          input.type = 'hidden'\n          input.name = key\n          input.value = params[key]\n          form.appendChild(input)\n        })\n        form.submit()\n      })\n    </script>\n  </body>\n</html>`
     await fs.writeFile(ssoPath, html)
     return ssoPath
   }

--- a/test/unit/commands/addons/open.unit.test.ts
+++ b/test/unit/commands/addons/open.unit.test.ts
@@ -137,7 +137,11 @@ describe('The addons:open command', function () {
       expect(stdout).to.equal(`Opening ${lastArg}...\n`)
 
       const file = await fs.readFile(normalizedPath.replace(`file:${path.sep}${path.sep}`, ''))
-      expect(file.toString().includes('Opening db2 on myapp...')).to.be.true
+      const html = file.toString()
+      expect(html.includes('Opening db2 on myapp...')).to.be.true
+      expect(html.includes('googleapis.com')).to.be.false
+      expect(html.includes('DOMContentLoaded')).to.be.true
+      expect(html.includes('form.submit()')).to.be.true
       return api.done()
     })
   })


### PR DESCRIPTION
## Summary

- Removes the `<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js">` tag from the SSO HTML page generated by `writeSudoTemplate` in `src/commands/addons/open.ts`
- Replaces the jQuery-dependent form-building code (`$.each`, `$('<input>')`, `$(document).ready`) with a vanilla JS equivalent using `document.addEventListener('DOMContentLoaded', ...)` and `Object.keys(params).forEach(...)`
- Updates the existing unit test (`test/unit/commands/addons/open.unit.test.ts`) to assert: the generated HTML does **not** contain `googleapis.com`, and **does** contain `DOMContentLoaded` and `form.submit()`

**Motivation**: The SSO template is a locally-generated HTML page that handles authentication. Loading jQuery 2.0.0 (released 2013) from an external Google CDN at auth time is a supply-chain risk — the page silently fetches a decade-old, potentially compromised script from a third party. Vanilla JS removes the external dependency entirely with no loss of functionality.

Fixes #1541 | W-23597891

## Test plan

- [ ] Run `npm test -- --grep "file path using sudo via sso"` — verifies the generated HTML has no `googleapis.com` and does contain `DOMContentLoaded` / `form.submit()`
- [ ] Manually set `HEROKU_SUDO=true` and run `heroku addons:open <addon> --app <app>` against an app with a POST-method SSO add-on to confirm the browser opens the add-on dashboard correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)