### PR TITLE
refactor: use sdk poller to restore status messages

### DIFF
--- a/V12-CHANGES.md
+++ b/V12-CHANGES.md
@@ -1,13 +1,7 @@
 # Heroku CLI v12 - User-Facing Changes
 
-## Domains commands
-
-- `domains:wait` now shows a single spinner for multiple pending domains: `Waiting for all pending domains for app ${app}... done`
-- `domains:add --wait` no longer shows `Waiting for ${hostname)... done`
-
 ## Certs commands
 
-- `certs:add` no longer shows the `Waiting for stable domains to be created...` spinner while domains stabilize; the wait now happens silently before the certificate is associated
 - `certs:add` matches wildcard certificates against your app's domains more strictly: a `*.example.com` certificate now matches only direct subdomains (e.g. `www.example.com`), no longer matching deeper or trailing-suffix domains
 
 ## Run commands

--- a/package-lock.json
+++ b/package-lock.json
@@ -3293,7 +3293,7 @@
     },
     "node_modules/@heroku/sdk": {
       "version": "0.5.4",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#9c803e208caa16d326637473c7959eee6bd0e155",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#6785d04b470b2ccdac6a419f031c6cf0f212e848",
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku/heroku-fetch": "^0.1.3",

--- a/src/commands/certs/add.ts
+++ b/src/commands/certs/add.ts
@@ -49,6 +49,15 @@ export default class Add extends Command {
         files.crt.toString(),
         files.key.toString(),
         {
+          domainPoller: {
+            onStart() {
+              // Stop the current spinner
+              ux.action.stop()
+              // Start a new spinner
+              ux.action.start('Waiting for stable domains to be created')
+            },
+            onStop: () => ux.action.stop(),
+          },
           resolveDomains: async (candidates: string[]) => {
             ux.action.stop()
             hux.styledHeader('Almost done! Which of these domains on this application would you like this certificate associated with?')

--- a/src/commands/container/rm.ts
+++ b/src/commands/container/rm.ts
@@ -34,7 +34,7 @@ export default class Rm extends Command {
     const processTypes = argv as string[]
 
     await platform.container.removeProcessTypes(app, processTypes, {
-      onProgress: {
+      poller: {
         onStart(processType) {
           ux.action.start(`Removing container ${processType} for ${color.app(app)}`)
         },

--- a/src/commands/domains/add.ts
+++ b/src/commands/domains/add.ts
@@ -104,6 +104,7 @@ export default class DomainsAdd extends Command {
       sniEndpoint: flags.cert,
       wait: flags.wait,
     })
+    ux.action.stop()
 
     if (flags.json) {
       hux.styledJSON(domain)
@@ -118,7 +119,5 @@ export default class DomainsAdd extends Command {
         ux.stdout(`Run ${color.code(command)} to wait for completion`)
       }
     }
-
-    ux.action.stop()
   }
 }

--- a/src/commands/domains/add.ts
+++ b/src/commands/domains/add.ts
@@ -85,6 +85,15 @@ export default class DomainsAdd extends Command {
     ux.action.start(`Adding ${color.name(hostname)} to ${color.app(flags.app)}`)
 
     const domain = await platform.domain.add(flags.app, hostname, {
+      poller: {
+        onStart(domain) {
+          // Stop the current spinner
+          ux.action.stop()
+          // Start a new spinner
+          ux.action.start(`Waiting for ${color.name(domain.hostname || 'domain')}`)
+        },
+        onStop: () => ux.action.stop(),
+      },
       resolveSniEndpoint: async (certs: SniEndpoint[]) => {
         ux.action.stop('resolving SNI endpoint')
         const certSelection = await this.certSelect(certs, inquirer)

--- a/src/commands/domains/add.ts
+++ b/src/commands/domains/add.ts
@@ -90,7 +90,7 @@ export default class DomainsAdd extends Command {
           // Stop the current spinner
           ux.action.stop()
           // Start a new spinner
-          ux.action.start(`Waiting for ${color.name(domain.hostname || 'domain')}`)
+          ux.action.start(`Waiting for ${color.name(domain.hostname)}`)
         },
         onStop: () => ux.action.stop(),
       },

--- a/src/commands/domains/wait.ts
+++ b/src/commands/domains/wait.ts
@@ -22,9 +22,9 @@ export default class DomainsWait extends Command {
     await platform.domain.wait(flags.app, {
       hostname: args.hostname,
       poller: {
-        onStart: (domain) => ux.action.start(`Waiting for ${color.name(domain.hostname || 'domain')}`),
+        onStart: domain => ux.action.start(`Waiting for ${color.name(domain.hostname || 'domain')}`),
         onStop: () => ux.action.stop(),
-      }
+      },
     })
   }
 }

--- a/src/commands/domains/wait.ts
+++ b/src/commands/domains/wait.ts
@@ -19,10 +19,12 @@ export default class DomainsWait extends Command {
     const {args, flags} = await this.parse(DomainsWait)
     const {platform} = new HerokuSDK({extensions: [domainExtensions]})
 
-    const target = args.hostname ? color.name(args.hostname) : `all pending domains for app ${flags.app}`
-
-    ux.action.start(`Waiting for ${target}`)
-    await platform.domain.wait(flags.app, {hostname: args.hostname})
-    ux.action.stop()
+    await platform.domain.wait(flags.app, {
+      hostname: args.hostname,
+      poller: {
+        onStart: (domain) => ux.action.start(`Waiting for ${color.name(domain.hostname || 'domain')}`),
+        onStop: () => ux.action.stop(),
+      }
+    })
   }
 }

--- a/src/commands/domains/wait.ts
+++ b/src/commands/domains/wait.ts
@@ -22,7 +22,7 @@ export default class DomainsWait extends Command {
     await platform.domain.wait(flags.app, {
       hostname: args.hostname,
       poller: {
-        onStart: domain => ux.action.start(`Waiting for ${color.name(domain.hostname || 'domain')}`),
+        onStart: domain => ux.action.start(`Waiting for ${color.name(domain.hostname)}`),
         onStop: () => ux.action.stop(),
       },
     })

--- a/test/unit/commands/certs/add.unit.test.ts
+++ b/test/unit/commands/certs/add.unit.test.ts
@@ -165,4 +165,22 @@ describe('heroku certs:add', function () {
     expect(stdout).to.contain('Certificate details:')
     expect(stdout).to.contain('Common Name(s): foo.example.org')
   })
+
+  it('# waits for domains to be ready', async function () {
+    fakePlatform.sniEndpoint.createAndAssociate.callsFake(async (_app, _crt, _key, opts) => {
+      opts.onDomainPoll.onStart()
+      opts.onDomainPoll.onStop()
+      return endpointStables
+    })
+
+    const {stderr} = await runCommand(Cmd, [
+      '--app',
+      'example',
+      'pem_file',
+      'key_file',
+    ])
+
+    expect(stderr).to.contain('Adding SSL certificate to ⬢ example... done')
+    expect(stderr).to.contain('Waiting for stable domains to be created... done')
+  })
 })

--- a/test/unit/commands/certs/add.unit.test.ts
+++ b/test/unit/commands/certs/add.unit.test.ts
@@ -181,7 +181,9 @@ describe('heroku certs:add', function () {
       'key_file',
     ])
 
-    expect(stderr).to.contain('Adding SSL certificate to ⬢ example... done')
-    expect(stderr).to.contain('Waiting for stable domains to be created... done')
+    const addingIndex = stderr.indexOf('Adding SSL certificate to ⬢ example... done')
+    const waitingIndex = stderr.indexOf('Waiting for stable domains to be created... done')
+    expect(addingIndex).to.be.greaterThan(-1)
+    expect(waitingIndex).to.be.greaterThan(addingIndex)
   })
 })

--- a/test/unit/commands/certs/add.unit.test.ts
+++ b/test/unit/commands/certs/add.unit.test.ts
@@ -1,5 +1,6 @@
 import {runCommand} from '@heroku-cli/test-utils'
 import {HerokuSDK} from '@heroku/sdk'
+import {CreateAndAssociateOptions} from '@heroku/sdk/extensions/platform'
 import {ux} from '@oclif/core'
 import {expect} from 'chai'
 import * as sinon from 'sinon'
@@ -167,9 +168,9 @@ describe('heroku certs:add', function () {
   })
 
   it('# waits for domains to be ready', async function () {
-    fakePlatform.sniEndpoint.createAndAssociate.callsFake(async (_app, _crt, _key, opts) => {
-      opts.onDomainPoll.onStart()
-      opts.onDomainPoll.onStop()
+    fakePlatform.sniEndpoint.createAndAssociate.callsFake(async (_app: string, _crt: string, _key: string, opts: CreateAndAssociateOptions) => {
+      opts?.domainPoller?.onStart?.()
+      opts?.domainPoller?.onStop?.()
       return endpointStables
     })
 

--- a/test/unit/commands/container/rm.unit.test.ts
+++ b/test/unit/commands/container/rm.unit.test.ts
@@ -68,10 +68,10 @@ describe('container removal', function () {
   context('when the app is a container app', function () {
     beforeEach(function () {
       fakePlatform.container.ensureContainerStack.resolves()
-      fakePlatform.container.removeProcessTypes.callsFake(async (_app: string, processTypes: string[], options?: RemoveProcessTypesOpts) => {
+      fakePlatform.container.removeProcessTypes.callsFake(async (_app: string, processTypes: string[], opts?: RemoveProcessTypesOpts) => {
         for (const processType of processTypes) {
-          options?.poller?.onStart?.(processType)
-          options?.poller?.onStop?.(processType)
+          opts?.poller?.onStart?.(processType)
+          opts?.poller?.onStop?.(processType)
         }
       })
     })

--- a/test/unit/commands/container/rm.unit.test.ts
+++ b/test/unit/commands/container/rm.unit.test.ts
@@ -70,8 +70,8 @@ describe('container removal', function () {
       fakePlatform.container.ensureContainerStack.resolves()
       fakePlatform.container.removeProcessTypes.callsFake(async (_app: string, processTypes: string[], options?: RemoveProcessTypesOpts) => {
         for (const processType of processTypes) {
-          options?.onProgress?.onStart?.(processType)
-          options?.onProgress?.onStop?.(processType)
+          options?.poller?.onStart?.(processType)
+          options?.poller?.onStop?.(processType)
         }
       })
     })

--- a/test/unit/commands/domains/add.unit.test.ts
+++ b/test/unit/commands/domains/add.unit.test.ts
@@ -69,9 +69,9 @@ describe('domains:add', function () {
       })
 
       it('adds the domain to the app with the --wait flag', async function () {
-        fakePlatform.domain.add.callsFake(async (_app: string, hostname: string, options?: CreateAndWaitOptions) => {
-          options?.poller?.onStart?.({hostname} as Domain)
-          options?.poller?.onStop?.({hostname} as Domain)
+        fakePlatform.domain.add.callsFake(async (_app: string, hostname: string, opts?: CreateAndWaitOptions) => {
+          opts?.poller?.onStart?.({hostname} as Domain)
+          opts?.poller?.onStop?.({hostname} as Domain)
           return domainsResponseWithEndpoint
         })
 

--- a/test/unit/commands/domains/add.unit.test.ts
+++ b/test/unit/commands/domains/add.unit.test.ts
@@ -1,5 +1,7 @@
 import {runCommand} from '@heroku-cli/test-utils'
 import {HerokuSDK} from '@heroku/sdk'
+import {CreateAndWaitOptions} from '@heroku/sdk/extensions/platform'
+import {Domain} from '@heroku/types/3.sdk'
 import {expect} from 'chai'
 import {restore, SinonStub, stub} from 'sinon'
 
@@ -67,10 +69,15 @@ describe('domains:add', function () {
       })
 
       it('adds the domain to the app with the --wait flag', async function () {
-        fakePlatform.domain.add.resolves(domainsResponseWithEndpoint)
+        fakePlatform.domain.add.callsFake(async (_app: string, hostname: string, options?: CreateAndWaitOptions) => {
+          options?.poller?.onStart?.({hostname} as Domain)
+          options?.poller?.onStop?.({hostname} as Domain)
+          return domainsResponseWithEndpoint
+        })
 
         const {stderr} = await runCommand(DomainsAdd, ['example.com', '--app', 'myapp', '--cert', 'my-cert', '--wait'])
         expect(stderr).to.contain('Adding example.com to ⬢ myapp... done')
+        expect(stderr).to.contain('Waiting for example.com... done')
 
         const [app, hostname, options] = fakePlatform.domain.add.firstCall.args
         expect(app).to.equal('myapp')

--- a/test/unit/commands/domains/wait.unit.test.ts
+++ b/test/unit/commands/domains/wait.unit.test.ts
@@ -60,4 +60,23 @@ describe('domains:wait', function () {
     expect(options.hostname).to.equal(undefined)
     expect(options.poller).to.be.an('object')
   })
+
+  it('waits on multiple domains when no hostname is provided', async function () {
+    fakePlatform.domain.wait.callsFake(async (_app: string, opts?: WaitForReadyOptions) => {
+      for (const hostname of ['example1.com', 'example2.com']) {
+        opts?.poller?.onStart?.({hostname} as Domain)
+        opts?.poller?.onStop?.({hostname} as Domain)
+      }
+
+      return [
+        {hostname: 'example1.com', id: 123, status: 'succeeded'},
+        {hostname: 'example2.com', id: 456, status: 'succeeded'},
+      ]
+    })
+
+    const {stderr} = await runCommand(DomainsWait, ['--app', 'myapp'])
+
+    expect(stderr).to.contain('Waiting for example1.com... done')
+    expect(stderr).to.contain('Waiting for example2.com... done')
+  })
 })

--- a/test/unit/commands/domains/wait.unit.test.ts
+++ b/test/unit/commands/domains/wait.unit.test.ts
@@ -1,5 +1,7 @@
 import {runCommand} from '@heroku-cli/test-utils'
 import {HerokuSDK} from '@heroku/sdk'
+import {WaitForReadyOptions} from '@heroku/sdk/extensions/platform'
+import {Domain} from '@heroku/types/3.sdk'
 import {expect} from 'chai'
 import {restore, SinonStub, stub} from 'sinon'
 
@@ -28,20 +30,34 @@ describe('domains:wait', function () {
   })
 
   it('waits on domain status succeeded', async function () {
-    fakePlatform.domain.wait.resolves([{hostname: 'example.com', id: 123, status: 'succeeded'}])
+    fakePlatform.domain.wait.callsFake(async (_app: string, options?: WaitForReadyOptions) => {
+      options?.poller?.onStart?.({hostname: options?.hostname} as Domain)
+      options?.poller?.onStop?.({hostname: options?.hostname} as Domain)
+      return [{hostname: 'example.com', id: 123, status: 'succeeded'}]
+    })
 
     const {stderr} = await runCommand(DomainsWait, ['example.com', '--app', 'myapp'])
 
     expect(stderr).to.contain('Waiting for example.com... done')
-    expect(fakePlatform.domain.wait.calledOnceWithExactly('myapp', {hostname: 'example.com'})).to.equal(true)
+    const [app, options] = fakePlatform.domain.wait.firstCall.args
+    expect(app).to.equal('myapp')
+    expect(options.hostname).to.equal('example.com')
+    expect(options.poller).to.be.an('object')
   })
 
   it('waits on domains when no hostname is provided', async function () {
-    fakePlatform.domain.wait.resolves([{hostname: 'example.com', id: 123, status: 'succeeded'}])
+    fakePlatform.domain.wait.callsFake(async (_app: string, options?: WaitForReadyOptions) => {
+      options?.poller?.onStart?.({hostname: 'example.com'} as Domain)
+      options?.poller?.onStop?.({hostname: 'example.com'} as Domain)
+      return [{hostname: 'example.com', id: 123, status: 'succeeded'}]
+    })
 
     const {stderr} = await runCommand(DomainsWait, ['--app', 'myapp'])
 
-    expect(stderr).to.contain('Waiting for all pending domains for app myapp... done')
-    expect(fakePlatform.domain.wait.calledOnceWithExactly('myapp', {hostname: undefined})).to.equal(true)
+    expect(stderr).to.contain('Waiting for example.com... done')
+    const [app, options] = fakePlatform.domain.wait.firstCall.args
+    expect(app).to.equal('myapp')
+    expect(options.hostname).to.equal(undefined)
+    expect(options.poller).to.be.an('object')
   })
 })

--- a/test/unit/commands/domains/wait.unit.test.ts
+++ b/test/unit/commands/domains/wait.unit.test.ts
@@ -30,9 +30,9 @@ describe('domains:wait', function () {
   })
 
   it('waits on domain status succeeded', async function () {
-    fakePlatform.domain.wait.callsFake(async (_app: string, options?: WaitForReadyOptions) => {
-      options?.poller?.onStart?.({hostname: options?.hostname} as Domain)
-      options?.poller?.onStop?.({hostname: options?.hostname} as Domain)
+    fakePlatform.domain.wait.callsFake(async (_app: string, opts?: WaitForReadyOptions) => {
+      opts?.poller?.onStart?.({hostname: opts?.hostname} as Domain)
+      opts?.poller?.onStop?.({hostname: opts?.hostname} as Domain)
       return [{hostname: 'example.com', id: 123, status: 'succeeded'}]
     })
 
@@ -46,9 +46,9 @@ describe('domains:wait', function () {
   })
 
   it('waits on domains when no hostname is provided', async function () {
-    fakePlatform.domain.wait.callsFake(async (_app: string, options?: WaitForReadyOptions) => {
-      options?.poller?.onStart?.({hostname: 'example.com'} as Domain)
-      options?.poller?.onStop?.({hostname: 'example.com'} as Domain)
+    fakePlatform.domain.wait.callsFake(async (_app: string, opts?: WaitForReadyOptions) => {
+      opts?.poller?.onStart?.({hostname: 'example.com'} as Domain)
+      opts?.poller?.onStop?.({hostname: 'example.com'} as Domain)
       return [{hostname: 'example.com', id: 123, status: 'succeeded'}]
     })
 


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
This PR makes use of the `@heroku/sdk`'s `poller` option for status-spinner callbacks and uses it to restore per-item spinner messaging that was dropped when `domains:wait`, `domains:add --wait`, and `certs:add` were migrated to the SDK.

- **`domains:wait`** — replaces the command-level spinner with a `poller: {onStart, onStop}` option passed into the SDK call, so the spinner now reports the actual domain hostname being waited on (`Waiting for ${hostname}... done`) instead of a generic "all pending domains for app" message.
- **`domains:add`** — adds a `poller` option to `platform.domain.add` so `--wait` shows a `Waiting for ${hostname}... done` spinner while the domain stabilizes, restoring the previously-dropped wait feedback.
- **`certs:add`** — adds a `domainPoller` option to `sniEndpoint.createAndAssociate` so a `Waiting for stable domains to be created... done` spinner shows again while domains stabilize before the certificate is associated.
- **`container:rm`** — renames the `removeProcessTypes` callback option from `onProgress` to `poller` to match the SDK's now-standardized naming. No message or behavior change.
- **`V12-CHANGES.md`** — removes the entries documenting the dropped/changed spinner behavior for `domains:wait`, `domains:add --wait`, and `certs:add`, since this PR restores that behavior.

**Tests** — updates the `certs:add`, `container:rm`, `domains:add`, and `domains:wait` unit tests to stub the `poller`/`domainPoller` callbacks and assert on the resulting spinner output.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
<!-- Add any context/setup necessary for testing. -->
The SDK uses `heroku-fetch` to make API calls, which looks for a netrc file. Therefore, we must log in with `HEROKU_NETRC_WRITE=true`.

**Setup**:
- Pull down this branch
- `npm i && npm run build`
- `heroku logout`
- `HEROKU_NETRC_WRITE=true ./bin/run login`

**Steps**:
- `./bin/run domains:add test.example1.com --app APP --wait`
   - Expect: `Waiting for test.example1.com... done`
- `./bin/run domains:wait test.example1.com --app APP`
   - Expect: `Waiting for test.example1.com... done`
- `./bin/run domains:add test.example2.com --app APP && ./bin/run domains:wait --app APP`
   - Expect: `Waiting for test.example2.com... done`
- `./bin/run certs:generate test.example1.com --app APP --selfsigned --now`
- `./bin/run certs:add test.example1.com.crt test1.example.com.key --app APP`
   - Expect: `Adding SSL certificate to ⬢ APP... done`
   - Expect: `Waiting for stable domains to be created... done`

**Cleanup**:
- `./bin/run domains:clear --app APP`
- `./bin/run certs --app APP`
- `./bin/run certs:remove --app APP --name CERT_NAME`
- `rm test.example1.com.key && rm test.example1.com.crt`
- `./bin/run logout`

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-23751094](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002gm6mjYAA/view)