### PR TITLE
refactor: update container:rm message

### DIFF
--- a/V12-CHANGES.md
+++ b/V12-CHANGES.md
@@ -10,10 +10,6 @@
 - `certs:add` no longer shows the `Waiting for stable domains to be created...` spinner while domains stabilize; the wait now happens silently before the certificate is associated
 - `certs:add` matches wildcard certificates against your app's domains more strictly: a `*.example.com` certificate now matches only direct subdomains (e.g. `www.example.com`), no longer matching deeper or trailing-suffix domains
 
-## Container commands
-
-- `container:rm` now shows a single spinner for batch removal (for example: `Removing containers web, worker, clock from example-app... done`)
-
 ## Run commands
 
 - `run`, `run:detached`, and `run:inside` now create dynos through `@heroku/sdk` (`platform.dyno.run`) instead of raw API calls.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3292,8 +3292,8 @@
       }
     },
     "node_modules/@heroku/sdk": {
-      "version": "0.5.1",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#de9993dd90a7717db56ccfd2faddda3f4d0a0bb2",
+      "version": "0.5.3",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#65b247bfbb5233a1e93b5980bdb3c1d907305a0f",
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku/heroku-fetch": "^0.1.1-beta",

--- a/src/commands/container/rm.ts
+++ b/src/commands/container/rm.ts
@@ -32,8 +32,16 @@ export default class Rm extends Command {
     await ensureContainerStack(platform, app, 'rm')
 
     const processTypes = argv as string[]
-    ux.action.start(`Removing containers ${processTypes.join(', ')} from ${color.app(app)}`)
-    await platform.container.removeProcessTypes(app, processTypes)
-    ux.action.stop()
+
+    await platform.container.removeProcessTypes(app, processTypes, {
+      onProgress: {
+        onStart(processType) {
+          ux.action.start(`Removing container ${processType} for ${color.app(app)}`)
+        },
+        onStop() {
+          ux.action.stop()
+        },
+      },
+    })
   }
 }

--- a/test/unit/commands/container/rm.unit.test.ts
+++ b/test/unit/commands/container/rm.unit.test.ts
@@ -1,6 +1,6 @@
 import {expectOutput, runCommand} from '@heroku-cli/test-utils'
 import {HerokuSDK} from '@heroku/sdk'
-import {NotAContainerAppError} from '@heroku/sdk/extensions/platform'
+import {NotAContainerAppError, type RemoveProcessTypesOpts} from '@heroku/sdk/extensions/platform'
 import {Errors} from '@oclif/core'
 import {expect} from 'chai'
 import {restore, SinonStub, stub} from 'sinon'
@@ -68,6 +68,12 @@ describe('container removal', function () {
   context('when the app is a container app', function () {
     beforeEach(function () {
       fakePlatform.container.ensureContainerStack.resolves()
+      fakePlatform.container.removeProcessTypes.callsFake(async (_app: string, processTypes: string[], options?: RemoveProcessTypesOpts) => {
+        for (const processType of processTypes) {
+          options?.onProgress?.onStart?.(processType)
+          options?.onProgress?.onStop?.(processType)
+        }
+      })
     })
 
     it('removes one container', async function () {
@@ -77,7 +83,7 @@ describe('container removal', function () {
         'web',
       ])
       expectOutput(stdout, '')
-      expect(stderr).to.contain('Removing containers web from ⬢ testapp... done')
+      expect(stderr).to.contain('Removing container web for ⬢ testapp... done')
       expect(fakePlatform.container.removeProcessTypes.calledOnceWith('testapp', ['web'])).to.equal(true)
     })
 
@@ -89,7 +95,8 @@ describe('container removal', function () {
         'worker',
       ])
       expectOutput(stdout, '')
-      expect(stderr).to.contain('Removing containers web, worker from ⬢ testapp... done')
+      expect(stderr).to.contain('Removing container web for ⬢ testapp... done')
+      expect(stderr).to.contain('Removing container worker for ⬢ testapp... done')
       expect(fakePlatform.container.removeProcessTypes.calledOnceWith('testapp', ['web', 'worker'])).to.equal(true)
     })
   })


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
This PR updates `container:rm` to show per-process-type progress spinners instead of one combined message.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
<!-- Add any context/setup necessary for testing. -->
The SDK uses `heroku-fetch` to make API calls, which looks for a netrc file. Therefore, we must log in with `HEROKU_NETRC_WRITE=true`.

Requires a container-based app that is used for testing. The following steps include destructive actions.

**Setup**:
- Pull down this branch
- `npm i && npm run build`
- `heroku logout`
- `HEROKU_NETRC_WRITE=true ./bin/run login`

**Steps**:
- Start Docker Desktop
- `./bin/run container:login`
- `./bin/run container:push web --app APP`
- `./bin/run container:push worker --app APP`
- `./bin/run container:release web worker --app APP`
- `./bin/run container:rm web worker --app APP`
   - Expect: two spinners
      - `Removing container web for ⬢ APP... done`
      - `Removing container worker for ⬢ APP... done`

**Cleanup:**
- `./bin/run container:logout`
- `./bin/run logout`

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-23711143](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002gXoGBYA0/view)