### PR TITLE
fix: parse Procfile process types containing dashes in heroku local

### DIFF
--- a/src/lib/local/load-foreman-procfile.ts
+++ b/src/lib/local/load-foreman-procfile.ts
@@ -6,7 +6,7 @@ function parseProcfile(content: string): Record<string, string> {
       return false
     }
 
-    if (/\w/.test(line) && !/^\s*\w+:/.test(line)) {
+    if (/\w/.test(line) && !/^\s*[\w-]+:/.test(line)) {
       throw new Error('line ' + (i + 1) + ' parse error: ' + line)
     }
 

--- a/test/unit/lib/local/load-foreman-procfile.unit.test.ts
+++ b/test/unit/lib/local/load-foreman-procfile.unit.test.ts
@@ -57,6 +57,23 @@ describe('load-foreman-procfile', function () {
     expect(() => loadProc(procfilePath)).to.throw('line 2 parse error: not a valid procfile line')
   })
 
+  it('supports dashes and underscores in process type names', function () {
+    const procfilePath = path.join(tempDir, 'Procfile')
+    fs.writeFileSync(procfilePath, [
+      'web: npm run start',
+      'worker-primary: npm run worker:primary',
+      'worker_secondary: npm run worker:secondary',
+      '',
+    ].join('\n'))
+
+    const procHash = loadProc(procfilePath)
+    expect(procHash).to.deep.equal({
+      'web': 'npm run start',
+      'worker-primary': 'npm run worker:primary',
+      'worker_secondary': 'npm run worker:secondary',
+    })
+  })
+
   it('supports additional colons in process commands', function () {
     const procfilePath = path.join(tempDir, 'Procfile')
     fs.writeFileSync(procfilePath, [

--- a/test/unit/lib/local/load-foreman-procfile.unit.test.ts
+++ b/test/unit/lib/local/load-foreman-procfile.unit.test.ts
@@ -68,9 +68,9 @@ describe('load-foreman-procfile', function () {
 
     const procHash = loadProc(procfilePath)
     expect(procHash).to.deep.equal({
-      'web': 'npm run start',
+      web: 'npm run start',
       'worker-primary': 'npm run worker:primary',
-      'worker_secondary': 'npm run worker:secondary',
+      worker_secondary: 'npm run worker:secondary',
     })
   })
 


### PR DESCRIPTION
## Summary
`heroku local` fails to parse a Procfile when a process type name contains a dash (e.g. `worker-primary`), throwing `line N parse error: ...`. This worked in v10.17.0 and regressed in v11.1.1 when the Procfile parser was rewritten.

The line-validation regex in `parseProcfile` used `\w` (`[A-Za-z0-9_]`) for the process-type name, which excludes dashes. For a line like `worker-primary: ...`, `\w+` matched only `worker`, then expected `:` but hit `-`, so the line was treated as malformed and rejected.

The fix broadens the character class to `[\w-]`, i.e. `[A-Za-z0-9_-]`. This restores the exact character set the previous parser allowed (`src/lib/local/foreman/procfile.cjs` used `[A-Za-z0-9_-]+`) and matches Heroku's documented Procfile process-type format. Underscores were already accepted via `\w`; dashes are the missing piece. Genuinely malformed lines (no colon, invalid characters) are still rejected.

Fixes #3653.

## Type of Change
### Patch Updates (patch semver update)
- [x] **fix**: Bug fix

## Testing
**Notes**:
No setup required. The change is in the Procfile parser used by `heroku local`.

**Steps**:
1. Create a `Procfile` containing a process type with a dash, e.g.:
   ```
   web: npm run start
   worker-primary: npm run worker
   ```
2. Run `heroku local` (or `heroku local:run`).
3. Before this change: it errors with `line 2 parse error: worker-primary: ...`.
4. After this change: the Procfile parses and the processes start as expected.
5. Unit tests: `npx mocha "test/unit/lib/local/load-foreman-procfile.unit.test.ts"` — includes a new regression test covering dashes and underscores; all pass.

## Related Issues
GitHub issue: #3653