### PR TITLE
feat: infer --pipeline from heroku.remote git config in CI commands (W-23597910, #1318)

### DIFF
--- a/src/lib/ci/pipelines.ts
+++ b/src/lib/ci/pipelines.ts
@@ -43,10 +43,7 @@ export class PipelineService {
     let pipeline
 
     // Resolve app from --remote flag or heroku.remote git config when --pipeline and --app are absent
-    let resolvedApp = flags.app
-    if (!flags.pipeline && !resolvedApp) {
-      resolvedApp = this.resolveAppFromRemote(flags.remote) ?? null
-    }
+    const resolvedApp = flags.app ?? this.resolveAppFromRemote(flags.remote) ?? null
 
     if (!flags.pipeline && !resolvedApp) {
       ux.error('Required flag:  --pipeline PIPELINE or --app APP')

--- a/src/lib/ci/pipelines.ts
+++ b/src/lib/ci/pipelines.ts
@@ -1,4 +1,4 @@
-import {APIClient} from '@heroku-cli/command'
+import {APIClient, configRemote, getGitRemotes} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core/ux'
 import inquirer from 'inquirer'
@@ -39,10 +39,16 @@ export class PipelineService {
     }
   }
 
-  async getPipeline(flags: {app: null | string; pipeline: null | string}) {
+  async getPipeline(flags: {app: null | string; pipeline: null | string; remote?: null | string}) {
     let pipeline
 
-    if ((!flags.pipeline) && (!flags.app)) {
+    // Resolve app from --remote flag or heroku.remote git config when --pipeline and --app are absent
+    let resolvedApp = flags.app
+    if (!flags.pipeline && !resolvedApp) {
+      resolvedApp = this.resolveAppFromRemote(flags.remote) ?? null
+    }
+
+    if (!flags.pipeline && !resolvedApp) {
       ux.error('Required flag:  --pipeline PIPELINE or --app APP')
     }
 
@@ -53,11 +59,11 @@ export class PipelineService {
         pipeline = pipeline.pipeline
       } // in case prompt returns an object like { pipeline: { ... } }
     } else {
-      const {body: coupling} = await this.herokuAPI.get<Heroku.PipelineCoupling>(`/apps/${flags.app}/pipeline-couplings`)
+      const {body: coupling} = await this.herokuAPI.get<Heroku.PipelineCoupling>(`/apps/${resolvedApp}/pipeline-couplings`)
       if ((coupling) && (coupling.pipeline)) {
         pipeline = coupling.pipeline
       } else {
-        ux.error(`No pipeline found with application ${flags.app}`)
+        ux.error(`No pipeline found with application ${resolvedApp}`)
       }
     }
 
@@ -73,6 +79,17 @@ export class PipelineService {
     }]
 
     return inquirer.prompt(questions)
+  }
+
+  /**
+   * Resolves an app name from a git remote name or heroku.remote git config.
+   * Returns undefined if no matching heroku git remote is found.
+   */
+  protected resolveAppFromRemote(remote: null | string | undefined): string | undefined {
+    const remoteName = remote || configRemote()
+    if (!remoteName) return undefined
+    const gitRemotes = getGitRemotes(remoteName)
+    return gitRemotes.length > 0 ? gitRemotes[0].app : undefined
   }
 }
 

--- a/test/unit/lib/ci/pipelines.unit.test.ts
+++ b/test/unit/lib/ci/pipelines.unit.test.ts
@@ -1,7 +1,6 @@
 import {APIClient} from '@heroku-cli/command'
 import {expect} from 'chai'
 import nock from 'nock'
-import {createSandbox} from 'sinon'
 
 import {getPipeline, PipelineService} from '../../../../src/lib/ci/pipelines.js'
 import {getHerokuAPI} from '../../../helpers/test-instances.js'
@@ -49,16 +48,6 @@ describe('pipelines.ts', function () {
     })
 
     describe('remote inference', function () {
-      let sandbox: ReturnType<typeof createSandbox>
-
-      beforeEach(function () {
-        sandbox = createSandbox()
-      })
-
-      afterEach(function () {
-        sandbox.restore()
-      })
-
       it('resolves the pipeline via --remote flag when --pipeline and --app are absent', async function () {
         const app = 'my-heroku-app'
         const coupling = {pipeline: PIPELINE}

--- a/test/unit/lib/ci/pipelines.unit.test.ts
+++ b/test/unit/lib/ci/pipelines.unit.test.ts
@@ -1,8 +1,9 @@
 import {APIClient} from '@heroku-cli/command'
 import {expect} from 'chai'
 import nock from 'nock'
+import {createSandbox} from 'sinon'
 
-import {getPipeline} from '../../../../src/lib/ci/pipelines.js'
+import {getPipeline, PipelineService} from '../../../../src/lib/ci/pipelines.js'
 import {getHerokuAPI} from '../../../helpers/test-instances.js'
 
 const PIPELINE = {
@@ -45,6 +46,76 @@ describe('pipelines.ts', function () {
       const response = await getPipeline({app}, herokuAPI)
       expect(response).to.deep.eq(PIPELINE)
       api.done()
+    })
+
+    describe('remote inference', function () {
+      let sandbox: ReturnType<typeof createSandbox>
+
+      beforeEach(function () {
+        sandbox = createSandbox()
+      })
+
+      afterEach(function () {
+        sandbox.restore()
+      })
+
+      it('resolves the pipeline via --remote flag when --pipeline and --app are absent', async function () {
+        const app = 'my-heroku-app'
+        const coupling = {pipeline: PIPELINE}
+
+        // Subclass PipelineService to inject a controlled resolveAppFromRemote
+        class TestPipelineService extends PipelineService {
+          protected override resolveAppFromRemote(_remote: null | string | undefined): string | undefined {
+            return app
+          }
+        }
+
+        const api = nock('https://api.heroku.com')
+          .get(`/apps/${app}/pipeline-couplings`)
+          .reply(200, coupling)
+
+        const service = new TestPipelineService(herokuAPI)
+        const response = await service.getPipeline({app: null, pipeline: null, remote: 'heroku'})
+        expect(response).to.deep.eq(PIPELINE)
+        api.done()
+      })
+
+      it('resolves the pipeline via heroku.remote git config when --pipeline, --app, and --remote are absent', async function () {
+        const app = 'git-config-app'
+        const coupling = {pipeline: PIPELINE}
+
+        // Subclass PipelineService to inject a controlled resolveAppFromRemote
+        class TestPipelineService extends PipelineService {
+          protected override resolveAppFromRemote(_remote: null | string | undefined): string | undefined {
+            return app
+          }
+        }
+
+        const api = nock('https://api.heroku.com')
+          .get(`/apps/${app}/pipeline-couplings`)
+          .reply(200, coupling)
+
+        const service = new TestPipelineService(herokuAPI)
+        const response = await service.getPipeline({app: null, pipeline: null})
+        expect(response).to.deep.eq(PIPELINE)
+        api.done()
+      })
+
+      it('errors when --pipeline, --app, and --remote are absent and no heroku git remote is found', async function () {
+        class TestPipelineService extends PipelineService {
+          protected override resolveAppFromRemote(_remote: null | string | undefined): string | undefined {
+            return undefined
+          }
+        }
+
+        const service = new TestPipelineService(herokuAPI)
+        try {
+          await service.getPipeline({app: null, pipeline: null})
+          expect.fail('should have thrown')
+        } catch (error: any) {
+          expect(error.message).to.contain('Required flag:  --pipeline PIPELINE or --app APP')
+        }
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary

- Wires `--remote` flag and `heroku.remote` git config into `getPipeline()` in `src/lib/ci/pipelines.ts`, so CI commands (`ci:run`, `ci:rerun`, `ci:debug`, `ci:info`, `ci:last`, `ci:open`, `ci:config`, etc.) can resolve their pipeline the same way `heroku run` and other app-flag commands already do
- Adds a protected `resolveAppFromRemote()` helper on `PipelineService` that calls `configRemote()` / `getGitRemotes()` from `@heroku-cli/command`, keeping the git resolution logic injectable and testable via subclassing
- Updates `getPipeline`'s flag type signature to include `remote?: null | string`

## What changed

`src/lib/ci/pipelines.ts`:
- Import `configRemote` and `getGitRemotes` from `@heroku-cli/command`
- Before erroring on missing `--pipeline`/`--app`, try to resolve an app from `flags.remote` or the `heroku.remote` git config value; if a matching Heroku git remote is found, use that app to look up the pipeline coupling as usual

`test/unit/lib/ci/pipelines.unit.test.ts`:
- Add three new test cases under a `remote inference` block that cover: resolution via `--remote`, resolution via git config, and the fall-through error when no remote resolves an app

## Why

Fixes GUS W-23597910 / GitHub #1318. Users who set `heroku.remote` in their git config (or pass `--remote`) expect CI commands to pick up the pipeline automatically, consistent with all other Heroku CLI commands that accept `--remote`.

## Test plan

- [x] `test/unit/lib/ci/pipelines.unit.test.ts` — 5 tests pass (3 new + 2 existing)
- [x] `test/unit/commands/ci/run.unit.test.ts` — 3 tests pass
- [x] `test/unit/commands/ci/rerun.unit.test.ts` — 3 tests pass
- [x] `npm run build` — TypeScript compiles cleanly
- [x] `npx eslint src/lib/ci/pipelines.ts test/unit/lib/ci/pipelines.unit.test.ts` — 0 errors, 2 pre-existing `any` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)