### PR TITLE
feat: add --no-cache flag to container:push (W-23597904, #1390)

### DIFF
--- a/src/commands/container/push.ts
+++ b/src/commands/container/push.ts
@@ -21,7 +21,7 @@ export default class Push extends Command {
     app: flags.app({required: true}),
     arg: flags.string({description: 'set build-time variables'}),
     'context-path': flags.string({description: 'path to use as build context (defaults to Dockerfile dir)'}),
-    'no-cache': flags.boolean({description: 'do not use cache when building the image'}),
+    'no-cache': flags.boolean({description: 'don\'t use cache when building the image'}),
     recursive: flags.boolean({char: 'R', description: 'pushes Dockerfile.<process> found in current and subdirectories'}),
     remote: flags.remote({char: 'r'}),
     verbose: flags.boolean({char: 'v'}),

--- a/src/commands/container/push.ts
+++ b/src/commands/container/push.ts
@@ -21,6 +21,7 @@ export default class Push extends Command {
     app: flags.app({required: true}),
     arg: flags.string({description: 'set build-time variables'}),
     'context-path': flags.string({description: 'path to use as build context (defaults to Dockerfile dir)'}),
+    'no-cache': flags.boolean({description: 'do not use cache when building the image'}),
     recursive: flags.boolean({char: 'R', description: 'pushes Dockerfile.<process> found in current and subdirectories'}),
     remote: flags.remote({char: 'r'}),
     verbose: flags.boolean({char: 'v'}),
@@ -31,7 +32,7 @@ export default class Push extends Command {
 
   async run(): Promise<void> {
     const {argv: processTypes, flags} = await this.parse(Push)
-    const {app, arg, 'context-path': contextPath, recursive, verbose} = flags
+    const {app, arg, 'context-path': contextPath, 'no-cache': noCache, recursive, verbose} = flags
 
     if (verbose) {
       debug.enabled = true
@@ -71,6 +72,7 @@ export default class Push extends Command {
           arch: this.config.arch,
           buildArgs,
           dockerfile: job.dockerfile,
+          noCache,
           path: contextPath,
           resource: job.resource,
         })

--- a/src/lib/container/docker-helper.ts
+++ b/src/lib/container/docker-helper.ts
@@ -30,17 +30,20 @@ type BuildImageParams = {
   arch?: string,
   buildArgs: string[],
   dockerfile: string,
+  noCache?: boolean,
   path?: string,
   resource: string,
 }
 
 export class DockerHelper {
-  async buildImage({arch, buildArgs, dockerfile, path, resource}: BuildImageParams): Promise<string> {
+  async buildImage({arch, buildArgs, dockerfile, noCache, path, resource}: BuildImageParams): Promise<string> {
     const cwd = path || Path.dirname(dockerfile)
     const args = ['build', '-f', dockerfile, '-t', resource]
     // Older Docker versions don't allow for this flag, but we are
     // adding it here when necessary to allow for pushing a docker build from m1/m2 Macs.
     if (arch === 'arm64' || arch === 'aarch64') args.push('--platform', 'linux/amd64')
+
+    if (noCache) args.push('--no-cache')
 
     // newer docker versions support attestations and software bill of materials, so we want to disable them to save time/space
     // Heroku's container registry doesn't support pushing them right now

--- a/test/unit/commands/container/push.unit.test.ts
+++ b/test/unit/commands/container/push.unit.test.ts
@@ -312,6 +312,28 @@ describe('container push', function () {
       sandbox.assert.calledOnce(push)
     })
 
+    it('passes --no-cache to buildImage when flag is set', async function () {
+      const dockerfiles = sandbox.stub(DockerHelper.prototype, 'getDockerfiles')
+        .returns(['/path/to/Dockerfile'])
+      const build = sandbox.stub(DockerHelper.prototype, 'buildImage')
+      const push = sandbox.stub(DockerHelper.prototype, 'pushImage')
+        .withArgs('registry.heroku.com/testapp/web')
+
+      const {stdout} = await runCommand(Cmd, [
+        '--app',
+        'testapp',
+        '--no-cache',
+        'web',
+      ])
+
+      expect(stdout).to.contain('Building web (/path/to/Dockerfile)')
+      expect(stdout).to.contain('Pushing web (/path/to/Dockerfile)')
+      sandbox.assert.calledOnce(dockerfiles)
+      sandbox.assert.calledOnce(build)
+      expect(build.getCall(0).args[0].noCache).to.equal(true)
+      sandbox.assert.calledOnce(push)
+    })
+
     it('does not find an image to push', async function () {
       const dockerfiles = sandbox.stub(DockerHelper.prototype, 'getDockerfiles')
         .returns([])

--- a/test/unit/lib/container/docker-helper.unit.test.ts
+++ b/test/unit/lib/container/docker-helper.unit.test.ts
@@ -375,5 +375,48 @@ describe('DockerHelper', function () {
       const options = eventStub.getCall(0).args[2]
       expect(eventStub.calledWith('docker', argsArray, options)).to.equal(true)
     })
+
+    it('includes the --no-cache flag when noCache is true', async function () {
+      const argsArray = [
+        'build',
+        '-f',
+        'dockerfile',
+        '-t',
+        'registry.heroku.com/test-app/web',
+        '--no-cache',
+        '.',
+      ]
+      const eventStub = sandbox.stub(childProcess, 'spawn').callsFake(eventMock)
+
+      await helper.buildImage({
+        buildArgs: [],
+        dockerfile: 'dockerfile',
+        noCache: true,
+        resource: 'registry.heroku.com/test-app/web',
+      })
+      const actualArgs = eventStub.getCall(0).args[1]
+      expect(actualArgs).to.deep.equal(argsArray)
+    })
+
+    it('does not include the --no-cache flag when noCache is false', async function () {
+      const argsArray = [
+        'build',
+        '-f',
+        'dockerfile',
+        '-t',
+        'registry.heroku.com/test-app/web',
+        '.',
+      ]
+      const eventStub = sandbox.stub(childProcess, 'spawn').callsFake(eventMock)
+
+      await helper.buildImage({
+        buildArgs: [],
+        dockerfile: 'dockerfile',
+        noCache: false,
+        resource: 'registry.heroku.com/test-app/web',
+      })
+      const actualArgs = eventStub.getCall(0).args[1]
+      expect(actualArgs).to.deep.equal(argsArray)
+    })
   })
 })


### PR DESCRIPTION
## Summary

- Adds `--no-cache` boolean flag to `heroku container:push`
- Passes `--no-cache` to the underlying `docker build` command when the flag is set
- Adds `noCache?: boolean` to the `BuildImageParams` type in `DockerHelper`

## Test plan

- [ ] `npm run test:file test/unit/lib/container/docker-helper.unit.test.ts` — 2 new tests for `noCache: true` and `noCache: false`
- [ ] `npm run test:file test/unit/commands/container/push.unit.test.ts` — 1 new test verifying `--no-cache` is passed through to `buildImage`
- [ ] `npx eslint src/lib/container/docker-helper.ts src/commands/container/push.ts` — no errors

Closes #1390

🤖 Generated with [Claude Code](https://claude.com/claude-code)