### PR TITLE
refactor: use @heroku/sdk for authorizations commands

### DIFF
--- a/src/commands/authorizations/create.ts
+++ b/src/commands/authorizations/create.ts
@@ -1,8 +1,8 @@
 import {Command, flags} from '@heroku-cli/command'
 import {ScopeCompletion} from '@heroku-cli/command/lib/completions.js'
-import * as Heroku from '@heroku-cli/schema'
 import {hux} from '@heroku/heroku-cli-util'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {ux} from '@oclif/core/ux'
 
 import {display} from '../../lib/authorizations/authorizations.js'
@@ -21,22 +21,21 @@ export default class AuthorizationsCreate extends Command {
   }
 
   async run() {
+    const {platform} = new HerokuSDK()
     const {flags} = await this.parse(AuthorizationsCreate)
 
     ux.action.start('Creating OAuth Authorization')
 
-    const {body: auth} = await this.heroku.post<Heroku.OAuthAuthorization>('/oauth/authorizations', {
-      body: {
-        description: flags.description,
-        expires_in: flags['expires-in'],
-        scope: flags.scope ? flags.scope.split(',') : undefined,
-      },
+    const auth = await platform.oauthAuthorization.create({
+      description: flags.description,
+      expires_in: flags['expires-in'],
+      scope: flags.scope ? flags.scope.split(',') : undefined,
     })
 
     ux.action.stop()
 
     if (flags.short) {
-      ux.stdout(auth.access_token && auth.access_token.token)
+      ux.stdout(auth.access_token?.token)
     } else if (flags.json) {
       hux.styledJSON(auth)
     } else {

--- a/src/commands/authorizations/index.ts
+++ b/src/commands/authorizations/index.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import {color, hux} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
 import {ux} from '@oclif/core/ux'
 
 export default class AuthorizationsIndex extends Command {
@@ -13,9 +13,10 @@ export default class AuthorizationsIndex extends Command {
   }
 
   async run() {
+    const {platform} = new HerokuSDK()
     const {flags} = await this.parse(AuthorizationsIndex)
 
-    const {body: authorizations} = await this.heroku.get<Array<Heroku.OAuthAuthorization>>('/oauth/authorizations')
+    const authorizations = await platform.oauthAuthorization.list()
 
     if (flags.json) {
       hux.styledJSON(authorizations.sort((a, b) => a.description.localeCompare(b.description)))

--- a/src/commands/authorizations/info.ts
+++ b/src/commands/authorizations/info.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import {hux} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args} from '@oclif/core'
 
 import {display} from '../../lib/authorizations/authorizations.js'
@@ -15,9 +15,10 @@ export default class AuthorizationsInfo extends Command {
   }
 
   async run() {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(AuthorizationsInfo)
 
-    const {body: authentication} = await this.heroku.get<Heroku.OAuthAuthorization>(`/oauth/authorizations/${args.id}`)
+    const authentication = await platform.oauthAuthorization.info(args.id)
 
     if (flags.json) {
       hux.styledJSON(authentication)

--- a/src/commands/authorizations/revoke.ts
+++ b/src/commands/authorizations/revoke.ts
@@ -1,6 +1,6 @@
 import {Command} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 
 export default class AuthorizationsRevoke extends Command {
@@ -14,10 +14,11 @@ export default class AuthorizationsRevoke extends Command {
   ]
 
   async run() {
+    const {platform} = new HerokuSDK()
     const {args} = await this.parse(AuthorizationsRevoke)
 
     ux.action.start('Revoking OAuth Authorization')
-    const {body: auth} = await this.heroku.delete<Heroku.OAuthAuthorization>(`/oauth/authorizations/${encodeURIComponent(args.id)}`)
+    const auth = await platform.oauthAuthorization.delete(args.id)
     ux.action.stop(`done, revoked authorization from ${color.cyan(auth.description)}`)
   }
 }

--- a/src/commands/authorizations/rotate.ts
+++ b/src/commands/authorizations/rotate.ts
@@ -1,5 +1,5 @@
 import {Command} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 
 import {display} from '../../lib/authorizations/authorizations.js'
@@ -11,10 +11,11 @@ export default class AuthorizationsRotate extends Command {
   static description = 'updates an OAuth authorization token'
 
   async run() {
+    const {platform} = new HerokuSDK()
     const {args} = await this.parse(AuthorizationsRotate)
 
     ux.action.start('Rotating OAuth Authorization')
-    const {body: authorization} = await this.heroku.post<Heroku.OAuthAuthorization>(`/oauth/authorizations/${encodeURIComponent(args.id)}/actions/regenerate-tokens`)
+    const authorization = await platform.oauthAuthorization.regenerate(args.id)
     ux.action.stop()
 
     display(authorization)

--- a/src/commands/authorizations/update.ts
+++ b/src/commands/authorizations/update.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
+import {HerokuSDK} from '@heroku/sdk'
+import {OauthAuthorizationUpdateOpts} from '@heroku/types/3.sdk'
 import {Args, ux} from '@oclif/core'
 
 import {display} from '../../lib/authorizations/authorizations.js'
@@ -16,6 +17,7 @@ export default class AuthorizationsUpdate extends Command {
   }
 
   async run() {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(AuthorizationsUpdate)
 
     ux.action.start('Updating OAuth Authorization')
@@ -28,15 +30,10 @@ export default class AuthorizationsUpdate extends Command {
       }
     }
 
-    const {body: authentication} = await this.heroku.patch<Heroku.OAuthAuthorization>(
-      `/oauth/authorizations/${args.id}`,
-      {
-        body: {
-          client,
-          description: flags.description,
-        },
-      },
-    )
+    const authentication = await platform.oauthAuthorization.update(args.id, {
+      client,
+      description: flags.description,
+    } as OauthAuthorizationUpdateOpts)
 
     ux.action.stop()
 

--- a/src/lib/authorizations/authorizations.ts
+++ b/src/lib/authorizations/authorizations.ts
@@ -1,8 +1,8 @@
-import * as Heroku from '@heroku-cli/schema'
 import {hux} from '@heroku/heroku-cli-util'
+import {OauthAuthorization} from '@heroku/types/3.sdk'
 import {addSeconds, formatDistanceToNow} from 'date-fns'
 
-export function display(auth: Heroku.OAuthAuthorization) {
+export function display(auth: OauthAuthorization) {
   interface StyledObject {
     Client?: string;
     Description: string | undefined;

--- a/test/unit/commands/authorizations/create.unit.test.ts
+++ b/test/unit/commands/authorizations/create.unit.test.ts
@@ -1,50 +1,65 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import AuthorizationsCreate from '../../../../src/commands/authorizations/create.js'
 
+type FakePlatform = {
+  oauthAuthorization: {create: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    oauthAuthorization: {create: sinon.stub()},
+  }
+}
+
 describe('authorizations:create', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('creates the authorization', async function () {
-    api
-      .post('/oauth/authorizations', {description: 'awesome'})
-      .reply(201, {access_token: {token: 'secrettoken'}, scope: ['global']})
+    fakePlatform.oauthAuthorization.create.resolves({access_token: {token: 'secrettoken'}, scope: ['global']})
 
     const {stdout} = await runCommand(AuthorizationsCreate, ['--description', 'awesome'])
 
     expect(stdout).to.contain('Client: <none>\n')
     expect(stdout).to.contain('Scope:  global\n')
     expect(stdout).to.contain('Token:  secrettoken\n')
+    expect(fakePlatform.oauthAuthorization.create.calledOnceWithExactly({
+      description: 'awesome',
+      expires_in: undefined,
+      scope: undefined,
+    })).to.equal(true)
   })
 
   context('with short flag', function () {
     it('only prints token', async function () {
-      api
-        .post('/oauth/authorizations', {expires_in: '10000'})
-        .reply(201, {access_token: {token: 'secrettoken'}, scope: ['global']})
+      fakePlatform.oauthAuthorization.create.resolves({access_token: {token: 'secrettoken'}, scope: ['global']})
 
       const {stdout} = await runCommand(AuthorizationsCreate, ['--expires-in', '10000', '--short'])
 
       expect(stdout).to.equal('secrettoken\n')
+      expect(fakePlatform.oauthAuthorization.create.calledOnceWithExactly({
+        description: undefined,
+        expires_in: '10000',
+        scope: undefined,
+      })).to.equal(true)
     })
   })
 
   context('with json flag', function () {
     it('prints json', async function () {
-      api
-        .post('/oauth/authorizations', {})
-        .reply(201, {access_token: {token: 'secrettoken'}, scope: ['global']})
+      fakePlatform.oauthAuthorization.create.resolves({access_token: {token: 'secrettoken'}, scope: ['global']})
 
       const {stdout} = await runCommand(AuthorizationsCreate, ['--json'])
 

--- a/test/unit/commands/authorizations/index.unit.test.ts
+++ b/test/unit/commands/authorizations/index.unit.test.ts
@@ -1,20 +1,31 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Authorizations from '../../../../src/commands/authorizations/index.js'
 import removeAllWhitespace from '../../../helpers/utils/remove-whitespaces.js'
 
+type FakePlatform = {
+  oauthAuthorization: {list: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    oauthAuthorization: {list: sinon.stub()},
+  }
+}
+
 describe('authorizations', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   const exampleAuthorization1 = {
@@ -29,9 +40,7 @@ describe('authorizations', function () {
   }
 
   it('lists the authorizations alphabetically by description', async function () {
-    api
-      .get('/oauth/authorizations')
-      .reply(200, [exampleAuthorization1, exampleAuthorization2])
+    fakePlatform.oauthAuthorization.list.resolves([exampleAuthorization1, exampleAuthorization2])
 
     const {stdout} = await runCommand(Authorizations, [])
 
@@ -44,9 +53,7 @@ describe('authorizations', function () {
 
   context('with json flag', function () {
     it('lists the authorizations alphabetically as json', async function () {
-      api
-        .get('/oauth/authorizations')
-        .reply(200, [exampleAuthorization1, exampleAuthorization2])
+      fakePlatform.oauthAuthorization.list.resolves([exampleAuthorization1, exampleAuthorization2])
 
       const {stdout} = await runCommand(Authorizations, ['--json'])
 
@@ -58,9 +65,7 @@ describe('authorizations', function () {
 
   context('without authorizations', function () {
     it('shows no authorizations message', async function () {
-      api
-        .get('/oauth/authorizations')
-        .reply(200, [])
+      fakePlatform.oauthAuthorization.list.resolves([])
 
       const {stdout} = await runCommand(Authorizations, [])
 

--- a/test/unit/commands/authorizations/info.unit.test.ts
+++ b/test/unit/commands/authorizations/info.unit.test.ts
@@ -1,20 +1,31 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
 import {formatDistanceToNow} from 'date-fns'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import AuthorizationsInfo from '../../../../src/commands/authorizations/info.js'
 
+type FakePlatform = {
+  oauthAuthorization: {info: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    oauthAuthorization: {info: sinon.stub()},
+  }
+}
+
 describe('authorizations:info', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   const authorizationID = '4UTHOri24tIoN-iD-3X4mPl3'
@@ -31,9 +42,7 @@ describe('authorizations:info', function () {
   }
 
   it('shows the authorization', async function () {
-    api
-      .get(`/oauth/authorizations/${authorizationID}`)
-      .reply(200, authorization)
+    fakePlatform.oauthAuthorization.info.resolves(authorization)
 
     const {stdout} = await runCommand(AuthorizationsInfo, [authorizationID])
 
@@ -43,12 +52,11 @@ describe('authorizations:info', function () {
       + 'Scope:       global\n'
       + 'Token:       secrettoken\n'
       + `Updated at:  ${new Date(0)} (${formatDistanceToNow(new Date(0))} ago)\n`)
+    expect(fakePlatform.oauthAuthorization.info.calledOnceWithExactly(authorizationID)).to.equal(true)
   })
 
   it('shows expires in', async function () {
-    api
-      .get(`/oauth/authorizations/${authorizationID}`)
-      .reply(200, authorizationWithExpiration)
+    fakePlatform.oauthAuthorization.info.resolves(authorizationWithExpiration)
 
     const {stdout} = await runCommand(AuthorizationsInfo, [authorizationID])
 
@@ -57,9 +65,7 @@ describe('authorizations:info', function () {
 
   describe('with json flag', function () {
     it('shows the authorization as json', async function () {
-      api
-        .get(`/oauth/authorizations/${authorizationID}`)
-        .reply(200, authorization)
+      fakePlatform.oauthAuthorization.info.resolves(authorization)
 
       const {stdout} = await runCommand(AuthorizationsInfo, [authorizationID, '--json'])
 

--- a/test/unit/commands/authorizations/revoke.unit.test.ts
+++ b/test/unit/commands/authorizations/revoke.unit.test.ts
@@ -1,30 +1,40 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import AuthorizationsRevoke from '../../../../src/commands/authorizations/revoke.js'
 
+type FakePlatform = {
+  oauthAuthorization: {delete: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    oauthAuthorization: {delete: sinon.stub()},
+  }
+}
+
 describe('authorizations:revoke', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
   const authorizationID = '4UTHOri24tIoN-iD-3X4mPl3'
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('revokes the authorization', async function () {
-    api
-      .delete(`/oauth/authorizations/${authorizationID}`)
-      .reply(200, {description: 'Example Auth'})
+    fakePlatform.oauthAuthorization.delete.resolves({description: 'Example Auth'})
 
     const {stderr} = await runCommand(AuthorizationsRevoke, [authorizationID])
 
     expect(stderr).to.contain('done, revoked authorization from Example Auth')
+    expect(fakePlatform.oauthAuthorization.delete.calledOnceWithExactly(authorizationID)).to.equal(true)
   })
 
   context('without an ID argument', function () {

--- a/test/unit/commands/authorizations/rotate.unit.test.ts
+++ b/test/unit/commands/authorizations/rotate.unit.test.ts
@@ -1,26 +1,35 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import AuthorizationsRotate from '../../../../src/commands/authorizations/rotate.js'
 
+type FakePlatform = {
+  oauthAuthorization: {regenerate: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    oauthAuthorization: {regenerate: sinon.stub()},
+  }
+}
+
 describe('authorizations:rotate', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
   const authorizationID = '4UTHOri24tIoN-iD-3X4mPl3'
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('rotates and prints the authentication', async function () {
-    api
-      .post(`/oauth/authorizations/${authorizationID}/actions/regenerate-tokens`)
-      .reply(200, {access_token: {token: 'secrettoken'}, scope: ['global', 'app']})
+    fakePlatform.oauthAuthorization.regenerate.resolves({access_token: {token: 'secrettoken'}, scope: ['global', 'app']})
 
     const {stderr, stdout} = await runCommand(AuthorizationsRotate, [authorizationID])
 
@@ -28,5 +37,6 @@ describe('authorizations:rotate', function () {
     expect(stdout).to.contain('Scope:  global,app\n')
     expect(stdout).to.contain('Token:  secrettoken\n')
     expect(stderr).to.contain('Rotating OAuth Authorization... done')
+    expect(fakePlatform.oauthAuthorization.regenerate.calledOnceWithExactly(authorizationID)).to.equal(true)
   })
 })

--- a/test/unit/commands/authorizations/update.unit.test.ts
+++ b/test/unit/commands/authorizations/update.unit.test.ts
@@ -1,37 +1,40 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import AuthorizationsUpdate from '../../../../src/commands/authorizations/update.js'
 
+type FakePlatform = {
+  oauthAuthorization: {update: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    oauthAuthorization: {update: sinon.stub()},
+  }
+}
+
 describe('authorizations:update', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
   const authorizationID = '4UTHOri24tIoN-iD-3X4mPl3'
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('updates the authorization', async function () {
-    api
-      .patch(
-        `/oauth/authorizations/${authorizationID}`,
-        {client: {id: '100', secret: 'secret'}, description: 'awesome'},
-      )
-      .reply(
-        200,
-        {
-          access_token: {token: 'secrettoken'},
-          description: 'awesome',
-          id: '100',
-          scope: ['global'],
-        },
-      )
+    fakePlatform.oauthAuthorization.update.resolves({
+      access_token: {token: 'secrettoken'},
+      description: 'awesome',
+      id: '100',
+      scope: ['global'],
+    })
 
     const {stdout} = await runCommand(AuthorizationsUpdate, [authorizationID, '--client-id', '100', '--client-secret', 'secret', '--description', 'awesome'])
 
@@ -40,5 +43,9 @@ describe('authorizations:update', function () {
       + 'Description: awesome\n'
       + 'Scope:       global\n'
       + 'Token:       secrettoken\n')
+    expect(fakePlatform.oauthAuthorization.update.calledOnceWithExactly(
+      authorizationID,
+      {client: {id: '100', secret: 'secret'}, description: 'awesome'},
+    )).to.equal(true)
   })
 })

--- a/test/unit/lib/authorizations/authorizations.unit.test.ts
+++ b/test/unit/lib/authorizations/authorizations.unit.test.ts
@@ -1,5 +1,5 @@
-import * as Heroku from '@heroku-cli/schema'
 import {captureOutput} from '@heroku-cli/test-utils'
+import {OauthAuthorization} from '@heroku/types/3.sdk'
 import {expect} from 'chai'
 import {addSeconds, formatDistanceToNow} from 'date-fns'
 
@@ -10,11 +10,11 @@ describe('display', function () {
   const authDesc = 'a cool auth'
 
   context('with an auth', function () {
-    const auth: Heroku.OAuthAuthorization = {
+    const auth = {
       description: authDesc,
       id: authId,
       scope: ['global', 'app'],
-    }
+    } as OauthAuthorization
 
     it('prints the styled authorization', async function () {
       const {stdout} = await captureOutput(async () => {
@@ -36,7 +36,7 @@ describe('display', function () {
 
   context('with an auth access token', function () {
     const updatedAt = new Date(0)
-    const auth: Heroku.OAuthAuthorization = {
+    const auth = {
       access_token: {
         expires_in: 10_000,
         token: '1234abcd-129f-42d2-854b-EfGhIjKlMn12',
@@ -45,7 +45,7 @@ describe('display', function () {
       id: authId,
       scope: ['global', 'app'],
       updated_at: `${updatedAt}`,
-    }
+    } as OauthAuthorization
 
     it('prints the styled authorization with access token info', async function () {
       const {stdout} = await captureOutput(async () => {
@@ -70,16 +70,16 @@ describe('display', function () {
   })
 
   context('with a client', function () {
-    const client: Heroku.OAuthClient = {
+    const client = {
       name: 'a cool client',
       redirect_uri: 'https://myapp.com',
     }
 
-    const auth: Heroku.OAuthAuthorization = {
+    const auth = {
       client,
       description: authDesc,
       id: authId,
-    }
+    } as OauthAuthorization
 
     it('prints the styled authorization with client info', async function () {
       const {stdout} = await captureOutput(async () => {


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
Migrates the following `authorizations` commands to `@heroku/sdk`:
- `authorizations/create`
- `authorizations/index`
- `authorizations/info`
- `authorizations/revoke`
- `authorizations/rotate`
- `authorizations/update`

### Details
- Replaced direct API calls with the SDK via `platform.oauthAuthorization.*`
- Updated the `display()` helper's type import from `@heroku-cli/schema` to `@heroku/types/3.sdk`
- Rewrote tests to stub the SDK directly instead of using `nock`

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
<!-- Add any context/setup necessary for testing. -->
The SDK uses `heroku-fetch` to make API calls, which looks for a netrc file. Therefore, we must log in with `HEROKU_NETRC_WRITE=true`.

**Setup**:
- Pull down this branch
- `npm i && npm run build`
- `heroku logout`
- `HEROKU_NETRC_WRITE=true ./bin/run login`

**Steps**:
- `./bin/run authorizations:create --description "CLI v12 test" --expires-in 3600 --short` 
   - Expect: displays token only
- `./bin/run authorizations`
   - Expect: list of authorizations, including the authorization created in Step 1
- `./bin/run authorizations:info ID`
   - Expect: object with `Client`, `ID`, `Description`, `Scope`, `Token`, `Expires at`, `Updated at`
- `./bin/run authorizations:rotate ID`
   - Expect: object with updated `Token`
- `./bin/run authorizations:update ID --description "updated CLI v12 test description"`
   - Expect: object with updated `Description`
- `./bin/run authorizations:revoke ID`
   - Expect: revokes without error
- `./bin/run authorizations`
   - Expect: list of authorizations, excluding the authorization created in Step 1

**Cleanup:**
- `./bin/run logout`

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-23387377](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eMiKQYA0/view)