### PR TITLE
refactor: remove useless step in Ubuntu install script (PR #2020 recreation)

### DIFF
--- a/install-ubuntu.sh
+++ b/install-ubuntu.sh
@@ -14,12 +14,6 @@
     $SUDO sh <<SCRIPT
   set -ex
 
-  # if apt-transport-https is not installed, clear out old sources, update, then install apt-transport-https
-  dpkg -s apt-transport-https 1>/dev/null 2>/dev/null || \
-    (echo "" > /etc/apt/sources.list.d/heroku.list \
-      && apt-get update \
-      && apt-get install -y apt-transport-https)
-
   # Download Heroku's release key
   curl -fsS https://cli-assets.heroku.com/channels/stable/apt/release.key -o /tmp/heroku-archive-keyring.asc
 
@@ -32,8 +26,8 @@
 
     mkdir -p /etc/apt/keyrings
 
-    # We use the --dearmor flag to convert the ASCII key to GPG format. 
-    # This is necessary because we need to point `signed-by` (in the apt sources 
+    # We use the --dearmor flag to convert the ASCII key to GPG format.
+    # This is necessary because we need to point `signed-by` (in the apt sources
     # list) to a GPG formatted key.
     gpg --dearmor < /tmp/heroku-archive-keyring.asc > /etc/apt/keyrings/heroku-archive-keyring.gpg
     echo "deb [signed-by=/etc/apt/keyrings/heroku-archive-keyring.gpg] https://cli-assets.heroku.com/channels/stable/apt ./" > /etc/apt/sources.list.d/heroku.list


### PR DESCRIPTION
## Summary

In #2020 an external contributor signaled a really old (now 8-year old) monkey-patch used by our Ubuntu install script that's no longer needed.

The change is still relevant because that deprecated package installation needs to be removed from the script as it's no longer shipped with Ubuntu. It's no longer required since Ubuntu 17.10, which entered EOL in July 2018.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [X] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing

**Steps**:
1. Passing CI suffices.

## Related Issues

Github PR refactored: #2020 
