### PR TITLE
fix: flag value autocompletion (PR #3686 recreation)

### DIFF
--- a/src/commands/autocomplete/options.ts
+++ b/src/commands/autocomplete/options.ts
@@ -134,7 +134,7 @@ export default class Options extends AutocompleteBase {
       // variable arg (strict: false)
       if (!Klass.strict) {
         cacheKey = cmdArgs[0] && cmdArgs[0].name.toLowerCase()
-        cacheCompletion = this.findCompletion(cacheKey, id)
+        cacheCompletion = this.findCompletion(id, cacheKey)
         if (!cacheCompletion) this.throwError(`Cannot complete variable arg position for ${id}`)
       } else if (argsIndex > cmdArgs.length - 1) {
         this.throwError(`Cannot complete arg position ${argsIndex} for ${id}`)
@@ -146,7 +146,7 @@ export default class Options extends AutocompleteBase {
 
     // try to auto-populate the completion object
     if (!cacheCompletion) {
-      cacheCompletion = this.findCompletion(cacheKey, id)
+      cacheCompletion = this.findCompletion(id, cacheKey)
     }
 
     return {cacheCompletion, cacheKey}

--- a/test/unit/commands/autocomplete/options.unit.test.ts
+++ b/test/unit/commands/autocomplete/options.unit.test.ts
@@ -136,4 +136,48 @@ describe('AutocompleteOptions', function () {
       })
     })
   })
+
+  describe('#determineCompletion', function () {
+    it('resolves app completion for an app arg', function () {
+      const commandStateVars = {
+        argsIndex: 0,
+        curPositionIsFlag: false,
+        curPositionIsFlagValue: false,
+        id: 'apps:info',
+        Klass: {args: [{name: 'app'}], flags: {}, strict: true},
+        slicedArgv: [],
+      }
+      const {cacheCompletion, cacheKey} = cmd.determineCompletion(commandStateVars)
+      expect(cacheKey).to.eq('app')
+      expect(cacheCompletion).to.not.be.undefined
+    })
+
+    it('resolves completion via key alias for config:get key arg', function () {
+      const commandStateVars = {
+        argsIndex: 0,
+        curPositionIsFlag: false,
+        curPositionIsFlagValue: false,
+        id: 'config:get',
+        Klass: {args: [{name: 'key'}], flags: {}, strict: true},
+        slicedArgv: [],
+      }
+      const {cacheCompletion, cacheKey} = cmd.determineCompletion(commandStateVars)
+      expect(cacheKey).to.eq('key')
+      expect(cacheCompletion).to.not.be.undefined
+    })
+
+    it('resolves app completion for a non-strict command', function () {
+      const commandStateVars = {
+        argsIndex: -1,
+        curPositionIsFlag: false,
+        curPositionIsFlagValue: false,
+        id: 'apps:info',
+        Klass: {args: [{name: 'app'}], flags: {}, strict: false},
+        slicedArgv: [],
+      }
+      const {cacheCompletion, cacheKey} = cmd.determineCompletion(commandStateVars)
+      expect(cacheKey).to.eq('app')
+      expect(cacheCompletion).to.not.be.undefined
+    })
+  })
 })


### PR DESCRIPTION
## Summary

This migrate an externally collaborated PR (#3686) to a new PR in order for it to be approved and merged.

The original PR implements a fix for autocomplete that is sound and was tested locally to fix the long standing issue.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [X] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:

Testing autocomplete locally isn't easy to do because you can't directly use `./bin/run`, but your real `heroku` binary. I tested it by building the CLI with `npm run build` and copying the built file for the one changed in this PR `./dist/commands/autocomplete/options.js` to my currently running Heroku CLI installation folder, verifying the fix is working.

## Related Issues
GitHub issue: closes #2275
