### PR TITLE
refactor(spaces): adopt @heroku/types 4.6.0 and remove redundant space casts

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -137,6 +137,7 @@ HRKU
 howmany
 hstore
 htcat
+hyperschema
 Icann
 infile
 iname

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@heroku/mcp-server": "^1.2.5",
         "@heroku/sdk": "github:heroku/heroku-sdk#main",
         "@heroku/socksv5": "^0.0.9",
-        "@heroku/types": "^4.1.0",
+        "@heroku/types": "^4.6.0",
         "@inquirer/prompts": "^7.0",
         "@oclif/core": "^4.8.4",
         "@oclif/plugin-commands": "^4.1.40",
@@ -2708,9 +2708,9 @@
       }
     },
     "node_modules/@heroku/types": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@heroku/types/-/types-4.2.0.tgz",
-      "integrity": "sha512-rHcx/walVVQBYYUt+EVMMjMUEydITxWX0UkyqpmP8tbOW76d5ExqH6HNWENF9qHFs5nr0ZfR+ODBXlG3U6yWLw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@heroku/types/-/types-4.6.0.tgz",
+      "integrity": "sha512-ylGXhUe4irMJ49+/qXwN0jggd6asfAZq4uMx0Jv9URsVXEGilaLpJ57oKLdTSUWixtjd5SLG6HVthxUdl6CdVQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@heroku/mcp-server": "^1.2.5",
     "@heroku/sdk": "github:heroku/heroku-sdk#main",
     "@heroku/socksv5": "^0.0.9",
-    "@heroku/types": "^4.1.0",
+    "@heroku/types": "^4.6.0",
     "@inquirer/prompts": "^7.0",
     "@oclif/core": "^4.8.4",
     "@oclif/plugin-commands": "^4.1.40",

--- a/src/commands/spaces/create.ts
+++ b/src/commands/spaces/create.ts
@@ -1,5 +1,3 @@
-import type {SpaceCreateOpts} from '@heroku/types/3.sdk'
-
 import {Command, flags} from '@heroku-cli/command'
 import {RegionCompletion} from '@heroku-cli/command/lib/completions.js'
 import {color, hux} from '@heroku/heroku-cli-util'
@@ -10,7 +8,6 @@ import tsheredoc from 'tsheredoc'
 import {getGeneration} from '../../lib/apps/generation.js'
 import {splitCsv} from '../../lib/spaces/parsers.js'
 import {displayShieldState} from '../../lib/spaces/spaces.js'
-import {Space} from '../../lib/types/fir.js'
 
 const heredoc = tsheredoc.default
 
@@ -75,14 +72,13 @@ export default class Create extends Command {
       data_cidr: dataCidr,
       features: splitCsv(features),
       generation,
-      // kpi_url isn't declared on SpaceCreateOpts but is forwarded at runtime via the route's JSON body.
       kpi_url: kpiUrl,
       log_drain_url: logDrainUrl,
       name: spaceName as string,
       region,
       shield,
       team,
-    } as SpaceCreateOpts) as Required<Space>
+    })
     ux.action.stop()
 
     ux.warn(`${color.warning('Spend Alert.')} Each Heroku ${spaceType} Private Space costs ~${dollarAmountHourly}/hour (max ${dollarAmountMonthly}/month), pro-rated to the second.`)

--- a/src/commands/spaces/topology.ts
+++ b/src/commands/spaces/topology.ts
@@ -89,6 +89,9 @@ export default class Topology extends Command {
     }
 
     const {platform} = new HerokuSDK()
+    // Narrow to the local render view-type: the generated SpaceTopology is intentionally looser
+    // (e.g. domains?: unknown[] and optional formation fields), while render() consumes the tighter
+    // shape (domains: string[], required fields). Kept until the hyperschema tightens those.
     const topology = await platform.spaceTopology.topology(spaceName as string) as SpaceTopology
     let appInfo: Heroku.App[] = []
     if (topology.apps) {

--- a/test/unit/commands/spaces/create.unit.test.ts
+++ b/test/unit/commands/spaces/create.unit.test.ts
@@ -239,4 +239,30 @@ describe('spaces:create', function () {
       Created at: ${now.toISOString()}
     `)
   })
+
+  it('forwards the kpi_url in the create request body when --kpi-url is set', async function () {
+    createStub.resolves({
+      cidr: '10.0.0.0/16',
+      created_at: now.toISOString(),
+      data_cidr: '172.23.0.0/20',
+      features: ['one', 'two'],
+      generation: 'cedar',
+      name: 'my-space',
+      region: {name: 'my-region'},
+      shield: false,
+      state: 'allocated',
+      team: {name: 'my-team'},
+    })
+
+    await runCommand(Cmd, [
+      '--team=my-team',
+      '--space=my-space',
+      '--region=my-region',
+      '--kpi-url=https://kpi.example.com',
+    ])
+
+    expect(createStub.calledOnce).to.equal(true)
+    const requestBody = createStub.firstCall.args[0]
+    expect(requestBody.kpi_url).to.eq('https://kpi.example.com')
+  })
 })

--- a/test/unit/commands/spaces/info.unit.test.ts
+++ b/test/unit/commands/spaces/info.unit.test.ts
@@ -71,7 +71,16 @@ describe('spaces:info', function () {
   })
 
   it('shows space info --json', async function () {
-    fakePlatform.space.info.resolves(space)
+    // Pins the migrated 3.sdk wire shape: `generation` is a string, and the
+    // `:v3_sdk` serializer also emits a `generation_object` ({id, name}) that
+    // the hyperschema doesn't declare yet. Attach it via a cast here (not by
+    // extending SpaceWithOutboundIps) and assert --json preserves both fields
+    // verbatim, so a regression to the old object-only `generation` shape fails.
+    const spaceWithGenerationObject = {
+      ...space,
+      generation_object: {id: '01234567-89ab-cdef-0123-456789abcdef', name: space.generation},
+    } as SpaceWithOutboundIps
+    fakePlatform.space.info.resolves(spaceWithGenerationObject)
 
     const {stdout} = await runCommand(Cmd, [
       '--space',
@@ -79,7 +88,7 @@ describe('spaces:info', function () {
       '--json',
     ])
     expect(fakePlatform.withHeaders.called).to.equal(false)
-    expectOutput(stdout, JSON.stringify(space, null, 2))
+    expectOutput(stdout, JSON.stringify(spaceWithGenerationObject, null, 2))
   })
 
   it('shows allocated space with enabled nat', async function () {


### PR DESCRIPTION
## Summary
Adopt `@heroku/types@4.6.0` in the `spaces` commands and remove the type casts it makes redundant, and pin the migrated `spaces:info --json` wire shape with regression tests. Follow-up to the review of #3881 (points #5/#6) — the cast removal is the payoff now that the types package declares space `kpi_url` and topology `formations`.

- Bump `@heroku/types` from `^4.1.0` to `^4.6.0` (adds space Create `kpi_url` and topology `formations`).
- Remove the redundant `as SpaceCreateOpts) as Required<Space>` cast and the now-unused `SpaceCreateOpts`/`Space` imports in `spaces:create`.
- Retain and document the `spaces:topology` `as SpaceTopology` cast — the generated type is intentionally looser (`domains?: unknown[]`, optional fields) than the local render view-type, so this narrows at the boundary.
- Add a `spaces:create` test asserting `--kpi-url` is forwarded in the request body.
- Pin the `spaces:info --json` shape (`generation` as string + `generation_object`) with a regression test.
- Add `hyperschema` to the cspell dictionary.

## Type of Change

- [ ] **fix**: Bug fix or issue (patch semvar update)
- [ ] **feat**: Introduces a new feature to the codebase (minor semvar update)
- [ ] **perf**: Performance improvement
- [ ] **docs**: Documentation only changes
- [x] **tests**: Adding missing tests or correcting existing tests
- [x] **refactor**: Restructures existing code without changing user-facing behavior
- [ ] **chore**: Code cleanup tasks, dependency updates, or other changes

<!-- Primary type is `refactor` (removes redundant casts from production command code, behavior unchanged); the `@heroku/types` bump (`deps`) that enables it and the added `tests` also apply. All patch-level. -->

## Verification

Passing CI suffices — the change is compile-time-only (cast removal) plus a dependency bump and a test. CI's `build` (`tsc`) validates that the removed casts were redundant, and the `test` matrix covers the new `--kpi-url` forwarding test and the `spaces:info --json` shape pin.

## Additional Context

The `spaces:topology` cast is intentionally kept: the generated `SpaceTopology` is looser than the tight shape `render()` consumes (`domains: string[]`, required nested fields), so the cast narrows at the boundary rather than scattering optional-guards through `render()`. It's documented inline and can be dropped once the hyperschema tightens those fields.

## Related Work

[W-23943907](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002iO28LYAS/view)
