### PR TITLE
feat(ci): add not-in-git-repo guard to ci:run and ci:rerun (W-23597902, #1761)

### DIFF
--- a/src/commands/ci/rerun.ts
+++ b/src/commands/ci/rerun.ts
@@ -28,7 +28,7 @@ export default class CiReRun extends Command {
     const {args, flags} = await this.parse(CiReRun)
 
     if (!gitService.inGitRepo()) {
-      this.error('Not in a git repository. ci:rerun must be run from within your app\'s git repo.')
+      this.error(`You can't run ${color.command('heroku ci:rerun')} outside of your app's git repository.`)
     }
 
     const pipeline = await getPipeline(flags, this.heroku)

--- a/src/commands/ci/rerun.ts
+++ b/src/commands/ci/rerun.ts
@@ -3,6 +3,7 @@ import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
 import {Args, ux} from '@oclif/core'
 
+import {gitService} from '../../lib/ci/git.js'
 import * as Kolkrabbi from '../../lib/ci/interfaces/kolkrabbi.js'
 import {getPipeline} from '../../lib/ci/pipelines.js'
 import {createSourceBlob} from '../../lib/ci/source.js'
@@ -25,6 +26,11 @@ export default class CiReRun extends Command {
 
   async run() {
     const {args, flags} = await this.parse(CiReRun)
+
+    if (!gitService.inGitRepo()) {
+      this.error('Not in a git repository. ci:rerun must be run from within your app\'s git repo.')
+    }
+
     const pipeline = await getPipeline(flags, this.heroku)
 
     let sourceTestRun: Heroku.TestRun

--- a/src/commands/ci/run.ts
+++ b/src/commands/ci/run.ts
@@ -23,6 +23,11 @@ export default class CiRun extends Command {
 
   async run() {
     const {flags} = await this.parse(CiRun)
+
+    if (!gitService.inGitRepo()) {
+      this.error('Not in a git repository. ci:run must be run from within your app\'s git repo.')
+    }
+
     const pipeline = await getPipeline(flags, this.heroku)
     const commit = await gitService.readCommit('HEAD')
 

--- a/src/commands/ci/run.ts
+++ b/src/commands/ci/run.ts
@@ -25,7 +25,7 @@ export default class CiRun extends Command {
     const {flags} = await this.parse(CiRun)
 
     if (!gitService.inGitRepo()) {
-      this.error('Not in a git repository. ci:run must be run from within your app\'s git repo.')
+      this.error(`You can't run ${color.command('heroku ci:run')} outside of your app's git repository.`)
     }
 
     const pipeline = await getPipeline(flags, this.heroku)

--- a/test/unit/commands/ci/rerun.unit.test.ts
+++ b/test/unit/commands/ci/rerun.unit.test.ts
@@ -29,6 +29,26 @@ describe('ci:rerun', function () {
     }
   })
 
+  describe('when not in a git repository', function () {
+    let sandbox: ReturnType<typeof createSandbox>
+
+    beforeEach(function () {
+      sandbox = createSandbox()
+      sandbox.stub(gitService, 'inGitRepo').returns(false as any)
+    })
+
+    afterEach(function () {
+      sandbox.restore()
+    })
+
+    it('errors with a clear message', async function () {
+      const {error} = await runCommand(Cmd, ['--pipeline=my-pipeline'])
+      expect(error).to.exist
+      expect(error?.message).to.contain('Not in a git repository')
+      expect(error?.message).to.contain('ci:rerun must be run from within your app\'s git repo')
+    })
+  })
+
   describe('when specifying a pipeline', function () {
     const pipeline = {id: '14402644-c207-43aa-9bc1-974a34914010', name: 'pipeline'}
     const ghRepository = {
@@ -58,6 +78,7 @@ describe('ci:rerun', function () {
       sandbox = createSandbox()
 
       // Stub gitService methods
+      sandbox.stub(gitService, 'inGitRepo').returns(true)
       sandbox.stub(gitService, 'githubRepository').resolves({repo: ghRepository.repo, user: ghRepository.user} as any)
       sandbox.stub(gitService, 'createArchive').resolves('new-archive.tgz')
 

--- a/test/unit/commands/ci/rerun.unit.test.ts
+++ b/test/unit/commands/ci/rerun.unit.test.ts
@@ -1,4 +1,5 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import ansis from 'ansis'
 import {expect} from 'chai'
 import {got} from 'got'
 import nock from 'nock'
@@ -44,8 +45,7 @@ describe('ci:rerun', function () {
     it('errors with a clear message', async function () {
       const {error} = await runCommand(Cmd, ['--pipeline=my-pipeline'])
       expect(error).to.exist
-      expect(error?.message).to.contain('Not in a git repository')
-      expect(error?.message).to.contain('ci:rerun must be run from within your app\'s git repo')
+      expect(ansis.strip(error?.message ?? '')).to.contain('You can\'t run  $ heroku ci:rerun  outside of your app\'s git repository.')
     })
   })
 

--- a/test/unit/commands/ci/run.unit.test.ts
+++ b/test/unit/commands/ci/run.unit.test.ts
@@ -29,6 +29,26 @@ describe('ci:run', function () {
     }
   })
 
+  describe('when not in a git repository', function () {
+    let sandbox: ReturnType<typeof createSandbox>
+
+    beforeEach(function () {
+      sandbox = createSandbox()
+      sandbox.stub(gitService, 'inGitRepo').returns(false as any)
+    })
+
+    afterEach(function () {
+      sandbox.restore()
+    })
+
+    it('errors with a clear message', async function () {
+      const {error} = await runCommand(Cmd, ['--pipeline=my-pipeline'])
+      expect(error).to.exist
+      expect(error?.message).to.contain('Not in a git repository')
+      expect(error?.message).to.contain('ci:run must be run from within your app\'s git repo')
+    })
+  })
+
   describe('when specifying a pipeline', function () {
     const pipeline = {id: '14402644-c207-43aa-9bc1-974a34914010', name: 'pipeline'}
     const ghRepository = {
@@ -53,6 +73,7 @@ describe('ci:run', function () {
       sandbox = createSandbox()
 
       // Stub gitService methods
+      sandbox.stub(gitService, 'inGitRepo').returns(true)
       sandbox.stub(gitService, 'readCommit').resolves({branch: ghRepository.branch, message: `pushed to ${ghRepository.branch}`, ref: ghRepository.ref})
       sandbox.stub(gitService, 'githubRepository').resolves({repo: ghRepository.repo, user: ghRepository.user} as any)
       sandbox.stub(gitService, 'createArchive').resolves('new-archive.tgz')

--- a/test/unit/commands/ci/run.unit.test.ts
+++ b/test/unit/commands/ci/run.unit.test.ts
@@ -1,4 +1,5 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import ansis from 'ansis'
 import {expect} from 'chai'
 import {got} from 'got'
 import nock from 'nock'
@@ -44,8 +45,7 @@ describe('ci:run', function () {
     it('errors with a clear message', async function () {
       const {error} = await runCommand(Cmd, ['--pipeline=my-pipeline'])
       expect(error).to.exist
-      expect(error?.message).to.contain('Not in a git repository')
-      expect(error?.message).to.contain('ci:run must be run from within your app\'s git repo')
+      expect(ansis.strip(error?.message ?? '')).to.contain('You can\'t run  $ heroku ci:run  outside of your app\'s git repository.')
     })
   })
 


### PR DESCRIPTION
## Summary

- Adds an early `gitService.inGitRepo()` guard to `ci:run` and `ci:rerun` that throws a clear, user-friendly error when run outside a git repository
- Previously, running these commands outside a git repo would silently fail deep inside `createSourceBlob()` with a confusing error; now the user sees: _"Not in a git repository. ci:rerun must be run from within your app's git repo."_
- Uses the existing `gitService` singleton (already imported in `ci:run`; newly imported in `ci:rerun`) so the guard is stubbable in tests
- Adds a `when not in a git repository` test case to both `ci:run` and `ci:rerun` unit tests
- Stubs `gitService.inGitRepo` to `true` in the existing happy-path tests to keep them isolated

## Test plan

- [ ] `ci:run` — new test case `when not in a git repository` passes
- [ ] `ci:rerun` — new test case `when not in a git repository` passes
- [ ] All existing `ci:run` and `ci:rerun` tests continue to pass
- [ ] `npm run lint` reports no errors for touched files
- [ ] Manually run `heroku ci:run --pipeline=foo` outside a git repo and confirm the error message

Closes #1761 | GUS W-23597902

🤖 Generated with [Claude Code](https://claude.com/claude-code)