### PR TITLE
feat(pg,redis): add --as flag to pg:promote and redis:promote (W-23597911, #1819)

### DIFF
--- a/src/commands/pg/promote.ts
+++ b/src/commands/pg/promote.ts
@@ -18,6 +18,7 @@ export default class Promote extends Command {
   static description = 'sets DATABASE as your DATABASE_URL'
   static flags = {
     app: flags.app({required: true}),
+    as: flags.string({description: 'name for the database attachment'}),
     force: flags.boolean({char: 'f'}),
     remote: flags.remote(),
   }
@@ -25,7 +26,7 @@ export default class Promote extends Command {
 
   public async run(): Promise<void> {
     const {args, flags} = await this.parse(Promote)
-    const {app, force} = flags
+    const {app, as, force} = flags
     const {database} = args
     const dbResolver = new utils.pg.DatabaseResolver(this.heroku)
     const attachment = await dbResolver.getAttachment(app, database)
@@ -87,7 +88,7 @@ export default class Promote extends Command {
         addon: {name: attachment.addon.name},
         app: {name: app},
         confirm: app,
-        name: 'DATABASE',
+        name: as || 'DATABASE',
         namespace: attachment.namespace || null,
       },
     })

--- a/src/commands/redis/promote.ts
+++ b/src/commands/redis/promote.ts
@@ -11,14 +11,16 @@ export default class Promote extends Command {
   static description = 'sets DATABASE as your REDIS_URL'
   static flags = {
     app: flags.app({required: true}),
+    as: flags.string({description: 'name for the Key-Value Store attachment'}),
     remote: flags.remote(),
   }
   static topic = 'redis'
 
   public async run(): Promise<void> {
     const {args, flags} = await this.parse(Promote)
-    const api = apiFactory(flags.app, args.database, false, this.heroku)
-    const {body: addonsList} = await this.heroku.get<Required<Heroku.AddOn>[]>(`/apps/${flags.app}/addons`)
+    const {app, as} = flags
+    const api = apiFactory(app, args.database, false, this.heroku)
+    const {body: addonsList} = await this.heroku.get<Required<Heroku.AddOn>[]>(`/apps/${app}/addons`)
     const addon = await api.getRedisAddon(addonsList)
     const redisFilter = api.makeAddonsFilter('REDIS_URL')
     const redis = redisFilter(addonsList) as Required<Heroku.AddOn>[]
@@ -26,15 +28,15 @@ export default class Promote extends Command {
       const attachment = redis[0]
       await this.heroku.post('/addon-attachments', {
         body: {
-          addon: {name: attachment.name}, app: {name: flags.app}, confirm: flags.app,
+          addon: {name: attachment.name}, app: {name: app}, confirm: app,
         },
       })
     }
 
-    ux.stdout(`Promoting ${addon.name} to REDIS_URL on ${flags.app}`)
+    ux.stdout(`Promoting ${addon.name} to REDIS_URL on ${app}`)
     await this.heroku.post('/addon-attachments', {
       body: {
-        addon: {name: addon.name}, app: {name: flags.app}, confirm: flags.app, name: 'REDIS',
+        addon: {name: addon.name}, app: {name: app}, confirm: app, name: as || 'REDIS',
       },
     })
   }

--- a/test/unit/commands/pg/promote.unit.test.ts
+++ b/test/unit/commands/pg/promote.unit.test.ts
@@ -227,6 +227,45 @@ describe('pg:promote when argument is database', function () {
     `))
   })
 
+  it('promotes the db with a custom attachment name when --as is provided', async function () {
+    nock('https://api.heroku.com')
+      .get('/apps/myapp/formation')
+      .reply(200, [])
+      .get('/apps/myapp/addon-attachments')
+      .reply(200, [
+        {
+          addon: {name: 'postgres-2'},
+          name: 'DATABASE',
+          namespace: null,
+        },
+        {
+          addon: {name: 'postgres-2'},
+          name: 'RED',
+          namespace: null,
+        },
+      ])
+      .post('/addon-attachments', {
+        addon: {name: addon.name},
+        app: {name: 'myapp'},
+        confirm: 'myapp',
+        name: 'CUSTOM_DB',
+        namespace: null,
+      })
+      .reply(201)
+
+    const {stderr} = await runCommand(Cmd, [
+      '--app',
+      'myapp',
+      '--as',
+      'CUSTOM_DB',
+      'DATABASE',
+    ])
+    expectOutput(stderr, heredoc(`
+      Ensuring an alternate alias for existing ⛁ DATABASE_URL... RED_URL
+      Promoting ⛁ ${addon.name} to ⛁ DATABASE_URL on ⬢ myapp... done
+    `))
+  })
+
   it('does not promote the db if is already is DATABASE', async function () {
     nock('https://api.heroku.com')
       .get('/apps/myapp/formation')

--- a/test/unit/commands/redis/promote.unit.test.ts
+++ b/test/unit/commands/redis/promote.unit.test.ts
@@ -49,6 +49,43 @@ describe('heroku redis:promote', function () {
     expect(stderr).to.equal('')
   })
 
+  it('# promotes with a custom attachment name when --as is provided', async function () {
+    const app = nock('https://api.heroku.com:443')
+      .get('/apps/example/addons')
+      .reply(200, [
+        {
+          addon_service: {name: 'heroku-redis'},
+          config_vars: ['REDIS_URL', 'HEROKU_REDIS_SILVER_URL'],
+          name: 'redis-silver-haiku',
+        }, {
+          addon_service: {name: 'heroku-redis'},
+          config_vars: ['HEROKU_REDIS_GOLD_URL'],
+          name: 'redis-gold-haiku',
+        },
+      ])
+
+    const attach = nock('https://api.heroku.com:443')
+      .post('/addon-attachments', {
+        addon: {name: 'redis-gold-haiku'},
+        app: {name: 'example'},
+        confirm: 'example',
+        name: 'CUSTOM_REDIS',
+      })
+      .reply(200, {})
+
+    const {stderr, stdout} = await runCommand(Cmd, [
+      '--app',
+      'example',
+      '--as',
+      'CUSTOM_REDIS',
+      'redis-gold-haiku',
+    ])
+    app.done()
+    attach.done()
+    expect(stdout).to.equal('Promoting redis-gold-haiku to REDIS_URL on example\n')
+    expect(stderr).to.equal('')
+  })
+
   it('# promotes and replaces attachment of existing REDIS_URL if necessary', async function () {
     const app = nock('https://api.heroku.com:443')
       .get('/apps/example/addons')


### PR DESCRIPTION
## Summary

- Adds `--as NAME` flag to `heroku pg:promote` — allows creating the promoted database attachment under a custom name instead of the hardcoded `DATABASE`
- Adds `--as NAME` flag to `heroku redis:promote` — allows creating the promoted Key-Value Store attachment under a custom name instead of the hardcoded `REDIS`
- When `--as` is omitted both commands fall back to the original default names, so existing behavior is unchanged
- Follows the same `flags.as` pattern already established in `addons:attach` and `pg:connection-pooling:attach`

Resolves GUS W-23597911 / GitHub #1819

## Test plan

- [ ] `pg:promote` unit tests pass, including new test for `--as CUSTOM_DB` which asserts the attachment POST sends `name: 'CUSTOM_DB'`
- [ ] `redis:promote` unit tests pass, including new test for `--as CUSTOM_REDIS` which asserts the attachment POST sends `name: 'CUSTOM_REDIS'`
- [ ] ESLint passes with zero new errors on changed files
- [ ] `heroku pg:promote --app <app> <db> --as STAGING_DB` creates attachment named `STAGING_DB_URL`
- [ ] `heroku redis:promote --app <app> <redis> --as STAGING_REDIS` creates attachment named `STAGING_REDIS_URL`
- [ ] Omitting `--as` still promotes to `DATABASE_URL` / `REDIS_URL` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)