### PR TITLE
refactor: use sdk for addons commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3293,7 +3293,7 @@
     },
     "node_modules/@heroku/sdk": {
       "version": "0.5.1",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#de9993dd90a7717db56ccfd2faddda3f4d0a0bb2",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#92932d816440d24363cb106d0829f80fee88d9a4",
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku/heroku-fetch": "^0.1.1-beta",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3132,9 +3132,9 @@
       }
     },
     "node_modules/@heroku/heroku-fetch": {
-      "version": "0.1.1-beta.0",
-      "resolved": "https://registry.npmjs.org/@heroku/heroku-fetch/-/heroku-fetch-0.1.1-beta.0.tgz",
-      "integrity": "sha512-ICT2s4gREkLvM6LURr871WD64CMtT+ZeMzgq9kb3MiP054FUSvzWh/KgpzqPhKIVEXd5KVB+0wfyH2I8sqWx0A==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@heroku/heroku-fetch/-/heroku-fetch-0.1.3.tgz",
+      "integrity": "sha512-iR4lPn/Y/O1XE1SL14jW06W9Ce7S7i26MdfSG6CP1FT5MqAJpCPwGaPWaNHnoU1wLHCBf9OL4kIzRsIuhyPpAw==",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.3.4",
@@ -3292,11 +3292,11 @@
       }
     },
     "node_modules/@heroku/sdk": {
-      "version": "0.5.3",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#65b247bfbb5233a1e93b5980bdb3c1d907305a0f",
+      "version": "0.5.4",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#9c803e208caa16d326637473c7959eee6bd0e155",
       "license": "Apache-2.0",
       "dependencies": {
-        "@heroku/heroku-fetch": "^0.1.1-beta",
+        "@heroku/heroku-fetch": "^0.1.3",
         "@heroku/types": "^4.0.1",
         "debug": "^4.4.0"
       },

--- a/src/commands/addons/attach.ts
+++ b/src/commands/addons/attach.ts
@@ -1,6 +1,9 @@
+import type {AddOnAttachment, AddOnConfig} from '@heroku/types/3.sdk'
+
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuApiClient} from '@heroku/heroku-fetch'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 
 import {trapConfirmationRequired} from '../../lib/addons/util.js'
@@ -19,10 +22,11 @@ export default class Attach extends Command {
   }
   static topic = 'addons'
 
-  public async run(): Promise<void> {
+  public async run(): Promise<AddOnAttachment> {
     const {args,  flags} = await this.parse(Attach)
     const {app, as, confirm, credential} = flags
-    const {body: addon} = await this.heroku.get<Heroku.AddOn>(`/addons/${encodeURIComponent(args.addon_name)}`)
+    const {platform} = new HerokuSDK()
+    const addon = await platform.addOn.info(args.addon_name)
     const createAttachment = async (confirmed?: string) =>  {
       let namespace: string | undefined
       if (credential && credential !== 'default') {
@@ -30,12 +34,12 @@ export default class Attach extends Command {
       }
 
       const body = {
-        addon: {name: addon.name}, app: {name: app}, confirm: confirmed, name: as, namespace,
+        addon: addon.name!, app, confirm: confirmed, name: as, namespace,
       }
 
       try {
         ux.action.start(`Attaching ${credential ? color.name(credential) + ' of ' : ''}${color.datastore(addon.name || '')}${as ? ' as ' + color.attachment(as) : ''} to ${color.app(app)}`)
-        const {body: attachment} = await this.heroku.post<Heroku.AddOnAttachment>('/addon-attachments', {body})
+        const attachment = await platform.addOnAttachment.create(body)
         ux.action.stop()
 
         return attachment
@@ -46,17 +50,21 @@ export default class Attach extends Command {
     }
 
     if (credential && credential !== 'default') {
-      const {body: credentialConfig} = await this.heroku.get<Heroku.AddOnConfig[]>(`/addons/${addon.name}/config/credential:${encodeURIComponent(credential)}`)
+      const client = new HerokuApiClient()
+      const response = await client.get(`/addons/${addon.name}/config/credential:${encodeURIComponent(credential)}`)
+      const credentialConfig = await response.json() as AddOnConfig[]
       if (credentialConfig.length === 0) {
         throw new Error(`Could not find credential ${color.name(credential)} for database ${color.datastore(addon.name || '')}`)
       }
     }
 
-    const attachment = await trapConfirmationRequired<Heroku.AddOnAttachment>(app, confirm, (confirmed?: string) => createAttachment(confirmed))
+    const attachment = await trapConfirmationRequired<AddOnAttachment>(app, confirm, (confirmed?: string) => createAttachment(confirmed))
     ux.action.start(`Setting ${color.attachment(attachment.name || '')} config vars and restarting ${color.app(app)}`)
-    const {body: releases} = await this.heroku.get<Heroku.Release[]>(`/apps/${app}/releases`, {
-      headers: {Range: 'version ..; max=1, order=desc'}, partial: true,
-    })
+    const releases = await platform
+      .withHeaders({Range: 'version ..; max=1, order=desc'})
+      .release.list(app)
     ux.action.stop(`done, v${releases[0].version}`)
+
+    return attachment
   }
 }

--- a/src/commands/addons/create.ts
+++ b/src/commands/addons/create.ts
@@ -5,7 +5,6 @@ import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
 import createAddon from '../../lib/addons/create-addon.js'
-import * as util from '../../lib/addons/util.js'
 import notify from '../../lib/notify.js'
 
 const heredoc = tsheredoc.default

--- a/src/commands/addons/destroy.ts
+++ b/src/commands/addons/destroy.ts
@@ -1,10 +1,14 @@
+import type {AddOn} from '@heroku/types/3.sdk'
+
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
-import {color, utils} from '@heroku/heroku-cli-util'
+import {color, pg, utils} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
+import {addOnExtensions} from '@heroku/sdk/extensions/platform'
+import {AddonProvisioningFailedError} from '@heroku/sdk/resources/platform/add-on'
 import {Args} from '@oclif/core'
+import {ux} from '@oclif/core/ux'
 import _ from 'lodash'
 
-import destroyAddon from '../../lib/addons/destroy-addon.js'
 import ConfirmCommand from '../../lib/confirm-command.js'
 import notify from '../../lib/notify.js'
 
@@ -26,11 +30,12 @@ export default class Destroy extends Command {
   static strict = false
   static topic = 'addons'
 
-  public async run(): Promise<void> {
+  public async run(): Promise<AddOn[]> {
     const {argv, flags} = await this.parse(Destroy)
     const {app, confirm, wait} = flags
     const force = flags.force || process.env.HEROKU_FORCE === '1'
     const addonResolver = new utils.AddonResolver(this.heroku)
+    const {platform} = new HerokuSDK({extensions: [addOnExtensions]})
 
     const addons = await Promise.all(argv.map((name: string) => addonResolver.resolve(name as string, app)))
     for (const addon of addons) {
@@ -41,24 +46,75 @@ export default class Destroy extends Command {
       }
     }
 
-    for (const addonApps of Object.entries(_.groupBy<Heroku.AddOn>(addons, 'app.name'))) {
+    const destroyed: AddOn[] = []
+    for (const addonApps of Object.entries(_.groupBy(addons, 'app.name'))) {
       const currentAddons = addonApps[1]
       const appName = addonApps[0]
       await new ConfirmCommand().confirm(appName, confirm)
       for (const addon of currentAddons) {
+        const addonName = addon.name ?? ''
+        const appIdentity = addon.app?.name ?? ''
         try {
-          await destroyAddon(this.heroku, addon, force, wait)
-          if (wait) {
-            Destroy.notifier(`heroku addons:destroy ${addon.name}`, 'Add-on successfully deprovisioned')
-          }
-        } catch (error) {
-          if (wait) {
-            Destroy.notifier(`heroku addons:destroy ${addon.name}`, 'Add-on failed to deprovision', false)
+          ux.action.start(`Destroying ${color.addon(addonName)} on ${color.app(appIdentity)}`)
+          const result = await platform.addOn.destroyAndWait(appIdentity, addonName, {
+            force,
+            onDeprovisioning() {
+              // Two-phase UX: stop the "Destroying … on <app>" spinner as pending,
+              // then surface a dedicated wait spinner while the SDK polls.
+              ux.action.stop(color.info('pending'))
+              ux.stdout(`Waiting for ${color.addon(addonName)}...`)
+              ux.action.start(`Destroying ${color.addon(addonName)}`)
+            },
+            wait,
+          })
+
+          const resultState = result.state as string
+          if (resultState === 'deprovisioning') {
+            // Async deprovisioning without --wait: leave the destruction running in the background.
+            ux.action.stop(color.info('pending'))
+            ux.stdout(`${color.addon(addonName)} is being destroyed in the background. The app will restart when complete...`)
+            ux.stdout(`Run ${color.code('heroku addons:info ' + addonName)} to check destruction progress`)
+          } else if (resultState === 'deprovisioned') {
+            ux.action.stop()
+          } else {
+            // A synchronous delete that settled into an unexpected terminal state.
+            ux.action.stop()
+            throw new AddonProvisioningFailedError(result)
           }
 
-          throw error
+          if (wait) {
+            Destroy.notifier(`heroku addons:destroy ${addonName}`, 'Add-on successfully deprovisioned')
+          }
+
+          destroyed.push(result)
+        } catch (error) {
+          if (wait) {
+            Destroy.notifier(`heroku addons:destroy ${addonName}`, 'Add-on failed to deprovision', false)
+          }
+
+          throw this.toDestroyError(addon, error)
         }
       }
     }
+
+    return destroyed
+  }
+
+  // The SDK's destroyAndWait surfaces platform/HTTP errors verbatim; the CLI owns the
+  // friendly "can't destroy your database" / "add-on was unable to be destroyed" copy.
+  private toDestroyError(addon: pg.ExtendedAddon, error: unknown): Error {
+    const isAdvancedDatabase = utils.pg.isAdvancedDatabase(addon)
+
+    if (error instanceof AddonProvisioningFailedError) {
+      const {state} = error.addon
+      return isAdvancedDatabase
+        ? new Error(`You can't destroy a database with a ${state} status.`)
+        : new Error(`The add-on was unable to be destroyed, with status ${state}.`)
+    }
+
+    const errorMessage = (error instanceof Error ? error.message : undefined) ?? error
+    return isAdvancedDatabase
+      ? new Error(`We can't destroy your database due to an error: ${errorMessage}. Try again or open a ticket with Heroku Support: https://help.heroku.com/`)
+      : new Error(`The add-on was unable to be destroyed: ${errorMessage}.`)
   }
 }

--- a/src/commands/addons/docs.ts
+++ b/src/commands/addons/docs.ts
@@ -1,10 +1,9 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
+import {addOnExtensions} from '@heroku/sdk/extensions/platform'
 import {Args, ux} from '@oclif/core'
 import open from 'open'
-
-import {resolveAddon} from '../../lib/addons/resolve.js'
 
 export default class Docs extends Command {
   static args = {
@@ -19,14 +18,14 @@ export default class Docs extends Command {
   static topic = 'addons'
   public static urlOpener: (url: string) => Promise<unknown> = open
 
-  public async run(): Promise<void> {
-    const {args,  flags} = await this.parse(Docs)
+  public async run(): Promise<string> {
+    const {args, flags} = await this.parse(Docs)
     const {app} = flags
+    const {platform} = new HerokuSDK({extensions: [addOnExtensions]})
     const id = args.addon.split(':')[0]
-    const addonResponse = await this.heroku.get<Heroku.AddOn>(`/addon-services/${encodeURIComponent(id)}`)
-      .catch(() => null)
+    const addonService = await platform.addOnService.info(id).catch(() => null)
 
-    const addon = addonResponse?.body ?? (await resolveAddon(this.heroku, app, id)).addon_service
+    const addon = addonService ?? (await platform.addOn.resolve(id, {appIdentity: app})).addon_service
 
     const url = `https://devcenter.heroku.com/articles/${addon.name}`
     if (flags['show-url']) {
@@ -35,5 +34,7 @@ export default class Docs extends Command {
       ux.stdout(`Opening ${color.info(url)}...`)
       await Docs.urlOpener(url)
     }
+
+    return url
   }
 }

--- a/src/commands/addons/open.ts
+++ b/src/commands/addons/open.ts
@@ -122,7 +122,28 @@ export default class Open extends Command {
     // scoped to the attached add-on; otherwise resolve the identifier directly.
     const addonIdentity = attachment?.name ?? addon
     const resolvedAddon = await platform.addOn.resolve(addonIdentity, {appIdentity: app})
-    const webUrl = resolvedAddon.web_url as string
+
+    // `AddOn.web_url` is the add-on's own (billing-app) dashboard. For a shared
+    // add-on opened from a non-billing app we want the attachment's `web_url`,
+    // which is scoped to the attached app's context (matching pre-SDK behavior).
+    // Look up the add-on's attachments and prefer the one tied to the requested
+    // app; fall back to the add-on's own URL when none matches.
+    let webUrl = resolvedAddon.web_url as string
+    if (app && resolvedAddon.id) {
+      try {
+        const attachments = await platform.addOnAttachment.listByAddOn(resolvedAddon.id)
+        const contextAttachment = attachments.find(({app: attachedApp}) => attachedApp?.name === app)
+        if (contextAttachment?.web_url) {
+          webUrl = contextAttachment.web_url
+        }
+      } catch (error) {
+        // Failing to enumerate attachments shouldn't block opening; keep the
+        // add-on's dashboard URL. Rethrow anything that isn't a 404.
+        if (!isNotFound(error)) {
+          throw error
+        }
+      }
+    }
 
     if (flags['show-url']) {
       ux.stdout(webUrl)

--- a/src/commands/addons/open.ts
+++ b/src/commands/addons/open.ts
@@ -116,13 +116,13 @@ export default class Open extends Command {
       }
     }
 
-    let webUrl: string
-    if (attachment) {
-      webUrl = attachment.web_url as string
-    } else {
-      const resolvedAddon = await platform.addOn.resolve(addon, {appIdentity: app})
-      webUrl = resolvedAddon.web_url as string
-    }
+    // `resolveByAttachment` returns only the add-on's identity ({id, name, app}),
+    // not its `web_url`, so resolve the add-on itself to get the dashboard URL.
+    // Prefer the attachment's add-on name when we found one so the lookup stays
+    // scoped to the attached add-on; otherwise resolve the identifier directly.
+    const addonIdentity = attachment?.name ?? addon
+    const resolvedAddon = await platform.addOn.resolve(addonIdentity, {appIdentity: app})
+    const webUrl = resolvedAddon.web_url as string
 
     if (flags['show-url']) {
       ux.stdout(webUrl)

--- a/src/commands/addons/open.ts
+++ b/src/commands/addons/open.ts
@@ -11,9 +11,7 @@ import os from 'node:os'
 import path from 'node:path'
 import open from 'open'
 
-function isNotFound(error: unknown): boolean {
-  return typeof error === 'object' && error !== null && 'statusCode' in error && (error as {statusCode: unknown}).statusCode === 404
-}
+import {isNotFound} from '../../lib/addons/addons-wait.js'
 
 export interface AddonSso {
   /**

--- a/src/commands/addons/open.ts
+++ b/src/commands/addons/open.ts
@@ -1,15 +1,19 @@
 
 import {Command, flags} from '@heroku-cli/command'
-import {AddOnAttachment} from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
-import {HTTP, HTTPError} from '@heroku/http-call'
+import {HTTP} from '@heroku/http-call'
+import {HerokuSDK} from '@heroku/sdk'
+import {addOnExtensions} from '@heroku/sdk/extensions/platform'
+import {AddonNotFoundError, type ResolvedAddOn} from '@heroku/sdk/resources/platform/add-on'
 import {Args, ux} from '@oclif/core'
 import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import open from 'open'
 
-import {attachmentResolver, resolveAddon} from '../../lib/addons/resolve.js'
+function isNotFound(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'statusCode' in error && (error as {statusCode: unknown}).statusCode === 404
+}
 
 export interface AddonSso {
   /**
@@ -97,11 +101,17 @@ export default class Open extends Command {
       return this.sudo(app, addon)
     }
 
-    let attachment: AddOnAttachment | null | void = null
+    const {platform} = new HerokuSDK({extensions: [addOnExtensions]})
+
+    let attachment: null | ResolvedAddOn = null
     try {
-      attachment = await attachmentResolver(this.heroku, app, addon)
+      attachment = await platform.addOn.resolveByAttachment(app, addon)
     } catch (error) {
-      if (error instanceof HTTPError && error.statusCode !== 404) {
+      // Swallow not-found so we fall through to a direct add-on resolve.
+      // `resolveByAttachment` throws `AddonNotFoundError` (statusCode 404),
+      // and the underlying attachment resolution can surface other 404s;
+      // rethrow anything that isn't a 404.
+      if (!(error instanceof AddonNotFoundError) && !isNotFound(error)) {
         throw error
       }
     }
@@ -110,7 +120,7 @@ export default class Open extends Command {
     if (attachment) {
       webUrl = attachment.web_url as string
     } else {
-      const resolvedAddon = await resolveAddon(this.heroku, app, addon)
+      const resolvedAddon = await platform.addOn.resolve(addon, {appIdentity: app})
       webUrl = resolvedAddon.web_url as string
     }
 

--- a/src/commands/addons/open.ts
+++ b/src/commands/addons/open.ts
@@ -4,7 +4,7 @@ import * as color from '@heroku/heroku-cli-util/color'
 import {HTTP} from '@heroku/http-call'
 import {HerokuSDK} from '@heroku/sdk'
 import {addOnExtensions} from '@heroku/sdk/extensions/platform'
-import {AddonNotFoundError, type ResolvedAddOn} from '@heroku/sdk/resources/platform/add-on'
+import {AddonNotFoundError, type ResolvedAddOnAttachment} from '@heroku/sdk/resources/platform/add-on'
 import {Args, ux} from '@oclif/core'
 import fs from 'node:fs/promises'
 import os from 'node:os'
@@ -101,46 +101,30 @@ export default class Open extends Command {
 
     const {platform} = new HerokuSDK({extensions: [addOnExtensions]})
 
-    let attachment: null | ResolvedAddOn = null
+    let attachment: null | ResolvedAddOnAttachment = null
     try {
-      attachment = await platform.addOn.resolveByAttachment(app, addon)
+      attachment = await platform.addOn.describeAttachment(app, addon)
     } catch (error) {
       // Swallow not-found so we fall through to a direct add-on resolve.
-      // `resolveByAttachment` throws `AddonNotFoundError` (statusCode 404),
-      // and the underlying attachment resolution can surface other 404s;
-      // rethrow anything that isn't a 404.
+      // `describeAttachment` throws `AddonNotFoundError` when no attachment
+      // matches, and the underlying attachment resolution can surface other
+      // 404s; rethrow anything that isn't a 404.
       if (!(error instanceof AddonNotFoundError) && !isNotFound(error)) {
         throw error
       }
     }
 
-    // `resolveByAttachment` returns only the add-on's identity ({id, name, app}),
-    // not its `web_url`, so resolve the add-on itself to get the dashboard URL.
-    // Prefer the attachment's add-on name when we found one so the lookup stays
-    // scoped to the attached add-on; otherwise resolve the identifier directly.
-    const addonIdentity = attachment?.name ?? addon
-    const resolvedAddon = await platform.addOn.resolve(addonIdentity, {appIdentity: app})
-
-    // `AddOn.web_url` is the add-on's own (billing-app) dashboard. For a shared
-    // add-on opened from a non-billing app we want the attachment's `web_url`,
-    // which is scoped to the attached app's context (matching pre-SDK behavior).
-    // Look up the add-on's attachments and prefer the one tied to the requested
-    // app; fall back to the add-on's own URL when none matches.
-    let webUrl = resolvedAddon.web_url as string
-    if (app && resolvedAddon.id) {
-      try {
-        const attachments = await platform.addOnAttachment.listByAddOn(resolvedAddon.id)
-        const contextAttachment = attachments.find(({app: attachedApp}) => attachedApp?.name === app)
-        if (contextAttachment?.web_url) {
-          webUrl = contextAttachment.web_url
-        }
-      } catch (error) {
-        // Failing to enumerate attachments shouldn't block opening; keep the
-        // add-on's dashboard URL. Rethrow anything that isn't a 404.
-        if (!isNotFound(error)) {
-          throw error
-        }
-      }
+    let webUrl: string
+    if (attachment?.web_url) {
+      // Context-scoped URL: the dashboard for this add-on *from this app*
+      // (differs from the add-on's own billing-app `web_url`).
+      webUrl = attachment.web_url
+    } else {
+      // No attachment (app-less invocation or a bare add-on identity), or an
+      // add-on with no web dashboard: fall back to resolving the add-on for
+      // its own (billing-app) web_url.
+      const resolvedAddon = await platform.addOn.resolve(addon, {appIdentity: app})
+      webUrl = resolvedAddon.web_url as string
     }
 
     if (flags['show-url']) {

--- a/src/commands/addons/upgrade.ts
+++ b/src/commands/addons/upgrade.ts
@@ -9,6 +9,8 @@ import {Args, ux} from '@oclif/core'
 
 import {formatPriceText} from '../../lib/addons/util.js'
 
+type Platform = HerokuSDK<readonly [typeof addOnExtensions]>['platform']
+
 function isApiError(error: unknown): error is Error & {statusCode: number} {
   return error instanceof Error && 'statusCode' in error && typeof (error as {statusCode?: unknown}).statusCode === 'number'
 }
@@ -80,20 +82,19 @@ ${color.cyan('https://devcenter.heroku.com/articles/managing-add-ons')}`
     return {addon, plan}
   }
 
-  protected async getPlans(addonServiceName: string | undefined): Promise<Plan[]> {
+  protected async getPlans(addonServiceName: string | undefined, platform: Platform): Promise<Plan[]> {
     if (!addonServiceName) {
       return []
     }
 
     try {
-      const {platform} = new HerokuSDK({extensions: [addOnExtensions]})
       return (await platform.addOn.listPlans(addonServiceName)) as unknown as Plan[]
     } catch {
       return []
     }
   }
 
-  public async run(): Promise<void> {
+  public async run(): Promise<Required<AddOn>> {
     const ctx = await this.parse(Upgrade)
     const {args, flags: {app}} = ctx
     // called with just one argument in the form of `heroku addons:upgrade heroku-redis:hobby`
@@ -123,7 +124,7 @@ ${color.cyan('https://devcenter.heroku.com/articles/managing-add-ons')}`
       if (isApiError(error)) {
         const message = error.message || ''
         if (error.statusCode === 422 && message.startsWith('Couldn\'t find either the add-on')) {
-          const plans = await this.getPlans(addonServiceName)
+          const plans = await this.getPlans(addonServiceName, platform)
           errorToThrow = new Error(`${message}
 
 Here are the available plans for ${color.addon(addonServiceName || '')}:
@@ -143,5 +144,7 @@ ${color.cyan('https://devcenter.heroku.com/articles/managing-add-ons')}`)
     if (updatedAddon.provision_message) {
       ux.stdout(updatedAddon.provision_message)
     }
+
+    return updatedAddon
   }
 }

--- a/src/commands/addons/wait.ts
+++ b/src/commands/addons/wait.ts
@@ -1,12 +1,16 @@
 import {Command, flags} from '@heroku-cli/command'
 import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
+import {addOnExtensions} from '@heroku/sdk/extensions/platform'
 import {Args, ux} from '@oclif/core'
 
-import {waitForAddonDeprovisioning, waitForAddonProvisioning} from '../../lib/addons/addons-wait.js'
-import {resolveAddon} from '../../lib/addons/resolve.js'
+import {pollAddonUntilDeprovisioned, waitForAddonProvisioning} from '../../lib/addons/addons-wait.js'
 import notify from '../../lib/notify.js'
 import {ExtendedAddon} from '../../lib/pg/types.js'
+
+// TODO: remove this type once the schema is fixed
+type AddonWithDeprovisioningState = Omit<ExtendedAddon, 'state'> & {state?: 'deprovisioning' | ExtendedAddon['state']}
 
 export default class Wait extends Command {
   static args = {
@@ -21,18 +25,17 @@ export default class Wait extends Command {
   public static notifier: (subtitle: string, message: string, success?: boolean) => void = notify
   static topic = 'addons'
 
-  public async run(): Promise<void> {
+  public async run(): Promise<AddonWithDeprovisioningState[]> {
     const {args, flags} = await this.parse(Wait)
-    // TODO: remove this type once the schema is fixed
-    type AddonWithDeprovisioningState  = Omit<ExtendedAddon, 'state'> & {state?: 'deprovisioning' | ExtendedAddon['state']}
+    const {platform} = new HerokuSDK({extensions: [addOnExtensions]})
     let addonsToWaitFor: AddonWithDeprovisioningState[]
     if (args.addon) {
-      addonsToWaitFor = [await resolveAddon(this.heroku, flags.app, args.addon)]
+      addonsToWaitFor = [await platform.addOn.resolve(args.addon, {appIdentity: flags.app}) as unknown as AddonWithDeprovisioningState]
     } else if (flags.app) {
-      const {body: addons} = await this.heroku.get<AddonWithDeprovisioningState[]>(`/apps/${flags.app}/addons`)
+      const addons = await platform.addOn.listByApp(flags.app) as unknown as AddonWithDeprovisioningState[]
       addonsToWaitFor = addons
     } else {
-      const {body: addons} = await this.heroku.get<AddonWithDeprovisioningState[]>('/addons')
+      const addons = await platform.addOn.list() as unknown as AddonWithDeprovisioningState[]
       addonsToWaitFor = addons
     }
 
@@ -48,7 +51,7 @@ export default class Wait extends Command {
       if (addon.state === 'provisioning') {
         let addonResponse
         try {
-          addonResponse = await waitForAddonProvisioning(addon as Heroku.AddOn, interval)
+          addonResponse = await waitForAddonProvisioning(platform, addon as Heroku.AddOn, interval)
         } catch (error) {
           Wait.notifier(`heroku addons:wait ${addonName}`, 'Add-on failed to provision', false)
           throw error
@@ -65,11 +68,13 @@ export default class Wait extends Command {
           Wait.notifier(`heroku addons:wait ${addonName}`, 'Add-on successfully provisioned')
         }
       } else if (addon.state === 'deprovisioning') {
-        await waitForAddonDeprovisioning(this.heroku, addon as Heroku.AddOn, interval)
+        await pollAddonUntilDeprovisioned(platform, addon as Heroku.AddOn, interval)
         if (Date.now() - startTime.valueOf() >= 1000 * 5) {
           Wait.notifier(`heroku addons:wait ${addonName}`, 'Add-on successfully deprovisioned')
         }
       }
     }
+
+    return addonsToWaitFor
   }
 }

--- a/src/lib/addons/addons-wait.ts
+++ b/src/lib/addons/addons-wait.ts
@@ -4,14 +4,15 @@ import * as color from '@heroku/heroku-cli-util/color'
 import {HerokuSDK} from '@heroku/sdk'
 import {ux} from '@oclif/core/ux'
 
-export const waitForAddonProvisioning = async function (addon: Heroku.AddOn, interval: number) {
+type Platform = HerokuSDK['platform']
+
+export const waitForAddonProvisioning = async function (platform: Platform, addon: Heroku.AddOn, interval: number) {
   const app = addon.app?.name || ''
   const addonName = addon.name
   let addonBody = {...addon}
 
   ux.action.start(`Creating ${color.addon(addonName || '')}`)
 
-  const {platform} = new HerokuSDK()
   const platformWithExpansion = platform.withHeaders({'Accept-Expansion': 'addon_service,plan'})
   while (addonBody.state === 'provisioning') {
     // eslint-disable-next-line no-promise-executor-return
@@ -46,6 +47,40 @@ export const waitForAddonDeprovisioning = async function (api: APIClient, addon:
     }).then(response => {
       addonResponse = response?.body
     }).catch(error => {
+      // Not ideal, but API deletes the record returning a 404 when deprovisioned.
+      if (error.statusCode === 404 || error.http?.statusCode === 404) {
+        addonResponse.state = 'deprovisioned'
+      } else {
+        throw error
+      }
+    })
+  }
+
+  ux.action.stop()
+  return addonResponse
+}
+
+export const pollAddonUntilDeprovisioned = async function (platform: Platform, addon: Heroku.AddOn, interval: number) {
+  const app = addon.app?.name || ''
+  const addonName = addon.name || ''
+  let addonResponse = {...addon}
+
+  ux.action.start(`Destroying ${color.addon(addonName)}`)
+
+  const platformWithExpansion = platform.withHeaders({'Accept-Expansion': 'addon_service,plan'})
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  while (addonResponse.state === 'deprovisioning') {
+    // eslint-disable-next-line no-promise-executor-return
+    await new Promise(resolve => setTimeout(resolve, interval * 1000))
+
+    // eslint-disable-next-line no-await-in-loop
+    await (app
+      ? platformWithExpansion.addOn.infoByApp(app, addonName)
+      : platformWithExpansion.addOn.info(addonName)
+    ).then(response => {
+      addonResponse = response as unknown as Heroku.AddOn
+    }).catch((error: {http?: {statusCode?: number}, statusCode?: number}) => {
       // Not ideal, but API deletes the record returning a 404 when deprovisioned.
       if (error.statusCode === 404 || error.http?.statusCode === 404) {
         addonResponse.state = 'deprovisioned'

--- a/src/lib/addons/addons-wait.ts
+++ b/src/lib/addons/addons-wait.ts
@@ -6,6 +6,20 @@ import {ux} from '@oclif/core/ux'
 
 type Platform = HerokuSDK['platform']
 
+/**
+ * Whether an error represents a 404 not-found. Some SDK/heroku-fetch errors
+ * expose a top-level `statusCode`, others nest it under `http.statusCode`, so
+ * check both. Shared with `commands/addons/open.ts` to keep the checks in sync.
+ */
+export const isNotFound = function (error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false
+  }
+
+  const {http, statusCode} = error as {http?: {statusCode?: number}, statusCode?: number}
+  return statusCode === 404 || http?.statusCode === 404
+}
+
 export const waitForAddonProvisioning = async function (platform: Platform, addon: Heroku.AddOn, interval: number) {
   const app = addon.app?.name || ''
   const addonName = addon.name
@@ -46,9 +60,9 @@ export const waitForAddonDeprovisioning = async function (api: APIClient, addon:
       headers: {'Accept-Expansion': 'addon_service,plan'},
     }).then(response => {
       addonResponse = response?.body
-    }).catch(error => {
+    }).catch((error: unknown) => {
       // Not ideal, but API deletes the record returning a 404 when deprovisioned.
-      if (error.statusCode === 404 || error.http?.statusCode === 404) {
+      if (isNotFound(error)) {
         addonResponse.state = 'deprovisioned'
       } else {
         throw error
@@ -80,9 +94,9 @@ export const pollAddonUntilDeprovisioned = async function (platform: Platform, a
       : platformWithExpansion.addOn.info(addonName)
     ).then(response => {
       addonResponse = response as unknown as Heroku.AddOn
-    }).catch((error: {http?: {statusCode?: number}, statusCode?: number}) => {
+    }).catch((error: unknown) => {
       // Not ideal, but API deletes the record returning a 404 when deprovisioned.
-      if (error.statusCode === 404 || error.http?.statusCode === 404) {
+      if (isNotFound(error)) {
         addonResponse.state = 'deprovisioned'
       } else {
         throw error

--- a/test/unit/commands/addons/attach.unit.test.ts
+++ b/test/unit/commands/addons/attach.unit.test.ts
@@ -1,37 +1,38 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuApiClient} from '@heroku/heroku-fetch'
 import ansis from 'ansis'
 import {expect} from 'chai'
-import nock from 'nock'
 import {restore, SinonStub, stub} from 'sinon'
 
 import Cmd from '../../../../src/commands/addons/attach.js'
 import ConfirmCommand from '../../../../src/lib/confirm-command.js'
+import {type MockSDK, mockSDKPlatform} from '../../../helpers/mock-sdk.js'
 
 let confirmStub: SinonStub
 
 describe('addons:attach', function () {
-  let api: nock.Scope
+  let sdkMock: MockSDK
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
     confirmStub = stub(ConfirmCommand.prototype, 'confirm').resolves()
   })
 
   afterEach(function () {
     confirmStub.restore()
-    api.done()
-    nock.cleanAll()
+    sdkMock.restore()
     restore()
   })
 
   it('attaches an add-on', async function () {
-    api
-      .get('/addons/redis-123')
-      .reply(200, {name: 'redis-123'})
-      .post('/addon-attachments', {addon: {name: 'redis-123'}, app: {name: 'myapp'}})
-      .reply(201, {name: 'REDIS'})
-      .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
+    const infoStub = stub().resolves({name: 'redis-123'})
+    const createStub = stub().resolves({name: 'REDIS'})
+    const listReleasesStub = stub().resolves([{version: 10}])
+    const fakePlatform = {
+      addOn: {info: infoStub},
+      addOnAttachment: {create: createStub},
+      withHeaders: stub().returns({release: {list: listReleasesStub}}),
+    }
+    sdkMock = mockSDKPlatform(fakePlatform)
 
     const {stderr, stdout} = await runCommand(Cmd, [
       '--app',
@@ -41,16 +42,22 @@ describe('addons:attach', function () {
     expect(stdout).to.equal('')
     expect(stderr).to.contain('Attaching ⛁ redis-123 to ⬢ myapp... done')
     expect(stderr).to.contain('\nSetting REDIS config vars and restarting ⬢ myapp... done, v10')
+    expect(infoStub.calledOnceWith('redis-123')).to.be.true
+    expect(createStub.calledOnceWith({
+      addon: 'redis-123', app: 'myapp', confirm: undefined, name: undefined, namespace: undefined,
+    })).to.be.true
   })
 
   it('attaches an add-on as foo', async function () {
-    api
-      .get('/addons/redis-123')
-      .reply(200, {name: 'redis-123'})
-      .post('/addon-attachments', {addon: {name: 'redis-123'}, app: {name: 'myapp'}, name: 'foo'})
-      .reply(201, {name: 'foo'})
-      .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
+    const infoStub = stub().resolves({name: 'redis-123'})
+    const createStub = stub().resolves({name: 'foo'})
+    const listReleasesStub = stub().resolves([{version: 10}])
+    const fakePlatform = {
+      addOn: {info: infoStub},
+      addOnAttachment: {create: createStub},
+      withHeaders: stub().returns({release: {list: listReleasesStub}}),
+    }
+    sdkMock = mockSDKPlatform(fakePlatform)
 
     const {stderr, stdout} = await runCommand(Cmd, [
       '--app',
@@ -62,20 +69,25 @@ describe('addons:attach', function () {
     expect(stdout).to.equal('')
     expect(stderr).to.contain('Attaching ⛁ redis-123 as foo to ⬢ myapp... done')
     expect(stderr).to.contain('\nSetting foo config vars and restarting ⬢ myapp... done, v10')
+    expect(createStub.calledOnceWith({
+      addon: 'redis-123', app: 'myapp', confirm: undefined, name: 'foo', namespace: undefined,
+    })).to.be.true
   })
 
   it('overwrites an add-on as foo when confirmation is set', async function () {
-    api
-      .get('/addons/redis-123')
-      .reply(200, {name: 'redis-123'})
-      .post('/addon-attachments', {addon: {name: 'redis-123'}, app: {name: 'myapp'}, name: 'foo'})
-      .reply(400, {id: 'confirmation_required'})
-      .post('/addon-attachments', {
-        addon: {name: 'redis-123'}, app: {name: 'myapp'}, confirm: 'myapp', name: 'foo',
-      })
-      .reply(201, {name: 'foo'})
-      .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
+    const infoStub = stub().resolves({name: 'redis-123'})
+    const listReleasesStub = stub().resolves([{version: 10}])
+    // first call throws confirmation_required, second (confirmed) succeeds
+    const confirmationError = Object.assign(new Error('confirmation required'), {body: {id: 'confirmation_required'}})
+    const createStub = stub()
+    createStub.onFirstCall().rejects(confirmationError)
+    createStub.onSecondCall().resolves({name: 'foo'})
+    const fakePlatform = {
+      addOn: {info: infoStub},
+      addOnAttachment: {create: createStub},
+      withHeaders: stub().returns({release: {list: listReleasesStub}}),
+    }
+    sdkMock = mockSDKPlatform(fakePlatform)
 
     const {stderr, stdout} = await runCommand(Cmd, [
       '--app',
@@ -91,13 +103,15 @@ describe('addons:attach', function () {
   })
 
   it('attaches an addon without a namespace if the credential flag is set to default', async function () {
-    api
-      .get('/addons/postgres-123')
-      .reply(200, {name: 'postgres-123'})
-      .post('/addon-attachments', {addon: {name: 'postgres-123'}, app: {name: 'myapp'}})
-      .reply(201, {name: 'POSTGRES_HELLO'})
-      .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
+    const infoStub = stub().resolves({name: 'postgres-123'})
+    const createStub = stub().resolves({name: 'POSTGRES_HELLO'})
+    const listReleasesStub = stub().resolves([{version: 10}])
+    const fakePlatform = {
+      addOn: {info: infoStub},
+      addOnAttachment: {create: createStub},
+      withHeaders: stub().returns({release: {list: listReleasesStub}}),
+    }
+    sdkMock = mockSDKPlatform(fakePlatform)
 
     const {stderr, stdout} = await runCommand(Cmd, [
       '--app',
@@ -109,18 +123,24 @@ describe('addons:attach', function () {
     expect(stdout).to.equal('')
     expect(stderr).to.contain('Attaching default of ⛁ postgres-123 to ⬢ myapp... done')
     expect(stderr).to.contain('Setting POSTGRES_HELLO config vars and restarting ⬢ myapp... done, v10')
+    // credential 'default' does not hit the escape-hatch config route and uses no namespace
+    expect(createStub.calledOnceWith({
+      addon: 'postgres-123', app: 'myapp', confirm: undefined, name: undefined, namespace: undefined,
+    })).to.be.true
   })
 
   it('attaches in the credential namespace if the credential flag is specified', async function () {
-    api
-      .get('/addons/postgres-123')
-      .reply(200, {name: 'postgres-123'})
-      .get('/addons/postgres-123/config/credential:hello')
-      .reply(200, [{some: 'config'}])
-      .post('/addon-attachments', {addon: {name: 'postgres-123'}, app: {name: 'myapp'}, namespace: 'credential:hello'})
-      .reply(201, {name: 'POSTGRES_HELLO'})
-      .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
+    const infoStub = stub().resolves({name: 'postgres-123'})
+    const createStub = stub().resolves({name: 'POSTGRES_HELLO'})
+    const listReleasesStub = stub().resolves([{version: 10}])
+    const fakePlatform = {
+      addOn: {info: infoStub},
+      addOnAttachment: {create: createStub},
+      withHeaders: stub().returns({release: {list: listReleasesStub}}),
+    }
+    sdkMock = mockSDKPlatform(fakePlatform)
+    const getStub: SinonStub = stub(HerokuApiClient.prototype, 'get')
+    getStub.resolves({json: async () => [{some: 'config'}]})
 
     const {stderr, stdout} = await runCommand(Cmd, [
       '--app',
@@ -132,14 +152,24 @@ describe('addons:attach', function () {
     expect(stdout).to.equal('')
     expect(stderr).to.contain('Attaching hello of ⛁ postgres-123 to ⬢ myapp... done')
     expect(stderr).to.contain('Setting POSTGRES_HELLO config vars and restarting ⬢ myapp... done, v10')
+    expect(getStub.calledOnceWith('/addons/postgres-123/config/credential:hello')).to.be.true
+    expect(createStub.calledOnceWith({
+      addon: 'postgres-123', app: 'myapp', confirm: undefined, name: undefined, namespace: 'credential:hello',
+    })).to.be.true
   })
 
   it('errors if the credential flag is specified but that credential does not exist for that addon', async function () {
-    api
-      .get('/addons/postgres-123')
-      .reply(200, {name: 'postgres-123'})
-      .get('/addons/postgres-123/config/credential:hello')
-      .reply(200, [])
+    const infoStub = stub().resolves({name: 'postgres-123'})
+    const createStub = stub().resolves({name: 'POSTGRES_HELLO'})
+    const listReleasesStub = stub().resolves([{version: 10}])
+    const fakePlatform = {
+      addOn: {info: infoStub},
+      addOnAttachment: {create: createStub},
+      withHeaders: stub().returns({release: {list: listReleasesStub}}),
+    }
+    sdkMock = mockSDKPlatform(fakePlatform)
+    const getStub: SinonStub = stub(HerokuApiClient.prototype, 'get')
+    getStub.resolves({json: async () => []})
 
     const {error} = await runCommand(Cmd, [
       '--app',

--- a/test/unit/commands/addons/destroy.unit.test.ts
+++ b/test/unit/commands/addons/destroy.unit.test.ts
@@ -1,47 +1,55 @@
-import * as Heroku from '@heroku-cli/schema'
+import type {AddOn} from '@heroku/types/3.sdk'
+
 import {runCommand} from '@heroku-cli/test-utils'
+import {AddonProvisioningFailedError} from '@heroku/sdk/resources/platform/add-on'
 import ansis from 'ansis'
 import {expect} from 'chai'
-import * as lolex from 'lolex'
 import nock from 'nock'
-import {createSandbox} from 'sinon'
+import {createSandbox, match, SinonStub} from 'sinon'
 
 import Cmd from '../../../../src/commands/addons/destroy.js'
+import {type MockSDK, mockSDKPlatform} from '../../../helpers/mock-sdk.js'
+
+const baseAddon: AddOn = {
+  addon_service: {name: 'heroku-postgresql'},
+  app: {
+    id: '01234567-89ab-cdef-0123-456789abcdef',
+    name: 'myapp',
+  },
+  config_vars: ['DATABASE_URL'],
+  id: '01234567-89ab-cdef-0123-456789abcdef',
+  name: 'postgresql-swiftly-123',
+  plan: {
+    name: 'heroku-postgresql:standard-0',
+    price: {cents: 10_000, unit: 'month'},
+  },
+  state: 'provisioned',
+} as unknown as AddOn
 
 describe('addons:destroy', function () {
   let api: nock.Scope
+  let sdkMock: MockSDK
+  let destroyAndWait: SinonStub
 
   beforeEach(function () {
     api = nock('https://api.heroku.com')
+    destroyAndWait = createSandbox().stub()
+    sdkMock = mockSDKPlatform({addOn: {destroyAndWait}})
   })
 
   afterEach(function () {
     api.done()
     nock.cleanAll()
+    sdkMock.restore()
   })
 
   context('when an add-on implements sync deprovisioning', function () {
     it('destroys the add-on synchronously', async function () {
-      const addon: Heroku.AddOn = {
-        addon_service: {name: 'heroku-postgresql'},
-        app: {
-          id: '01234567-89ab-cdef-0123-456789abcdef',
-          name: 'myapp',
-        },
-        config_vars: ['DATABASE_URL'],
-        id: '01234567-89ab-cdef-0123-456789abcdef',
-        name: 'postgresql-swiftly-123',
-        plan: {
-          name: 'heroku-postgresql:standard-0',
-          price: {cents: 10_000, unit: 'month'},
-        },
-        state: 'provisioned',
-      }
+      const addon = baseAddon
       api
         .post('/actions/addons/resolve', {addon: 'postgresql-swiftly-123', app: 'myapp'})
         .reply(200, [addon])
-        .delete(`/apps/${addon.app?.id}/addons/${addon.id}`, {force: false})
-        .reply(200, {...addon, state: 'deprovisioned'})
+      destroyAndWait.resolves({...addon, state: 'deprovisioned'})
 
       const {stderr, stdout} = await runCommand(Cmd, [
         '--app',
@@ -52,30 +60,19 @@ describe('addons:destroy', function () {
       ])
       expect(stdout).to.equal('')
       expect(stderr).to.contain('Destroying postgresql-swiftly-123 on ⬢ myapp... done\n')
+      expect(destroyAndWait.calledOnceWith('myapp', 'postgresql-swiftly-123', match.has('force', false))).to.equal(true)
+      expect(destroyAndWait.getCall(0).args[2].wait).to.not.equal(true)
     })
   })
+
   context('when an add-on implements async deprovisioning', function () {
     it('destroys the add-on asynchronously', async function () {
-      const addon: Heroku.AddOn = {
-        addon_service: {name: 'heroku-postgresql'},
-        app: {
-          id: '01234567-89ab-cdef-0123-456789abcdef',
-          name: 'myapp',
-        },
-        config_vars: ['DATABASE_URL'],
-        id: '01234567-89ab-cdef-0123-456789abcdef',
-        name: 'postgresql-swiftly-123',
-        plan: {
-          name: 'heroku-postgresql:standard-0',
-          price: {cents: 10_000, unit: 'month'},
-        },
-        state: 'provisioned',
-      }
+      const addon = baseAddon
       api
         .post('/actions/addons/resolve', {addon: 'postgresql-swiftly-123', app: 'myapp'})
         .reply(200, [addon])
-        .delete(`/apps/${addon.app?.id}/addons/${addon.id}`, {force: false})
-        .reply(202, {...addon, state: 'deprovisioning'})
+      destroyAndWait.resolves({...addon, state: 'deprovisioning'})
+
       const {stderr, stdout} = await runCommand(Cmd, [
         '--app',
         'myapp',
@@ -86,80 +83,71 @@ describe('addons:destroy', function () {
       expect(stdout).to.equal('postgresql-swiftly-123 is being destroyed in the background. The app will restart when complete...\nRun heroku addons:info postgresql-swiftly-123 to check destruction progress\n')
       expect(ansis.strip(stderr)).to.contain(ansis.strip('Destroying postgresql-swiftly-123 on ⬢ myapp... pending'))
     })
-    context('--wait', function () {
-      let clock: ReturnType<typeof lolex.install>
-      let sandbox: ReturnType<typeof createSandbox>
-      beforeEach(function () {
-        sandbox = createSandbox()
-        clock = lolex.install()
-        clock.setTimeout = function (callback: () => void, timeout: number, ...args: any[]): number {
-          callback()
-          return 1
-        }
+
+    it('with --wait, waits for response and notifies', async function () {
+      const addon = baseAddon
+      const sandbox = createSandbox()
+      const notifySpy = sandbox.spy(Cmd, 'notifier')
+      api
+        .post('/actions/addons/resolve', {addon: 'postgresql-swiftly-123', app: 'myapp'})
+        .reply(200, [addon])
+      // The SDK's destroyAndWait fires onDeprovisioning before polling; mimic that
+      // two-phase UX here, then resolve as fully deprovisioned.
+      destroyAndWait.callsFake(async (_appIdentity, _addonIdentity, options) => {
+        await options.onDeprovisioning?.({...addon, state: 'deprovisioning'})
+        return {...addon, state: 'deprovisioned'}
       })
-      afterEach(function () {
-        clock.uninstall()
-        sandbox.restore()
-      })
-      it('waits for response and notifies', async function () {
-        const addon: Heroku.AddOn = {
-          addon_service: {name: 'heroku-postgresql'},
-          app: {
-            id: '01234567-89ab-cdef-0123-456789abcdef',
-            name: 'myapp',
-          },
-          config_vars: ['DATABASE_URL'],
-          id: '01234567-89ab-cdef-0123-456789abcdef',
-          name: 'postgresql-swiftly-123',
-          plan: {
-            name: 'heroku-postgresql:standard-0',
-            price: {cents: 10_000, unit: 'month'},
-          },
-          state: 'provisioned',
-        }
-        const notifySpy = sandbox.spy(Cmd, 'notifier')
-        api
-          .post('/actions/addons/resolve', {addon: 'postgresql-swiftly-123', app: 'myapp'})
-          .reply(200, [addon])
-          .delete(`/apps/${addon.app?.id}/addons/${addon.id}`, {force: false})
-          .reply(202, {...addon, state: 'deprovisioning'})
-          .get('/apps/myapp/addons/postgresql-swiftly-123')
-          .reply(200, {...addon, state: 'deprovisioning'})
-          .get('/apps/myapp/addons/postgresql-swiftly-123')
-          .reply(404, {id: 'not_found', message: 'Not found'})
-        const {stderr, stdout} = await runCommand(Cmd, [
-          '--app',
-          'myapp',
-          '--confirm',
-          'myapp',
-          '--wait',
-          'postgresql-swiftly-123',
-        ])
-        expect(notifySpy.called).to.equal(true)
-        expect(notifySpy.calledOnce).to.equal(true)
-        expect(ansis.strip(stderr)).to.contain('Destroying postgresql-swiftly-123 on ⬢ myapp... pending')
-        expect(stderr).to.contain('Destroying postgresql-swiftly-123... done\n')
-        expect(stdout).to.equal('Waiting for postgresql-swiftly-123...\n')
-      })
+
+      const {stderr, stdout} = await runCommand(Cmd, [
+        '--app',
+        'myapp',
+        '--confirm',
+        'myapp',
+        '--wait',
+        'postgresql-swiftly-123',
+      ])
+      expect(notifySpy.called).to.equal(true)
+      expect(notifySpy.calledOnce).to.equal(true)
+      expect(ansis.strip(stderr)).to.contain('Destroying postgresql-swiftly-123 on ⬢ myapp... pending')
+      expect(stderr).to.contain('Destroying postgresql-swiftly-123... done\n')
+      expect(stdout).to.equal('Waiting for postgresql-swiftly-123...\n')
+      expect(destroyAndWait.calledOnceWith('myapp', 'postgresql-swiftly-123', match({force: false, wait: true}))).to.equal(true)
+      expect(destroyAndWait.getCall(0).args[2].wait).to.equal(true)
+      sandbox.restore()
+    })
+
+    it('with --wait, notifies of failure and rethrows when deprovisioning fails', async function () {
+      const addon = baseAddon
+      const sandbox = createSandbox()
+      const notifySpy = sandbox.spy(Cmd, 'notifier')
+      api
+        .post('/actions/addons/resolve', {addon: 'postgresql-swiftly-123', app: 'myapp'})
+        .reply(200, [addon])
+      destroyAndWait.rejects(new AddonProvisioningFailedError({...addon, state: 'provisioned'}))
+
+      const {error} = await runCommand(Cmd, [
+        '--app',
+        'myapp',
+        '--confirm',
+        'myapp',
+        '--wait',
+        'postgresql-swiftly-123',
+      ])
+      expect(notifySpy.calledOnce).to.equal(true)
+      expect(notifySpy.calledWith('heroku addons:destroy postgresql-swiftly-123', 'Add-on failed to deprovision', false)).to.equal(true)
+      expect(error?.message).to.equal('The add-on was unable to be destroyed, with status provisioned.')
+      sandbox.restore()
     })
   })
 
   it('fails when addon app is not the app specified', async function () {
-    const addonInOtherApp: Heroku.AddOn = {
-      addon_service: {name: 'heroku-postgresql'},
+    const addonInOtherApp: AddOn = {
+      ...baseAddon,
       app: {
         id: '01234567-89ab-cdef-0123-456789abcdef',
         name: 'myotherapp',
       },
-      config_vars: ['DATABASE_URL'],
-      id: '01234567-89ab-cdef-0123-456789abcdef',
-      name: 'postgresql-swiftly-123',
-      plan: {
-        name: 'heroku-postgresql:standard-0',
-        price: {cents: 10_000, unit: 'month'},
-      },
-      state: 'provisioned',
-    }
+    } as unknown as AddOn
     api
       .post('/actions/addons/resolve', {addon: 'DATABASE', app: 'myapp'})
       .reply(200, [addonInOtherApp])
@@ -171,29 +159,16 @@ describe('addons:destroy', function () {
       'DATABASE',
     ])
     expect(ansis.strip(error?.message || '')).to.equal('postgresql-swiftly-123 is on ⬢ myotherapp not ⬢ myapp')
+    expect(destroyAndWait.called).to.equal(false)
   })
 
   it('shows that it failed to deprovision when there are errors returned', async function () {
-    const addon: Omit<Heroku.AddOn, 'state'> & {state: 'suspended'} = {
-      addon_service: {name: 'heroku-postgresql'},
-      app: {
-        id: '01234567-89ab-cdef-0123-456789abcdef',
-        name: 'myapp',
-      },
-      config_vars: ['DATABASE_URL'],
-      id: '01234567-89ab-cdef-0123-456789abcdef',
-      name: 'postgresql-swiftly-123',
-      plan: {
-        name: 'heroku-postgresql:standard-0',
-        price: {cents: 10_000, unit: 'month'},
-      },
-      state: 'suspended',
-    }
+    const addon = baseAddon
     api
       .post('/actions/addons/resolve', {addon: 'postgresql-swiftly-123', app: 'myapp'})
       .reply(200, [addon])
-      .delete(`/apps/${addon.app?.id}/addons/${addon.id}`, {force: false})
-      .reply(403, {id: 'forbidden', message: 'Cannot delete a suspended addon'})
+    destroyAndWait.rejects(new Error('Cannot delete a suspended addon'))
+
     const {error} = await runCommand(Cmd, [
       '--app',
       'myapp',
@@ -203,45 +178,40 @@ describe('addons:destroy', function () {
     ])
     expect(error?.message).to.equal('The add-on was unable to be destroyed: Cannot delete a suspended addon.')
   })
+
+  it('surfaces the database-specific error copy for advanced databases', async function () {
+    const advancedAddon: AddOn = {
+      ...baseAddon,
+      plan: {
+        name: 'heroku-postgresql:advanced-0',
+        price: {cents: 100_000, unit: 'month'},
+      },
+    } as unknown as AddOn
+    api
+      .post('/actions/addons/resolve', {addon: 'postgresql-swiftly-123', app: 'myapp'})
+      .reply(200, [advancedAddon])
+    destroyAndWait.rejects(new Error('Cannot delete a suspended addon'))
+
+    const {error} = await runCommand(Cmd, [
+      '--app',
+      'myapp',
+      '--confirm',
+      'myapp',
+      'postgresql-swiftly-123',
+    ])
+    expect(error?.message).to.equal('We can\'t destroy your database due to an error: Cannot delete a suspended addon. Try again or open a ticket with Heroku Support: https://help.heroku.com/')
+  })
+
   context('when multiple add-ons are provided', function () {
     it('destroys them all', async function () {
-      const addon: Heroku.AddOn = {
-        addon_service: {name: 'heroku-postgresql'},
-        app: {
-          id: '01234567-89ab-cdef-0123-456789abcdef',
-          name: 'myapp',
-        },
-        config_vars: ['DATABASE_URL'],
-        id: '01234567-89ab-cdef-0123-456789abcdef',
-        name: 'postgresql-swiftly-123',
-        plan: {
-          name: 'heroku-postgresql:standard-0',
-          price: {cents: 10_000, unit: 'month'},
-        },
-        state: 'provisioned',
-      }
-      const addon1: Heroku.AddOn = {
-        addon_service: {name: 'heroku-postgresql'},
-        app: {
-          id: '01234567-89ab-cdef-0123-456789abcdef',
-          name: 'myapp',
-        },
-        config_vars: ['DATABASE_URL'],
-        id: '01234567-89ab-cdef-0123-456789abcdef',
-        name: 'postgresql-swiftly-124',
-        plan: {
-          name: 'heroku-postgresql:standard-0',
-          price: {cents: 10_000, unit: 'month'},
-        },
-        state: 'provisioned',
-      }
+      const addon = baseAddon
+      const addon1: AddOn = {...baseAddon, name: 'postgresql-swiftly-124'} as unknown as AddOn
       api
         .post('/actions/addons/resolve', {addon: 'postgresql-swiftly-123', app: 'myapp'}).reply(200, [addon])
-        .delete(`/apps/${addon.app?.id}/addons/${addon.id}`, {force: false})
-        .reply(200, {...addon, state: 'deprovisioned'})
         .post('/actions/addons/resolve', {addon: 'postgresql-swiftly-124', app: 'myapp'}).reply(200, [addon1])
-        .delete(`/apps/${addon1.app?.id}/addons/${addon1.id}`, {force: false})
-        .reply(200, {...addon, state: 'deprovisioned'})
+      destroyAndWait
+        .withArgs('myapp', 'postgresql-swiftly-123', match.any).resolves({...addon, state: 'deprovisioned'})
+        .withArgs('myapp', 'postgresql-swiftly-124', match.any).resolves({...addon1, state: 'deprovisioned'})
 
       const {stderr, stdout} = await runCommand(Cmd, [
         '--app',
@@ -254,39 +224,20 @@ describe('addons:destroy', function () {
       expect(stdout).to.equal('')
       expect(stderr).to.contain('Destroying postgresql-swiftly-123 on ⬢ myapp... done\n')
       expect(stderr).to.contain('Destroying postgresql-swiftly-124 on ⬢ myapp... done\n')
+      expect(destroyAndWait.calledTwice).to.equal(true)
     })
 
     it('fails when additional addon app is not the app specified', async function () {
-      const addon: Heroku.AddOn = {
-        addon_service: {name: 'heroku-postgresql'},
-        app: {
-          id: '01234567-89ab-cdef-0123-456789abcdef',
-          name: 'myapp',
-        },
-        config_vars: ['DATABASE_URL'],
-        id: '01234567-89ab-cdef-0123-456789abcdef',
-        name: 'postgresql-swiftly-123',
-        plan: {
-          name: 'heroku-postgresql:standard-0',
-          price: {cents: 10_000, unit: 'month'},
-        },
-        state: 'provisioned',
-      }
-      const addon1: Heroku.AddOn = {
-        addon_service: {name: 'heroku-postgresql'},
+      const addon = baseAddon
+      const addon1: AddOn = {
+        ...baseAddon,
         app: {
           id: '01234567-89ab-cdef-0123-456789abcdef',
           name: 'myapp2',
         },
         config_vars: ['FOREIGN_DATABASE_URL'],
-        id: '01234567-89ab-cdef-0123-456789abcdef',
         name: 'postgresql-swiftly-124',
-        plan: {
-          name: 'heroku-postgresql:standard-0',
-          price: {cents: 10_000, unit: 'month'},
-        },
-        state: 'provisioned',
-      }
+      } as unknown as AddOn
       api
         .post('/actions/addons/resolve', {addon: 'DATABASE', app: 'myapp'}).reply(200, [addon])
         .post('/actions/addons/resolve', {addon: 'FOREIGN_DATABASE', app: 'myapp'}).reply(200, [addon1])
@@ -300,6 +251,7 @@ describe('addons:destroy', function () {
         'FOREIGN_DATABASE',
       ])
       expect(ansis.strip(error?.message || '')).to.equal('postgresql-swiftly-124 is on ⬢ myapp2 not ⬢ myapp')
+      expect(destroyAndWait.called).to.equal(false)
     })
   })
 })

--- a/test/unit/commands/addons/docs.unit.test.ts
+++ b/test/unit/commands/addons/docs.unit.test.ts
@@ -1,64 +1,61 @@
 import {runCommand} from '@heroku-cli/test-utils'
 import {expect} from 'chai'
-import nock from 'nock'
 import {SinonStub, stub} from 'sinon'
 
 import Cmd from '../../../../src/commands/addons/docs.js'
+import {type MockSDK, mockSDKPlatform} from '../../../helpers/mock-sdk.js'
 
 describe('addons:docs', function () {
+  let sdkMock: MockSDK
   let urlOpenerStub: SinonStub
+  let infoStub: SinonStub
+  let resolveStub: SinonStub
 
   beforeEach(function () {
     urlOpenerStub = stub(Cmd, 'urlOpener').callsFake(async () => {})
+    infoStub = stub()
+    resolveStub = stub()
+    sdkMock = mockSDKPlatform({
+      addOn: {resolve: resolveStub},
+      addOnService: {info: infoStub},
+    })
   })
 
   afterEach(function () {
     urlOpenerStub.reset()
     urlOpenerStub.restore()
-    nock.cleanAll()
+    sdkMock.restore()
   })
 
   it('opens an addon by name', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/addon-services/slowdb')
-      .reply(200, {name: 'slowdb'})
+    infoStub.resolves({name: 'slowdb'})
 
     const {stderr, stdout} = await runCommand(Cmd, ['--show-url', 'slowdb'])
     expect(stdout).to.equal('https://devcenter.heroku.com/articles/slowdb\n')
     expect(stderr).to.equal('')
-    api.done()
   })
 
   it('opens an addon by name with no url flag passed', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/addon-services/slowdb')
-      .reply(200, {name: 'slowdb'})
+    infoStub.resolves({name: 'slowdb'})
 
     const {stdout} = await runCommand(Cmd, ['slowdb'])
     expect(stdout).to.equal('Opening https://devcenter.heroku.com/articles/slowdb...\n')
     expect(urlOpenerStub.calledWith('https://devcenter.heroku.com/articles/slowdb')).to.be.true
-    api.done()
   })
 
   it('opens an addon by attachment name', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/addon-services/my-attachment-1111')
-      .reply(404)
-      .post('/actions/addons/resolve', {addon: 'my-attachment-1111', app: null})
-      .reply(200, [{addon_service: {name: 'slowdb'}}])
+    infoStub.rejects(new Error('not found'))
+    resolveStub.resolves({addon_service: {name: 'slowdb'}})
 
     const {stderr, stdout} = await runCommand(Cmd, ['--show-url', 'my-attachment-1111'])
     expect(stdout).to.equal('https://devcenter.heroku.com/articles/slowdb\n')
     expect(stderr).to.equal('')
-    api.done()
+    expect(resolveStub.calledWith('my-attachment-1111', {appIdentity: undefined})).to.be.true
   })
 
   it('opens an addon by app/attachment name', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/addon-services/my-attachment-1111')
-      .reply(404)
-      .post('/actions/addons/resolve', {addon: 'my-attachment-1111', app: 'myapp'})
-      .reply(200, [{addon_service: {name: 'slowdb'}}])
+    infoStub.rejects(new Error('not found'))
+    resolveStub.resolves({addon_service: {name: 'slowdb'}})
 
     const {stderr, stdout} = await runCommand(Cmd, [
       '--app',
@@ -68,6 +65,6 @@ describe('addons:docs', function () {
     ])
     expect(stdout).to.equal('https://devcenter.heroku.com/articles/slowdb\n')
     expect(stderr).to.equal('')
-    api.done()
+    expect(resolveStub.calledWith('my-attachment-1111', {appIdentity: 'myapp'})).to.be.true
   })
 })

--- a/test/unit/commands/addons/open.unit.test.ts
+++ b/test/unit/commands/addons/open.unit.test.ts
@@ -117,6 +117,37 @@ describe('The addons:open command', function () {
       expect(resolveStub.calledWith('postgresql-rugged-40855', {appIdentity: 'myApp'})).to.be.true
     })
 
+    it('falls through to a direct resolve when resolveByAttachment throws a plain 404', async function () {
+      // resolveByAttachment can surface a non-AddonNotFoundError 404 (statusCode
+      // 404). isNotFound() must recognize it so we swallow it and resolve the
+      // add-on directly rather than rethrowing.
+      resolveByAttachmentStub.rejects(Object.assign(new Error('Not Found'), {statusCode: 404}))
+      resolveStub.resolves({name: 'db2', web_url: 'http://db2'})
+
+      const {stdout} = await runCommand(Cmd, [
+        '--app',
+        'myApp',
+        '--show-url',
+        'db2',
+      ])
+      expect(stdout).to.equal('http://db2\n')
+      expect(resolveStub.calledWith('db2', {appIdentity: 'myApp'})).to.be.true
+    })
+
+    it('rethrows non-404 errors from resolveByAttachment', async function () {
+      // Anything that is neither AddonNotFoundError nor a 404 must propagate.
+      resolveByAttachmentStub.rejects(Object.assign(new Error('Boom'), {statusCode: 500}))
+
+      const {error} = await runCommand(Cmd, [
+        '--app',
+        'myApp',
+        '--show-url',
+        'db2',
+      ])
+      expect(error?.message).to.equal('Boom')
+      expect(resolveStub.called).to.be.false
+    })
+
     it('url using sudo via sso.', async function () {
       process.env.HEROKU_SUDO = 'true'
       const api = nock('https://api.heroku.com:443')

--- a/test/unit/commands/addons/open.unit.test.ts
+++ b/test/unit/commands/addons/open.unit.test.ts
@@ -47,7 +47,10 @@ describe('The addons:open command', function () {
   })
 
   it('should open an attached addon, by slug, with the correct `context_app`.', async function () {
-    resolveByAttachmentStub.resolves({id: 'c7c9cf20-ec87-11e5-aea4-0002a5d5c51b', web_url: 'http://myapp-2-slowdb'})
+    // resolveByAttachment returns only the add-on identity, not its web_url;
+    // the command resolves the add-on to get the dashboard URL.
+    resolveByAttachmentStub.resolves({id: 'c7c9cf20-ec87-11e5-aea4-0002a5d5c51b', name: 'slowdb'})
+    resolveStub.resolves({name: 'slowdb', web_url: 'http://myapp-2-slowdb'})
 
     const {stdout} = await runCommand(Cmd, [
       '--app',
@@ -57,6 +60,7 @@ describe('The addons:open command', function () {
     expect(urlOpenerStub.calledWith('http://myapp-2-slowdb')).to.be.true
     expect(stdout).to.equal('Opening http://myapp-2-slowdb...\n')
     expect(resolveByAttachmentStub.calledWith('myapp-2', 'slowdb')).to.be.true
+    expect(resolveStub.calledWith('slowdb', {appIdentity: 'myapp-2'})).to.be.true
   })
 
   describe('should open the specified addon', function () {
@@ -65,7 +69,8 @@ describe('The addons:open command', function () {
     })
 
     it('url via the standard happy path.', async function () {
-      resolveByAttachmentStub.resolves({name: 'REDIS', web_url: 'https://heroku.com'})
+      resolveByAttachmentStub.resolves({name: 'REDIS'})
+      resolveStub.resolves({name: 'REDIS', web_url: 'https://heroku.com'})
 
       const {stdout} = await runCommand(Cmd, [
         '--app',
@@ -75,10 +80,13 @@ describe('The addons:open command', function () {
       expect(urlOpenerStub.calledWith('https://heroku.com')).to.be.true
       expect(stdout).to.equal('Opening https://heroku.com...\n')
       expect(resolveByAttachmentStub.calledWith('myApp', 'redis-321')).to.be.true
+      // Resolves by the attachment's add-on name, keeping the lookup scoped.
+      expect(resolveStub.calledWith('REDIS', {appIdentity: 'myApp'})).to.be.true
     })
 
     it('url when "::" exists in the addon_attachment.', async function () {
-      resolveByAttachmentStub.resolves({name: 'REDIS', web_url: 'https://heroku.com'})
+      resolveByAttachmentStub.resolves({name: 'REDIS'})
+      resolveStub.resolves({name: 'REDIS', web_url: 'https://heroku.com'})
 
       const {stdout} = await runCommand(Cmd, [
         '--app',
@@ -88,6 +96,25 @@ describe('The addons:open command', function () {
       expect(urlOpenerStub.calledWith('https://heroku.com')).to.be.true
       expect(stdout).to.equal('Opening https://heroku.com...\n')
       expect(resolveByAttachmentStub.calledWith('myApp', 'redis::321')).to.be.true
+    })
+
+    it('resolves the add-on for its web_url even when resolveByAttachment omits it (regression: addons:open printed a blank line)', async function () {
+      // The SDK's resolveByAttachment returns only the add-on identity
+      // ({id, name, app}) — no web_url. Regression guard: the command must
+      // NOT read web_url off the attachment (that yields undefined → blank
+      // output); it must resolve the add-on to obtain the dashboard URL.
+      resolveByAttachmentStub.resolves({app: {name: 'myApp'}, id: 'db-uuid', name: 'postgresql-rugged-40855'})
+      resolveStub.resolves({name: 'postgresql-rugged-40855', web_url: 'https://addons-sso.heroku.com/apps/x/addons/y'})
+
+      const {stdout} = await runCommand(Cmd, [
+        '--app',
+        'myApp',
+        '--show-url',
+        'postgresql-rugged-40855',
+      ])
+      expect(stdout).to.equal('https://addons-sso.heroku.com/apps/x/addons/y\n')
+      expect(resolveByAttachmentStub.calledWith('myApp', 'postgresql-rugged-40855')).to.be.true
+      expect(resolveStub.calledWith('postgresql-rugged-40855', {appIdentity: 'myApp'})).to.be.true
     })
 
     it('url using sudo via sso.', async function () {

--- a/test/unit/commands/addons/open.unit.test.ts
+++ b/test/unit/commands/addons/open.unit.test.ts
@@ -1,5 +1,5 @@
-import {AddOnAttachment} from '@heroku-cli/schema'
 import {runCommand} from '@heroku-cli/test-utils'
+import {AddonNotFoundError} from '@heroku/sdk/resources/platform/add-on'
 import {expect} from 'chai'
 import nock from 'nock'
 import fs from 'node:fs/promises'
@@ -7,28 +7,33 @@ import path from 'node:path'
 import {SinonStub, stub} from 'sinon'
 
 import Cmd from '../../../../src/commands/addons/open.js'
+import {type MockSDK, mockSDKPlatform} from '../../../helpers/mock-sdk.js'
 
 describe('The addons:open command', function () {
   let urlOpenerStub: SinonStub
+  let sdkMock: MockSDK
+  let resolveByAttachmentStub: SinonStub
+  let resolveStub: SinonStub
 
   beforeEach(function () {
     urlOpenerStub = stub(Cmd, 'urlOpener').callsFake(async () => {})
+    resolveByAttachmentStub = stub()
+    resolveStub = stub()
+    sdkMock = mockSDKPlatform({
+      addOn: {resolve: resolveStub, resolveByAttachment: resolveByAttachmentStub},
+    })
   })
 
   afterEach(function () {
     urlOpenerStub.reset()
     urlOpenerStub.restore()
+    sdkMock.restore()
     nock.cleanAll()
   })
 
   it('should only print the url when --show-url is used', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .post('/actions/addon-attachments/resolve', {addon_attachment: 'db2', app: 'myApp'})
-      .reply(404, {addon_attachment: 'db2', addon_service: undefined, app: 'myApp'})
-      .post('/actions/addons/resolve', {addon: 'db2', app: 'myApp'})
-      .reply(200, [{addon_service: undefined, id: 'db2', web_url: 'http://db2'}])
-      .get('/addons/db2/addon-attachments')
-      .reply(200, [])
+    resolveByAttachmentStub.rejects(new AddonNotFoundError())
+    resolveStub.resolves({id: 'db2', web_url: 'http://db2'})
 
     const {stdout} = await runCommand(Cmd, [
       '--app',
@@ -37,24 +42,13 @@ describe('The addons:open command', function () {
       'db2',
     ])
     expect(stdout).to.equal('http://db2\n')
-    return api.done()
+    expect(resolveByAttachmentStub.calledWith('myApp', 'db2')).to.be.true
+    expect(resolveStub.calledWith('db2', {appIdentity: 'myApp'})).to.be.true
   })
 
   it('should open an attached addon, by slug, with the correct `context_app`.', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .post('/actions/addon-attachments/resolve', {addon_attachment: 'slowdb', app: 'myapp-2'})
-      .reply(404, {resource: 'add_on attachment'})
-      .post('/actions/addons/resolve', {addon: 'slowdb', app: 'myapp-2'})
-      .reply(404, {resource: 'add_on'})
-      .post('/actions/addons/resolve', {addon: 'slowdb', app: null})
-      .reply(200, [{id: 'c7c9cf20-ec87-11e5-aea4-0002a5d5c51b', web_url: 'http://myapp-slowdb'}])
-      .get('/addons/c7c9cf20-ec87-11e5-aea4-0002a5d5c51b/addon-attachments')
-      .reply(200, [
-        {app: {name: 'myapp'}, web_url: 'http://myapp-slowdb'}, {
-          app: {name: 'myapp-2'},
-          web_url: 'http://myapp-2-slowdb',
-        },
-      ])
+    resolveByAttachmentStub.resolves({id: 'c7c9cf20-ec87-11e5-aea4-0002a5d5c51b', web_url: 'http://myapp-2-slowdb'})
+
     const {stdout} = await runCommand(Cmd, [
       '--app',
       'myapp-2',
@@ -62,7 +56,7 @@ describe('The addons:open command', function () {
     ])
     expect(urlOpenerStub.calledWith('http://myapp-2-slowdb')).to.be.true
     expect(stdout).to.equal('Opening http://myapp-2-slowdb...\n')
-    return api.done()
+    expect(resolveByAttachmentStub.calledWith('myapp-2', 'slowdb')).to.be.true
   })
 
   describe('should open the specified addon', function () {
@@ -71,10 +65,7 @@ describe('The addons:open command', function () {
     })
 
     it('url via the standard happy path.', async function () {
-      const responseBody: AddOnAttachment[] = [{name: 'REDIS', web_url: 'https://heroku.com'}]
-      const api = nock('https://api.heroku.com:443')
-        .post('/actions/addon-attachments/resolve', {addon_attachment: 'redis-321', app: 'myApp'})
-        .reply(201, responseBody)
+      resolveByAttachmentStub.resolves({name: 'REDIS', web_url: 'https://heroku.com'})
 
       const {stdout} = await runCommand(Cmd, [
         '--app',
@@ -83,14 +74,11 @@ describe('The addons:open command', function () {
       ])
       expect(urlOpenerStub.calledWith('https://heroku.com')).to.be.true
       expect(stdout).to.equal('Opening https://heroku.com...\n')
-      return api.done()
+      expect(resolveByAttachmentStub.calledWith('myApp', 'redis-321')).to.be.true
     })
 
     it('url when "::" exists in the addon_attachment.', async function () {
-      const responseBody: AddOnAttachment[] = [{name: 'REDIS', web_url: 'https://heroku.com'}]
-      const api = nock('https://api.heroku.com:443')
-        .post('/actions/addon-attachments/resolve', {addon_attachment: 'redis::321', app: null})
-        .reply(201, responseBody)
+      resolveByAttachmentStub.resolves({name: 'REDIS', web_url: 'https://heroku.com'})
 
       const {stdout} = await runCommand(Cmd, [
         '--app',
@@ -99,7 +87,7 @@ describe('The addons:open command', function () {
       ])
       expect(urlOpenerStub.calledWith('https://heroku.com')).to.be.true
       expect(stdout).to.equal('Opening https://heroku.com...\n')
-      return api.done()
+      expect(resolveByAttachmentStub.calledWith('myApp', 'redis::321')).to.be.true
     })
 
     it('url using sudo via sso.', async function () {

--- a/test/unit/commands/addons/open.unit.test.ts
+++ b/test/unit/commands/addons/open.unit.test.ts
@@ -14,13 +14,18 @@ describe('The addons:open command', function () {
   let sdkMock: MockSDK
   let resolveByAttachmentStub: SinonStub
   let resolveStub: SinonStub
+  let listByAddOnStub: SinonStub
 
   beforeEach(function () {
     urlOpenerStub = stub(Cmd, 'urlOpener').callsFake(async () => {})
     resolveByAttachmentStub = stub()
     resolveStub = stub()
+    // Default to no attachments so the command falls back to the add-on's own
+    // web_url; tests exercising the context-scoped URL override this.
+    listByAddOnStub = stub().resolves([])
     sdkMock = mockSDKPlatform({
       addOn: {resolve: resolveStub, resolveByAttachment: resolveByAttachmentStub},
+      addOnAttachment: {listByAddOn: listByAddOnStub},
     })
   })
 
@@ -47,10 +52,17 @@ describe('The addons:open command', function () {
   })
 
   it('should open an attached addon, by slug, with the correct `context_app`.', async function () {
-    // resolveByAttachment returns only the add-on identity, not its web_url;
-    // the command resolves the add-on to get the dashboard URL.
+    // Restored pre-SDK intent: for a SHARED add-on attached to more than one
+    // app, opening from a non-billing app must use that attachment's
+    // context-scoped web_url — NOT the add-on's own (billing-app) dashboard.
+    // Regression guard: reading web_url straight off the resolved add-on would
+    // open http://myapp-slowdb (the billing app) instead of http://myapp-2-slowdb.
     resolveByAttachmentStub.resolves({id: 'c7c9cf20-ec87-11e5-aea4-0002a5d5c51b', name: 'slowdb'})
-    resolveStub.resolves({name: 'slowdb', web_url: 'http://myapp-2-slowdb'})
+    resolveStub.resolves({id: 'c7c9cf20-ec87-11e5-aea4-0002a5d5c51b', name: 'slowdb', web_url: 'http://myapp-slowdb'})
+    listByAddOnStub.resolves([
+      {app: {name: 'myapp'}, web_url: 'http://myapp-slowdb'},
+      {app: {name: 'myapp-2'}, web_url: 'http://myapp-2-slowdb'},
+    ])
 
     const {stdout} = await runCommand(Cmd, [
       '--app',
@@ -60,7 +72,7 @@ describe('The addons:open command', function () {
     expect(urlOpenerStub.calledWith('http://myapp-2-slowdb')).to.be.true
     expect(stdout).to.equal('Opening http://myapp-2-slowdb...\n')
     expect(resolveByAttachmentStub.calledWith('myapp-2', 'slowdb')).to.be.true
-    expect(resolveStub.calledWith('slowdb', {appIdentity: 'myapp-2'})).to.be.true
+    expect(listByAddOnStub.calledWith('c7c9cf20-ec87-11e5-aea4-0002a5d5c51b')).to.be.true
   })
 
   describe('should open the specified addon', function () {
@@ -146,6 +158,53 @@ describe('The addons:open command', function () {
       ])
       expect(error?.message).to.equal('Boom')
       expect(resolveStub.called).to.be.false
+    })
+
+    it('falls back to the add-on web_url when no attachment matches the requested app', async function () {
+      // The add-on has attachments, but none for the requested app (edge case:
+      // resolved globally). Keep the add-on's own dashboard URL.
+      resolveByAttachmentStub.rejects(new AddonNotFoundError())
+      resolveStub.resolves({id: 'redis-uuid', name: 'REDIS', web_url: 'https://dashboard/REDIS'})
+      listByAddOnStub.resolves([{app: {name: 'some-other-app'}, web_url: 'https://dashboard/other'}])
+
+      const {stdout} = await runCommand(Cmd, [
+        '--app',
+        'myApp',
+        '--show-url',
+        'redis-321',
+      ])
+      expect(stdout).to.equal('https://dashboard/REDIS\n')
+      expect(listByAddOnStub.calledWith('redis-uuid')).to.be.true
+    })
+
+    it('opens the add-on dashboard when listing its attachments 404s', async function () {
+      // A 404 enumerating attachments must not block opening; fall back to the
+      // add-on's own web_url.
+      resolveByAttachmentStub.rejects(new AddonNotFoundError())
+      resolveStub.resolves({id: 'redis-uuid', name: 'REDIS', web_url: 'https://dashboard/REDIS'})
+      listByAddOnStub.rejects(Object.assign(new Error('Not Found'), {statusCode: 404}))
+
+      const {stdout} = await runCommand(Cmd, [
+        '--app',
+        'myApp',
+        '--show-url',
+        'redis-321',
+      ])
+      expect(stdout).to.equal('https://dashboard/REDIS\n')
+    })
+
+    it('rethrows non-404 errors raised while listing attachments', async function () {
+      resolveByAttachmentStub.rejects(new AddonNotFoundError())
+      resolveStub.resolves({id: 'redis-uuid', name: 'REDIS', web_url: 'https://dashboard/REDIS'})
+      listByAddOnStub.rejects(Object.assign(new Error('Boom'), {statusCode: 500}))
+
+      const {error} = await runCommand(Cmd, [
+        '--app',
+        'myApp',
+        '--show-url',
+        'redis-321',
+      ])
+      expect(error?.message).to.equal('Boom')
     })
 
     it('url using sudo via sso.', async function () {

--- a/test/unit/commands/addons/open.unit.test.ts
+++ b/test/unit/commands/addons/open.unit.test.ts
@@ -13,20 +13,15 @@ import {type MockSDK, mockSDKPlatform} from '../../../helpers/mock-sdk.js'
 describe('The addons:open command', function () {
   let urlOpenerStub: SinonStub
   let sdkMock: MockSDK
-  let resolveByAttachmentStub: SinonStub
+  let describeAttachmentStub: SinonStub
   let resolveStub: SinonStub
-  let listByAddOnStub: SinonStub
 
   beforeEach(function () {
     urlOpenerStub = stub(Cmd, 'urlOpener').callsFake(async () => {})
-    resolveByAttachmentStub = stub()
+    describeAttachmentStub = stub()
     resolveStub = stub()
-    // Default to no attachments so the command falls back to the add-on's own
-    // web_url; tests exercising the context-scoped URL override this.
-    listByAddOnStub = stub().resolves([])
     sdkMock = mockSDKPlatform({
-      addOn: {resolve: resolveStub, resolveByAttachment: resolveByAttachmentStub},
-      addOnAttachment: {listByAddOn: listByAddOnStub},
+      addOn: {describeAttachment: describeAttachmentStub, resolve: resolveStub},
     })
   })
 
@@ -38,7 +33,7 @@ describe('The addons:open command', function () {
   })
 
   it('should only print the url when --show-url is used', async function () {
-    resolveByAttachmentStub.rejects(new AddonNotFoundError())
+    describeAttachmentStub.rejects(new AddonNotFoundError())
     resolveStub.resolves({id: 'db2', web_url: 'http://db2'})
 
     const {stdout} = await runCommand(Cmd, [
@@ -48,7 +43,7 @@ describe('The addons:open command', function () {
       'db2',
     ])
     expect(stdout).to.equal('http://db2\n')
-    expect(resolveByAttachmentStub.calledWith('myApp', 'db2')).to.be.true
+    expect(describeAttachmentStub.calledWith('myApp', 'db2')).to.be.true
     expect(resolveStub.calledWith('db2', {appIdentity: 'myApp'})).to.be.true
   })
 
@@ -56,14 +51,12 @@ describe('The addons:open command', function () {
     // Restored pre-SDK intent: for a SHARED add-on attached to more than one
     // app, opening from a non-billing app must use that attachment's
     // context-scoped web_url — NOT the add-on's own (billing-app) dashboard.
-    // Regression guard: reading web_url straight off the resolved add-on would
-    // open http://myapp-slowdb (the billing app) instead of http://myapp-2-slowdb.
-    resolveByAttachmentStub.resolves({id: 'c7c9cf20-ec87-11e5-aea4-0002a5d5c51b', name: 'slowdb'})
-    resolveStub.resolves({id: 'c7c9cf20-ec87-11e5-aea4-0002a5d5c51b', name: 'slowdb', web_url: 'http://myapp-slowdb'})
-    listByAddOnStub.resolves([
-      {app: {name: 'myapp'}, web_url: 'http://myapp-slowdb'},
-      {app: {name: 'myapp-2'}, web_url: 'http://myapp-2-slowdb'},
-    ])
+    // Regression guard: the single describeAttachment call carries the
+    // context-scoped web_url directly, so resolve must NOT be hit.
+    describeAttachmentStub.resolves({
+      addon: {app: {id: 'x'}, id: 'c7c9cf20-ec87-11e5-aea4-0002a5d5c51b'},
+      web_url: 'http://myapp-2-slowdb',
+    })
 
     const {stdout} = await runCommand(Cmd, [
       '--app',
@@ -72,8 +65,8 @@ describe('The addons:open command', function () {
     ])
     expect(urlOpenerStub.calledWith('http://myapp-2-slowdb')).to.be.true
     expect(stdout).to.equal('Opening http://myapp-2-slowdb...\n')
-    expect(resolveByAttachmentStub.calledWith('myapp-2', 'slowdb')).to.be.true
-    expect(listByAddOnStub.calledWith('c7c9cf20-ec87-11e5-aea4-0002a5d5c51b')).to.be.true
+    expect(describeAttachmentStub.calledWith('myapp-2', 'slowdb')).to.be.true
+    expect(resolveStub.called).to.be.false
   })
 
   describe('should open the specified addon', function () {
@@ -82,8 +75,7 @@ describe('The addons:open command', function () {
     })
 
     it('url via the standard happy path.', async function () {
-      resolveByAttachmentStub.resolves({name: 'REDIS'})
-      resolveStub.resolves({name: 'REDIS', web_url: 'https://heroku.com'})
+      describeAttachmentStub.resolves({web_url: 'https://heroku.com'})
 
       const {stdout} = await runCommand(Cmd, [
         '--app',
@@ -92,14 +84,13 @@ describe('The addons:open command', function () {
       ])
       expect(urlOpenerStub.calledWith('https://heroku.com')).to.be.true
       expect(stdout).to.equal('Opening https://heroku.com...\n')
-      expect(resolveByAttachmentStub.calledWith('myApp', 'redis-321')).to.be.true
-      // Resolves by the attachment's add-on name, keeping the lookup scoped.
-      expect(resolveStub.calledWith('REDIS', {appIdentity: 'myApp'})).to.be.true
+      // describeAttachment receives the raw addon arg and app — a single call.
+      expect(describeAttachmentStub.calledWith('myApp', 'redis-321')).to.be.true
+      expect(resolveStub.called).to.be.false
     })
 
     it('url when "::" exists in the addon_attachment.', async function () {
-      resolveByAttachmentStub.resolves({name: 'REDIS'})
-      resolveStub.resolves({name: 'REDIS', web_url: 'https://heroku.com'})
+      describeAttachmentStub.resolves({web_url: 'https://heroku.com'})
 
       const {stdout} = await runCommand(Cmd, [
         '--app',
@@ -108,33 +99,33 @@ describe('The addons:open command', function () {
       ])
       expect(urlOpenerStub.calledWith('https://heroku.com')).to.be.true
       expect(stdout).to.equal('Opening https://heroku.com...\n')
-      expect(resolveByAttachmentStub.calledWith('myApp', 'redis::321')).to.be.true
+      expect(describeAttachmentStub.calledWith('myApp', 'redis::321')).to.be.true
+      expect(resolveStub.called).to.be.false
     })
 
-    it('resolves the add-on for its web_url even when resolveByAttachment omits it (regression: addons:open printed a blank line)', async function () {
-      // The SDK's resolveByAttachment returns only the add-on identity
-      // ({id, name, app}) — no web_url. Regression guard: the command must
-      // NOT read web_url off the attachment (that yields undefined → blank
-      // output); it must resolve the add-on to obtain the dashboard URL.
-      resolveByAttachmentStub.resolves({app: {name: 'myApp'}, id: 'db-uuid', name: 'postgresql-rugged-40855'})
-      resolveStub.resolves({name: 'postgresql-rugged-40855', web_url: 'https://addons-sso.heroku.com/apps/x/addons/y'})
+    it('falls back to resolve when the attachment has no web_url', async function () {
+      // The source explicitly guards on `attachment?.web_url` — a null web_url
+      // means we can't open a context-scoped dashboard, so resolve the add-on
+      // for its own web_url.
+      describeAttachmentStub.resolves({web_url: null})
+      resolveStub.resolves({web_url: 'http://fallback'})
 
       const {stdout} = await runCommand(Cmd, [
         '--app',
         'myApp',
         '--show-url',
-        'postgresql-rugged-40855',
+        'redis-321',
       ])
-      expect(stdout).to.equal('https://addons-sso.heroku.com/apps/x/addons/y\n')
-      expect(resolveByAttachmentStub.calledWith('myApp', 'postgresql-rugged-40855')).to.be.true
-      expect(resolveStub.calledWith('postgresql-rugged-40855', {appIdentity: 'myApp'})).to.be.true
+      expect(stdout).to.equal('http://fallback\n')
+      expect(describeAttachmentStub.calledWith('myApp', 'redis-321')).to.be.true
+      expect(resolveStub.calledWith('redis-321', {appIdentity: 'myApp'})).to.be.true
     })
 
-    it('falls through to a direct resolve when resolveByAttachment throws a plain 404', async function () {
-      // resolveByAttachment can surface a non-AddonNotFoundError 404 (statusCode
+    it('falls through to a direct resolve when describeAttachment throws a plain 404', async function () {
+      // describeAttachment can surface a non-AddonNotFoundError 404 (statusCode
       // 404). isNotFound() must recognize it so we swallow it and resolve the
       // add-on directly rather than rethrowing.
-      resolveByAttachmentStub.rejects(new NotFoundError(new Response('', {status: 404})))
+      describeAttachmentStub.rejects(new NotFoundError(new Response('', {status: 404})))
       resolveStub.resolves({name: 'db2', web_url: 'http://db2'})
 
       const {stdout} = await runCommand(Cmd, [
@@ -147,9 +138,9 @@ describe('The addons:open command', function () {
       expect(resolveStub.calledWith('db2', {appIdentity: 'myApp'})).to.be.true
     })
 
-    it('rethrows non-404 errors from resolveByAttachment', async function () {
+    it('rethrows non-404 errors from describeAttachment', async function () {
       // Anything that is neither AddonNotFoundError nor a 404 must propagate.
-      resolveByAttachmentStub.rejects(Object.assign(new Error('Boom'), {statusCode: 500}))
+      describeAttachmentStub.rejects(Object.assign(new Error('Boom'), {statusCode: 500}))
 
       const {error} = await runCommand(Cmd, [
         '--app',
@@ -159,53 +150,6 @@ describe('The addons:open command', function () {
       ])
       expect(error?.message).to.equal('Boom')
       expect(resolveStub.called).to.be.false
-    })
-
-    it('falls back to the add-on web_url when no attachment matches the requested app', async function () {
-      // The add-on has attachments, but none for the requested app (edge case:
-      // resolved globally). Keep the add-on's own dashboard URL.
-      resolveByAttachmentStub.rejects(new AddonNotFoundError())
-      resolveStub.resolves({id: 'redis-uuid', name: 'REDIS', web_url: 'https://dashboard/REDIS'})
-      listByAddOnStub.resolves([{app: {name: 'some-other-app'}, web_url: 'https://dashboard/other'}])
-
-      const {stdout} = await runCommand(Cmd, [
-        '--app',
-        'myApp',
-        '--show-url',
-        'redis-321',
-      ])
-      expect(stdout).to.equal('https://dashboard/REDIS\n')
-      expect(listByAddOnStub.calledWith('redis-uuid')).to.be.true
-    })
-
-    it('opens the add-on dashboard when listing its attachments 404s', async function () {
-      // A 404 enumerating attachments must not block opening; fall back to the
-      // add-on's own web_url.
-      resolveByAttachmentStub.rejects(new AddonNotFoundError())
-      resolveStub.resolves({id: 'redis-uuid', name: 'REDIS', web_url: 'https://dashboard/REDIS'})
-      listByAddOnStub.rejects(new NotFoundError(new Response('', {status: 404})))
-
-      const {stdout} = await runCommand(Cmd, [
-        '--app',
-        'myApp',
-        '--show-url',
-        'redis-321',
-      ])
-      expect(stdout).to.equal('https://dashboard/REDIS\n')
-    })
-
-    it('rethrows non-404 errors raised while listing attachments', async function () {
-      resolveByAttachmentStub.rejects(new AddonNotFoundError())
-      resolveStub.resolves({id: 'redis-uuid', name: 'REDIS', web_url: 'https://dashboard/REDIS'})
-      listByAddOnStub.rejects(Object.assign(new Error('Boom'), {statusCode: 500}))
-
-      const {error} = await runCommand(Cmd, [
-        '--app',
-        'myApp',
-        '--show-url',
-        'redis-321',
-      ])
-      expect(error?.message).to.equal('Boom')
     })
 
     it('url using sudo via sso.', async function () {

--- a/test/unit/commands/addons/open.unit.test.ts
+++ b/test/unit/commands/addons/open.unit.test.ts
@@ -1,4 +1,5 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {NotFoundError} from '@heroku/heroku-fetch'
 import {AddonNotFoundError} from '@heroku/sdk/resources/platform/add-on'
 import {expect} from 'chai'
 import nock from 'nock'
@@ -133,7 +134,7 @@ describe('The addons:open command', function () {
       // resolveByAttachment can surface a non-AddonNotFoundError 404 (statusCode
       // 404). isNotFound() must recognize it so we swallow it and resolve the
       // add-on directly rather than rethrowing.
-      resolveByAttachmentStub.rejects(Object.assign(new Error('Not Found'), {statusCode: 404}))
+      resolveByAttachmentStub.rejects(new NotFoundError(new Response('', {status: 404})))
       resolveStub.resolves({name: 'db2', web_url: 'http://db2'})
 
       const {stdout} = await runCommand(Cmd, [
@@ -182,7 +183,7 @@ describe('The addons:open command', function () {
       // add-on's own web_url.
       resolveByAttachmentStub.rejects(new AddonNotFoundError())
       resolveStub.resolves({id: 'redis-uuid', name: 'REDIS', web_url: 'https://dashboard/REDIS'})
-      listByAddOnStub.rejects(Object.assign(new Error('Not Found'), {statusCode: 404}))
+      listByAddOnStub.rejects(new NotFoundError(new Response('', {status: 404})))
 
       const {stdout} = await runCommand(Cmd, [
         '--app',

--- a/test/unit/commands/addons/upgrade.unit.test.ts
+++ b/test/unit/commands/addons/upgrade.unit.test.ts
@@ -41,6 +41,7 @@ describe('addons:upgrade', function () {
     ])
     expect(stdout).to.equal('provision msg\n')
     expect(stderr).to.contain('Changing kafka-swiftly-123 on ⬢ myapp from premium-0 to heroku-kafka:hobby... done, free')
+    expect(upgradeStub.calledOnce).to.be.true
   })
 
   it('displays hourly and monthly price when upgrading an add-on', async function () {

--- a/test/unit/commands/addons/wait.unit.test.ts
+++ b/test/unit/commands/addons/wait.unit.test.ts
@@ -233,6 +233,28 @@ Destroying www-redis-2... done
         expect(notifySpy.called).to.be.true
         expect(notifySpy.calledOnce).to.be.true
       })
+      it('rethrows non-404 errors raised while polling for deprovisioning', async function () {
+        // pollAddonUntilDeprovisioned treats a 404 as "deprovisioned"; any
+        // other error (e.g. a transient 500) must propagate, not be swallowed.
+        const deprovisioningAddon = _.clone(fixtures.addons['www-redis-2'])
+
+        const resolveStub = stub().resolves(deprovisioningAddon)
+        const serverError = Object.assign(new Error('Internal Server Error'), {statusCode: 500})
+        const infoByAppStub = stub()
+          .onFirstCall().resolves(_.clone(deprovisioningAddon))
+          .onSecondCall().rejects(serverError)
+        sdkMock = mockSDKPlatform({
+          addOn: {resolve: resolveStub},
+          withHeaders: stub().returns({addOn: {info: infoByAppStub, infoByApp: infoByAppStub}}),
+        })
+
+        const {error} = await runCommand(Cmd, [
+          '--wait-interval',
+          '1',
+          'www-redis-2',
+        ])
+        expect(error?.message).to.equal('Internal Server Error')
+      })
     })
   })
   context('waiting for add-ons', function () {

--- a/test/unit/commands/addons/wait.unit.test.ts
+++ b/test/unit/commands/addons/wait.unit.test.ts
@@ -1,12 +1,14 @@
 import {expectOutput, runCommand} from '@heroku-cli/test-utils'
+import {NotFoundError} from '@heroku/heroku-fetch'
 import {expect} from 'chai'
 import _ from 'lodash'
-import nock from 'nock'
 import {createSandbox, type SinonFakeTimers, stub} from 'sinon'
 
 import Cmd from '../../../../src/commands/addons/wait.js'
 import * as fixtures from '../../../fixtures/addons/fixtures.js'
 import {type MockSDK, mockSDKPlatform} from '../../../helpers/mock-sdk.js'
+
+const notFound = () => new NotFoundError(new Response('', {status: 404}))
 
 describe('addons:wait', function () {
   let sandbox: any
@@ -15,7 +17,6 @@ describe('addons:wait', function () {
 
   beforeEach(function () {
     sandbox = createSandbox()
-    nock.cleanAll()
     // Fake only Date so the >5s notifier threshold can be advanced
     // synchronously without faking setTimeout (the SDK's polling loop
     // needs real setTimeout to drive the test forward).
@@ -25,47 +26,40 @@ describe('addons:wait', function () {
   afterEach(function () {
     sandbox.restore()
     sdkMock?.restore()
-    nock.cleanAll()
   })
   context('waiting for an individual add-on to provision', function () {
     context('when the add-on is provisioned', function () {
-      beforeEach(function () {
-        // resolveAddon uses this.heroku to POST /actions/addons/resolve
-        nock('https://api.heroku.com')
-          .post('/actions/addons/resolve', {addon: 'www-db', app: null})
-          .reply(200, [fixtures.addons['www-db']])
-        // No SDK polling needed since www-db is already provisioned
+      it('prints output indicating that it is done', async function () {
+        // addOn.resolve returns an already-provisioned add-on, so no polling occurs.
+        const resolveStub = stub().resolves(fixtures.addons['www-db'])
         const infoByAppStub = stub().resolves(fixtures.addons['www-db'])
         sdkMock = mockSDKPlatform({
-          addOn: {infoByApp: infoByAppStub},
-          withHeaders: stub().returns({addOn: {infoByApp: infoByAppStub}}),
+          addOn: {infoByApp: infoByAppStub, resolve: resolveStub},
+          withHeaders: stub().returns({addOn: {info: infoByAppStub, infoByApp: infoByAppStub}}),
         })
-      })
-      it('prints output indicating that it is done', async function () {
+
         const {stderr, stdout} = await runCommand(Cmd, [
           'www-db',
         ])
         expectOutput(stdout, '')
         expectOutput(stderr, '')
+        expect(resolveStub.calledOnceWith('www-db', {appIdentity: undefined})).to.be.true
       })
     })
     context('for an add-on that is still provisioning', function () {
       it('waits until the add-on is provisioned, then shows config vars', async function () {
-        // resolveAddon uses this.heroku
-        nock('https://api.heroku.com')
-          .post('/actions/addons/resolve', {addon: 'www-redis', app: null})
-          .reply(200, [fixtures.addons['www-redis']])
-
-        // waitForAddonProvisioning uses SDK for polling
         const provisionedAddon = _.clone(fixtures.addons['www-redis'])
         provisionedAddon.state = 'provisioned'
         provisionedAddon.config_vars = ['REDIS_URL']
+
+        const resolveStub = stub().resolves(fixtures.addons['www-redis'])
+        // waitForAddonProvisioning polls via platform.withHeaders(...).addOn.infoByApp
         const infoByAppStub = stub()
           .onFirstCall().resolves(fixtures.addons['www-redis'])
           .onSecondCall().resolves(provisionedAddon)
         sdkMock = mockSDKPlatform({
-          addOn: {infoByApp: infoByAppStub},
-          withHeaders: stub().returns({addOn: {infoByApp: infoByAppStub}}),
+          addOn: {resolve: resolveStub},
+          withHeaders: stub().returns({addOn: {info: infoByAppStub, infoByApp: infoByAppStub}}),
         })
 
         const {stderr, stdout} = await runCommand(Cmd, [
@@ -82,17 +76,16 @@ Created www-redis as REDIS_URL
       })
       it('does NOT notify the user when provisioning takes less than 5 seconds', async function () {
         const notifySpy = sandbox.spy(Cmd, 'notifier')
-        nock('https://api.heroku.com')
-          .post('/actions/addons/resolve', {addon: 'www-redis', app: null})
-          .reply(200, [fixtures.addons['www-redis']])
 
         const provisionedAddon = _.clone(fixtures.addons['www-redis'])
         provisionedAddon.state = 'provisioned'
         provisionedAddon.config_vars = ['REDIS_URL']
+
+        const resolveStub = stub().resolves(fixtures.addons['www-redis'])
         const infoByAppStub = stub().resolves(provisionedAddon)
         sdkMock = mockSDKPlatform({
-          addOn: {infoByApp: infoByAppStub},
-          withHeaders: stub().returns({addOn: {infoByApp: infoByAppStub}}),
+          addOn: {resolve: resolveStub},
+          withHeaders: stub().returns({addOn: {info: infoByAppStub, infoByApp: infoByAppStub}}),
         })
 
         await runCommand(Cmd, [
@@ -106,20 +99,18 @@ Created www-redis as REDIS_URL
       it('notifies the user when provisioning takes longer than 5 seconds', async function () {
         const notifySpy = sandbox.spy(Cmd, 'notifier')
 
-        nock('https://api.heroku.com')
-          .post('/actions/addons/resolve', {addon: 'www-redis', app: null})
-          .reply(200, [fixtures.addons['www-redis']])
-
         const provisionedAddon = _.clone(fixtures.addons['www-redis'])
         provisionedAddon.state = 'provisioned'
         provisionedAddon.config_vars = ['REDIS_URL']
+
+        const resolveStub = stub().resolves(fixtures.addons['www-redis'])
         const infoByAppStub = stub().callsFake(() => {
           clock.tick(5000)
           return Promise.resolve(provisionedAddon)
         })
         sdkMock = mockSDKPlatform({
-          addOn: {infoByApp: infoByAppStub},
-          withHeaders: stub().returns({addOn: {infoByApp: infoByAppStub}}),
+          addOn: {resolve: resolveStub},
+          withHeaders: stub().returns({addOn: {info: infoByAppStub, infoByApp: infoByAppStub}}),
         })
 
         await runCommand(Cmd, [
@@ -135,40 +126,34 @@ Created www-redis as REDIS_URL
       it('shows notification', async function () {
         const notifySpy = sandbox.spy(Cmd, 'notifier')
 
-        nock('https://api.heroku.com')
-          .post('/actions/addons/resolve', {addon: 'www-redis', app: null})
-          .reply(200, [fixtures.addons['www-redis']])
-
-        // waitForAddonProvisioning uses SDK - returns deprovisioned
+        const resolveStub = stub().resolves(fixtures.addons['www-redis'])
+        // waitForAddonProvisioning polls and finds the add-on deprovisioned
         const deprovisionedAddon = _.clone(fixtures.addons['www-redis'])
         deprovisionedAddon.state = 'deprovisioned'
         const infoByAppStub = stub().resolves(deprovisionedAddon)
         sdkMock = mockSDKPlatform({
-          addOn: {infoByApp: infoByAppStub},
-          withHeaders: stub().returns({addOn: {infoByApp: infoByAppStub}}),
+          addOn: {resolve: resolveStub},
+          withHeaders: stub().returns({addOn: {info: infoByAppStub, infoByApp: infoByAppStub}}),
         })
 
-        await runCommand(Cmd, ['www-redis'])
-          .catch(error => {
-            expect(error.message).to.equal('The add-on was unable to be created, with status deprovisioned')
-            expect(notifySpy.called).to.be.true
-            expect(notifySpy.calledOnce).to.be.true
-          })
+        const {error} = await runCommand(Cmd, ['--wait-interval', '1', 'www-redis'])
+        expect(error?.message).to.equal('The add-on was unable to be created, with status deprovisioned')
+        expect(notifySpy.calledWith('heroku addons:wait www-redis', 'Add-on failed to provision', false)).to.be.true
+        expect(notifySpy.calledOnce).to.be.true
       })
       it('shows that it failed to provision', async function () {
-        nock('https://api.heroku.com')
-          .post('/actions/addons/resolve', {addon: 'www-redis', app: null})
-          .reply(200, [fixtures.addons['www-redis']])
-
+        const resolveStub = stub().resolves(fixtures.addons['www-redis'])
         const deprovisionedAddon = _.clone(fixtures.addons['www-redis'])
         deprovisionedAddon.state = 'deprovisioned'
         const infoByAppStub = stub().resolves(deprovisionedAddon)
         sdkMock = mockSDKPlatform({
-          addOn: {infoByApp: infoByAppStub},
-          withHeaders: stub().returns({addOn: {infoByApp: infoByAppStub}}),
+          addOn: {resolve: resolveStub},
+          withHeaders: stub().returns({addOn: {info: infoByAppStub, infoByApp: infoByAppStub}}),
         })
 
         const {error} = await runCommand(Cmd, [
+          '--wait-interval',
+          '1',
           'www-redis',
         ])
         expect(error?.message).to.equal('The add-on was unable to be created, with status deprovisioned')
@@ -178,22 +163,15 @@ Created www-redis as REDIS_URL
   context('waiting for an individual add-on to deprovision', function () {
     context('for an add-on that is still deprovisioning', function () {
       it('waits until the add-on is deprovisioned', async function () {
-        // resolveAddon uses this.heroku
-        nock('https://api.heroku.com')
-          .post('/actions/addons/resolve', {addon: 'www-redis-2', app: null})
-          .reply(200, [fixtures.addons['www-redis-2']])
-        // waitForAddonDeprovisioning uses this.heroku for polling
-        nock('https://api.heroku.com')
-          .get('/apps/acme-inc-www/addons/www-redis-2')
-          .reply(200, fixtures.addons['www-redis-2'])
-          .get('/apps/acme-inc-www/addons/www-redis-2')
-          .reply(404, {id: 'not_found', message: 'Not found.'})
-
-        // SDK mock needed since waitForAddonProvisioning is imported
+        const resolveStub = stub().resolves(_.clone(fixtures.addons['www-redis-2']))
+        // pollAddonUntilDeprovisioned polls via platform.withHeaders(...).addOn.infoByApp;
+        // the record is deleted (404) once deprovisioned.
         const infoByAppStub = stub()
+          .onFirstCall().resolves(_.clone(fixtures.addons['www-redis-2']))
+          .onSecondCall().rejects(notFound())
         sdkMock = mockSDKPlatform({
-          addOn: {infoByApp: infoByAppStub},
-          withHeaders: stub().returns({addOn: {infoByApp: infoByAppStub}}),
+          addOn: {resolve: resolveStub},
+          withHeaders: stub().returns({addOn: {info: infoByAppStub, infoByApp: infoByAppStub}}),
         })
 
         const {stderr, stdout} = await runCommand(Cmd, [
@@ -212,16 +190,12 @@ Destroying www-redis-2... done
         const deprovisioningAddon = _.clone(fixtures.addons['www-redis-2'])
         deprovisioningAddon.id = '37f27548-db4a-4ae0-bb48-57125df0ddc2'
         deprovisioningAddon.name = 'www-redis-3'
-        nock('https://api.heroku.com')
-          .post('/actions/addons/resolve', {addon: 'www-redis-3', app: null})
-          .reply(200, [deprovisioningAddon])
-          .get('/apps/acme-inc-www/addons/www-redis-3')
-          .reply(404, {id: 'not_found', message: 'Not found.'})
 
-        const infoByAppStub = stub()
+        const resolveStub = stub().resolves(deprovisioningAddon)
+        const infoByAppStub = stub().rejects(notFound())
         sdkMock = mockSDKPlatform({
-          addOn: {infoByApp: infoByAppStub},
-          withHeaders: stub().returns({addOn: {infoByApp: infoByAppStub}}),
+          addOn: {resolve: resolveStub},
+          withHeaders: stub().returns({addOn: {info: infoByAppStub, infoByApp: infoByAppStub}}),
         })
 
         await runCommand(Cmd, [
@@ -238,21 +212,17 @@ Destroying www-redis-2... done
         const deprovisioningAddon = _.clone(fixtures.addons['www-redis-2'])
         deprovisioningAddon.id = '967dff74-99b4-4fd2-a0f0-79b523d5c0e1'
         deprovisioningAddon.name = 'www-redis-4'
-        nock('https://api.heroku.com')
-          .post('/actions/addons/resolve', {addon: 'www-redis-4', app: null})
-          .reply(200, [deprovisioningAddon])
-          .get('/apps/acme-inc-www/addons/www-redis-4')
-          .reply(200, () => {
-            clock.tick(5000)
-            return deprovisioningAddon
-          })
-          .get('/apps/acme-inc-www/addons/www-redis-4')
-          .reply(404, {id: 'not_found', message: 'Not found.'})
 
+        const resolveStub = stub().resolves(deprovisioningAddon)
         const infoByAppStub = stub()
+          .onFirstCall().callsFake(() => {
+            clock.tick(5000)
+            return Promise.resolve(_.clone(deprovisioningAddon))
+          })
+          .onSecondCall().rejects(notFound())
         sdkMock = mockSDKPlatform({
-          addOn: {infoByApp: infoByAppStub},
-          withHeaders: stub().returns({addOn: {infoByApp: infoByAppStub}}),
+          addOn: {resolve: resolveStub},
+          withHeaders: stub().returns({addOn: {info: infoByAppStub, infoByApp: infoByAppStub}}),
         })
 
         await runCommand(Cmd, [
@@ -279,19 +249,6 @@ Destroying www-redis-2... done
         // @ts-ignore
         redis2Addon.state = 'deprovisioning'
 
-        // this.heroku.get for listing addons by app
-        nock('https://api.heroku.com')
-          .get('/apps/acme-inc-www/addons')
-          .reply(200, [ignoredAddon, wwwAddon, redisAddon, redis2Addon])
-
-        // waitForAddonDeprovisioning uses this.heroku for polling
-        nock('https://api.heroku.com')
-          .get('/apps/acme-inc-www/addons/www-redis-2')
-          .reply(200, redis2Addon)
-          .get('/apps/acme-inc-www/addons/www-redis-2')
-          .reply(404, {id: 'not_found', message: 'Not found.'})
-
-        // waitForAddonProvisioning uses SDK
         const provisionedWwwAddon = _.clone(fixtures.addons['www-db'])
         provisionedWwwAddon.state = 'provisioned'
         provisionedWwwAddon.config_vars = ['WWW_URL']
@@ -299,6 +256,12 @@ Destroying www-redis-2... done
         provisionedRedisAddon.state = 'provisioned'
         provisionedRedisAddon.config_vars = ['REDIS_URL']
 
+        // addOn.listByApp enumerates the app's add-ons
+        const listByAppStub = stub().resolves([ignoredAddon, wwwAddon, redisAddon, redis2Addon])
+
+        // The provisioning and deprovisioning helpers both poll via
+        // platform.withHeaders(...).addOn.infoByApp. www-redis-2 is deleted
+        // (404) once deprovisioned.
         const callCounts: Record<string, number> = {}
         const infoByAppStub = stub().callsFake((_app: string, name: string) => {
           callCounts[name] = (callCounts[name] || 0) + 1
@@ -310,11 +273,15 @@ Destroying www-redis-2... done
             return Promise.resolve(callCounts[name] === 1 ? redisAddon : provisionedRedisAddon)
           }
 
+          if (name === 'www-redis-2') {
+            return callCounts[name] === 1 ? Promise.resolve(redis2Addon) : Promise.reject(notFound())
+          }
+
           return Promise.resolve(null)
         })
         sdkMock = mockSDKPlatform({
-          addOn: {infoByApp: infoByAppStub},
-          withHeaders: stub().returns({addOn: {infoByApp: infoByAppStub}}),
+          addOn: {listByApp: listByAppStub},
+          withHeaders: stub().returns({addOn: {info: infoByAppStub, infoByApp: infoByAppStub}}),
         })
 
         const {stderr, stdout} = await runCommand(Cmd, [
@@ -332,6 +299,7 @@ Destroying www-redis-2... done
 Created www-db as WWW_URL
 Created www-redis as REDIS_URL
 `)
+        expect(listByAppStub.calledOnceWith('acme-inc-www')).to.be.true
       })
     })
     context('for all', function () {
@@ -347,25 +315,15 @@ Created www-redis as REDIS_URL
         // @ts-ignore
         redis2Addon.state = 'deprovisioning'
 
-        // this.heroku.get for listing all addons
-        nock('https://api.heroku.com')
-          .get('/addons')
-          .reply(200, [ignoredAddon, wwwAddon, redisAddon, redis2Addon])
-
-        // waitForAddonDeprovisioning uses this.heroku for polling
-        nock('https://api.heroku.com')
-          .get('/apps/acme-inc-www/addons/www-redis-2')
-          .reply(200, redis2Addon)
-          .get('/apps/acme-inc-www/addons/www-redis-2')
-          .reply(404, {id: 'not_found', message: 'Not found.'})
-
-        // waitForAddonProvisioning uses SDK
         const provisionedWwwAddon = _.clone(fixtures.addons['www-db'])
         provisionedWwwAddon.state = 'provisioned'
         provisionedWwwAddon.config_vars = ['WWW_URL']
         const provisionedRedisAddon = _.clone(fixtures.addons['www-redis'])
         provisionedRedisAddon.state = 'provisioned'
         provisionedRedisAddon.config_vars = ['REDIS_URL']
+
+        // addOn.list enumerates all add-ons
+        const listStub = stub().resolves([ignoredAddon, wwwAddon, redisAddon, redis2Addon])
 
         const callCounts: Record<string, number> = {}
         const infoByAppStub = stub().callsFake((_app: string, name: string) => {
@@ -378,11 +336,15 @@ Created www-redis as REDIS_URL
             return Promise.resolve(callCounts[name] === 1 ? redisAddon : provisionedRedisAddon)
           }
 
+          if (name === 'www-redis-2') {
+            return callCounts[name] === 1 ? Promise.resolve(redis2Addon) : Promise.reject(notFound())
+          }
+
           return Promise.resolve(null)
         })
         sdkMock = mockSDKPlatform({
-          addOn: {infoByApp: infoByAppStub},
-          withHeaders: stub().returns({addOn: {infoByApp: infoByAppStub}}),
+          addOn: {list: listStub},
+          withHeaders: stub().returns({addOn: {info: infoByAppStub, infoByApp: infoByAppStub}}),
         })
 
         const {stderr, stdout} = await runCommand(Cmd, [
@@ -398,6 +360,7 @@ Destroying www-redis-2... done
 Created www-db as WWW_URL
 Created www-redis as REDIS_URL
 `)
+        expect(listStub.calledOnce).to.be.true
       })
     })
   })

--- a/test/unit/lib/addons/addons-wait.unit.test.ts
+++ b/test/unit/lib/addons/addons-wait.unit.test.ts
@@ -1,0 +1,34 @@
+import {NotFoundError} from '@heroku/heroku-fetch'
+import {AddonNotFoundError} from '@heroku/sdk/resources/platform/add-on'
+import {expect} from 'chai'
+
+import {isNotFound} from '../../../../src/lib/addons/addons-wait.js'
+
+// `isNotFound` classifies the 404s the deprovisioning poll loops rely on. These
+// cases assert it against REAL error instances so the test fails if either SDK
+// error type stops exposing its 404 in a shape the helper understands (guards
+// against future SDK shape drift), plus the nested http.statusCode shape.
+describe('isNotFound', function () {
+  it('returns true for a real AddonNotFoundError', function () {
+    expect(isNotFound(new AddonNotFoundError())).to.be.true
+  })
+
+  it('returns true for a real heroku-fetch NotFoundError', function () {
+    expect(isNotFound(new NotFoundError(new Response('', {status: 404})))).to.be.true
+  })
+
+  it('returns true for a 404 nested under http.statusCode', function () {
+    expect(isNotFound({http: {statusCode: 404}})).to.be.true
+  })
+
+  it('returns false for a non-404 error', function () {
+    expect(isNotFound(Object.assign(new Error('Boom'), {statusCode: 500}))).to.be.false
+  })
+
+  it('returns false for null/undefined/non-object', function () {
+    expect(isNotFound(null)).to.be.false
+    // eslint-disable-next-line unicorn/no-useless-undefined
+    expect(isNotFound(undefined)).to.be.false
+    expect(isNotFound('nope')).to.be.false
+  })
+})

--- a/test/unit/lib/addons/destroy-addon.unit.test.ts
+++ b/test/unit/lib/addons/destroy-addon.unit.test.ts
@@ -1,0 +1,66 @@
+import {APIClient} from '@heroku-cli/command'
+import * as Heroku from '@heroku-cli/schema'
+import {expect} from 'chai'
+import _ from 'lodash'
+import nock from 'nock'
+
+import {waitForAddonDeprovisioning} from '../../../../src/lib/addons/addons-wait.js'
+import {addon} from '../../../fixtures/data/pg/fixtures.js'
+import {getHerokuAPI} from '../../../helpers/test-instances.js'
+
+// `waitForAddonDeprovisioning` is the API-client polling helper retained for
+// the destroy path (src/lib/addons/destroy-addon.ts). addons:wait migrated to
+// the SDK-based `pollAddonUntilDeprovisioned`, so these tests keep the retained
+// helper's poll loop guarded against regressions.
+describe('waitForAddonDeprovisioning', function () {
+  let herokuAPI: APIClient
+
+  beforeEach(async function () {
+    herokuAPI = await getHerokuAPI()
+  })
+
+  afterEach(function () {
+    return nock.cleanAll()
+  })
+
+  it('polls until the add-on record is gone (404), then reports it deprovisioned', async function () {
+    const deprovisioning = _.clone(addon) as Heroku.AddOn
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    deprovisioning.state = 'deprovisioning'
+
+    // The API deletes the record and returns 404 once deprovisioned.
+    const api = nock('https://api.heroku.com')
+      .get(`/apps/${addon.app!.name}/addons/${addon.name}`)
+      .reply(200, {...deprovisioning, state: 'deprovisioning'})
+      .get(`/apps/${addon.app!.name}/addons/${addon.name}`)
+      .reply(404, {message: 'Not found'})
+
+    // interval 0 keeps the poll loop instant under mocha's default timeout.
+    const result = await waitForAddonDeprovisioning(herokuAPI, deprovisioning, 0)
+
+    api.done()
+    expect(result.state).to.equal('deprovisioned')
+  })
+
+  it('rethrows non-404 errors raised while polling', async function () {
+    const deprovisioning = _.clone(addon) as Heroku.AddOn
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    deprovisioning.state = 'deprovisioning'
+
+    const api = nock('https://api.heroku.com')
+      .get(`/apps/${addon.app!.name}/addons/${addon.name}`)
+      .reply(500, {message: 'Internal Server Error'})
+
+    let error: Error | undefined
+    try {
+      await waitForAddonDeprovisioning(herokuAPI, deprovisioning, 0)
+    } catch (error_) {
+      error = error_ as Error
+    }
+
+    api.done()
+    expect(error).to.exist
+  })
+})


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary

Migrates addons to use the SDK

- `upgrade` — fixed double `new HerokuSDK()` (single instance)
- `destroy` — `platform.addOn.destroyAndWait`; CLI keeps the pg error copy
- `wait` — `waitForProvisioning` + new `pollAddonUntilDeprovisioned` helper

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [x] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing

SDK reads netrc, so log in with `HEROKU_NETRC_WRITE=true`. Throwaway app; last step is destructive. Keep the order — `upgrade`/`attach` mutate the add-on, `destroy` removes it.

**Setup**
- `npm i && npm run build`
- `HEROKU_NETRC_WRITE=true ./bin/run login`
- `./bin/run apps:create APP`
- `./bin/run addons:create heroku-postgresql:essential-0 --app APP --wait` — note the add-on name (ADDON)

**Run each migrated command**
- `./bin/run addons:wait --app APP` — lists status
- `./bin/run addons:upgrade ADDON heroku-postgresql:essential-1 --app APP` — plan changes
- `./bin/run addons:docs ADDON --app APP --show-url` — prints docs URL
- `./bin/run addons:open ADDON --app APP --show-url` — prints dashboard URL
- `./bin/run addons:attach ADDON --app APP --as MYDB` — attaches, prints `done, v<N>`
- `./bin/run addons:destroy ADDON --app APP --confirm APP` — `Destroying ADDON on ⬢ APP... done`

**Cleanup**
- `./bin/run apps:destroy --app APP --confirm APP`

## Screenshots (if applicable)

## Related Issues

GUS work item: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eHU1qYAG/view
