### PR TITLE
fix: autocomplete zsh setup guards compinit to prevent double-init

### DIFF
--- a/src/commands/autocomplete/create.ts
+++ b/src/commands/autocomplete/create.ts
@@ -152,7 +152,7 @@ ${AC_LIB_PATH}/zsh
 $fpath
 );
 autoload -Uz compinit;
-compinit;
+(( \${+functions[compdef]} )) || compinit;
 `
   }
 

--- a/test/unit/commands/autocomplete/create.unit.test.ts
+++ b/test/unit/commands/autocomplete/create.unit.test.ts
@@ -131,7 +131,7 @@ ${AC_LIB_PATH}/zsh
 $fpath
 );
 autoload -Uz compinit;
-compinit;
+(( \${+functions[compdef]} )) || compinit;
 `)
   })
 
@@ -149,7 +149,7 @@ ${AC_LIB_PATH}/zsh
 $fpath
 );
 autoload -Uz compinit;
-compinit;
+(( \${+functions[compdef]} )) || compinit;
 `)
     process.env = oldEnv
   })


### PR DESCRIPTION
## Summary

- Wraps the `compinit` call in `(( ${+functions[compdef]} )) || compinit` so it only runs if `compinit` has not already been loaded
- Users who already call `compinit` in their `.zshrc` no longer experience doubled shell startup time
- The `autoload -Uz compinit` line remains unconditional — it is cheap and idempotent
- Updates the two `#zshSetupScript` unit tests to expect the new guarded form

Closes #1686
W-23597892

## Background

`heroku autocomplete` generates a `zsh_setup` script that is sourced on every shell start. It previously called `compinit` unconditionally. For users who already call `compinit` in their `.zshrc`, this triggers a full zsh completion system re-initialization, which can add hundreds of milliseconds to shell startup.

The fix uses the canonical zsh idiom: `(( ${+functions[compdef]} )) || compinit`. The `compdef` function is registered by `compinit`; if it exists, compinit has already run and we skip it.

## Test plan

- [ ] `npm test -- --grep zshSetupScript` passes with updated expected strings
- [ ] Manual: `heroku autocomplete` on a shell that already calls `compinit` — verify startup time is not doubled
- [ ] Manual: `heroku autocomplete` on a shell with no existing `compinit` call — verify completions still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)