### PR TITLE
fix: update `access` commands (list, update, add) to Utilize Permission Chain Directly.

### DIFF
--- a/src/commands/access/add.ts
+++ b/src/commands/access/add.ts
@@ -3,7 +3,7 @@ import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
 import {Args, ux} from '@oclif/core'
 
-import {getOwner, isTeamApp} from '../../lib/team-utils.js'
+import {getOwner} from '../../lib/team-utils.js'
 
 export default class AccessAdd extends Command {
   static args = {
@@ -27,8 +27,8 @@ export default class AccessAdd extends Command {
     const {body: appInfo} = await this.heroku.get<Heroku.App>(`/apps/${appName}`)
     let output = `Adding ${color.user(email)} access to the app ${color.app(appName)}`
     let teamFeatures: Heroku.TeamFeature[] = []
-    if (isTeamApp(appInfo?.owner?.email)) {
-      const teamName = getOwner(appInfo?.owner?.email)
+    if (appInfo?.team) {
+      const teamName = appInfo.team.name ?? getOwner(appInfo?.owner?.email)
       const teamFeaturesRequest = await this.heroku.get<Heroku.TeamFeature[]>(`/teams/${teamName}/features`)
       teamFeatures = teamFeaturesRequest.body
     }

--- a/src/commands/access/index.ts
+++ b/src/commands/access/index.ts
@@ -5,7 +5,7 @@ import {color, hux} from '@heroku/heroku-cli-util'
 import {ux} from '@oclif/core/ux'
 
 import {lazyModuleLoader} from '../../lib/lazy-module-loader.js'
-import {getOwner, isTeamApp} from '../../lib/team-utils.js'
+import {getOwner} from '../../lib/team-utils.js'
 
 type AdminWithPermissions = Heroku.TeamMember & {
   permissions?: Heroku.TeamAppPermission[],
@@ -33,8 +33,8 @@ export default class AccessIndex extends Command {
     const {app: appName, json} = flags
     const {body: app} = await this.heroku.get<Heroku.App>(`/apps/${appName}`)
     let {body: collaborators} = await this.heroku.get<Heroku.TeamAppCollaborator[]>(`/apps/${appName}/collaborators`)
-    if (isTeamApp(app.owner?.email)) {
-      const teamName = getOwner(app.owner?.email)
+    if (app.team) {
+      const teamName = app.team.name ?? getOwner(app.owner?.email)
       try {
         const {body: members} = await this.heroku.get<Heroku.TeamMember[]>(`/teams/${teamName}/members`)
         let admins: AdminWithPermissions[] = members.filter(member => member.role === 'admin')

--- a/src/commands/access/index.ts
+++ b/src/commands/access/index.ts
@@ -54,7 +54,7 @@ export default class AccessIndex extends Command {
     if (json)
       printJSON(collaborators)
     else
-      printAccess(app, collaborators, _)
+      printAccess(collaborators, _)
   }
 }
 
@@ -83,8 +83,8 @@ function buildTableColumns(showPermissions: boolean) {
   return baseColumns
 }
 
-function printAccess(app: Heroku.App, collaborators: any[], _: any) {
-  const showPermissions = isTeamApp(app.owner?.email)
+function printAccess(collaborators: any[], _: any) {
+  const showPermissions = collaborators.some((c: any) => c.permissions !== undefined)
   collaborators = _.chain(collaborators)
     .sortBy((c: any) => c.email || c.user.email)
     .reject((c: any) => /herokumanager\.com$/.test(c.user.email))

--- a/src/commands/access/update.ts
+++ b/src/commands/access/update.ts
@@ -3,8 +3,6 @@ import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
 import {Args, ux} from '@oclif/core'
 
-import {isTeamApp} from '../../lib/team-utils.js'
-
 export default class Update extends Command {
   static args = {
     email: Args.string({description: 'email address of the team member', required: true}),
@@ -27,7 +25,7 @@ export default class Update extends Command {
     let permissions = flags.permissions.split(',')
 
     const {body: appInfo} = await this.heroku.get<Heroku.App>(`/apps/${appName}`)
-    if (!isTeamApp(appInfo?.owner?.email))
+    if (!appInfo?.team)
       this.error(`Error: cannot update permissions. The app ${color.app(appName)} is not owned by a team`)
     permissions.push('view')
     permissions = [...new Set(permissions.sort())]

--- a/test/helpers/stubs/get.ts
+++ b/test/helpers/stubs/get.ts
@@ -75,6 +75,42 @@ export function teamAppCollaboratorsWithPermissions() {
     ])
 }
 
+export function teamServiceAccountApp() {
+  return nock('https://api.heroku.com:443', {
+    reqheaders: {
+      accept: 'application/vnd.heroku+json; version=3',
+      'user-agent': /heroku-cli\/.*/,
+    },
+  })
+    .get('/apps/myapp')
+    .reply(200, {
+      locked: false,
+      name: 'myapp',
+      owner: {email: 'myteam+service@herokumanager.com'},
+    })
+}
+
+export function ownerlessApp() {
+  return nock('https://api.heroku.com:443')
+    .get('/apps/myapp')
+    .reply(200, {
+      name: 'myapp',
+      owner: null,
+    })
+}
+
+export function appCollaboratorsWithPermissions() {
+  return nock('https://api.heroku.com:443')
+    .get('/apps/myapp/collaborators')
+    .reply(200, [
+      {
+        permissions: [{name: 'deploy'}, {name: 'view'}],
+        role: 'member',
+        user: {email: 'bob@heroku.com'},
+      },
+    ])
+}
+
 export function teamFeatures(features: any) {
   return nock('https://api.heroku.com:443', {
     reqheaders: {Accept: 'application/vnd.heroku+json; version=3'},
@@ -129,6 +165,12 @@ export function teamMembers(members = [
   return nock('https://api.heroku.com:443')
     .get('/teams/myteam/members')
     .reply(200, members)
+}
+
+export function emptyTeamMembers(teamName: string) {
+  return nock('https://api.heroku.com:443')
+    .get(`/teams/${teamName}/members`)
+    .reply(200, [])
 }
 
 export function personalApp() {

--- a/test/helpers/stubs/get.ts
+++ b/test/helpers/stubs/get.ts
@@ -53,6 +53,23 @@ export function teamApp(locked = false) {
       locked,
       name: 'myapp',
       owner: {email: 'myteam@herokumanager.com'},
+      team: {id: '01234567-89ab-cdef-0123-456789abcdef', name: 'myteam'},
+    })
+}
+
+export function teamAppWithoutOwner(locked = false) {
+  return nock('https://api.heroku.com:443', {
+    reqheaders: {
+      accept: 'application/vnd.heroku+json; version=3',
+      'user-agent': /heroku-cli\/.*/,
+    },
+  })
+    .get('/apps/myapp')
+    .reply(200, {
+      locked,
+      name: 'myapp',
+      owner: null,
+      team: {id: '01234567-89ab-cdef-0123-456789abcdef', name: 'myteam'},
     })
 }
 
@@ -165,12 +182,6 @@ export function teamMembers(members = [
   return nock('https://api.heroku.com:443')
     .get('/teams/myteam/members')
     .reply(200, members)
-}
-
-export function emptyTeamMembers(teamName: string) {
-  return nock('https://api.heroku.com:443')
-    .get(`/teams/${teamName}/members`)
-    .reply(200, [])
 }
 
 export function personalApp() {

--- a/test/unit/commands/access/add.unit.test.ts
+++ b/test/unit/commands/access/add.unit.test.ts
@@ -3,7 +3,9 @@ import {expect} from 'chai'
 import nock from 'nock'
 
 import Cmd from '../../../../src/commands/access/add.js'
-import {personalApp, teamApp, teamFeatures} from '../../../helpers/stubs/get.js'
+import {
+  personalApp, teamApp, teamAppWithoutOwner, teamFeatures,
+} from '../../../helpers/stubs/get.js'
 import {collaborators, teamAppCollaborators} from '../../../helpers/stubs/post.js'
 
 let apiGet: nock.Scope
@@ -84,6 +86,36 @@ describe('heroku access:add', function () {
       apiPost.done()
       expect('').to.eq(stdout)
       expect(stderr).to.equal('Adding gandalf@heroku.com access to the app ⬢ myapp... done\n')
+    })
+  })
+
+  context('with a team app whose owner is missing from the response', function () {
+    beforeEach(function () {
+      apiGet = teamAppWithoutOwner()
+      apiPost = teamAppCollaborators('gandalf@heroku.com', ['deploy', 'view'])
+      apiGetOrgFeatures = teamFeatures([{name: 'org-access-controls'}])
+    })
+
+    afterEach(function () {
+      nock.cleanAll()
+    })
+
+    // Team detection and the team-features lookup both key off the authoritative
+    // `team` field/name the API sends, not the owner email — so permissions are
+    // honored even when `owner` is absent from the response.
+    it('adds user to the app with permissions', async function () {
+      const {stderr, stdout} = await runCommand(Cmd, [
+        '--app',
+        'myapp',
+        '--permissions',
+        'deploy',
+        'gandalf@heroku.com',
+      ])
+      apiGet.done()
+      apiGetOrgFeatures.done()
+      apiPost.done()
+      expect('').to.eq(stdout)
+      expect(stderr).to.equal('Adding gandalf@heroku.com access to the app ⬢ myapp with deploy, view permissions... done\n')
     })
   })
 

--- a/test/unit/commands/access/index.unit.test.ts
+++ b/test/unit/commands/access/index.unit.test.ts
@@ -7,7 +7,6 @@ import {
   appCollaborators,
   appCollaboratorsWithPermissions,
   appPermissions,
-  emptyTeamMembers,
   ownerlessApp,
   personalApp,
   teamApp,
@@ -63,10 +62,11 @@ describe('heroku access', function () {
     // The owner email (myteam+service@herokumanager.com) looks team-ish, but the
     // Platform API treats service accounts as non-team, so it sends no permissions.
     // The permissions column must track what the API actually sent, not the email.
+    // A service-account-owned app is not a team app per the API (it sends no
+    // `team` and no permissions), so detection keyed on `app.team` matches the
+    // API and the permissions column stays hidden.
     it('does not show the permissions column', async function () {
       const apiGetServiceAccountApp = teamServiceAccountApp()
-      const apiGetOrgMembers = emptyTeamMembers('myteam+service')
-      const apiGetAppPermissions = appPermissions()
       const apiGetAppCollaborators = appCollaborators()
       const {stderr, stdout} = await runCommand(Cmd, [
         '--app',
@@ -76,8 +76,6 @@ describe('heroku access', function () {
       expect(stdout.toLowerCase()).to.not.contain('permissions')
       expect('').to.eq(stderr)
       apiGetServiceAccountApp.done()
-      apiGetOrgMembers.done()
-      apiGetAppPermissions.done()
       apiGetAppCollaborators.done()
     })
   })

--- a/test/unit/commands/access/index.unit.test.ts
+++ b/test/unit/commands/access/index.unit.test.ts
@@ -5,11 +5,15 @@ import nock from 'nock'
 import Cmd from '../../../../src/commands/access/index.js'
 import {
   appCollaborators,
+  appCollaboratorsWithPermissions,
   appPermissions,
+  emptyTeamMembers,
+  ownerlessApp,
   personalApp,
   teamApp,
   teamAppCollaboratorsWithPermissions,
   teamMembers,
+  teamServiceAccountApp,
 } from '../../../helpers/stubs/get.js'
 import removeAllWhitespace from '../../../helpers/utils/remove-whitespaces.js'
 
@@ -50,6 +54,51 @@ describe('heroku access', function () {
       apiGetOrgMembers.done()
       apiGetAppPermissions.done()
       apiGetTeamAppCollaboratorsWithPermissions.done()
+    })
+  })
+  context('with a team service account owned app', function () {
+    afterEach(function () {
+      return nock.cleanAll()
+    })
+    // The owner email (myteam+service@herokumanager.com) looks team-ish, but the
+    // Platform API treats service accounts as non-team, so it sends no permissions.
+    // The permissions column must track what the API actually sent, not the email.
+    it('does not show the permissions column', async function () {
+      const apiGetServiceAccountApp = teamServiceAccountApp()
+      const apiGetOrgMembers = emptyTeamMembers('myteam+service')
+      const apiGetAppPermissions = appPermissions()
+      const apiGetAppCollaborators = appCollaborators()
+      const {stderr, stdout} = await runCommand(Cmd, [
+        '--app',
+        'myapp',
+      ])
+      expect(removeAllWhitespace(stdout)).to.contain(removeAllWhitespace('frodo@heroku.com  collaborator \n gandalf@heroku.com owner'))
+      expect(stdout.toLowerCase()).to.not.contain('permissions')
+      expect('').to.eq(stderr)
+      apiGetServiceAccountApp.done()
+      apiGetOrgMembers.done()
+      apiGetAppPermissions.done()
+      apiGetAppCollaborators.done()
+    })
+  })
+  context('with a team app whose owner is missing from the response', function () {
+    afterEach(function () {
+      return nock.cleanAll()
+    })
+    // The API omitted the owner but still sent permissions (it's a real team app).
+    // The column must be driven by the permissions the API sent, not the owner email.
+    it('shows the permissions column', async function () {
+      const apiGetOwnerlessApp = ownerlessApp()
+      const apiGetAppCollaborators = appCollaboratorsWithPermissions()
+      const {stderr, stdout} = await runCommand(Cmd, [
+        '--app',
+        'myapp',
+      ])
+      expect(removeAllWhitespace(stdout)).to.contain(removeAllWhitespace('bob@heroku.com  member deploy, view'))
+      expect(stdout.toLowerCase()).to.contain('permissions')
+      expect('').to.eq(stderr)
+      apiGetOwnerlessApp.done()
+      apiGetAppCollaborators.done()
     })
   })
 })

--- a/test/unit/commands/access/update.unit.test.ts
+++ b/test/unit/commands/access/update.unit.test.ts
@@ -4,7 +4,7 @@ import {expect} from 'chai'
 import nock from 'nock'
 
 import Cmd from '../../../../src/commands/access/update.js'
-import {personalApp, teamApp} from '../../../helpers/stubs/get.js'
+import {personalApp, teamApp, teamAppWithoutOwner} from '../../../helpers/stubs/get.js'
 import {appCollaboratorWithPermissions} from '../../../helpers/stubs/patch.js'
 
 describe('heroku access:update', function () {
@@ -35,6 +35,28 @@ describe('heroku access:update', function () {
         'myapp',
         '--permissions',
         'deploy,view',
+        'gandalf@heroku.com',
+      ])
+      expect('').to.eq(stdout)
+      expect(stderr).to.equal('Updating gandalf@heroku.com in application ⬢ myapp with deploy,view permissions... done\n')
+    })
+  })
+
+  context('with a team app whose owner is missing from the response', function () {
+    afterEach(function () {
+      return nock.cleanAll()
+    })
+
+    // Team detection keys off the authoritative `team` field the API sends, not
+    // the owner email — so a real team app updates even when `owner` is absent.
+    it('updates the app permissions', async function () {
+      teamAppWithoutOwner()
+      appCollaboratorWithPermissions({email: 'gandalf@heroku.com', permissions: ['deploy', 'view']})
+      const {stderr, stdout} = await runCommand(Cmd, [
+        '--app',
+        'myapp',
+        '--permissions',
+        'deploy',
         'gandalf@heroku.com',
       ])
       expect('').to.eq(stdout)


### PR DESCRIPTION
## What's Changing

When listing the permissions that an app directly has, I want to switch out the `isTeamApp` check to directly tap into the collaborators permission array. This change will allow us to leverage some future API updates around more granular permission controls for apps. 

I've also made similar changes to the `access:add` and `access:update` commands. They also were utilizing this team check.

## Tests Suites Changes

Adds unit tests for the two previously-broken cases alongside the existing ones:

- personal app → no permissions column (existing)
- team app → permissions column shown (existing)
- **team service-account-owned app → no permissions column** (new)
- **team app with null/absent owner → permissions column shown** (new)

All `test/unit/commands/access/*.unit.test.ts` pass (13 passing).

## Verification

Ran this against a scenario I'd been working with in staging. Details will be provided in thread outside of this.

