### PR TITLE
refactor(spaces:vpn): use @heroku/sdk

### DIFF
--- a/V12-CHANGES.md
+++ b/V12-CHANGES.md
@@ -14,3 +14,6 @@
 - `run`, `run:detached`, and `run:inside` now create dynos through `@heroku/sdk` (`platform.dyno.run`) instead of raw API calls.
 - Release-conflict (`409`) retries during one-off dyno creation are now handled by the SDK; the CLI no longer runs its own retry loop.
 
+# Spaces commands
+- `spaces:vpn:wait` no longer shows `VPN has been allocated.` when the status is already `active`. Instead it immediately shows `Waiting for VPN Connection ${name} to allocate... done`
+- `spaces:vpn:wait` now has three dots (`.`) instead of six in `Waiting for VPN Connection ${name} to allocate... done`

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,7 +146,7 @@
         "typescript": "5.9.3"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@actions/core": {
@@ -2684,7 +2684,7 @@
     },
     "node_modules/@heroku/sdk": {
       "version": "0.5.7",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#a5a24fec41522b844f762ccea32ae01e9fcc2d35",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#ed3e589c45b6abd4618d1e49e78da5b187ae6d4f",
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku/heroku-fetch": "^0.1.4",

--- a/src/commands/spaces/vpn/config.ts
+++ b/src/commands/spaces/vpn/config.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import {color, hux} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -44,15 +44,16 @@ export default class Config extends Command {
   static topic = 'spaces'
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Config)
     const {json, space} = flags
     const {name} = args
 
-    const {body: vpnConnection} = await this.heroku.get<Heroku.PrivateSpacesVpn>(`/spaces/${space}/vpn-connections/${name}`)
+    const vpnConnection = await platform.vpnConnection.info(space, name)
     if (json) {
       hux.styledJSON(vpnConnection)
     } else {
-      displayVPNConfigInfo(space, name, vpnConnection)
+      displayVPNConfigInfo(name, vpnConnection)
     }
   }
 }

--- a/src/commands/spaces/vpn/connect.ts
+++ b/src/commands/spaces/vpn/connect.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -32,18 +33,17 @@ export default class Connect extends Command {
   static topic = 'spaces'
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Connect)
     const {cidrs, ip, space} = flags
     const {name} = args
-    const parsed_cidrs = splitCsv(cidrs)
+    const parsedCidrs = splitCsv(cidrs)
 
     ux.action.start(`Creating VPN Connection in space ${color.space(space)}`)
-    await this.heroku.post(`/spaces/${space}/vpn-connections`, {
-      body: {
-        name,
-        public_ip: ip,
-        routable_cidrs: parsed_cidrs,
-      },
+    await platform.vpnConnection.create(space, {
+      name,
+      public_ip: ip,
+      routable_cidrs: parsedCidrs,
     })
     ux.action.stop()
 

--- a/src/commands/spaces/vpn/connections.ts
+++ b/src/commands/spaces/vpn/connections.ts
@@ -1,12 +1,13 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import {color, hux} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
+import {VpnConnection} from '@heroku/types/3.sdk'
 import {ux} from '@oclif/core/ux'
 import tsheredoc from 'tsheredoc'
 
 import {displayVPNStatus} from '../../../lib/spaces/format.js'
 
-type VpnConnectionTunnels = Required<Heroku.PrivateSpacesVpn>['tunnels']
+type VpnConnectionTunnels = VpnConnection['tunnels']
 
 const heredoc = tsheredoc.default
 
@@ -24,7 +25,7 @@ export default class Connections extends Command {
   }
   static topic = 'spaces'
 
-  protected displayVPNConnections(space: string, connections: Required<Heroku.PrivateSpacesVpn>[]) {
+  protected displayVPNConnections(space: string, connections: VpnConnection[]) {
     if (connections.length === 0) {
       ux.stdout('No VPN Connections have been created yet')
       return
@@ -36,19 +37,19 @@ export default class Connections extends Command {
       connections,
       {
         Name: {
-          get: c => c.name || c.id,
+          get: (c: any) => c.name || c.id,
         },
         Status: {
-          get: c => displayVPNStatus(c.status),
+          get: (c: any) => displayVPNStatus(c.status),
         },
         Tunnels: {
-          get: c => this.tunnelFormat(c.tunnels),
+          get: (c: any) => this.tunnelFormat(c.tunnels),
         },
       },
     )
   }
 
-  protected render(space: string, connections: Required<Heroku.PrivateSpacesVpn>[], json: boolean) {
+  protected render(space: string, connections: VpnConnection[], json: boolean) {
     if (json) {
       hux.styledJSON(connections)
     } else {
@@ -57,9 +58,10 @@ export default class Connections extends Command {
   }
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {flags} = await this.parse(Connections)
     const {json, space} = flags
-    const {body: connections} = await this.heroku.get<Required<Heroku.PrivateSpacesVpn>[]>(`/spaces/${space}/vpn-connections`)
+    const connections = await platform.vpnConnection.list(space)
     this.render(space, connections, json)
   }
 

--- a/src/commands/spaces/vpn/destroy.ts
+++ b/src/commands/spaces/vpn/destroy.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -26,6 +27,7 @@ export default class Destroy extends Command {
   static topic = 'spaces'
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Destroy)
     const {confirm, space} = flags
     const {name} = args
@@ -40,7 +42,7 @@ export default class Destroy extends Command {
     )
 
     ux.action.start(`Tearing down VPN Connection ${color.cyan(name)} in space ${color.space(space)}`)
-    await this.heroku.delete(`/spaces/${space}/vpn-connections/${name}`)
+    await platform.vpnConnection.destroy(space, name)
     ux.action.stop()
   }
 }

--- a/src/commands/spaces/vpn/info.ts
+++ b/src/commands/spaces/vpn/info.ts
@@ -1,6 +1,7 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import {color, hux} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
+import {VpnConnection} from '@heroku/types/3.sdk'
 import {Args} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -42,15 +43,16 @@ export default class Info extends Command {
   static topic = 'spaces'
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Info)
     const {json, space} = flags
     const {name} = args
-    const {body: vpnConnection} = await this.heroku.get<Heroku.PrivateSpacesVpn>(`/spaces/${space}/vpn-connections/${name}`)
+    const vpnConnection = await platform.vpnConnection.info(space, name)
     const connectionName = vpnConnection.name || name
     this.render(connectionName, vpnConnection, json)
   }
 
-  private displayVPNInfo(name: string, vpnConnection: Heroku.PrivateSpacesVpn) {
+  private displayVPNInfo(name: string, vpnConnection: VpnConnection) {
     hux.styledHeader(`${name} VPN Info`)
     /* eslint-disable perfectionist/sort-objects */
     hux.styledObject({
@@ -62,10 +64,10 @@ export default class Info extends Command {
       'Status Message': vpnConnection.status_message,
     }, ['Name', 'ID', 'Public IP', 'Routable CIDRs', 'State', 'Status', 'Status Message'])
     /* eslint-enable perfectionist/sort-objects */
-    const vpnConnectionTunnels = vpnConnection.tunnels || []
-    for (const [i, val] of vpnConnectionTunnels.entries()) {
-      val.tunnel_id = 'Tunnel ' + (i + 1)
-    }
+    const vpnConnectionTunnels = (vpnConnection.tunnels || []).map((tunnel, index) => ({
+      ...tunnel,
+      tunnel_id: `Tunnel ${index + 1}`,
+    }))
 
     hux.styledHeader(`${name} VPN Tunnel Info`)
     /* eslint-disable perfectionist/sort-objects */
@@ -82,7 +84,7 @@ export default class Info extends Command {
     /* eslint-enable perfectionist/sort-objects */
   }
 
-  private render(name: string, vpnConnection: Heroku.PrivateSpacesVpn, json: boolean) {
+  private render(name: string, vpnConnection: VpnConnection, json: boolean) {
     if (json) {
       hux.styledJSON(vpnConnection)
     } else {

--- a/src/commands/spaces/vpn/update.ts
+++ b/src/commands/spaces/vpn/update.ts
@@ -1,5 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -29,16 +30,14 @@ export default class Update extends Command {
   static topic = 'spaces'
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Update)
     const {cidrs, space} = flags
     const {name} = args
     const parsedCidrs = splitCsv(cidrs)
 
     ux.action.start(`Updating VPN Connection in space ${color.space(space)}`)
-    await this.heroku.patch(
-      `/spaces/${space}/vpn-connections/${name}`,
-      {body: {routable_cidrs: parsedCidrs}},
-    )
+    await platform.vpnConnection.update(space, name, {routable_cidrs: parsedCidrs})
     ux.action.stop()
   }
 }

--- a/src/commands/spaces/vpn/wait.ts
+++ b/src/commands/spaces/vpn/wait.ts
@@ -1,7 +1,8 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import {hux} from '@heroku/heroku-cli-util'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
+import {vpnConnectionExtensions} from '@heroku/sdk/extensions/platform'
 import {Args, ux} from '@oclif/core'
 import tsheredoc from 'tsheredoc'
 
@@ -40,39 +41,26 @@ export default class Wait extends Command {
   static topic = 'spaces'
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK({extensions: [vpnConnectionExtensions]})
     const {args, flags} = await this.parse(Wait)
     const {json, space} = flags
     const {name} = args
     const interval = (flags.interval ? Number.parseInt(flags.interval, 10) : 10) * 1000
     const timeout = (flags.timeout ? Number.parseInt(flags.timeout, 10) : 20 * 60) * 1000
-    const deadline = new Date(Date.now() + timeout)
-    let {body: vpnConnection} = await this.heroku.get<Heroku.PrivateSpacesVpn>(`/spaces/${space}/vpn-connections/${name}`)
-    if (vpnConnection.status === 'active') {
-      ux.stdout('VPN has been allocated.')
-      return
-    }
 
-    ux.action.start(`Waiting for VPN Connection ${color.green(name)} to allocate...`)
-    while (vpnConnection.status !== 'active') {
-      if (new Date() > deadline) {
-        ux.error('Timeout waiting for VPN to become allocated.', {exit: 1})
-      }
+    const vpnConnection = await platform.vpnConnection.waitForActive(space, name, {
+      intervalMs: interval,
+      poller: {
+        onStart: () => ux.action.start(`Waiting for VPN Connection ${color.green(name)} to allocate`),
+        onStop: () => ux.action.stop(),
+      },
+      timeoutMs: timeout,
+    })
 
-      if (vpnConnection.status === 'failed') {
-        ux.error(vpnConnection.status_message || '', {exit: 1})
-      }
-
-      await wait(interval)
-      const {body: updatedVpnConnection} = await this.heroku.get<Heroku.PrivateSpacesVpn>(`/spaces/${space}/vpn-connections/${name}`)
-      vpnConnection = updatedVpnConnection
-    }
-
-    ux.action.stop()
-    const {body: newVpnConnection} = await this.heroku.get<Heroku.PrivateSpacesVpn>(`/spaces/${space}/vpn-connections/${name}`)
     if (json) {
-      hux.styledJSON(newVpnConnection)
+      hux.styledJSON(vpnConnection)
     } else {
-      displayVPNConfigInfo(space, name, newVpnConnection)
+      displayVPNConfigInfo(name, vpnConnection)
     }
   }
 }

--- a/src/lib/spaces/vpn-connections.ts
+++ b/src/lib/spaces/vpn-connections.ts
@@ -1,14 +1,14 @@
-import {PrivateSpacesVpn} from '@heroku-cli/schema'
 import {hux} from '@heroku/heroku-cli-util'
+import {VpnConnection} from '@heroku/types/3.sdk'
 
-export function displayVPNConfigInfo(space: string, name: string, config: PrivateSpacesVpn) {
+export function displayVPNConfigInfo(name: string, config: VpnConnection) {
   hux.styledHeader(`${name} VPN Tunnels`)
-  const configTunnels = config.tunnels || []
-  for (const [i, val] of configTunnels.entries()) {
-    val.tunnel_id = 'Tunnel ' + (i + 1)
-    val.routable_cidr = config.space_cidr_block
-    val.ike_version = config.ike_version
-  }
+  const configTunnels = (config.tunnels || []).map((tunnel, index) => ({
+    ...tunnel,
+    ike_version: config.ike_version,
+    routable_cidr: config.space_cidr_block,
+    tunnel_id: `Tunnel ${index + 1}`,
+  }))
 
   /* eslint-disable perfectionist/sort-objects */
   hux.table(configTunnels, {

--- a/test/unit/commands/container/pull.unit.test.ts
+++ b/test/unit/commands/container/pull.unit.test.ts
@@ -1,6 +1,7 @@
 import {runCommand} from '@heroku-cli/test-utils'
 import {HerokuSDK} from '@heroku/sdk'
 import {NotAContainerAppError} from '@heroku/sdk/extensions/platform'
+import {App} from '@heroku/types/3.sdk'
 import {Errors} from '@oclif/core'
 import {expect} from 'chai'
 import * as sinon from 'sinon'
@@ -48,7 +49,7 @@ describe('container pull', function () {
       id: 'test-id',
       name: 'testapp',
       stack: {id: 'test-id', name: 'heroku-24'},
-    }))
+    } as App))
     const {error, stdout} = await runCommand(Cmd, [
       '--app',
       'testapp',

--- a/test/unit/commands/container/push.unit.test.ts
+++ b/test/unit/commands/container/push.unit.test.ts
@@ -2,6 +2,7 @@ import {runCommand} from '@heroku-cli/test-utils'
 import * as color from '@heroku/heroku-cli-util/color'
 import {HerokuSDK} from '@heroku/sdk'
 import {NotAContainerAppError} from '@heroku/sdk/extensions/platform'
+import {App} from '@heroku/types/3.sdk'
 import {Errors} from '@oclif/core'
 import {expect} from 'chai'
 import * as sinon from 'sinon'
@@ -77,7 +78,7 @@ describe('container push', function () {
         id: 'test-id',
         name: 'testapp',
         stack: {id: 'test-id', name: 'heroku-24'},
-      }))
+      } as App))
     })
 
     it('exits', async function () {

--- a/test/unit/commands/container/release.unit.test.ts
+++ b/test/unit/commands/container/release.unit.test.ts
@@ -2,6 +2,7 @@ import {runCommand} from '@heroku-cli/test-utils'
 import * as color from '@heroku/heroku-cli-util/color'
 import {HerokuSDK} from '@heroku/sdk'
 import {NotAContainerAppError} from '@heroku/sdk/extensions/platform'
+import {App} from '@heroku/types/3.sdk'
 import {Errors} from '@oclif/core'
 import {expect} from 'chai'
 import nock from 'nock'
@@ -60,12 +61,11 @@ describe('container release', function () {
 
   it('exits when the app stack is not "container"', async function () {
     fakePlatform.container.ensureContainerStack.rejects(new NotAContainerAppError({
-
       build_stack: {id: 'heroku-24', name: 'heroku-24'},
       id: 'app-id',
       name: 'testapp',
       stack: {id: 'heroku-24', name: 'heroku-24'},
-    }))
+    } as App))
 
     const {error} = await runCommand(Cmd, [
       '--app',

--- a/test/unit/commands/container/rm.unit.test.ts
+++ b/test/unit/commands/container/rm.unit.test.ts
@@ -1,6 +1,7 @@
 import {expectOutput, runCommand} from '@heroku-cli/test-utils'
 import {HerokuSDK} from '@heroku/sdk'
 import {NotAContainerAppError, type RemoveProcessTypesOpts} from '@heroku/sdk/extensions/platform'
+import {App} from '@heroku/types/3.sdk'
 import {Errors} from '@oclif/core'
 import {expect} from 'chai'
 import {restore, SinonStub, stub} from 'sinon'
@@ -52,7 +53,7 @@ describe('container removal', function () {
       id: 'app-id',
       name: 'testapp',
       stack: {id: 'heroku-24', name: 'heroku-24'},
-    }))
+    } as App))
 
     const {error, stdout} = await runCommand(Cmd, [
       '--app',

--- a/test/unit/commands/container/run.unit.test.ts
+++ b/test/unit/commands/container/run.unit.test.ts
@@ -1,6 +1,7 @@
 import {expectOutput, runCommand} from '@heroku-cli/test-utils'
 import {HerokuSDK} from '@heroku/sdk'
 import {NotAContainerAppError} from '@heroku/sdk/extensions/platform'
+import {App} from '@heroku/types/3.sdk'
 import {Errors} from '@oclif/core'
 import {expect} from 'chai'
 import {createSandbox, SinonSandbox, SinonStub} from 'sinon'
@@ -84,7 +85,7 @@ describe('container run', function () {
       id: 'test-id',
       name: 'testapp',
       stack: {id: 'test-id', name: 'heroku-24'},
-    }))
+    } as App))
     const {error, stdout} = await runCommand(Cmd, [
       '--app',
       'testapp',

--- a/test/unit/commands/spaces/vpn/config.unit.test.ts
+++ b/test/unit/commands/spaces/vpn/config.unit.test.ts
@@ -1,15 +1,33 @@
-import * as Heroku from '@heroku-cli/schema'
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
+import {VpnConnection} from '@heroku/types/3.sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Cmd from '../../../../../src/commands/spaces/vpn/config.js'
 import removeAllWhitespace from '../../../../helpers/utils/remove-whitespaces.js'
 
+type FakePlatform = {
+  vpnConnection: {
+    info: sinon.SinonStub,
+  }
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    vpnConnection: {
+      info: sinon.stub(),
+    },
+  }
+}
+
 describe('spaces:vpn:config', function () {
-  let vpnConnection: Heroku.PrivateSpacesVpn
+  let fakePlatform: FakePlatform
+  let vpnConnection: VpnConnection
 
   beforeEach(function () {
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
     vpnConnection = {
       id: '123456789012',
       ike_version: 1,
@@ -40,10 +58,12 @@ describe('spaces:vpn:config', function () {
     }
   })
 
+  afterEach(function () {
+    sinon.restore()
+  })
+
   it('gets VPN config', async function () {
-    nock('https://api.heroku.com')
-      .get('/spaces/my-space/vpn-connections/vpn-connection-name-config')
-      .reply(200, vpnConnection)
+    fakePlatform.vpnConnection.info.resolves(vpnConnection)
 
     const {stdout} = await runCommand(Cmd, [
       '--space',
@@ -56,12 +76,11 @@ describe('spaces:vpn:config', function () {
     expect(actual).to.include(removeAllWhitespace('VPN Tunnel Customer Gateway VPN Gateway   Pre-shared Key Routable Subnets IKE Version'))
     expect(actual).to.include(removeAllWhitespace('Tunnel 1   52.44.146.197    52.44.146.196 apresharedkey1 10.0.0.0/16      1'))
     expect(actual).to.include(removeAllWhitespace('Tunnel 2   52.44.146.199    52.44.146.198 apresharedkey2 10.0.0.0/16      1'))
+    expect(fakePlatform.vpnConnection.info.calledOnceWithExactly('my-space', 'vpn-connection-name-config')).to.equal(true)
   })
 
   it('gets VPN config in JSON', async function () {
-    nock('https://api.heroku.com')
-      .get('/spaces/my-space/vpn-connections/vpn-connection-name-config')
-      .reply(200, vpnConnection)
+    fakePlatform.vpnConnection.info.resolves(vpnConnection)
 
     const {stdout} = await runCommand(Cmd, [
       '--space',

--- a/test/unit/commands/spaces/vpn/connect.unit.test.ts
+++ b/test/unit/commands/spaces/vpn/connect.unit.test.ts
@@ -1,34 +1,41 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import ansis from 'ansis'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 import tsheredoc from 'tsheredoc'
 
 import Cmd from '../../../../../src/commands/spaces/vpn/connect.js'
 
 const heredoc = tsheredoc.default
 
+type FakePlatform = {
+  vpnConnection: {
+    create: sinon.SinonStub,
+  }
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    vpnConnection: {
+      create: sinon.stub().resolves(),
+    },
+  }
+}
+
 describe('spaces:vpn:connect', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('creates a VPN', async function () {
-    api
-      .post('/spaces/my-space/vpn-connections', {
-        name: 'office',
-        public_ip: '192.168.0.1',
-        routable_cidrs: ['192.168.0.1/16', '192.168.0.2/16'],
-      })
-      .reply(201)
-
     const {stderr} = await runCommand(Cmd, [
       'office',
       '--space',
@@ -38,12 +45,14 @@ describe('spaces:vpn:connect', function () {
       '--cidrs',
       '192.168.0.1/16,192.168.0.2/16',
     ])
-    api.done()
     expect(stderr).to.contain('Creating VPN Connection in space ⬡ my-space... done\n')
     expect(ansis.strip(stderr)).to.contain(heredoc`
       Use heroku spaces:vpn:wait to track allocation.
     `)
-
-    nock.cleanAll()
+    expect(fakePlatform.vpnConnection.create.calledOnceWithExactly('my-space', {
+      name: 'office',
+      public_ip: '192.168.0.1',
+      routable_cidrs: ['192.168.0.1/16', '192.168.0.2/16'],
+    })).to.equal(true)
   })
 })

--- a/test/unit/commands/spaces/vpn/connections.unit.test.ts
+++ b/test/unit/commands/spaces/vpn/connections.unit.test.ts
@@ -1,16 +1,39 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
+import {VpnConnection} from '@heroku/types/3.sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Cmd from '../../../../../src/commands/spaces/vpn/connections.js'
 import removeAllWhitespace from '../../../../helpers/utils/remove-whitespaces.js'
 
+type FakePlatform = {
+  vpnConnection: {
+    list: sinon.SinonStub,
+  }
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    vpnConnection: {
+      list: sinon.stub(),
+    },
+  }
+}
+
 describe('spaces:vpn:connections', function () {
-  afterEach(function () {
-    nock.cleanAll()
+  let fakePlatform: FakePlatform
+
+  beforeEach(function () {
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
-  const space = {
+  afterEach(function () {
+    sinon.restore()
+  })
+
+  const space: VpnConnection = {
     id: '123456789012',
     ike_version: 1,
     name: 'office',
@@ -42,30 +65,24 @@ describe('spaces:vpn:connections', function () {
   }
 
   it('displays no connection message if none exist', async function () {
-    const api = nock('https://api.heroku.com')
-      .get('/spaces/my-space/vpn-connections')
-      .reply(200, [])
+    fakePlatform.vpnConnection.list.resolves([])
 
     const {stdout} = await runCommand(Cmd, [
       '--space',
       'my-space',
     ])
 
-    api.done()
     expect(stdout).to.eq('No VPN Connections have been created yet\n')
+    expect(fakePlatform.vpnConnection.list.calledOnceWithExactly('my-space')).to.equal(true)
   })
 
   it('displays VPN Connections', async function () {
-    const api = nock('https://api.heroku.com')
-      .get('/spaces/my-space/vpn-connections')
-      .reply(200, [space])
+    fakePlatform.vpnConnection.list.resolves([space])
 
     const {stdout} = await runCommand(Cmd, [
       '--space',
       'my-space',
     ])
-
-    api.done()
 
     const actual = removeAllWhitespace(stdout)
     expect(actual).to.include(removeAllWhitespace('=== my-space VPN Connections'))
@@ -75,16 +92,12 @@ describe('spaces:vpn:connections', function () {
 
   it('displays VPN Connection ID when name is unavailable', async function () {
     const conn = {...space, name: ''}
-    const api = nock('https://api.heroku.com')
-      .get('/spaces/my-space/vpn-connections')
-      .reply(200, [conn])
+    fakePlatform.vpnConnection.list.resolves([conn])
 
     const {stdout} = await runCommand(Cmd, [
       '--space',
       'my-space',
     ])
-
-    api.done()
 
     const actual = removeAllWhitespace(stdout)
     expect(actual).to.include(removeAllWhitespace('=== my-space VPN Connections'))
@@ -93,9 +106,7 @@ describe('spaces:vpn:connections', function () {
   })
 
   it('displays VPN Connections in JSON', async function () {
-    const api = nock('https://api.heroku.com')
-      .get('/spaces/my-space/vpn-connections')
-      .reply(200, [space])
+    fakePlatform.vpnConnection.list.resolves([space])
 
     const {stdout} = await runCommand(Cmd, [
       '--space',
@@ -103,7 +114,6 @@ describe('spaces:vpn:connections', function () {
       '--json',
     ])
 
-    api.done()
     expect(JSON.parse(stdout)).to.eql([space])
   })
 })

--- a/test/unit/commands/spaces/vpn/destroy.unit.test.ts
+++ b/test/unit/commands/spaces/vpn/destroy.unit.test.ts
@@ -1,15 +1,37 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Cmd from '../../../../../src/commands/spaces/vpn/destroy.js'
 
-describe('spaces:vpn:destroy', function () {
-  it('destroys a VPN Connection when name is specified', async function () {
-    const api = nock('https://api.heroku.com')
-      .delete('/spaces/my-space/vpn-connections/my-vpn-connection')
-      .reply(202)
+type FakePlatform = {
+  vpnConnection: {
+    destroy: sinon.SinonStub,
+  }
+}
 
+function buildFakePlatform(): FakePlatform {
+  return {
+    vpnConnection: {
+      destroy: sinon.stub().resolves(),
+    },
+  }
+}
+
+describe('spaces:vpn:destroy', function () {
+  let fakePlatform: FakePlatform
+
+  beforeEach(function () {
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
+  })
+
+  afterEach(function () {
+    sinon.restore()
+  })
+
+  it('destroys a VPN Connection when name is specified', async function () {
     const {stderr} = await runCommand(Cmd, [
       'my-vpn-connection',
       '--space',
@@ -17,9 +39,7 @@ describe('spaces:vpn:destroy', function () {
       '--confirm',
       'my-vpn-connection',
     ])
-    api.done()
     expect(stderr).to.eq('Tearing down VPN Connection my-vpn-connection in space ⬡ my-space... done\n')
-
-    nock.cleanAll()
+    expect(fakePlatform.vpnConnection.destroy.calledOnceWithExactly('my-space', 'my-vpn-connection')).to.equal(true)
   })
 })

--- a/test/unit/commands/spaces/vpn/info.unit.test.ts
+++ b/test/unit/commands/spaces/vpn/info.unit.test.ts
@@ -1,15 +1,33 @@
-import * as Heroku from '@heroku-cli/schema'
-import {expectOutput, runCommand} from '@heroku-cli/test-utils'
+import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
+import {VpnConnection} from '@heroku/types/3.sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Cmd from '../../../../../src/commands/spaces/vpn/info.js'
 import removeAllWhitespace from '../../../../helpers/utils/remove-whitespaces.js'
 
+type FakePlatform = {
+  vpnConnection: {
+    info: sinon.SinonStub,
+  }
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    vpnConnection: {
+      info: sinon.stub(),
+    },
+  }
+}
+
 describe('spaces:vpn:info', function () {
-  let vpnConnection: Heroku.PrivateSpacesVpn
+  let fakePlatform: FakePlatform
+  let vpnConnection: VpnConnection
 
   beforeEach(function () {
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
     vpnConnection = {
       id: '123456789012',
       ike_version: 1,
@@ -40,10 +58,12 @@ describe('spaces:vpn:info', function () {
     }
   })
 
+  afterEach(function () {
+    sinon.restore()
+  })
+
   it('gets VPN info', async function () {
-    nock('https://api.heroku.com')
-      .get(`/spaces/my-space/vpn-connections/${vpnConnection.name}`)
-      .reply(200, vpnConnection)
+    fakePlatform.vpnConnection.info.resolves(vpnConnection)
 
     const {stdout} = await runCommand(Cmd, [
       '--space',
@@ -63,31 +83,28 @@ describe('spaces:vpn:info', function () {
     expect(actual).to.include(removeAllWhitespace('VPN Tunnel IP Address    Status Status Last Changed  Details'))
     expect(actual).to.include(removeAllWhitespace('Tunnel 1   52.44.146.197 UP     2016-10-25T22:09:05Z status message'))
     expect(actual).to.include(removeAllWhitespace('Tunnel 2   52.44.146.197 UP     2016-10-25T22:09:05Z status message'))
+    expect(fakePlatform.vpnConnection.info.calledOnceWithExactly('my-space', vpnConnection.name)).to.equal(true)
   })
 
   it('gets VPN info in JSON', async function () {
-    nock('https://api.heroku.com')
-      .get('/spaces/my-space/vpn-connections/vpn-connection-name')
-      .reply(200, vpnConnection)
+    fakePlatform.vpnConnection.info.resolves(vpnConnection)
 
     const {stdout} = await runCommand(Cmd, [
       '--space',
       'my-space',
-      vpnConnection.name as string,
+      vpnConnection.name,
       '--json',
     ])
-    expectOutput(stdout, JSON.stringify(vpnConnection, null, 2))
+    expect(JSON.parse(stdout)).to.eql(vpnConnection)
   })
 
   it('gets VPN info with id', async function () {
-    nock('https://api.heroku.com')
-      .get(`/spaces/my-space/vpn-connections/${vpnConnection.id}`)
-      .reply(200, vpnConnection)
+    fakePlatform.vpnConnection.info.resolves(vpnConnection)
 
     const {stdout} = await runCommand(Cmd, [
       '--space',
       'my-space',
-      vpnConnection.id as string,
+      vpnConnection.id,
     ])
 
     const actual = removeAllWhitespace(stdout)

--- a/test/unit/commands/spaces/vpn/update.unit.test.ts
+++ b/test/unit/commands/spaces/vpn/update.unit.test.ts
@@ -1,17 +1,37 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Cmd from '../../../../../src/commands/spaces/vpn/update.js'
 
-describe('spaces:vpn:update', function () {
-  it('updates VPN', async function () {
-    const api = nock('https://api.heroku.com')
-      .patch('/spaces/my-space/vpn-connections/office', {
-        routable_cidrs: ['192.168.0.1/16', '192.168.0.2/16'],
-      })
-      .reply(201)
+type FakePlatform = {
+  vpnConnection: {
+    update: sinon.SinonStub,
+  }
+}
 
+function buildFakePlatform(): FakePlatform {
+  return {
+    vpnConnection: {
+      update: sinon.stub().resolves(),
+    },
+  }
+}
+
+describe('spaces:vpn:update', function () {
+  let fakePlatform: FakePlatform
+
+  beforeEach(function () {
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
+  })
+
+  afterEach(function () {
+    sinon.restore()
+  })
+
+  it('updates VPN', async function () {
     const {stderr} = await runCommand(Cmd, [
       'office',
       '--space',
@@ -19,9 +39,9 @@ describe('spaces:vpn:update', function () {
       '--cidrs',
       '192.168.0.1/16,192.168.0.2/16',
     ])
-    api.done()
     expect(stderr).to.eq('Updating VPN Connection in space ⬡ my-space... done\n')
-
-    nock.cleanAll()
+    expect(fakePlatform.vpnConnection.update.calledOnceWithExactly('my-space', 'office', {
+      routable_cidrs: ['192.168.0.1/16', '192.168.0.2/16'],
+    })).to.equal(true)
   })
 })

--- a/test/unit/commands/spaces/vpn/wait.unit.test.ts
+++ b/test/unit/commands/spaces/vpn/wait.unit.test.ts
@@ -1,82 +1,78 @@
-import {expectOutput, runCommand} from '@heroku-cli/test-utils'
-import {Errors} from '@oclif/core'
+import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
+import {VpnConnectionFailedError, WaitForActiveOptions} from '@heroku/sdk/extensions/platform'
+import {VpnConnection} from '@heroku/types/3.sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Cmd from '../../../../../src/commands/spaces/vpn/wait.js'
 import removeAllWhitespace from '../../../../helpers/utils/remove-whitespaces.js'
 
-type CLIError = Errors.CLIError
+type FakePlatform = {
+  vpnConnection: {
+    waitForActive: sinon.SinonStub,
+  }
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    vpnConnection: {
+      waitForActive: sinon.stub(),
+    },
+  }
+}
+
+function buildVpnConnection(overrides: Partial<VpnConnection> = {}): VpnConnection {
+  return {
+    id: '123456789012',
+    ike_version: 1,
+    name: 'vpn-connection-name-wait',
+    public_ip: '35.161.69.30',
+    routable_cidrs: ['172.16.0.0/16'],
+    space_cidr_block: '10.0.0.0/16',
+    status: 'active',
+    status_message: '',
+    tunnels: [
+      {
+        customer_ip: '52.44.146.197',
+        ip: '52.44.146.196',
+        last_status_change: '2016-10-25T22:09:05Z',
+        pre_shared_key: 'apresharedkey1',
+        status: 'UP',
+        status_message: 'status message',
+      },
+      {
+        customer_ip: '52.44.146.199',
+        ip: '52.44.146.198',
+        last_status_change: '2016-10-25T22:09:05Z',
+        pre_shared_key: 'apresharedkey2',
+        status: 'UP',
+        status_message: 'status message',
+      },
+    ],
+    ...overrides,
+  }
+}
 
 describe('spaces:vpn:wait', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
+
+  beforeEach(function () {
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
+  })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('returns an error if the VPN status is updated to failed', async function () {
-    let errorMessage = ''
-    api = nock('https://api.heroku.com:443')
-      .get('/spaces/my-space/vpn-connections/vpn-connection-name-wait')
-      .reply(200, {
-        id: '123456789012',
-        ike_version: 1,
-        name: 'vpn-connection-name-wait',
-        public_ip: '35.161.69.30',
-        routable_cidrs: ['172.16.0.0/16'],
-        space_cidr_block: '10.0.0.0/16',
-        status: 'pending',
-        status_message: 'supplied CIDR block already in use',
-        tunnels: [
-          {
-            customer_ip: '52.44.146.197',
-            ip: '52.44.146.196', // The one needed right now
-            last_status_change: '2016-10-25T22:09:05Z',
-            pre_shared_key: 'apresharedkey1',
-            status: 'UP',
-            status_message: 'status message',
-          },
-          {
-            customer_ip: '52.44.146.199',
-            ip: '52.44.146.198',
-            last_status_change: '2016-10-25T22:09:05Z',
-            pre_shared_key: 'apresharedkey2',
-            status: 'UP',
-            status_message: 'status message',
-          },
-        ],
-      })
-      .get('/spaces/my-space/vpn-connections/vpn-connection-name-wait')
-      .reply(200, {
-        id: '123456789012',
-        ike_version: 1,
-        name: 'vpn-connection-name-wait',
-        public_ip: '35.161.69.30',
-        routable_cidrs: ['172.16.0.0/16'],
-        space_cidr_block: '10.0.0.0/16',
-        status: 'failed',
-        status_message: 'supplied CIDR block already in use',
-        tunnels: [
-          {
-            customer_ip: '52.44.146.197',
-            ip: '52.44.146.196', // The one needed right now
-            last_status_change: '2016-10-25T22:09:05Z',
-            pre_shared_key: 'apresharedkey1',
-            status: 'UP',
-            status_message: 'status message',
-          },
-          {
-            customer_ip: '52.44.146.199',
-            ip: '52.44.146.198',
-            last_status_change: '2016-10-25T22:09:05Z',
-            pre_shared_key: 'apresharedkey2',
-            status: 'UP',
-            status_message: 'status message',
-          },
-        ],
-      })
+    const vpnConnection = buildVpnConnection({
+      status: 'failed',
+      status_message: 'supplied CIDR block already in use',
+    })
+
+    fakePlatform.vpnConnection.waitForActive.rejects(new VpnConnectionFailedError(vpnConnection))
 
     const {error} = await runCommand(Cmd, [
       'vpn-connection-name-wait',
@@ -85,100 +81,22 @@ describe('spaces:vpn:wait', function () {
       '--interval',
       '0',
     ])
-    errorMessage = (error as CLIError)?.message || ''
 
-    expect(errorMessage).to.equal('supplied CIDR block already in use')
+    expect(error?.message).to.equal('supplied CIDR block already in use')
   })
 
   it('waits for VPN to allocate and then shows space config', async function () {
-    api = nock('https://api.heroku.com:443')
-      .get('/spaces/my-space/vpn-connections/vpn-connection-name-wait')
-      .reply(200, {
-        id: '123456789012',
-        ike_version: 1,
-        name: 'vpn-connection-name-wait',
-        public_ip: '35.161.69.30',
-        routable_cidrs: ['172.16.0.0/16'],
-        space_cidr_block: '10.0.0.0/16',
-        status: 'pending',
-        status_message: 'supplied CIDR block already in use',
-        tunnels: [
-          {
-            customer_ip: '52.44.146.197',
-            ip: '52.44.146.196', // The one needed right now
-            last_status_change: '2016-10-25T22:09:05Z',
-            pre_shared_key: 'apresharedkey1',
-            status: 'UP',
-            status_message: 'status message',
-          },
-          {
-            customer_ip: '52.44.146.199',
-            ip: '52.44.146.198',
-            last_status_change: '2016-10-25T22:09:05Z',
-            pre_shared_key: 'apresharedkey2',
-            status: 'UP',
-            status_message: 'status message',
-          },
-        ],
-      })
-      .get('/spaces/my-space/vpn-connections/vpn-connection-name-wait')
-      .reply(200, {
-        id: '123456789012',
-        ike_version: 1,
-        name: 'vpn-connection-name-wait',
-        public_ip: '35.161.69.30',
-        routable_cidrs: ['172.16.0.0/16'],
-        space_cidr_block: '10.0.0.0/16',
-        status: 'active',
-        status_message: '',
-        tunnels: [
-          {
-            customer_ip: '52.44.146.197',
-            ip: '52.44.146.196', // The one needed right now
-            last_status_change: '2016-10-25T22:09:05Z',
-            pre_shared_key: 'apresharedkey1',
-            status: 'UP',
-            status_message: 'status message',
-          },
-          {
-            customer_ip: '52.44.146.199',
-            ip: '52.44.146.198',
-            last_status_change: '2016-10-25T22:09:05Z',
-            pre_shared_key: 'apresharedkey2',
-            status: 'UP',
-            status_message: 'status message',
-          },
-        ],
-      })
-      .get('/spaces/my-space/vpn-connections/vpn-connection-name-wait')
-      .reply(200, {
-        id: '123456789012',
-        ike_version: 1,
-        name: 'vpn-connection-name-wait',
-        public_ip: '35.161.69.30',
-        routable_cidrs: ['172.16.0.0/16'],
-        space_cidr_block: '10.0.0.0/16',
-        status: 'active',
-        status_message: '',
-        tunnels: [
-          {
-            customer_ip: '52.44.146.197',
-            ip: '52.44.146.196', // The one needed right now
-            last_status_change: '2016-10-25T22:09:05Z',
-            pre_shared_key: 'apresharedkey1',
-            status: 'UP',
-            status_message: 'status message',
-          },
-          {
-            customer_ip: '52.44.146.199',
-            ip: '52.44.146.198',
-            last_status_change: '2016-10-25T22:09:05Z',
-            pre_shared_key: 'apresharedkey2',
-            status: 'UP',
-            status_message: 'status message',
-          },
-        ],
-      })
+    const vpnConnection = buildVpnConnection({
+      status: 'active',
+      status_message: '',
+    })
+
+    fakePlatform.vpnConnection.waitForActive.callsFake(async (_space: string, _connection: string, opts?: WaitForActiveOptions) => {
+      opts?.poller?.onStart?.(vpnConnection)
+      opts?.poller?.onStop?.(vpnConnection)
+      return vpnConnection
+    })
+
     const {stderr, stdout} = await runCommand(Cmd, [
       'vpn-connection-name-wait',
       '--space',
@@ -186,37 +104,12 @@ describe('spaces:vpn:wait', function () {
       '--interval',
       '0',
     ])
-    expect(stderr).to.equal('Waiting for VPN Connection vpn-connection-name-wait to allocate...... done\n')
+    expect(stderr).to.equal('Waiting for VPN Connection vpn-connection-name-wait to allocate... done\n')
 
     const actual = removeAllWhitespace(stdout)
     expect(actual).to.include(removeAllWhitespace('=== vpn-connection-name-wait VPN Tunnels'))
     expect(actual).to.include(removeAllWhitespace('VPN Tunnel Customer Gateway VPN Gateway   Pre-shared Key Routable Subnets IKE Version'))
     expect(actual).to.include(removeAllWhitespace('Tunnel 1   52.44.146.197    52.44.146.196 apresharedkey1 10.0.0.0/16      1'))
     expect(actual).to.include(removeAllWhitespace('Tunnel 2   52.44.146.199    52.44.146.198 apresharedkey2 10.0.0.0/16      1'))
-  })
-
-  it('tells the user if the VPN has been allocated', async function () {
-    api = nock('https://api.heroku.com:443')
-      .get('/spaces/my-space/vpn-connections/vpn-connection-allocated')
-      .reply(200, {
-        id: '123456789012',
-        ike_version: 1,
-        name: 'vpn-connection-name-config',
-        public_ip: '35.161.69.30',
-        routable_cidrs: ['172.16.0.0/16'],
-        space_cidr_block: '10.0.0.0/16',
-        status: 'active',
-        status_message: '',
-      })
-
-    const {stderr, stdout} = await runCommand(Cmd, [
-      'vpn-connection-allocated',
-      '--space',
-      'my-space',
-      '--interval',
-      '0',
-    ])
-    expectOutput(stderr, '')
-    expectOutput(stdout, 'VPN has been allocated.\n')
   })
 })

--- a/test/unit/lib/spaces/vpn-connections.unit.test.ts
+++ b/test/unit/lib/spaces/vpn-connections.unit.test.ts
@@ -1,11 +1,11 @@
-import {PrivateSpacesVpn} from '@heroku-cli/schema'
 import {captureOutput} from '@heroku-cli/test-utils'
+import {VpnConnection} from '@heroku/types/3.sdk'
 import {expect} from 'chai'
 
 import {displayVPNConfigInfo} from '../../../../src/lib/spaces/vpn-connections.js'
 import removeAllWhitespace from '../../../helpers/utils/remove-whitespaces.js'
 
-const vpnConnection: PrivateSpacesVpn = {
+const vpnConnection: VpnConnection = {
   id: '123456789012',
   ike_version: 1,
   name: 'vpn-connection-name-config',
@@ -37,7 +37,7 @@ const vpnConnection: PrivateSpacesVpn = {
 describe('displayVPNConfigInfo', function () {
   it('displays VPN config info', async function () {
     const {stdout} = await captureOutput(async () => {
-      displayVPNConfigInfo('my-space', 'vpn-connection-name-config', vpnConnection)
+      displayVPNConfigInfo('vpn-connection-name-config', vpnConnection)
     })
 
     const actual = removeAllWhitespace(stdout)


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
This PR migrates the following `spaces` commands to use `@heroku/sdk`:

- `spaces:vpn:config`
- `spaces:vpn:connect`
- `spaces:vpn:connections`
- `spaces:vpn:destroy`
- `spaces:vpn:info`
- `spaces:vpn:update`
- `spaces:vpn:wait`

**Details:**
- Replaced direct API calls with the SDK
- Dropped the unused `space` parameter in `src/lib/spaces/vpn-connections.ts`'s `displayVPNConfigInfo`
- Rewrote tests to stub the SDK directly instead of using nock
- Fixed failing `container` unit tests

**Note:** Because `waitForActive` fires its `poller.onStart`/`onStop` callbacks unconditionally (before checking whether the connection is already active), `spaces:vpn:wait` now always prints `Waiting for VPN Connection ${name} to allocate... done` and renders the full tunnel table/JSON — even when the connection was already active on the very first check. Previously this case printed a bare `VPN has been allocated.` line and silently ignored `--json`. This behavior change is called out in `V12-CHANGES.md`.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
<!-- Add any context/setup necessary for testing. -->
The SDK uses `heroku-fetch` to make API calls, which looks for a netrc file. Therefore, we must log in with `HEROKU_NETRC_WRITE=true`. Requires a Cedar Private Space you can create/destroy a VPN connection against.

**Setup**:
- Pull down this branch
- `npm i && npm run build`
- `heroku logout`
- `HEROKU_NETRC_WRITE=true ./bin/run login`

**Steps**:
- `./bin/run spaces:vpn:connect v12-test-vpn --space SPACE --ip 8.8.8.8 --cidrs 172.16.0.0/16`
   - Expect: `Creating VPN Connection in space ⬡ SPACE... done`
- `./bin/run spaces:vpn:wait v12-test-vpn --space SPACE` (this command may take a while)
   - Expect: `Waiting for VPN Connection v12-test-vpn to allocate... done`
   - Expect: `v12-test-vpn VPN Tunnels` table
- `./bin/run spaces:vpn:connections --space SPACE`
   - Expect: list of connections, including the new connection
- `./bin/run spaces:vpn:info v12-test-vpn --space SPACE`
   - Expect: `v12-test-vpn VPN Info` object
   - Expect:`v12-test-vpn VPN Tunnel Info` table
- `./bin/run spaces:vpn:config v12-test-vpn --space SPACE`
   - Expect: `v12-test-vpn VPN Tunnels` table
- `./bin/run spaces:vpn:update v12-test-vpn --space SPACE --cidrs 172.16.0.0/16,192.168.0.0/16`
   - Expect: `Updating VPN Connection in space ⬡ SPACE... done`
- `./bin/run spaces:vpn:info v12-test-vpn --space SPACE`
   - Expect: `v12-test-vpn VPN Info` object shows updated `Routable CIDRs`
- `./bin/run spaces:vpn:destroy v12-test-vpn --space SPACE`
   - Expect: `Tearing down VPN Connection v12-test-vpn in space ⬡ SPACE... done`
- `./bin/run spaces:vpn:connections --space SPACE`
   - Expect: `No VPN Connections have been created yet` or `test-data-connectors VPN Connections` table with status `deprovisioning`

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-23385036](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eLBv1YAG/view)