### PR TITLE
refactor: use @heroku/sdk for spaces subcommands

### DIFF
--- a/src/commands/spaces/drains/get.ts
+++ b/src/commands/spaces/drains/get.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {ux} from '@oclif/core/ux'
 
 export default class Get extends Command {
@@ -13,12 +13,10 @@ export default class Get extends Command {
   static topic = 'spaces'
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {flags} = await this.parse(Get)
     const {json, space} = flags
-    const {body: drain} = await this.heroku.get<Required<Heroku.LogDrain>>(
-      `/spaces/${space}/log-drain`,
-      {headers: {Accept: 'application/vnd.heroku+json; version=3.dogwood'}},
-    )
+    const drain = await platform.spaceLogDrain.info(space)
 
     if (json) {
       ux.stdout(JSON.stringify(drain, null, 2))

--- a/src/commands/spaces/drains/set.ts
+++ b/src/commands/spaces/drains/set.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 
 export default class Set extends Command {
@@ -15,14 +15,12 @@ export default class Set extends Command {
   static topic = 'spaces'
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Set)
     const {url} = args
     const {space} = flags
-    const {body: drain} = await this.heroku.put<Heroku.LogDrain>(`/spaces/${space}/log-drain`, {
-      body: {url},
-      headers: {Accept: 'application/vnd.heroku+json; version=3.dogwood'},
-    })
-    ux.stdout(`Successfully set drain ${color.info(drain.url || '')} for ${color.space(space)}.`)
+    const drain = await platform.spaceLogDrain.update(space, {url})
+    ux.stdout(`Successfully set drain ${color.info(drain.url)} for ${color.space(space)}.`)
     ux.warn('It may take a few moments for the changes to take effect.')
   }
 }

--- a/src/commands/spaces/peerings/accept.ts
+++ b/src/commands/spaces/peerings/accept.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -21,6 +22,7 @@ Accepting and configuring peering connection pcx-4bd27022`)]
   static topic = 'spaces'
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Accept)
     const space = flags.space || args.space
     if (!space) {
@@ -28,10 +30,7 @@ Accepting and configuring peering connection pcx-4bd27022`)]
     }
 
     const pcxID = flags.pcxid || args.pcxid
-    await this.heroku.post(`/spaces/${space}/peerings`, {
-      body: {pcx_id: pcxID},
-      headers: {Accept: 'application/vnd.heroku+json; version=3.dogwood'},
-    })
+    await platform.peering.accept(space, {pcx_id: pcxID})
     ux.stdout(`Accepting and configuring peering connection ${color.name(pcxID)}`)
   }
 }

--- a/src/commands/spaces/peerings/destroy.ts
+++ b/src/commands/spaces/peerings/destroy.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -28,6 +29,7 @@ export default class Destroy extends Command {
   static topic = 'spaces'
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Destroy)
 
     const pcxID = flags.pcxid || args.pcxid
@@ -43,7 +45,7 @@ export default class Destroy extends Command {
       This command will attempt to destroy the peering connection ${color.warning(pcxID)}
     `))
     ux.action.start(`Tearing down peering connection ${color.name(pcxID)}`)
-    await this.heroku.delete(`/spaces/${flags.space}/peerings/${pcxID}`)
+    await platform.peering.destroy(flags.space, pcxID)
     ux.action.stop()
   }
 }

--- a/src/commands/spaces/peerings/index.ts
+++ b/src/commands/spaces/peerings/index.ts
@@ -1,5 +1,5 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -19,6 +19,7 @@ export default class Index extends Command {
   static topic = 'spaces'
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Index)
     const spaceName = flags.space || args.space
     if (!spaceName) {
@@ -28,7 +29,7 @@ export default class Index extends Command {
         `)
     }
 
-    const {body: peerings} = await this.heroku.get<Heroku.Peering[]>(`/spaces/${spaceName}/peerings`)
+    const peerings = await platform.peering.list(spaceName)
 
     if (flags.json)
       displayPeeringsAsJSON(peerings)

--- a/src/commands/spaces/peerings/info.ts
+++ b/src/commands/spaces/peerings/info.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -45,6 +45,7 @@ export default class Info extends Command {
   static topic = 'spaces'
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Info)
     const spaceName = flags.space || args.space
     if (!spaceName) {
@@ -55,7 +56,7 @@ export default class Info extends Command {
       `))
     }
 
-    const {body: pInfo} = await this.heroku.get<Heroku.PeeringInfo>(`/spaces/${spaceName}/peering-info`)
+    const pInfo = await platform.peering.info(spaceName)
     if (flags.json)
       ux.stdout(JSON.stringify(pInfo, null, 2))
     else

--- a/src/commands/spaces/trusted-ips/add.ts
+++ b/src/commands/spaces/trusted-ips/add.ts
@@ -1,8 +1,10 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
+
+import {ExtendedInboundRuleset} from '../../../lib/types/spaces.js'
 
 const heredoc = tsheredoc.default
 
@@ -24,20 +26,20 @@ export default class Add extends Command {
   static topic = 'spaces'
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Add)
     const {space} = flags
-    const url = `/spaces/${space}/inbound-ruleset`
-    const {body: ruleset} = await this.heroku.get<Heroku.InboundRuleset>(url)
+    const ruleset = await platform.inboundRuleset.current(space)
     if (!this.isUniqueRule(ruleset, args.source)) {
       throw new Error(`A rule already exists for ${args.source}.`)
     }
 
     ruleset.rules.push({action: 'allow', source: args.source})
-    await this.heroku.put(url, {body: ruleset})
+    await platform.inboundRuleset.create(space, {rules: ruleset.rules})
     ux.stdout(`Added ${color.name(args.source)} to trusted IP ranges on ${color.space(space)}`)
 
     // Fetch updated ruleset to check applied status
-    const {body: updatedRuleset} = await this.heroku.get<Heroku.InboundRuleset>(url)
+    const updatedRuleset = await platform.inboundRuleset.current(space) as ExtendedInboundRuleset
     // Check applied status to inform users whether rules are effectively applied to the space.
     // The applied field is optional for backward compatibility with API versions that don't include it yet.
     // Once the API always includes the applied field (W-19525612), this can be simplified to:
@@ -49,7 +51,7 @@ export default class Add extends Command {
     }
   }
 
-  private isUniqueRule(ruleset: Heroku.InboundRuleset, source: string): ruleset is Required<Heroku.InboundRuleset> {
+  private isUniqueRule(ruleset: ExtendedInboundRuleset, source: string): boolean {
     return Array.isArray(ruleset.rules) && !ruleset.rules.some(rs => rs.source === source)
   }
 }

--- a/src/commands/spaces/trusted-ips/index.ts
+++ b/src/commands/spaces/trusted-ips/index.ts
@@ -1,8 +1,10 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import {hux} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
+
+import {ExtendedInboundRuleset} from '../../../lib/types/spaces.js'
 
 const heredoc = tsheredoc.default
 
@@ -26,13 +28,14 @@ export default class Index extends Command {
   static topic = 'spaces'
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Index)
     const space = flags.space || args.space
     if (!space) {
       throw new Error('Space name required.\nUSAGE: heroku trusted-ips my-space')
     }
 
-    const {body: rules} = await this.heroku.get<Required<Heroku.InboundRuleset>>(`/spaces/${space}/inbound-ruleset`)
+    const rules = await platform.inboundRuleset.current(space)
 
     if (flags.json) {
       ux.stdout(JSON.stringify(rules, null, 2))
@@ -41,7 +44,7 @@ export default class Index extends Command {
     }
   }
 
-  private displayRules(space: string, ruleset: Required<Heroku.InboundRuleset>) {
+  private displayRules(space: string, ruleset: ExtendedInboundRuleset) {
     if (ruleset.rules.length > 0) {
       hux.styledHeader('Trusted IP Ranges')
       for (const rule of ruleset.rules) {

--- a/src/commands/spaces/trusted-ips/remove.ts
+++ b/src/commands/spaces/trusted-ips/remove.ts
@@ -1,8 +1,10 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
+
+import {ExtendedInboundRuleset} from '../../../lib/types/spaces.js'
 
 const heredoc = tsheredoc.default
 
@@ -25,25 +27,25 @@ export default class Remove extends Command {
   static topic = 'spaces'
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Remove)
     const {space} = flags
-    const url = `/spaces/${space}/inbound-ruleset`
-    const {body: rules} = await this.heroku.get<Heroku.InboundRuleset>(url)
-    if (rules.rules?.length === 0) {
+    let {rules} = await platform.inboundRuleset.current(space)
+    if (rules.length === 0) {
       throw new Error('No IP ranges are configured. Nothing to do.')
     }
 
-    const originalLength = rules.rules?.length
-    rules.rules = rules.rules?.filter(r => r.source !== args.source)
-    if (rules.rules?.length === originalLength) {
+    const originalLength = rules.length
+    rules = rules.filter(r => r.source !== args.source)
+    if (rules.length === originalLength) {
       throw new Error(`No IP range matching ${args.source} was found.`)
     }
 
-    await this.heroku.put(url, {body: rules})
+    await platform.inboundRuleset.create(space, {rules})
     ux.stdout(`Removed ${color.name(args.source)} from trusted IP ranges on ${color.space(space)}`)
 
     // Fetch updated ruleset to check applied status
-    const {body: updatedRuleset} = await this.heroku.get<Heroku.InboundRuleset>(url)
+    const updatedRuleset = await platform.inboundRuleset.current(space) as ExtendedInboundRuleset
     // Check applied status to inform users whether rules are effectively applied to the space.
     // The applied field is optional for backward compatibility with API versions that don't include it yet.
     // Once the API always includes the applied field (W-19525612), this can be simplified to:

--- a/src/lib/spaces/peering.ts
+++ b/src/lib/spaces/peering.ts
@@ -1,5 +1,5 @@
-import {Peering, PeeringInfo} from '@heroku-cli/schema'
 import {hux} from '@heroku/heroku-cli-util'
+import {Peering, PeeringInfo} from '@heroku/types/3.sdk'
 import {ux} from '@oclif/core/ux'
 
 import {displayCIDR, peeringStatus} from './format.js'
@@ -25,7 +25,7 @@ export function displayPeeringsAsJSON(peerings: Peering[]) {
 export function displayPeerings(space: string, peerings: Peering[]) {
   hux.styledHeader(`${space} Peerings`)
   /* eslint-disable perfectionist/sort-objects */
-  hux.table<Peering>(peerings, {
+  hux.table(peerings, {
     pcx_id: {
       header: 'PCX ID',
     },

--- a/src/lib/types/spaces.d.ts
+++ b/src/lib/types/spaces.d.ts
@@ -1,3 +1,4 @@
+import type {InboundRuleset} from '@heroku/types/3.sdk'
 import {
   Space,
   Region,
@@ -7,6 +8,12 @@ import {
 
 export type SpaceExpanded = Omit<Space, 'region'> & {
   region: SpaceRegion & Partial<Region>
+}
+
+// The applied field is optional for backward compatibility with API versions that don't include it yet.
+// Once the API always includes the applied field, this will be added directly to @heroku/types.
+export type ExtendedInboundRuleset = InboundRuleset & {
+  applied?: boolean
 }
 
 export type SpaceWithOutboundIps = SpaceExpanded & {

--- a/test/unit/commands/spaces/drains/get.unit.test.ts
+++ b/test/unit/commands/spaces/drains/get.unit.test.ts
@@ -1,40 +1,59 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
+import {LogDrain} from '@heroku/types/3.sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Cmd from '../../../../../src/commands/spaces/drains/get.js'
 
+type FakePlatform = {
+  spaceLogDrain: {info: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    spaceLogDrain: {info: sinon.stub()},
+  }
+}
+
 describe('spaces:drains:get', function () {
-  const drain = {
+  const drain: LogDrain = {
     addon: null,
+    app: {
+      id: 'app-123',
+      name: 'my-app',
+    },
     created_at: '2016-03-23T18:31:50Z',
     id: '047f80cc-0470-4564-b0cb-e9ad7605314a',
     token: 'd.a55ecbe1-5513-4d19-91e4-58a08b419d19',
     updated_at: '2016-03-23T18:31:50Z',
     url: 'https://example.com',
   }
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
-      .get('/spaces/my-space/log-drain')
-      .reply(200, drain)
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('shows the log drain', async function () {
+    fakePlatform.spaceLogDrain.info.resolves(drain)
+
     const {stdout} = await runCommand(Cmd, [
       '--space',
       'my-space',
     ])
     expect(stdout).to.eq('https://example.com (d.a55ecbe1-5513-4d19-91e4-58a08b419d19)\n')
+    expect(fakePlatform.spaceLogDrain.info.calledOnceWithExactly('my-space')).to.equal(true)
   })
 
   it('shows the log drain --json', async function () {
+    fakePlatform.spaceLogDrain.info.resolves(drain)
+
     const {stdout} = await runCommand(Cmd, [
       '--space',
       'my-space',

--- a/test/unit/commands/spaces/drains/set.unit.test.ts
+++ b/test/unit/commands/spaces/drains/set.unit.test.ts
@@ -1,37 +1,52 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
+import {LogDrain} from '@heroku/types/3.sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Set from '../../../../../src/commands/spaces/drains/set.js'
 
+type FakePlatform = {
+  spaceLogDrain: {update: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    spaceLogDrain: {update: sinon.stub()},
+  }
+}
+
 describe('spaces:drains:set', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('sets the log drain', async function () {
-    api
-      .put('/spaces/my-space/log-drain', {
-        url: 'https://example.com',
-      })
-      .reply(200, {
-        addon: null,
-        created_at: '2016-03-23T18:31:50Z',
-        id: '047f80cc-0470-4564-b0cb-e9ad7605314a',
-        token: 'd.a55ecbe1-5513-4d19-91e4-58a08b419d19',
-        updated_at: '2016-03-23T18:31:50Z',
-        url: 'https://example.com',
-      })
+    const drain: LogDrain = {
+      addon: null,
+      app: {
+        id: 'app-123',
+        name: 'my-app',
+      },
+      created_at: '2016-03-23T18:31:50Z',
+      id: '047f80cc-0470-4564-b0cb-e9ad7605314a',
+      token: 'd.a55ecbe1-5513-4d19-91e4-58a08b419d19',
+      updated_at: '2016-03-23T18:31:50Z',
+      url: 'https://example.com',
+    }
+
+    fakePlatform.spaceLogDrain.update.resolves(drain)
 
     const {stdout} = await runCommand(Set, ['https://example.com', '--space', 'my-space'])
 
     expect(stdout).to.equal('Successfully set drain https://example.com for ⬡ my-space.\n')
+    expect(fakePlatform.spaceLogDrain.update.calledOnceWithExactly('my-space', {url: 'https://example.com'})).to.equal(true)
   })
 })

--- a/test/unit/commands/spaces/peerings/accept.unit.test.ts
+++ b/test/unit/commands/spaces/peerings/accept.unit.test.ts
@@ -1,30 +1,38 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Accept from '../../../../../src/commands/spaces/peerings/accept.js'
 
+type FakePlatform = {
+  peering: {accept: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    peering: {accept: sinon.stub()},
+  }
+}
+
 describe('spaces:peerings:accept', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('accepts a pending peering connection', async function () {
-    api
-      .post('/spaces/my-space/peerings', {
-        pcx_id: 'pcx-12345',
-      })
-      .reply(202)
+    fakePlatform.peering.accept.resolves({pcx_id: 'pcx-12345'})
 
     const {stdout} = await runCommand(Accept, ['--pcxid', 'pcx-12345', '--space', 'my-space'])
 
     expect(stdout).to.equal('Accepting and configuring peering connection pcx-12345\n')
+    expect(fakePlatform.peering.accept.calledOnceWithExactly('my-space', {pcx_id: 'pcx-12345'})).to.equal(true)
   })
 })

--- a/test/unit/commands/spaces/peerings/destroy.unit.test.ts
+++ b/test/unit/commands/spaces/peerings/destroy.unit.test.ts
@@ -1,14 +1,34 @@
 import {expectOutput, runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Cmd from '../../../../../src/commands/spaces/peerings/destroy.js'
 
+type FakePlatform = {
+  peering: {destroy: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    peering: {destroy: sinon.stub()},
+  }
+}
+
 describe('spaces:peering:destroy', function () {
+  let fakePlatform: FakePlatform
+
+  beforeEach(function () {
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
+  })
+
+  afterEach(function () {
+    sinon.restore()
+  })
+
   it('destroys an active peering connection', async function () {
-    nock('https://api.heroku.com')
-      .delete('/spaces/my-space/peerings/pcx-12345')
-      .reply(202)
+    fakePlatform.peering.destroy.resolves()
 
     const {stderr} = await runCommand(Cmd, [
       '--space',
@@ -19,6 +39,7 @@ describe('spaces:peering:destroy', function () {
       'pcx-12345',
     ])
     expectOutput(stderr, 'Tearing down peering connection pcx-12345... done\n')
+    expect(fakePlatform.peering.destroy.calledOnceWithExactly('my-space', 'pcx-12345')).to.equal(true)
   })
 
   it('errors when pcxid is missing', async function () {

--- a/test/unit/commands/spaces/peerings/index.unit.test.ts
+++ b/test/unit/commands/spaces/peerings/index.unit.test.ts
@@ -1,30 +1,48 @@
-import * as Heroku from '@heroku-cli/schema'
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
+import {Peering} from '@heroku/types/3.sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Cmd from '../../../../../src/commands/spaces/peerings/index.js'
 import removeAllWhitespace from '../../../../helpers/utils/remove-whitespaces.js'
 
+type FakePlatform = {
+  peering: {list: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    peering: {list: sinon.stub()},
+  }
+}
+
 describe('spaces:peerings', function () {
-  let peerings: Heroku.Peering[]
+  let fakePlatform: FakePlatform
+  let peerings: Peering[]
 
   beforeEach(function () {
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
     peerings = [{
       aws_account_id: '012345678910',
       aws_region: 'us-west-2',
       aws_vpc_id: 'vpc-1234568a',
+      cidr_block: '10.0.0.0/16',
       cidr_blocks: ['10.0.0.0/16'],
+      expires: '',
       pcx_id: 'pcx-12345',
       status: 'active',
       type: 'heroku-managed',
     }]
   })
 
+  afterEach(function () {
+    sinon.restore()
+  })
+
   it('shows space peerings', async function () {
-    nock('https://api.heroku.com')
-      .get('/spaces/my-space/peerings')
-      .reply(200, peerings)
+    fakePlatform.peering.list.resolves(peerings)
 
     const {stdout} = await runCommand(Cmd, [
       '--space',
@@ -38,12 +56,11 @@ describe('spaces:peerings', function () {
 
     expect(actual).to.include(expectedHeader)
     expect(actual).to.include(expectedData)
+    expect(fakePlatform.peering.list.calledOnceWithExactly('my-space')).to.equal(true)
   })
 
   it('shows peerings --json', async function () {
-    nock('https://api.heroku.com')
-      .get('/spaces/my-space/peerings')
-      .reply(200, peerings)
+    fakePlatform.peering.list.resolves(peerings)
 
     const {stdout} = await runCommand(Cmd, [
       '--space',

--- a/test/unit/commands/spaces/peerings/info.unit.test.ts
+++ b/test/unit/commands/spaces/peerings/info.unit.test.ts
@@ -1,20 +1,35 @@
-import * as Heroku from '@heroku-cli/schema'
 import {expectOutput, runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
+import {PeeringInfo} from '@heroku/types/3.sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 import tsheredoc from 'tsheredoc'
 
 import Cmd from '../../../../../src/commands/spaces/peerings/info.js'
 
 const heredoc = tsheredoc.default
 
+type FakePlatform = {
+  peering: {info: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    peering: {info: sinon.stub()},
+  }
+}
+
 describe('spaces:peering:info', function () {
-  let peeringInfo: Heroku.PeeringInfo
+  let fakePlatform: FakePlatform
+  let peeringInfo: PeeringInfo
 
   beforeEach(function () {
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
     peeringInfo = {
       aws_account_id: '012345678900',
       aws_region: 'us-west-2',
+      dyno_cidr_blocks: ['10.0.128.0/20', '10.0.144.0/20'],
       space_cidr_blocks: ['10.0.128.0/20', '10.0.144.0/20'],
       unavailable_cidr_blocks: ['192.168.2.0/30'],
       vpc_cidr: '10.0.0.0/16',
@@ -22,10 +37,12 @@ describe('spaces:peering:info', function () {
     }
   })
 
+  afterEach(function () {
+    sinon.restore()
+  })
+
   it('shows space peering info', async function () {
-    nock('https://api.heroku.com')
-      .get('/spaces/my-space/peering-info')
-      .reply(200, peeringInfo)
+    fakePlatform.peering.info.resolves(peeringInfo)
 
     const {stdout} = await runCommand(Cmd, [
       '--space',
@@ -40,12 +57,11 @@ describe('spaces:peering:info', function () {
       Space CIDRs:       10.0.128.0/20, 10.0.144.0/20
       Unavailable CIDRs: 192.168.2.0/30
     `))
+    expect(fakePlatform.peering.info.calledOnceWithExactly('my-space')).to.equal(true)
   })
 
   it('shows peering:info --json', async function () {
-    nock('https://api.heroku.com')
-      .get('/spaces/my-space/peering-info')
-      .reply(200, peeringInfo)
+    fakePlatform.peering.info.resolves(peeringInfo)
 
     const {stdout} = await runCommand(Cmd, [
       '--space',

--- a/test/unit/commands/spaces/trusted-ips/add.unit.test.ts
+++ b/test/unit/commands/spaces/trusted-ips/add.unit.test.ts
@@ -1,79 +1,94 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Add from '../../../../../src/commands/spaces/trusted-ips/add.js'
+import {ExtendedInboundRuleset} from '../../../../../src/lib/types/spaces.js'
+
+type FakePlatform = {
+  inboundRuleset: {
+    create: sinon.SinonStub,
+    current: sinon.SinonStub,
+  }
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    inboundRuleset: {
+      create: sinon.stub(),
+      current: sinon.stub(),
+    },
+  }
+}
+
+function buildRuleset(overrides: Partial<ExtendedInboundRuleset> = {}): ExtendedInboundRuleset {
+  return {
+    created_at: '2024-01-01T00:00:00Z',
+    created_by: 'dickeyxxx',
+    id: 'ruleset-id',
+    rules: [
+      {action: 'allow', source: '128.0.0.1/20'},
+    ],
+    space: {id: 'space-id', name: 'my-space'},
+    ...overrides,
+  }
+}
 
 describe('trusted-ips:add', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('adds a CIDR entry to the trusted IP ranges', async function () {
-    api
-      .get('/spaces/my-space/inbound-ruleset')
-      .reply(200, {
-        created_by: 'dickeyxxx',
-        rules: [
-          {action: 'allow', source: '128.0.0.1/20'},
-        ],
-      })
-      .put('/spaces/my-space/inbound-ruleset', {
-        created_by: 'dickeyxxx',
-        rules: [
-          {action: 'allow', source: '128.0.0.1/20'},
-          {action: 'allow', source: '127.0.0.1/20'},
-        ],
-      })
-      .reply(200, {rules: []})
-      .get('/spaces/my-space/inbound-ruleset')
-      .reply(200, {
-        applied: true,
-        created_by: 'dickeyxxx',
-        rules: [
-          {action: 'allow', source: '128.0.0.1/20'},
-          {action: 'allow', source: '127.0.0.1/20'},
-        ],
-      })
+    fakePlatform.inboundRuleset.current.onFirstCall().resolves(buildRuleset())
+    fakePlatform.inboundRuleset.create.resolves(buildRuleset({
+      rules: [
+        {action: 'allow', source: '128.0.0.1/20'},
+        {action: 'allow', source: '127.0.0.1/20'},
+      ],
+    }))
+    fakePlatform.inboundRuleset.current.onSecondCall().resolves(buildRuleset({
+      applied: true,
+      rules: [
+        {action: 'allow', source: '128.0.0.1/20'},
+        {action: 'allow', source: '127.0.0.1/20'},
+      ],
+    }))
 
     const {stdout} = await runCommand(Add, ['127.0.0.1/20', '--space', 'my-space', '--confirm', 'my-space'])
 
     expect(stdout).to.eq('Added 127.0.0.1/20 to trusted IP ranges on ⬡ my-space\nTrusted IP rules are applied to this space.\n')
+    expect(fakePlatform.inboundRuleset.create.calledOnceWithExactly('my-space', {
+      rules: [
+        {action: 'allow', source: '128.0.0.1/20'},
+        {action: 'allow', source: '127.0.0.1/20'},
+      ],
+    })).to.equal(true)
   })
 
   it('shows message when applied is false after add', async function () {
-    api
-      .get('/spaces/my-space/inbound-ruleset')
-      .reply(200, {
-        created_by: 'dickeyxxx',
-        rules: [
-          {action: 'allow', source: '128.0.0.1/20'},
-        ],
-      })
-      .put('/spaces/my-space/inbound-ruleset', {
-        created_by: 'dickeyxxx',
-        rules: [
-          {action: 'allow', source: '128.0.0.1/20'},
-          {action: 'allow', source: '127.0.0.1/20'},
-        ],
-      })
-      .reply(200, {rules: []})
-      .get('/spaces/my-space/inbound-ruleset')
-      .reply(200, {
-        applied: false,
-        created_by: 'dickeyxxx',
-        rules: [
-          {action: 'allow', source: '128.0.0.1/20'},
-          {action: 'allow', source: '127.0.0.1/20'},
-        ],
-      })
+    fakePlatform.inboundRuleset.current.onFirstCall().resolves(buildRuleset())
+    fakePlatform.inboundRuleset.create.resolves(buildRuleset({
+      rules: [
+        {action: 'allow', source: '128.0.0.1/20'},
+        {action: 'allow', source: '127.0.0.1/20'},
+      ],
+    }))
+    fakePlatform.inboundRuleset.current.onSecondCall().resolves(buildRuleset({
+      applied: false,
+      rules: [
+        {action: 'allow', source: '128.0.0.1/20'},
+        {action: 'allow', source: '127.0.0.1/20'},
+      ],
+    }))
 
     const {stdout} = await runCommand(Add, ['127.0.0.1/20', '--space', 'my-space', '--confirm', 'my-space'])
 
@@ -82,33 +97,35 @@ describe('trusted-ips:add', function () {
   })
 
   it('shows nothing when applied is undefined (backward compatibility)', async function () {
-    api
-      .get('/spaces/my-space/inbound-ruleset')
-      .reply(200, {
-        created_by: 'dickeyxxx',
-        rules: [
-          {action: 'allow', source: '128.0.0.1/20'},
-        ],
-      })
-      .put('/spaces/my-space/inbound-ruleset', {
-        created_by: 'dickeyxxx',
-        rules: [
-          {action: 'allow', source: '128.0.0.1/20'},
-          {action: 'allow', source: '127.0.0.1/20'},
-        ],
-      })
-      .reply(200, {rules: []})
-      .get('/spaces/my-space/inbound-ruleset')
-      .reply(200, {
-        created_by: 'dickeyxxx',
-        rules: [
-          {action: 'allow', source: '128.0.0.1/20'},
-          {action: 'allow', source: '127.0.0.1/20'},
-        ],
-      })
+    fakePlatform.inboundRuleset.current.onFirstCall().resolves(buildRuleset())
+    fakePlatform.inboundRuleset.create.resolves(buildRuleset({
+      rules: [
+        {action: 'allow', source: '128.0.0.1/20'},
+        {action: 'allow', source: '127.0.0.1/20'},
+      ],
+    }))
+    fakePlatform.inboundRuleset.current.onSecondCall().resolves(buildRuleset({
+      rules: [
+        {action: 'allow', source: '128.0.0.1/20'},
+        {action: 'allow', source: '127.0.0.1/20'},
+      ],
+    }))
 
     const {stdout} = await runCommand(Add, ['127.0.0.1/20', '--space', 'my-space', '--confirm', 'my-space'])
 
     expect(stdout).to.eq('Added 127.0.0.1/20 to trusted IP ranges on ⬡ my-space\n')
+  })
+
+  it('errors when a rule already exists for the source', async function () {
+    fakePlatform.inboundRuleset.current.resolves(buildRuleset({
+      rules: [
+        {action: 'allow', source: '127.0.0.1/20'},
+      ],
+    }))
+
+    const {error} = await runCommand(Add, ['127.0.0.1/20', '--space', 'my-space', '--confirm', 'my-space'])
+
+    expect(error).to.exist
+    expect(error!.message).to.include('A rule already exists for 127.0.0.1/20.')
   })
 })

--- a/test/unit/commands/spaces/trusted-ips/index.unit.test.ts
+++ b/test/unit/commands/spaces/trusted-ips/index.unit.test.ts
@@ -1,39 +1,53 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 import tsheredoc from 'tsheredoc'
 
 import Index from '../../../../../src/commands/spaces/trusted-ips/index.js'
+import {ExtendedInboundRuleset} from '../../../../../src/lib/types/spaces.js'
 
 const heredoc = tsheredoc.default
 
 const now = new Date()
 
+type FakePlatform = {
+  inboundRuleset: {current: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    inboundRuleset: {current: sinon.stub()},
+  }
+}
+
+function buildRuleset(overrides: Partial<ExtendedInboundRuleset> = {}): ExtendedInboundRuleset {
+  return {
+    created_at: now.toISOString(),
+    created_by: 'dickeyxxx',
+    id: 'ruleset-id',
+    rules: [
+      {action: 'allow', source: '127.0.0.1/20'},
+    ],
+    space: {id: 'space-id', name: 'my-space'},
+    ...overrides,
+  }
+}
+
 describe('trusted-ips', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('shows the trusted IP ranges', async function () {
-    api
-      .get('/spaces/my-space/inbound-ruleset')
-      .reply(200, {
-        applied: true,
-        created_at: now,
-        created_by: 'dickeyxxx',
-        default_action: 'allow',
-        rules: [
-          {action: 'allow', source: '127.0.0.1/20'},
-        ],
-        version: '1',
-      })
+    fakePlatform.inboundRuleset.current.resolves(buildRuleset({applied: true}))
 
     const {stdout} = await runCommand(Index, ['--space', 'my-space'])
 
@@ -43,19 +57,11 @@ describe('trusted-ips', function () {
     127.0.0.1/20
     Trusted IP rules are applied to this space.
     `))
+    expect(fakePlatform.inboundRuleset.current.calledOnceWithExactly('my-space')).to.equal(true)
   })
 
   it('shows the trusted IP ranges with blank rules', async function () {
-    api
-      .get('/spaces/my-space/inbound-ruleset')
-      .reply(200, {
-        applied: true,
-        created_at: now,
-        created_by: 'dickeyxxx',
-        default_action: 'allow',
-        rules: [],
-        version: '1',
-      })
+    fakePlatform.inboundRuleset.current.resolves(buildRuleset({applied: true, rules: []}))
 
     const {stdout} = await runCommand(Index, ['--space', 'my-space'])
 
@@ -63,39 +69,16 @@ describe('trusted-ips', function () {
   })
 
   it('shows the trusted IP ranges --json', async function () {
-    const ruleSet = {
-      applied: true,
-      created_at: now.toISOString(),
-      created_by: 'dickeyxxx',
-      default_action: 'allow',
-      rules: [
-        {action: 'allow', source: '127.0.0.1/20'},
-      ],
-      version: '1',
-    }
-
-    api
-      .get('/spaces/my-space/inbound-ruleset')
-      .reply(200, ruleSet)
+    const ruleset = buildRuleset({applied: true})
+    fakePlatform.inboundRuleset.current.resolves(ruleset)
 
     const {stdout} = await runCommand(Index, ['--space', 'my-space', '--json', 'true'])
 
-    expect(JSON.parse(stdout)).to.eql(ruleSet)
+    expect(JSON.parse(stdout)).to.eql(ruleset)
   })
 
   it('shows message when applied is false', async function () {
-    api
-      .get('/spaces/my-space/inbound-ruleset')
-      .reply(200, {
-        applied: false,
-        created_at: now,
-        created_by: 'dickeyxxx',
-        default_action: 'allow',
-        rules: [
-          {action: 'allow', source: '127.0.0.1/20'},
-        ],
-        version: '1',
-      })
+    fakePlatform.inboundRuleset.current.resolves(buildRuleset({applied: false}))
 
     const {stdout} = await runCommand(Index, ['--space', 'my-space'])
 
@@ -103,17 +86,7 @@ describe('trusted-ips', function () {
   })
 
   it('shows nothing when applied is undefined (backward compatibility)', async function () {
-    api
-      .get('/spaces/my-space/inbound-ruleset')
-      .reply(200, {
-        created_at: now,
-        created_by: 'dickeyxxx',
-        default_action: 'allow',
-        rules: [
-          {action: 'allow', source: '127.0.0.1/20'},
-        ],
-        version: '1',
-      })
+    fakePlatform.inboundRuleset.current.resolves(buildRuleset())
 
     const {stdout} = await runCommand(Index, ['--space', 'my-space'])
 

--- a/test/unit/commands/spaces/trusted-ips/remove.unit.test.ts
+++ b/test/unit/commands/spaces/trusted-ips/remove.unit.test.ts
@@ -1,49 +1,69 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 import tsheredoc from 'tsheredoc'
 
 import Remove from '../../../../../src/commands/spaces/trusted-ips/remove.js'
+import {ExtendedInboundRuleset} from '../../../../../src/lib/types/spaces.js'
 
 const heredoc = tsheredoc.default
 
+type FakePlatform = {
+  inboundRuleset: {
+    create: sinon.SinonStub,
+    current: sinon.SinonStub,
+  }
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    inboundRuleset: {
+      create: sinon.stub(),
+      current: sinon.stub(),
+    },
+  }
+}
+
+function buildRuleset(overrides: Partial<ExtendedInboundRuleset> = {}): ExtendedInboundRuleset {
+  return {
+    created_at: '2024-01-01T00:00:00Z',
+    created_by: 'gandalf',
+    id: 'ruleset-id',
+    rules: [
+      {action: 'allow', source: '128.0.0.1/20'},
+      {action: 'allow', source: '127.0.0.1/20'},
+    ],
+    space: {id: 'space-id', name: 'my-space'},
+    ...overrides,
+  }
+}
+
 describe('trusted-ips:remove', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('removes a CIDR entry from the trusted IP ranges', async function () {
-    api
-      .get('/spaces/my-space/inbound-ruleset')
-      .reply(200, {
-        created_by: 'gandalf',
-        rules: [
-          {action: 'allow', source: '128.0.0.1/20'},
-          {action: 'allow', source: '127.0.0.1/20'},
-        ],
-      })
-      .put('/spaces/my-space/inbound-ruleset', {
-        created_by: 'gandalf',
-        rules: [
-          {action: 'allow', source: '128.0.0.1/20'},
-        ],
-      })
-      .reply(200, {rules: []})
-      .get('/spaces/my-space/inbound-ruleset')
-      .reply(200, {
-        applied: true,
-        created_by: 'gandalf',
-        rules: [
-          {action: 'allow', source: '128.0.0.1/20'},
-        ],
-      })
+    fakePlatform.inboundRuleset.current.onFirstCall().resolves(buildRuleset())
+    fakePlatform.inboundRuleset.create.resolves(buildRuleset({
+      rules: [
+        {action: 'allow', source: '128.0.0.1/20'},
+      ],
+    }))
+    fakePlatform.inboundRuleset.current.onSecondCall().resolves(buildRuleset({
+      applied: true,
+      rules: [
+        {action: 'allow', source: '128.0.0.1/20'},
+      ],
+    }))
 
     const {stdout} = await runCommand(Remove, ['127.0.0.1/20', '--space', 'my-space'])
 
@@ -51,33 +71,26 @@ describe('trusted-ips:remove', function () {
     Removed 127.0.0.1/20 from trusted IP ranges on ⬡ my-space
     Trusted IP rules are applied to this space.
     `))
+    expect(fakePlatform.inboundRuleset.create.calledOnceWithExactly('my-space', {
+      rules: [
+        {action: 'allow', source: '128.0.0.1/20'},
+      ],
+    })).to.equal(true)
   })
 
   it('shows message when applied is false after remove', async function () {
-    api
-      .get('/spaces/my-space/inbound-ruleset')
-      .reply(200, {
-        created_by: 'gandalf',
-        rules: [
-          {action: 'allow', source: '128.0.0.1/20'},
-          {action: 'allow', source: '127.0.0.1/20'},
-        ],
-      })
-      .put('/spaces/my-space/inbound-ruleset', {
-        created_by: 'gandalf',
-        rules: [
-          {action: 'allow', source: '128.0.0.1/20'},
-        ],
-      })
-      .reply(200, {rules: []})
-      .get('/spaces/my-space/inbound-ruleset')
-      .reply(200, {
-        applied: false,
-        created_by: 'gandalf',
-        rules: [
-          {action: 'allow', source: '128.0.0.1/20'},
-        ],
-      })
+    fakePlatform.inboundRuleset.current.onFirstCall().resolves(buildRuleset())
+    fakePlatform.inboundRuleset.create.resolves(buildRuleset({
+      rules: [
+        {action: 'allow', source: '128.0.0.1/20'},
+      ],
+    }))
+    fakePlatform.inboundRuleset.current.onSecondCall().resolves(buildRuleset({
+      applied: false,
+      rules: [
+        {action: 'allow', source: '128.0.0.1/20'},
+      ],
+    }))
 
     const {stdout} = await runCommand(Remove, ['127.0.0.1/20', '--space', 'my-space'])
 
@@ -86,34 +99,42 @@ describe('trusted-ips:remove', function () {
   })
 
   it('shows nothing when applied is undefined (backward compatibility)', async function () {
-    api
-      .get('/spaces/my-space/inbound-ruleset')
-      .reply(200, {
-        created_by: 'gandalf',
-        rules: [
-          {action: 'allow', source: '128.0.0.1/20'},
-          {action: 'allow', source: '127.0.0.1/20'},
-        ],
-      })
-      .put('/spaces/my-space/inbound-ruleset', {
-        created_by: 'gandalf',
-        rules: [
-          {action: 'allow', source: '128.0.0.1/20'},
-        ],
-      })
-      .reply(200, {rules: []})
-      .get('/spaces/my-space/inbound-ruleset')
-      .reply(200, {
-        created_by: 'gandalf',
-        rules: [
-          {action: 'allow', source: '128.0.0.1/20'},
-        ],
-      })
+    fakePlatform.inboundRuleset.current.onFirstCall().resolves(buildRuleset())
+    fakePlatform.inboundRuleset.create.resolves(buildRuleset({
+      rules: [
+        {action: 'allow', source: '128.0.0.1/20'},
+      ],
+    }))
+    fakePlatform.inboundRuleset.current.onSecondCall().resolves(buildRuleset({
+      rules: [
+        {action: 'allow', source: '128.0.0.1/20'},
+      ],
+    }))
 
     const {stdout} = await runCommand(Remove, ['127.0.0.1/20', '--space', 'my-space'])
 
     expect(stdout).to.eq(heredoc(`
     Removed 127.0.0.1/20 from trusted IP ranges on ⬡ my-space
     `))
+  })
+
+  it('errors when there are no ranges configured', async function () {
+    fakePlatform.inboundRuleset.current.resolves(buildRuleset({rules: []}))
+
+    const {error} = await runCommand(Remove, ['127.0.0.1/20', '--space', 'my-space'])
+
+    expect(error).to.exist
+    expect(error!.message).to.include('No IP ranges are configured. Nothing to do.')
+  })
+
+  it('errors when no matching range is found', async function () {
+    fakePlatform.inboundRuleset.current.resolves(buildRuleset({
+      rules: [{action: 'allow', source: '128.0.0.1/20'}],
+    }))
+
+    const {error} = await runCommand(Remove, ['127.0.0.1/20', '--space', 'my-space'])
+
+    expect(error).to.exist
+    expect(error!.message).to.include('No IP range matching 127.0.0.1/20 was found.')
   })
 })

--- a/test/unit/lib/spaces/peering.unit.test.ts
+++ b/test/unit/lib/spaces/peering.unit.test.ts
@@ -1,5 +1,5 @@
-import {Peering, PeeringInfo} from '@heroku-cli/schema'
 import {captureOutput, expectOutput} from '@heroku-cli/test-utils'
+import {Peering, PeeringInfo} from '@heroku/types/3.sdk'
 import {expect} from 'chai'
 import tsheredoc from 'tsheredoc'
 
@@ -13,7 +13,9 @@ const peerings: Peering[] = [
     aws_account_id: '012345678910',
     aws_region: 'us-west-2',
     aws_vpc_id: 'vpc-1234568a',
+    cidr_block: '10.0.0.0/16',
     cidr_blocks: ['10.0.0.0/16'],
+    expires: '2026-08-17T00:00:00Z',
     pcx_id: 'pcx-12345',
     status: 'active',
     type: 'heroku-managed',
@@ -22,7 +24,9 @@ const peerings: Peering[] = [
     aws_account_id: '012345678911',
     aws_region: 'us-west-2',
     aws_vpc_id: 'vpc-1234568b',
+    cidr_block: '10.0.0.0/16',
     cidr_blocks: ['10.0.0.0/16'],
+    expires: '2026-08-17T00:00:00Z',
     pcx_id: 'pcx-12346',
     status: 'active',
     type: 'heroku-managed',
@@ -33,6 +37,7 @@ describe('displayPeeringInfo', function () {
   const peeringInfo: PeeringInfo = {
     aws_account_id: '012345678900',
     aws_region: 'us-west-2',
+    dyno_cidr_blocks: ['10.0.0.0/16'],
     space_cidr_blocks: ['10.0.128.0/20', '10.0.144.0/20'],
     unavailable_cidr_blocks: ['192.168.2.0/30'],
     vpc_cidr: '10.0.0.0/16',


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
Migrates the following `spaces` commands to `@heroku/sdk`:
- `spaces:peerings`
   - `spaces/peerings/accept`
   - `spaces/peerings/destroy`
   - `spaces/peerings/index`
   - `spaces/peerings/info`
- `spaces:trusted-ips`
   - `spaces/trusted-ips/add`
   - `spaces/trusted-ips/index`
   - `spaces/trusted-ips/remove`
- `spaces:drains`
   - `spaces/drains/get`
   - `spaces/drains/set`

### Details
- Replaced direct API calls with the SDK
- Added `ExtendedInboundRuleset` to allow the optional `applied` field
- Rewrote tests to stub the SDK directly instead of using `nock`

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
<!-- Add any context/setup necessary for testing. -->
The SDK uses `heroku-fetch` to make API calls, which looks for a netrc file. Therefore, we must log in with `HEROKU_NETRC_WRITE=true`.

**Setup**:
- Pull down this branch
- `npm i && npm run build`
- `heroku logout`
- `HEROKU_NETRC_WRITE=true ./bin/run login`

**Steps**:

**`spaces:trusted-ips`**
- `./bin/run spaces:trusted-ips --space SPACE`
   - Expect: list of trusted IPs or `=== SPACE has no trusted IP ranges. All inbound web requests to dynos are blocked.`
- `./bin/run spaces:trusted-ips:add 192.0.2.0/24 --space SPACE`
   - Expect: `Added 192.0.2.0/24 to trusted IP ranges on ⬡ SPACE`
- `./bin/run spaces:trusted-ips --space SPACE`
   - Expect: list of trusted IPs, including the IP created above
- `./bin/run spaces:trusted-ips:remove 192.0.2.0/24 --space SPACE`
   - Expect: `Removed 192.0.2.0/24 from trusted IP ranges on ⬡ SPACE`
- `./bin/run spaces:trusted-ips --space SPACE`
   - Expect: list of trusted IPs, excluding the IP created above

**`spaces:drains`**
- `./bin/run spaces:drains:get --space SPACE`
   - Expect: output (`URL (TOKEN)`) or error (`This Private Space does not support direct logging.`)
- `./bin/run spaces:drains:set https://example.com --space SPACE`
   - Expect: output (`Successfully set drain https://example.com for ⬡ SPACE.`) or the same error

**Note:** without a Shield space configured with Private Space Logging at creation, you'll get `This Private Space does not support direct logging.` — that's expected and sufficient.

**`spaces:peerings`**
- `./bin/run spaces:peerings:info --space SPACE`
   - Expect: displays AWS Account ID, AWS Region, AWS VPC ID, AWS VPC CIDR, Space CIDRs, and Unavailable CIDRs
- `./bin/run spaces:peerings --space SPACE`
   - Expect: displays a table of existing peering connections, or an empty table if none exist

**Note:** `spaces:peerings:accept` and `spaces:peerings:destroy` were not manually tested in this pass — they require an active AWS VPC peering request already pending against the space (see [Private Space Peering](https://devcenter.heroku.com/articles/private-space-peering)), which wasn't readily available. Verified via code review and the corresponding unit tests instead.

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-23385114](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eL4qiYAC/view)