### PR TITLE
fix: fix misleading config output when 2FA fails

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -154,6 +154,7 @@ kolkrabbi
 libexec
 libpq
 localdb
+LOCALAPPDATA
 localspace
 logfile
 loglevel
@@ -266,6 +267,7 @@ otlpgrpc
 otlphttp
 papertrail
 passw
+PATHEXT
 pcxid
 peerings
 pgappname
@@ -298,6 +300,11 @@ postrelease
 postrun
 preassessment
 preauth
+preauthorization
+preauthorizations
+preauthorize
+preauthorizes
+preauthorizing
 prerun
 preupdate
 privkeypem
@@ -413,6 +420,7 @@ uxxxxxxxxx
 vcpu
 VERSINFO
 webfactory
+WINDIR
 withfig
 wrapline
 writeout

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "11.10.0",
       "license": "ISC",
       "dependencies": {
-        "@heroku-cli/command": "^13.0.0",
+        "@heroku-cli/command": "^13.2.0",
         "@heroku-cli/notifications": "^1.2.6",
         "@heroku-cli/schema": "^1.0.25",
         "@heroku/buildpack-registry": "^1.0.1",
@@ -1648,9 +1648,9 @@
       }
     },
     "node_modules/@heroku-cli/command": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@heroku-cli/command/-/command-13.1.0.tgz",
-      "integrity": "sha512-zGkvMMhbCxlzxBLYsIYshWeRPDp+TVwDNKAMA8/lDyhmZ+0dq5SOSpVEx8UU+eaFYOq60zP3d2Mvf4FeSff/nw==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@heroku-cli/command/-/command-13.2.0.tgz",
+      "integrity": "sha512-4+Bj3sOcmKDhYVB5i7bcb6HPZJoerXso0ibRNF/tbJ97YMGtT+2P9Kv4QHJulz2rcxLvojPuiCbMfyiS8nRMKA==",
       "license": "ISC",
       "dependencies": {
         "@heroku/http-call": "^5.5.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": "./bin/run.js",
   "bugs": "https://github.com/heroku/cli/issues",
   "dependencies": {
-    "@heroku-cli/command": "^13.0.0",
+    "@heroku-cli/command": "^13.2.0",
     "@heroku-cli/notifications": "^1.2.6",
     "@heroku-cli/schema": "^1.0.25",
     "@heroku/buildpack-registry": "^1.0.1",

--- a/src/commands/config/set.ts
+++ b/src/commands/config/set.ts
@@ -53,11 +53,17 @@ RACK_ENV:  staging`)]
     const varsCopy = argv.map((v: string) => color.name(v.split('=')[0])).join(', ')
     ux.action.start(`Setting ${varsCopy} and restarting ${color.app(flags.app)}`)
 
-    let {body: config} = await this.heroku.patch<Heroku.ConfigVars>(`/apps/${flags.app}/config-vars`, {
-      body: vars,
-    })
-    const release = await lastRelease(this.heroku, flags.app)
-    ux.action.stop(`done, ${color.name('v' + release.version)}`)
+    let config: Heroku.ConfigVars
+    try {
+      ({body: config} = await this.heroku.patch<Heroku.ConfigVars>(`/apps/${flags.app}/config-vars`, {
+        body: vars,
+      }))
+      const release = await lastRelease(this.heroku, flags.app)
+      ux.action.stop(`done, ${color.name('v' + release.version)}`)
+    } catch (error) {
+      ux.action.stop(color.red('!'))
+      throw error
+    }
 
     config = Object.fromEntries(Object.entries(config)
       .filter(([k]) => vars[k])

--- a/src/commands/config/unset.ts
+++ b/src/commands/config/unset.ts
@@ -41,11 +41,16 @@ Unsetting RAILS_ENV, RACK_ENV and restarting example... done, v10`)]
     const vars = argv.map(v => color.name(v)).join(', ')
 
     ux.action.start(`Unsetting ${vars} and restarting ${color.app(flags.app)}`)
-    await this.heroku.patch(`/apps/${flags.app}/config-vars`, {
-      // body will be like {FOO: null, BAR: null}
-      body: Object.fromEntries(argv.map(v => [v, null])),
-    })
-    const release = await lastRelease()
-    ux.action.stop('done, ' + color.name(`v${release.version}`))
+    try {
+      await this.heroku.patch(`/apps/${flags.app}/config-vars`, {
+        // body will be like {FOO: null, BAR: null}
+        body: Object.fromEntries(argv.map(v => [v, null])),
+      })
+      const release = await lastRelease()
+      ux.action.stop('done, ' + color.name(`v${release.version}`))
+    } catch (error) {
+      ux.action.stop(color.red('!'))
+      throw error
+    }
   }
 }

--- a/test/integration/config/set.integration.test.ts
+++ b/test/integration/config/set.integration.test.ts
@@ -1,0 +1,508 @@
+import {expect} from 'chai'
+import {spawn} from 'node:child_process'
+import {closeSync, openSync} from 'node:fs'
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises'
+import http from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+import {setTimeout as setNativeTimeout} from 'node:timers'
+import {fileURLToPath} from 'node:url'
+
+interface RequestRecord {
+  body: unknown
+  factorHeader?: boolean
+  method?: string
+  url?: string
+}
+
+const cliRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
+
+const sanitizeTranscript = (transcript: string) => transcript
+  .replaceAll(new RegExp(`${String.fromCodePoint(27)}\\[[0-?]*[ -/]*[@-~]`, 'g'), '')
+  .replaceAll('\r', '\n')
+  .replaceAll(/\n+/g, '\n')
+  .trim()
+
+const redactDiagnostic = (diagnostic: string) => diagnostic
+  .replaceAll('test-api-key', '[REDACTED]')
+  .replaceAll('123456', '[REDACTED]')
+  .replaceAll(/(authorization\s*[:=]\s*)(?:bearer|basic)\s+[^\s,}]+/gi, '$1[REDACTED]')
+  .replaceAll(/((?:two-factor|2fa)[ _-]?(?:code|token)\s*[:=]\s*)[^\s,}]+/gi, '$1[REDACTED]')
+  .replaceAll(/("?[A-Z][A-Z0-9_]*"?\s*[:=]\s*)("[^"]*"|[^\s,}]+)/g, '$1[REDACTED]')
+
+const childEnvironment = (tempDir: string, host: string): NodeJS.ProcessEnv => {
+  const env: NodeJS.ProcessEnv = {}
+  for (const name of ['ComSpec', 'LANG', 'LC_ALL', 'PATH', 'PATHEXT', 'SystemRoot', 'WINDIR']) {
+    if (process.env[name]) env[name] = process.env[name]
+  }
+
+  return {
+    ...env,
+    APPDATA: path.join(tempDir, 'appdata'),
+    COLUMNS: '80',
+    DISABLE_TELEMETRY: 'true',
+    FORCE_COLOR: '0',
+    HEROKU_API_KEY: 'test-api-key',
+    HEROKU_HOST: host,
+    HEROKU_SKIP_NEW_VERSION_CHECK: 'true',
+    HOME: tempDir,
+    HTTP_PROXY: '',
+    http_proxy: '',
+    HTTPS_PROXY: '',
+    https_proxy: '',
+    IS_HEROKU_TEST_ENV: 'true',
+    LINES: '24',
+    LOCALAPPDATA: path.join(tempDir, 'local-appdata'),
+    NO_PROXY: '127.0.0.1,localhost',
+    no_proxy: '127.0.0.1,localhost',
+    TEMP: tempDir,
+    TERM: 'dumb',
+    TMP: tempDir,
+    TMPDIR: tempDir,
+    USERPROFILE: tempDir,
+    XDG_CACHE_HOME: path.join(tempDir, 'cache'),
+    XDG_CONFIG_HOME: path.join(tempDir, 'config'),
+    XDG_DATA_HOME: path.join(tempDir, 'data'),
+  }
+}
+
+const stopChild = async (child: ReturnType<typeof spawn> | undefined) => {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return
+
+  await new Promise<void>((resolve, reject) => {
+    const onClose = () => {
+      clearTimeout(fallback)
+      resolve()
+    }
+
+    const fallback = setNativeTimeout(() => {
+      child.removeListener('close', onClose)
+      reject(new Error('subprocess did not close within 2000ms after SIGKILL'))
+    }, 2000)
+    child.once('close', onClose)
+    child.kill('SIGKILL')
+  })
+}
+
+const configDonePattern = /\.\.\.\s*done\b|^\s*done\b/im
+const configResultRowPattern = /^\s*[A-Z][A-Z0-9_]*:\s+\S/m
+
+describe('config:set', function () {
+  // The test keeps lifecycle cleanup and contract diagnostics together.
+  // eslint-disable-next-line complexity
+  it('rejects a 2fa challenge without an interactive terminal', async function () {
+    this.timeout(30_000)
+
+    const requests: RequestRecord[] = []
+    const requestViolations: string[] = []
+    const sockets = new Set<import('node:net').Socket>()
+    const server = http.createServer((request, response) => {
+      const chunks: Buffer[] = []
+      request.on('data', chunk => chunks.push(Buffer.from(chunk)))
+      request.on('end', () => {
+        const rawBody = Buffer.concat(chunks).toString('utf8')
+        let body: unknown
+        try {
+          body = JSON.parse(rawBody)
+        } catch {
+          body = rawBody
+          requestViolations.push(`expected JSON request body, received ${JSON.stringify(rawBody)}`)
+        }
+
+        requests.push({body, method: request.method, url: request.url})
+        if (request.method !== 'PATCH') requestViolations.push(`expected PATCH, received ${request.method}`)
+        if (request.url !== '/apps/myapp/config-vars') requestViolations.push(`expected /apps/myapp/config-vars, received ${request.url}`)
+        if (JSON.stringify(body) !== JSON.stringify({RACK_ENV: 'production'})) {
+          requestViolations.push(`expected {"RACK_ENV":"production"}, received ${JSON.stringify(body)}`)
+        }
+
+        response.writeHead(403, {'content-type': 'application/json'})
+        response.end(JSON.stringify({
+          app: {name: 'myapp'},
+          id: 'two_factor',
+          message: 'Two-factor authentication required',
+        }))
+      })
+    })
+    server.on('connection', socket => {
+      sockets.add(socket)
+      socket.on('close', () => sockets.delete(socket))
+    })
+
+    let child: ReturnType<typeof spawn> | undefined
+    let outputFd: number | undefined
+    let tempDir: string | undefined
+    let transcript = ''
+    let exitCode: null | number = null
+    let signal: NodeJS.Signals | null = null
+    let childError: Error | undefined
+    let timedOut = false
+    let testError: unknown
+    let cleanupError: unknown
+
+    try {
+      tempDir = await mkdtemp(path.join(os.tmpdir(), 'heroku-config-set-'))
+      const outputPath = path.join(tempDir, 'combined-output.log')
+      const cacheDirs = [
+        path.join(tempDir, 'cache', 'heroku'),
+        path.join(tempDir, 'Library', 'Caches', 'heroku'),
+      ]
+      await Promise.all(cacheDirs.map(async cacheDir => {
+        await mkdir(cacheDir, {recursive: true})
+        await writeFile(path.join(cacheDir, 'terms-of-service'), '')
+      }))
+      outputFd = openSync(outputPath, 'w+')
+
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(0, '127.0.0.1', resolve)
+      })
+      const address = server.address()
+      if (!address || typeof address === 'string') throw new Error('fixture server did not expose a TCP port')
+
+      child = spawn(process.execPath, [path.join(cliRoot, 'bin/run.js'), 'config:set', 'RACK_ENV=production', '--app', 'myapp'], {
+        cwd: cliRoot,
+        env: childEnvironment(tempDir, `http://127.0.0.1:${address.port}`),
+        stdio: ['pipe', outputFd, outputFd],
+      })
+      if (!child.stdin) throw new Error('subprocess stdin was not piped')
+      child.stdin.end()
+
+      await new Promise<void>(resolve => {
+        const timeout = setNativeTimeout(() => {
+          timedOut = true
+          child?.kill('SIGKILL')
+        }, 15_000)
+
+        child?.once('error', error => {
+          childError = error
+          clearTimeout(timeout)
+          resolve()
+        })
+        child?.once('close', (code, childSignal) => {
+          exitCode = code
+          signal = childSignal
+          clearTimeout(timeout)
+          resolve()
+        })
+      })
+
+      closeSync(outputFd)
+      outputFd = undefined
+      transcript = sanitizeTranscript(await readFile(outputPath, 'utf8'))
+
+      const violations = [...requestViolations]
+      if (requests.length !== 1) violations.push(`expected exactly one request, received ${requests.length}`)
+      if (childError) violations.push(`subprocess error: ${childError.message}`)
+      if (timedOut) violations.push('subprocess timed out')
+      if (typeof exitCode !== 'number' || exitCode === 0) violations.push(`expected a numeric nonzero exit code, received ${String(exitCode)}`)
+      if (signal !== null) violations.push(`expected no signal, received ${signal}`)
+
+      const actionMatch = /Setting\s+RACK_ENV\s+and restarting[^\n]*myapp/i.exec(transcript)
+      if (!actionMatch) {
+        violations.push('missing config action output')
+      }
+
+      const actionStart = actionMatch?.index ?? -1
+      const actionOutput = actionStart >= 0 ? transcript.slice(actionStart) : transcript
+      const failedMarkers = [...actionOutput.matchAll(/(?:^|\s)!(?=\s|$)/g)]
+      if (failedMarkers.length !== 1) violations.push(`expected one meaningful failed marker, received ${failedMarkers.length}`)
+      const failedMarkerRelativeIndex = failedMarkers[0]?.index ?? -1
+      const failedMarkerIndex = failedMarkerRelativeIndex < 0 ? -1 : actionStart + failedMarkerRelativeIndex + failedMarkers[0][0].lastIndexOf('!')
+
+      const promptFailureMatch = /Two-factor authentication requires an interactive terminal/i.exec(actionOutput)
+      if (!promptFailureMatch) {
+        violations.push('missing clear noninteractive two-factor error')
+      }
+
+      const promptFailureIndex = promptFailureMatch ? actionStart + promptFailureMatch.index : -1
+      if (actionStart >= 0 && failedMarkerIndex >= 0 && promptFailureIndex >= 0 && !(actionStart < failedMarkerIndex && failedMarkerIndex < promptFailureIndex)) {
+        violations.push('expected config action start before failed marker before noninteractive two-factor error')
+      }
+
+      if (/warning: detected unsettled top-level await/i.test(transcript)) {
+        violations.push('printed an unsettled top-level-await warning')
+      }
+
+      if (configDonePattern.test(actionOutput)) violations.push('printed a successful config action completion')
+      if (configResultRowPattern.test(actionOutput)) violations.push('printed a config result row')
+
+      const promptFailureSuffix = promptFailureMatch ? actionOutput.slice(promptFailureMatch.index + promptFailureMatch[0].length) : ''
+      if (configDonePattern.test(promptFailureSuffix)) violations.push('printed a successful config action completion after prompt failure')
+      if (configResultRowPattern.test(promptFailureSuffix)) violations.push('printed a config result row after prompt failure')
+
+      const diagnostic = [
+        `exit=${String(exitCode)} signal=${String(signal)}`,
+        `requests=${JSON.stringify(requests)}`,
+        `transcript:\n${transcript}`,
+      ].join('\n')
+      const redactedDiagnostic = redactDiagnostic(diagnostic)
+      expect(violations, redactedDiagnostic).to.deep.equal([])
+    } catch (error) {
+      testError = error
+    } finally {
+      try {
+        await stopChild(child)
+      } catch (error) {
+        cleanupError = error
+      }
+
+      try {
+        if (outputFd !== undefined) closeSync(outputFd)
+      } catch (error) {
+        cleanupError ??= error
+      }
+
+      for (const socket of sockets) socket.destroy()
+      try {
+        if (server.listening) {
+          await new Promise<void>(resolve => {
+            server.close(() => resolve())
+          })
+        }
+      } catch (error) {
+        cleanupError ??= error
+      }
+
+      try {
+        if (tempDir) await rm(tempDir, {force: true, recursive: true})
+      } catch (error) {
+        cleanupError ??= error
+      }
+    }
+
+    if (cleanupError && testError) throw new AggregateError([testError, cleanupError], 'test and cleanup failed')
+    if (cleanupError) throw cleanupError
+    if (testError) throw testError
+  })
+
+  // The test keeps lifecycle cleanup and contract diagnostics together.
+  // eslint-disable-next-line complexity
+  it('rejects a piped factor without preauthorizing', async function () {
+    this.timeout(30_000)
+
+    const requests: RequestRecord[] = []
+    const requestViolations: string[] = []
+    const sockets = new Set<import('node:net').Socket>()
+    let initialPatchReceivedResolve: (() => void) | undefined
+    const initialPatchReceived = new Promise<void>(resolve => {
+      initialPatchReceivedResolve = resolve
+    })
+    const server = http.createServer((request, response) => {
+      const chunks: Buffer[] = []
+      request.on('data', chunk => chunks.push(Buffer.from(chunk)))
+      request.on('end', () => {
+        const rawBody = Buffer.concat(chunks).toString('utf8')
+        const requestIndex = requests.length
+        let body: unknown = rawBody
+        if (rawBody) {
+          try {
+            body = JSON.parse(rawBody)
+          } catch {
+            requestViolations.push(`request ${requestIndex + 1} had invalid JSON body ${JSON.stringify(rawBody)}`)
+          }
+        }
+
+        const factorHeader = request.headers['heroku-two-factor-code']
+        requests.push({
+          body,
+          factorHeader: factorHeader !== undefined,
+          method: request.method,
+          url: request.url,
+        })
+
+        if (requestIndex === 0 && request.method === 'PATCH' && request.url === '/apps/myapp/config-vars') {
+          if (JSON.stringify(body) !== JSON.stringify({RACK_ENV: 'production'})) {
+            requestViolations.push(`initial config PATCH had unexpected body ${JSON.stringify(body)}`)
+          }
+
+          if (factorHeader !== undefined) requestViolations.push('initial config PATCH unexpectedly included a factor header')
+          response.writeHead(403, {'content-type': 'application/json'})
+          response.end(JSON.stringify({
+            app: {name: 'myapp'},
+            id: 'two_factor',
+            message: 'Two-factor authentication required',
+          }), initialPatchReceivedResolve)
+          return
+        }
+
+        requestViolations.push(`unexpected request ${requestIndex + 1}: ${request.method} ${request.url}`)
+        response.writeHead(500, {'content-type': 'application/json'})
+        response.end(JSON.stringify({id: 'unexpected_route', message: 'Unexpected fixture route'}))
+      })
+    })
+    server.on('connection', socket => {
+      sockets.add(socket)
+      socket.on('close', () => sockets.delete(socket))
+    })
+
+    let child: ReturnType<typeof spawn> | undefined
+    let outputFd: number | undefined
+    let tempDir: string | undefined
+    let transcript = ''
+    let exitCode: null | number = null
+    let signal: NodeJS.Signals | null = null
+    let childError: Error | undefined
+    let timedOut = false
+    let testError: unknown
+    let cleanupError: unknown
+
+    try {
+      tempDir = await mkdtemp(path.join(os.tmpdir(), 'heroku-config-set-'))
+      const outputPath = path.join(tempDir, 'combined-output.log')
+      const cacheDirs = [
+        path.join(tempDir, 'cache', 'heroku'),
+        path.join(tempDir, 'Library', 'Caches', 'heroku'),
+      ]
+      await Promise.all(cacheDirs.map(async cacheDir => {
+        await mkdir(cacheDir, {recursive: true})
+        await writeFile(path.join(cacheDir, 'terms-of-service'), '')
+      }))
+      outputFd = openSync(outputPath, 'w+')
+
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(0, '127.0.0.1', resolve)
+      })
+      const address = server.address()
+      if (!address || typeof address === 'string') throw new Error('fixture server did not expose a TCP port')
+
+      child = spawn(process.execPath, [path.join(cliRoot, 'bin/run.js'), 'config:set', 'RACK_ENV=production', '--app', 'myapp'], {
+        cwd: cliRoot,
+        env: childEnvironment(tempDir, `http://127.0.0.1:${address.port}`),
+        stdio: ['pipe', outputFd, outputFd],
+      })
+      if (!child.stdin) throw new Error('subprocess stdin was not piped')
+
+      const childCompletion = new Promise<void>(resolve => {
+        const timeout = setNativeTimeout(() => {
+          timedOut = true
+          child?.kill('SIGKILL')
+        }, 15_000)
+
+        child?.once('error', error => {
+          childError = error
+          clearTimeout(timeout)
+          resolve()
+        })
+        child?.once('close', (code, childSignal) => {
+          exitCode = code
+          signal = childSignal
+          clearTimeout(timeout)
+          resolve()
+        })
+      })
+
+      let initialPatchTimeout: NodeJS.Timeout | undefined
+      const initialPatchTimeoutPromise = new Promise<'timeout'>(resolve => {
+        initialPatchTimeout = setNativeTimeout(() => resolve('timeout'), 10_000)
+      })
+      const firstEvent = await Promise.race([
+        initialPatchReceived.then(() => 'patch' as const),
+        childCompletion.then(() => 'exit' as const),
+        initialPatchTimeoutPromise,
+      ])
+      if (initialPatchTimeout) clearTimeout(initialPatchTimeout)
+      if (firstEvent === 'exit') {
+        throw new Error(`subprocess exited before the initial config PATCH: exit=${String(exitCode)} signal=${String(signal)} error=${childError?.message ?? 'none'}`)
+      }
+
+      if (firstEvent === 'timeout') throw new Error('initial config PATCH was not received within 10000ms')
+
+      child.stdin.end('123456\n')
+      await childCompletion
+
+      closeSync(outputFd)
+      outputFd = undefined
+      transcript = sanitizeTranscript(await readFile(outputPath, 'utf8'))
+
+      const violations = [...requestViolations]
+      const expectedRequests: RequestRecord[] = [{
+        body: {RACK_ENV: 'production'},
+        factorHeader: false,
+        method: 'PATCH',
+        url: '/apps/myapp/config-vars',
+      }]
+      if (JSON.stringify(requests) !== JSON.stringify(expectedRequests)) violations.push('piped factor triggered an unexpected request')
+      if (childError) violations.push(`subprocess error: ${childError.message}`)
+      if (timedOut) violations.push('subprocess timed out')
+      if (typeof exitCode !== 'number' || exitCode === 0) violations.push(`expected a numeric nonzero exit code, received ${String(exitCode)}`)
+      if (signal !== null) violations.push(`expected no signal, received ${signal}`)
+
+      const actionMatch = /Setting\s+RACK_ENV\s+and restarting[^\n]*myapp/i.exec(transcript)
+      if (!actionMatch) violations.push('missing config action output')
+
+      const actionStart = actionMatch?.index ?? -1
+      const actionOutput = actionStart >= 0 ? transcript.slice(actionStart) : transcript
+      const failedMarkers = [...actionOutput.matchAll(/(?:^|\s)!(?=\s|$)/g)]
+      if (failedMarkers.length !== 1) violations.push(`expected one meaningful failed marker, received ${failedMarkers.length}`)
+      const failedMarkerRelativeIndex = failedMarkers[0]?.index ?? -1
+      const failedMarkerIndex = failedMarkerRelativeIndex < 0 ? -1 : actionStart + failedMarkerRelativeIndex + failedMarkers[0][0].lastIndexOf('!')
+
+      const rejectionMatch = /Two-factor authentication requires an interactive terminal/i.exec(actionOutput)
+      if (!rejectionMatch) violations.push('missing clear noninteractive two-factor error')
+      const rejectionIndex = rejectionMatch ? actionStart + rejectionMatch.index : -1
+      if (actionStart >= 0 && failedMarkerIndex >= 0 && rejectionIndex >= 0 && !(actionStart < failedMarkerIndex && failedMarkerIndex < rejectionIndex)) {
+        violations.push('expected config action start before failed marker before noninteractive two-factor error')
+      }
+
+      if (/warning: detected unsettled top-level await/i.test(transcript)) violations.push('printed an unsettled top-level-await warning')
+      if (configDonePattern.test(actionOutput)) violations.push('printed a successful config action completion')
+      if (configResultRowPattern.test(actionOutput)) violations.push('printed a config result row')
+      if (/\bdone,\s*v\d+\b|\brelease\s+v\d+\b/i.test(actionOutput)) violations.push('printed release success output')
+
+      const rejectionSuffix = rejectionMatch ? actionOutput.slice(rejectionMatch.index + rejectionMatch[0].length) : ''
+      if (configDonePattern.test(rejectionSuffix)) violations.push('printed a successful config action completion after the two-factor error')
+      if (configResultRowPattern.test(rejectionSuffix)) violations.push('printed a config result row after the two-factor error')
+
+      const diagnostic = [
+        `exit=${String(exitCode)} signal=${String(signal)}`,
+        `requests=${JSON.stringify(requests)}`,
+        `transcript:\n${transcript}`,
+      ].join('\n')
+      const redactedDiagnostic = redactDiagnostic(diagnostic)
+      expect(violations, redactedDiagnostic).to.deep.equal([])
+    } catch (error) {
+      testError = error
+    } finally {
+      try {
+        await stopChild(child)
+      } catch (error) {
+        cleanupError = error
+      }
+
+      try {
+        if (outputFd !== undefined) closeSync(outputFd)
+      } catch (error) {
+        cleanupError ??= error
+      }
+
+      for (const socket of sockets) socket.destroy()
+      try {
+        if (server.listening) {
+          await new Promise<void>(resolve => {
+            server.close(() => resolve())
+          })
+        }
+      } catch (error) {
+        cleanupError ??= error
+      }
+
+      try {
+        if (tempDir) await rm(tempDir, {force: true, recursive: true})
+      } catch (error) {
+        cleanupError ??= error
+      }
+    }
+
+    if (cleanupError && testError) throw new AggregateError([testError, cleanupError], 'test and cleanup failed')
+    if (cleanupError) throw cleanupError
+    if (testError) throw testError
+  })
+})

--- a/test/integration/config/set.integration.test.ts
+++ b/test/integration/config/set.integration.test.ts
@@ -21,6 +21,19 @@ interface RequestRecord {
   url?: string
 }
 
+interface ProcessResult {
+  childError?: Error
+  exitCode: null | number
+  signal: NodeJS.Signals | null
+  timedOut: boolean
+  transcript: string
+}
+
+interface ProcessContext {
+  child: ReturnType<typeof spawn>
+  completion: Promise<Omit<ProcessResult, 'transcript'>>
+}
+
 const cliRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
 
 const sanitizeTranscript = (transcript: string) => transcript
@@ -90,19 +103,133 @@ const stopChild = async (child: ReturnType<typeof spawn> | undefined) => {
   })
 }
 
+const waitForChild = (child: ReturnType<typeof spawn>): ProcessContext['completion'] => new Promise(resolve => {
+  let timedOut = false
+  const timeout = setNativeTimeout(() => {
+    timedOut = true
+    child.kill('SIGKILL')
+  }, 15_000)
+
+  child.once('error', childError => {
+    clearTimeout(timeout)
+    resolve({
+      childError,
+      exitCode: child.exitCode,
+      signal: child.signalCode,
+      timedOut,
+    })
+  })
+  child.once('close', (exitCode, signal) => {
+    clearTimeout(timeout)
+    resolve({exitCode, signal, timedOut})
+  })
+})
+
+const runConfigSetProcess = async (
+  requestListener: (request: http.IncomingMessage, response: http.ServerResponse) => void,
+  interact: (context: ProcessContext) => Promise<void> | void,
+): Promise<ProcessResult> => {
+  const sockets = new Set<import('node:net').Socket>()
+  const server = http.createServer(requestListener)
+  server.on('connection', socket => {
+    sockets.add(socket)
+    socket.on('close', () => sockets.delete(socket))
+  })
+
+  let child: ReturnType<typeof spawn> | undefined
+  let outputFd: number | undefined
+  let tempDir: string | undefined
+  let result: ProcessResult | undefined
+  let testError: unknown
+  let cleanupError: unknown
+
+  try {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'heroku-config-set-'))
+    const outputPath = path.join(tempDir, 'combined-output.log')
+    const cacheDirs = [
+      path.join(tempDir, 'cache', 'heroku'),
+      path.join(tempDir, 'Library', 'Caches', 'heroku'),
+    ]
+    await Promise.all(cacheDirs.map(async cacheDir => {
+      await mkdir(cacheDir, {recursive: true})
+      await writeFile(path.join(cacheDir, 'terms-of-service'), '')
+    }))
+    outputFd = openSync(outputPath, 'w+')
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+    const address = server.address()
+    if (!address || typeof address === 'string') throw new Error('fixture server did not expose a TCP port')
+
+    child = spawn(process.execPath, [path.join(cliRoot, 'bin/run.js'), 'config:set', 'RACK_ENV=production', '--app', 'myapp'], {
+      cwd: cliRoot,
+      env: childEnvironment(tempDir, `http://127.0.0.1:${address.port}`),
+      stdio: ['pipe', outputFd, outputFd],
+    })
+    const completion = waitForChild(child)
+    await interact({child, completion})
+    const processResult = await completion
+
+    closeSync(outputFd)
+    outputFd = undefined
+    result = {
+      ...processResult,
+      transcript: sanitizeTranscript(await readFile(outputPath, 'utf8')),
+    }
+  } catch (error) {
+    testError = error
+  } finally {
+    try {
+      await stopChild(child)
+    } catch (error) {
+      cleanupError = error
+    }
+
+    try {
+      if (outputFd !== undefined) closeSync(outputFd)
+    } catch (error) {
+      cleanupError ??= error
+    }
+
+    for (const socket of sockets) socket.destroy()
+    try {
+      if (server.listening) {
+        await new Promise<void>(resolve => {
+          server.close(() => resolve())
+        })
+      }
+    } catch (error) {
+      cleanupError ??= error
+    }
+
+    try {
+      if (tempDir) await rm(tempDir, {force: true, recursive: true})
+    } catch (error) {
+      cleanupError ??= error
+    }
+  }
+
+  if (cleanupError && testError) throw new AggregateError([testError, cleanupError], 'test and cleanup failed')
+  if (cleanupError) throw cleanupError
+  if (testError) throw testError
+  if (!result) throw new Error('config:set subprocess did not produce a result')
+  return result
+}
+
 const configDonePattern = /\.\.\.\s*done\b|^\s*done\b/im
 const configResultRowPattern = /^\s*[A-Z][A-Z0-9_]*:\s+\S/m
 
 describe('config:set', function () {
-  // The test keeps lifecycle cleanup and contract diagnostics together.
+  // The test keeps contract diagnostics together.
   // eslint-disable-next-line complexity
   it('rejects a 2fa challenge without an interactive terminal', async function () {
     this.timeout(30_000)
 
     const requests: RequestRecord[] = []
     const requestViolations: string[] = []
-    const sockets = new Set<import('node:net').Socket>()
-    const server = http.createServer((request, response) => {
+    const result = await runConfigSetProcess((request, response) => {
       const chunks: Buffer[] = []
       request.on('data', chunk => chunks.push(Buffer.from(chunk)))
       request.on('end', () => {
@@ -129,172 +256,73 @@ describe('config:set', function () {
           message: 'Two-factor authentication required',
         }))
       })
-    })
-    server.on('connection', socket => {
-      sockets.add(socket)
-      socket.on('close', () => sockets.delete(socket))
-    })
-
-    let child: ReturnType<typeof spawn> | undefined
-    let outputFd: number | undefined
-    let tempDir: string | undefined
-    let transcript = ''
-    let exitCode: null | number = null
-    let signal: NodeJS.Signals | null = null
-    let childError: Error | undefined
-    let timedOut = false
-    let testError: unknown
-    let cleanupError: unknown
-
-    try {
-      tempDir = await mkdtemp(path.join(os.tmpdir(), 'heroku-config-set-'))
-      const outputPath = path.join(tempDir, 'combined-output.log')
-      const cacheDirs = [
-        path.join(tempDir, 'cache', 'heroku'),
-        path.join(tempDir, 'Library', 'Caches', 'heroku'),
-      ]
-      await Promise.all(cacheDirs.map(async cacheDir => {
-        await mkdir(cacheDir, {recursive: true})
-        await writeFile(path.join(cacheDir, 'terms-of-service'), '')
-      }))
-      outputFd = openSync(outputPath, 'w+')
-
-      await new Promise<void>((resolve, reject) => {
-        server.once('error', reject)
-        server.listen(0, '127.0.0.1', resolve)
-      })
-      const address = server.address()
-      if (!address || typeof address === 'string') throw new Error('fixture server did not expose a TCP port')
-
-      child = spawn(process.execPath, [path.join(cliRoot, 'bin/run.js'), 'config:set', 'RACK_ENV=production', '--app', 'myapp'], {
-        cwd: cliRoot,
-        env: childEnvironment(tempDir, `http://127.0.0.1:${address.port}`),
-        stdio: ['pipe', outputFd, outputFd],
-      })
+    }, ({child}) => {
       if (!child.stdin) throw new Error('subprocess stdin was not piped')
       child.stdin.end()
+    })
 
-      await new Promise<void>(resolve => {
-        const timeout = setNativeTimeout(() => {
-          timedOut = true
-          child?.kill('SIGKILL')
-        }, 15_000)
+    const {childError, exitCode, signal, timedOut, transcript} = result
+    const violations = [...requestViolations]
+    if (requests.length !== 1) violations.push(`expected exactly one request, received ${requests.length}`)
+    if (childError) violations.push(`subprocess error: ${childError.message}`)
+    if (timedOut) violations.push('subprocess timed out')
+    if (typeof exitCode !== 'number' || exitCode === 0) violations.push(`expected a numeric nonzero exit code, received ${String(exitCode)}`)
+    if (signal !== null) violations.push(`expected no signal, received ${signal}`)
 
-        child?.once('error', error => {
-          childError = error
-          clearTimeout(timeout)
-          resolve()
-        })
-        child?.once('close', (code, childSignal) => {
-          exitCode = code
-          signal = childSignal
-          clearTimeout(timeout)
-          resolve()
-        })
-      })
-
-      closeSync(outputFd)
-      outputFd = undefined
-      transcript = sanitizeTranscript(await readFile(outputPath, 'utf8'))
-
-      const violations = [...requestViolations]
-      if (requests.length !== 1) violations.push(`expected exactly one request, received ${requests.length}`)
-      if (childError) violations.push(`subprocess error: ${childError.message}`)
-      if (timedOut) violations.push('subprocess timed out')
-      if (typeof exitCode !== 'number' || exitCode === 0) violations.push(`expected a numeric nonzero exit code, received ${String(exitCode)}`)
-      if (signal !== null) violations.push(`expected no signal, received ${signal}`)
-
-      const actionMatch = /Setting\s+RACK_ENV\s+and restarting[^\n]*myapp/i.exec(transcript)
-      if (!actionMatch) {
-        violations.push('missing config action output')
-      }
-
-      const actionStart = actionMatch?.index ?? -1
-      const actionOutput = actionStart >= 0 ? transcript.slice(actionStart) : transcript
-      const failedMarkers = [...actionOutput.matchAll(/(?:^|\s)!(?=\s|$)/g)]
-      if (failedMarkers.length !== 1) violations.push(`expected one meaningful failed marker, received ${failedMarkers.length}`)
-      const failedMarkerRelativeIndex = failedMarkers[0]?.index ?? -1
-      const failedMarkerIndex = failedMarkerRelativeIndex < 0 ? -1 : actionStart + failedMarkerRelativeIndex + failedMarkers[0][0].lastIndexOf('!')
-
-      const promptFailureMatch = /Two-factor authentication requires an interactive terminal/i.exec(actionOutput)
-      if (!promptFailureMatch) {
-        violations.push('missing clear noninteractive two-factor error')
-      }
-
-      const promptFailureIndex = promptFailureMatch ? actionStart + promptFailureMatch.index : -1
-      if (actionStart >= 0 && failedMarkerIndex >= 0 && promptFailureIndex >= 0 && !(actionStart < failedMarkerIndex && failedMarkerIndex < promptFailureIndex)) {
-        violations.push('expected config action start before failed marker before noninteractive two-factor error')
-      }
-
-      if (/warning: detected unsettled top-level await/i.test(transcript)) {
-        violations.push('printed an unsettled top-level-await warning')
-      }
-
-      if (configDonePattern.test(actionOutput)) violations.push('printed a successful config action completion')
-      if (configResultRowPattern.test(actionOutput)) violations.push('printed a config result row')
-
-      const promptFailureSuffix = promptFailureMatch ? actionOutput.slice(promptFailureMatch.index + promptFailureMatch[0].length) : ''
-      if (configDonePattern.test(promptFailureSuffix)) violations.push('printed a successful config action completion after prompt failure')
-      if (configResultRowPattern.test(promptFailureSuffix)) violations.push('printed a config result row after prompt failure')
-
-      const diagnostic = [
-        `exit=${String(exitCode)} signal=${String(signal)}`,
-        `requests=${JSON.stringify(requests)}`,
-        `transcript:\n${transcript}`,
-      ].join('\n')
-      const redactedDiagnostic = redactDiagnostic(diagnostic)
-      expect(violations, redactedDiagnostic).to.deep.equal([])
-    } catch (error) {
-      testError = error
-    } finally {
-      try {
-        await stopChild(child)
-      } catch (error) {
-        cleanupError = error
-      }
-
-      try {
-        if (outputFd !== undefined) closeSync(outputFd)
-      } catch (error) {
-        cleanupError ??= error
-      }
-
-      for (const socket of sockets) socket.destroy()
-      try {
-        if (server.listening) {
-          await new Promise<void>(resolve => {
-            server.close(() => resolve())
-          })
-        }
-      } catch (error) {
-        cleanupError ??= error
-      }
-
-      try {
-        if (tempDir) await rm(tempDir, {force: true, recursive: true})
-      } catch (error) {
-        cleanupError ??= error
-      }
+    const actionMatch = /Setting\s+RACK_ENV\s+and restarting[^\n]*myapp/i.exec(transcript)
+    if (!actionMatch) {
+      violations.push('missing config action output')
     }
 
-    if (cleanupError && testError) throw new AggregateError([testError, cleanupError], 'test and cleanup failed')
-    if (cleanupError) throw cleanupError
-    if (testError) throw testError
+    const actionStart = actionMatch?.index ?? -1
+    const actionOutput = actionStart >= 0 ? transcript.slice(actionStart) : transcript
+    const failedMarkers = [...actionOutput.matchAll(/(?:^|\s)!(?=\s|$)/g)]
+    if (failedMarkers.length !== 1) violations.push(`expected one meaningful failed marker, received ${failedMarkers.length}`)
+    const failedMarkerRelativeIndex = failedMarkers[0]?.index ?? -1
+    const failedMarkerIndex = failedMarkerRelativeIndex < 0 ? -1 : actionStart + failedMarkerRelativeIndex + failedMarkers[0][0].lastIndexOf('!')
+
+    const promptFailureMatch = /Two-factor authentication requires an interactive terminal/i.exec(actionOutput)
+    if (!promptFailureMatch) {
+      violations.push('missing clear noninteractive two-factor error')
+    }
+
+    const promptFailureIndex = promptFailureMatch ? actionStart + promptFailureMatch.index : -1
+    if (actionStart >= 0 && failedMarkerIndex >= 0 && promptFailureIndex >= 0 && !(actionStart < failedMarkerIndex && failedMarkerIndex < promptFailureIndex)) {
+      violations.push('expected config action start before failed marker before noninteractive two-factor error')
+    }
+
+    if (/warning: detected unsettled top-level await/i.test(transcript)) {
+      violations.push('printed an unsettled top-level-await warning')
+    }
+
+    if (configDonePattern.test(actionOutput)) violations.push('printed a successful config action completion')
+    if (configResultRowPattern.test(actionOutput)) violations.push('printed a config result row')
+
+    const promptFailureSuffix = promptFailureMatch ? actionOutput.slice(promptFailureMatch.index + promptFailureMatch[0].length) : ''
+    if (configDonePattern.test(promptFailureSuffix)) violations.push('printed a successful config action completion after prompt failure')
+    if (configResultRowPattern.test(promptFailureSuffix)) violations.push('printed a config result row after prompt failure')
+
+    const diagnostic = [
+      `exit=${String(exitCode)} signal=${String(signal)}`,
+      `requests=${JSON.stringify(requests)}`,
+      `transcript:\n${transcript}`,
+    ].join('\n')
+    const redactedDiagnostic = redactDiagnostic(diagnostic)
+    expect(violations, redactedDiagnostic).to.deep.equal([])
   })
 
-  // The test keeps lifecycle cleanup and contract diagnostics together.
+  // The test keeps contract diagnostics together.
   // eslint-disable-next-line complexity
   it('rejects a piped factor without preauthorizing', async function () {
     this.timeout(30_000)
 
     const requests: RequestRecord[] = []
     const requestViolations: string[] = []
-    const sockets = new Set<import('node:net').Socket>()
     let initialPatchReceivedResolve: (() => void) | undefined
     const initialPatchReceived = new Promise<void>(resolve => {
       initialPatchReceivedResolve = resolve
     })
-    const server = http.createServer((request, response) => {
+    const result = await runConfigSetProcess((request, response) => {
       const chunks: Buffer[] = []
       request.on('data', chunk => chunks.push(Buffer.from(chunk)))
       request.on('end', () => {
@@ -336,173 +364,75 @@ describe('config:set', function () {
         response.writeHead(500, {'content-type': 'application/json'})
         response.end(JSON.stringify({id: 'unexpected_route', message: 'Unexpected fixture route'}))
       })
-    })
-    server.on('connection', socket => {
-      sockets.add(socket)
-      socket.on('close', () => sockets.delete(socket))
-    })
-
-    let child: ReturnType<typeof spawn> | undefined
-    let outputFd: number | undefined
-    let tempDir: string | undefined
-    let transcript = ''
-    let exitCode: null | number = null
-    let signal: NodeJS.Signals | null = null
-    let childError: Error | undefined
-    let timedOut = false
-    let testError: unknown
-    let cleanupError: unknown
-
-    try {
-      tempDir = await mkdtemp(path.join(os.tmpdir(), 'heroku-config-set-'))
-      const outputPath = path.join(tempDir, 'combined-output.log')
-      const cacheDirs = [
-        path.join(tempDir, 'cache', 'heroku'),
-        path.join(tempDir, 'Library', 'Caches', 'heroku'),
-      ]
-      await Promise.all(cacheDirs.map(async cacheDir => {
-        await mkdir(cacheDir, {recursive: true})
-        await writeFile(path.join(cacheDir, 'terms-of-service'), '')
-      }))
-      outputFd = openSync(outputPath, 'w+')
-
-      await new Promise<void>((resolve, reject) => {
-        server.once('error', reject)
-        server.listen(0, '127.0.0.1', resolve)
-      })
-      const address = server.address()
-      if (!address || typeof address === 'string') throw new Error('fixture server did not expose a TCP port')
-
-      child = spawn(process.execPath, [path.join(cliRoot, 'bin/run.js'), 'config:set', 'RACK_ENV=production', '--app', 'myapp'], {
-        cwd: cliRoot,
-        env: childEnvironment(tempDir, `http://127.0.0.1:${address.port}`),
-        stdio: ['pipe', outputFd, outputFd],
-      })
+    }, async ({child, completion}) => {
       if (!child.stdin) throw new Error('subprocess stdin was not piped')
 
-      const childCompletion = new Promise<void>(resolve => {
-        const timeout = setNativeTimeout(() => {
-          timedOut = true
-          child?.kill('SIGKILL')
-        }, 15_000)
-
-        child?.once('error', error => {
-          childError = error
-          clearTimeout(timeout)
-          resolve()
-        })
-        child?.once('close', (code, childSignal) => {
-          exitCode = code
-          signal = childSignal
-          clearTimeout(timeout)
-          resolve()
-        })
-      })
-
       let initialPatchTimeout: NodeJS.Timeout | undefined
-      const initialPatchTimeoutPromise = new Promise<'timeout'>(resolve => {
-        initialPatchTimeout = setNativeTimeout(() => resolve('timeout'), 10_000)
+      const initialPatchTimeoutPromise = new Promise<{type: 'timeout'}>(resolve => {
+        initialPatchTimeout = setNativeTimeout(() => resolve({type: 'timeout'}), 10_000)
       })
       const firstEvent = await Promise.race([
-        initialPatchReceived.then(() => 'patch' as const),
-        childCompletion.then(() => 'exit' as const),
+        initialPatchReceived.then(() => ({type: 'patch'} as const)),
+        completion.then(processResult => ({processResult, type: 'exit'} as const)),
         initialPatchTimeoutPromise,
       ])
       if (initialPatchTimeout) clearTimeout(initialPatchTimeout)
-      if (firstEvent === 'exit') {
+      if (firstEvent.type === 'exit') {
+        const {childError, exitCode, signal} = firstEvent.processResult
         throw new Error(`subprocess exited before the initial config PATCH: exit=${String(exitCode)} signal=${String(signal)} error=${childError?.message ?? 'none'}`)
       }
 
-      if (firstEvent === 'timeout') throw new Error('initial config PATCH was not received within 10000ms')
+      if (firstEvent.type === 'timeout') throw new Error('initial config PATCH was not received within 10000ms')
 
       child.stdin.end('123456\n')
-      await childCompletion
+    })
 
-      closeSync(outputFd)
-      outputFd = undefined
-      transcript = sanitizeTranscript(await readFile(outputPath, 'utf8'))
+    const {childError, exitCode, signal, timedOut, transcript} = result
+    const violations = [...requestViolations]
+    const expectedRequests: RequestRecord[] = [{
+      body: {RACK_ENV: 'production'},
+      factorHeader: false,
+      method: 'PATCH',
+      url: '/apps/myapp/config-vars',
+    }]
+    if (JSON.stringify(requests) !== JSON.stringify(expectedRequests)) violations.push('piped factor triggered an unexpected request')
+    if (childError) violations.push(`subprocess error: ${childError.message}`)
+    if (timedOut) violations.push('subprocess timed out')
+    if (typeof exitCode !== 'number' || exitCode === 0) violations.push(`expected a numeric nonzero exit code, received ${String(exitCode)}`)
+    if (signal !== null) violations.push(`expected no signal, received ${signal}`)
 
-      const violations = [...requestViolations]
-      const expectedRequests: RequestRecord[] = [{
-        body: {RACK_ENV: 'production'},
-        factorHeader: false,
-        method: 'PATCH',
-        url: '/apps/myapp/config-vars',
-      }]
-      if (JSON.stringify(requests) !== JSON.stringify(expectedRequests)) violations.push('piped factor triggered an unexpected request')
-      if (childError) violations.push(`subprocess error: ${childError.message}`)
-      if (timedOut) violations.push('subprocess timed out')
-      if (typeof exitCode !== 'number' || exitCode === 0) violations.push(`expected a numeric nonzero exit code, received ${String(exitCode)}`)
-      if (signal !== null) violations.push(`expected no signal, received ${signal}`)
+    const actionMatch = /Setting\s+RACK_ENV\s+and restarting[^\n]*myapp/i.exec(transcript)
+    if (!actionMatch) violations.push('missing config action output')
 
-      const actionMatch = /Setting\s+RACK_ENV\s+and restarting[^\n]*myapp/i.exec(transcript)
-      if (!actionMatch) violations.push('missing config action output')
+    const actionStart = actionMatch?.index ?? -1
+    const actionOutput = actionStart >= 0 ? transcript.slice(actionStart) : transcript
+    const failedMarkers = [...actionOutput.matchAll(/(?:^|\s)!(?=\s|$)/g)]
+    if (failedMarkers.length !== 1) violations.push(`expected one meaningful failed marker, received ${failedMarkers.length}`)
+    const failedMarkerRelativeIndex = failedMarkers[0]?.index ?? -1
+    const failedMarkerIndex = failedMarkerRelativeIndex < 0 ? -1 : actionStart + failedMarkerRelativeIndex + failedMarkers[0][0].lastIndexOf('!')
 
-      const actionStart = actionMatch?.index ?? -1
-      const actionOutput = actionStart >= 0 ? transcript.slice(actionStart) : transcript
-      const failedMarkers = [...actionOutput.matchAll(/(?:^|\s)!(?=\s|$)/g)]
-      if (failedMarkers.length !== 1) violations.push(`expected one meaningful failed marker, received ${failedMarkers.length}`)
-      const failedMarkerRelativeIndex = failedMarkers[0]?.index ?? -1
-      const failedMarkerIndex = failedMarkerRelativeIndex < 0 ? -1 : actionStart + failedMarkerRelativeIndex + failedMarkers[0][0].lastIndexOf('!')
-
-      const rejectionMatch = /Two-factor authentication requires an interactive terminal/i.exec(actionOutput)
-      if (!rejectionMatch) violations.push('missing clear noninteractive two-factor error')
-      const rejectionIndex = rejectionMatch ? actionStart + rejectionMatch.index : -1
-      if (actionStart >= 0 && failedMarkerIndex >= 0 && rejectionIndex >= 0 && !(actionStart < failedMarkerIndex && failedMarkerIndex < rejectionIndex)) {
-        violations.push('expected config action start before failed marker before noninteractive two-factor error')
-      }
-
-      if (/warning: detected unsettled top-level await/i.test(transcript)) violations.push('printed an unsettled top-level-await warning')
-      if (configDonePattern.test(actionOutput)) violations.push('printed a successful config action completion')
-      if (configResultRowPattern.test(actionOutput)) violations.push('printed a config result row')
-      if (/\bdone,\s*v\d+\b|\brelease\s+v\d+\b/i.test(actionOutput)) violations.push('printed release success output')
-
-      const rejectionSuffix = rejectionMatch ? actionOutput.slice(rejectionMatch.index + rejectionMatch[0].length) : ''
-      if (configDonePattern.test(rejectionSuffix)) violations.push('printed a successful config action completion after the two-factor error')
-      if (configResultRowPattern.test(rejectionSuffix)) violations.push('printed a config result row after the two-factor error')
-
-      const diagnostic = [
-        `exit=${String(exitCode)} signal=${String(signal)}`,
-        `requests=${JSON.stringify(requests)}`,
-        `transcript:\n${transcript}`,
-      ].join('\n')
-      const redactedDiagnostic = redactDiagnostic(diagnostic)
-      expect(violations, redactedDiagnostic).to.deep.equal([])
-    } catch (error) {
-      testError = error
-    } finally {
-      try {
-        await stopChild(child)
-      } catch (error) {
-        cleanupError = error
-      }
-
-      try {
-        if (outputFd !== undefined) closeSync(outputFd)
-      } catch (error) {
-        cleanupError ??= error
-      }
-
-      for (const socket of sockets) socket.destroy()
-      try {
-        if (server.listening) {
-          await new Promise<void>(resolve => {
-            server.close(() => resolve())
-          })
-        }
-      } catch (error) {
-        cleanupError ??= error
-      }
-
-      try {
-        if (tempDir) await rm(tempDir, {force: true, recursive: true})
-      } catch (error) {
-        cleanupError ??= error
-      }
+    const rejectionMatch = /Two-factor authentication requires an interactive terminal/i.exec(actionOutput)
+    if (!rejectionMatch) violations.push('missing clear noninteractive two-factor error')
+    const rejectionIndex = rejectionMatch ? actionStart + rejectionMatch.index : -1
+    if (actionStart >= 0 && failedMarkerIndex >= 0 && rejectionIndex >= 0 && !(actionStart < failedMarkerIndex && failedMarkerIndex < rejectionIndex)) {
+      violations.push('expected config action start before failed marker before noninteractive two-factor error')
     }
 
-    if (cleanupError && testError) throw new AggregateError([testError, cleanupError], 'test and cleanup failed')
-    if (cleanupError) throw cleanupError
-    if (testError) throw testError
+    if (/warning: detected unsettled top-level await/i.test(transcript)) violations.push('printed an unsettled top-level-await warning')
+    if (configDonePattern.test(actionOutput)) violations.push('printed a successful config action completion')
+    if (configResultRowPattern.test(actionOutput)) violations.push('printed a config result row')
+    if (/\bdone,\s*v\d+\b|\brelease\s+v\d+\b/i.test(actionOutput)) violations.push('printed release success output')
+
+    const rejectionSuffix = rejectionMatch ? actionOutput.slice(rejectionMatch.index + rejectionMatch[0].length) : ''
+    if (configDonePattern.test(rejectionSuffix)) violations.push('printed a successful config action completion after the two-factor error')
+    if (configResultRowPattern.test(rejectionSuffix)) violations.push('printed a config result row after the two-factor error')
+
+    const diagnostic = [
+      `exit=${String(exitCode)} signal=${String(signal)}`,
+      `requests=${JSON.stringify(requests)}`,
+      `transcript:\n${transcript}`,
+    ].join('\n')
+    const redactedDiagnostic = redactDiagnostic(diagnostic)
+    expect(violations, redactedDiagnostic).to.deep.equal([])
   })
 })

--- a/test/unit/commands/apps/destroy.unit.test.ts
+++ b/test/unit/commands/apps/destroy.unit.test.ts
@@ -1,7 +1,8 @@
+import {prompter} from '@heroku-cli/command'
 import {runCommand} from '@heroku-cli/test-utils'
 import {expect} from 'chai'
 import nock from 'nock'
-import {createSandbox} from 'sinon'
+import {createSandbox, stub} from 'sinon'
 
 import Destroy from '../../../../src/commands/apps/destroy.js'
 import {gitService} from '../../../../src/lib/ci/git.js'
@@ -38,6 +39,31 @@ describe('apps:destroy', function () {
 
     expect(stdout).to.equal('')
     expect(stderr).to.include('Destroying ⬢ myapp (including all add-ons)... done')
+  })
+
+  it('pauses the action for 2fa and retries the delete', async function () {
+    const originalIsTTY = process.stdin.isTTY
+    Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: true})
+    const promptStub = stub(prompter, 'prompt').resolves({factor: '123456'})
+    api
+      .get('/apps/myapp').reply(200, {name: 'myapp'})
+      .delete('/apps/myapp').reply(403, {
+        app: {name: 'myapp'},
+        id: 'two_factor',
+        message: 'Two-factor authentication required',
+      })
+      .put('/apps/myapp/pre-authorizations').matchHeader('Heroku-Two-Factor-Code', '123456').reply(200, {})
+      .delete('/apps/myapp').reply(200)
+
+    try {
+      const {stderr} = await runCommand(Destroy, ['--app', 'myapp', '--confirm', 'myapp'])
+
+      expect(promptStub.calledOnce).to.be.true
+      expect(stderr).to.include('Destroying ⬢ myapp (including all add-ons)... done')
+    } finally {
+      promptStub.restore()
+      Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: originalIsTTY})
+    }
   })
 
   it('errors without an app', async function () {

--- a/test/unit/commands/config/set.unit.test.ts
+++ b/test/unit/commands/config/set.unit.test.ts
@@ -1,7 +1,9 @@
+import {prompter} from '@heroku-cli/command'
 import {runCommand} from '@heroku-cli/test-utils'
 import ansis from 'ansis'
 import {expect} from 'chai'
 import nock from 'nock'
+import {stub} from 'sinon'
 
 import ConfigSet from '../../../../src/commands/config/set.js'
 
@@ -43,6 +45,149 @@ describe('config:set', function () {
     expect(stdout).to.equal('\n')
     expect(stderr).to.include('Setting RACK_ENV and restarting ⬢ myapp')
     expect(stderr).to.include('done, v10')
+  })
+
+  it('prompts for 2fa, preauthorizes, and retries the config update', async function () {
+    const originalIsTTY = process.stdin.isTTY
+    Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: true})
+    const promptStub = stub(prompter, 'prompt').resolves({factor: '123456'})
+    api
+      .patch('/apps/myapp/config-vars', {RACK_ENV: 'production'})
+      .reply(403, {
+        app: {name: 'myapp'},
+        id: 'two_factor',
+        message: 'Two-factor authentication required',
+      })
+      .put('/apps/myapp/pre-authorizations')
+      .matchHeader('Heroku-Two-Factor-Code', '123456')
+      .reply(200, {})
+      .patch('/apps/myapp/config-vars', {RACK_ENV: 'production'})
+      .reply(200, {RACK_ENV: 'production'})
+      .get('/apps/myapp/releases')
+      .reply(200, [{version: 10}])
+
+    try {
+      const {stderr, stdout} = await runCommand(ConfigSet, ['RACK_ENV=production', '--app', 'myapp'])
+
+      expect(promptStub.calledOnce).to.be.true
+      expect(stderr).to.include('done, v10')
+      expect(stderr).not.to.include('!')
+      expect(stdout).to.equal('RACK_ENV: production\n')
+    } finally {
+      promptStub.restore()
+      Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: originalIsTTY})
+    }
+  })
+
+  it('ends the action with ! when the 2fa prompt is canceled', async function () {
+    const originalIsTTY = process.stdin.isTTY
+    Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: true})
+    const promptStub = stub(prompter, 'prompt').rejects(new Error('Two-factor prompt canceled'))
+    api
+      .patch('/apps/myapp/config-vars', {RACK_ENV: 'production'})
+      .reply(403, {
+        app: {name: 'myapp'},
+        id: 'two_factor',
+        message: 'Two-factor authentication required',
+      })
+
+    try {
+      const {error, stderr, stdout} = await runCommand(ConfigSet, ['RACK_ENV=production', '--app', 'myapp'])
+
+      expect(error?.message).to.equal('Two-factor prompt canceled')
+      expect(stderr).to.include('!')
+      expect(stderr).not.to.include('done')
+      expect(stdout).to.equal('')
+    } finally {
+      promptStub.restore()
+      Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: originalIsTTY})
+    }
+  })
+
+  it('ends the action with ! when app preauthorization fails', async function () {
+    const originalIsTTY = process.stdin.isTTY
+    Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: true})
+    const promptStub = stub(prompter, 'prompt').resolves({factor: '123456'})
+    api
+      .patch('/apps/myapp/config-vars', {RACK_ENV: 'production'})
+      .reply(403, {
+        app: {name: 'myapp'},
+        id: 'two_factor',
+        message: 'Two-factor authentication required',
+      })
+      .put('/apps/myapp/pre-authorizations')
+      .matchHeader('Heroku-Two-Factor-Code', '123456')
+      .reply(403, {id: 'forbidden', message: 'Preauthorization failed'})
+
+    try {
+      const {error, stderr, stdout} = await runCommand(ConfigSet, ['RACK_ENV=production', '--app', 'myapp'])
+
+      expect(error?.message).to.include('Preauthorization failed')
+      expect(stderr).to.include('!')
+      expect(stderr).not.to.include('done')
+      expect(stdout).to.equal('')
+    } finally {
+      promptStub.restore()
+      Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: originalIsTTY})
+    }
+  })
+
+  it('ends the action with ! when the config retry fails', async function () {
+    const originalIsTTY = process.stdin.isTTY
+    Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: true})
+    const promptStub = stub(prompter, 'prompt').resolves({factor: '123456'})
+    api
+      .patch('/apps/myapp/config-vars', {RACK_ENV: 'production'})
+      .reply(403, {
+        app: {name: 'myapp'},
+        id: 'two_factor',
+        message: 'Two-factor authentication required',
+      })
+      .put('/apps/myapp/pre-authorizations')
+      .matchHeader('Heroku-Two-Factor-Code', '123456')
+      .reply(200, {})
+      .patch('/apps/myapp/config-vars', {RACK_ENV: 'production'})
+      .reply(500, {id: 'server_error', message: 'Config retry failed'})
+
+    try {
+      const {error, stderr, stdout} = await runCommand(ConfigSet, ['RACK_ENV=production', '--app', 'myapp'])
+
+      expect(error?.message).to.include('Config retry failed')
+      expect(stderr).to.include('!')
+      expect(stderr).not.to.include('done')
+      expect(stdout).to.equal('')
+    } finally {
+      promptStub.restore()
+      Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: originalIsTTY})
+    }
+  })
+
+  it('ends the action with ! when the config update fails', async function () {
+    api
+      .patch('/apps/myapp/config-vars', {RACK_ENV: 'production'})
+      .reply(422, {id: 'invalid_params', message: 'Config update failed'})
+
+    const {error, stderr, stdout} = await runCommand(ConfigSet, ['RACK_ENV=production', '--app', 'myapp'])
+
+    expect(error?.message).to.include('Config update failed')
+    expect(stderr).to.include('!')
+    expect(stderr).not.to.include('done')
+    expect(stdout).to.equal('')
+  })
+
+  it('ends the action with ! when the release lookup fails', async function () {
+    api
+      .patch('/apps/myapp/config-vars', {RACK_ENV: 'production'})
+      .reply(200, {RACK_ENV: 'production'})
+      .get('/apps/myapp/releases')
+      .reply(500, {id: 'server_error', message: 'Release lookup failed'})
+
+    const {error, stderr, stdout} = await runCommand(ConfigSet, ['RACK_ENV=production', '--app', 'myapp'])
+
+    expect(error?.message).to.include('Release lookup failed')
+    expect(stderr).to.include('!')
+    expect(stderr).not.to.include('done')
+    expect(stdout).to.equal('')
   })
 
   it('errors without args', async function () {

--- a/test/unit/commands/config/unset.unit.test.ts
+++ b/test/unit/commands/config/unset.unit.test.ts
@@ -1,4 +1,5 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {expect} from 'chai'
 import nock from 'nock'
 
 import {ConfigUnset} from '../../../../src/commands/config/unset.js'
@@ -25,6 +26,34 @@ describe('config', function () {
       .get('/apps/myapp/releases')
       .reply(200, [{version: 1}])
 
-    await runCommand(ConfigUnset, ['-amyapp', 'FOO', 'RACK_ENV'])
+    const {stderr} = await runCommand(ConfigUnset, ['-amyapp', 'FOO', 'RACK_ENV'])
+
+    expect(stderr).to.include('done, v1')
+  })
+
+  it('ends the action with ! when the config update fails', async function () {
+    api
+      .patch('/apps/myapp/config-vars', {FOO: null})
+      .reply(422, {id: 'invalid_params', message: 'Config unset failed'})
+
+    const {error, stderr} = await runCommand(ConfigUnset, ['-amyapp', 'FOO'])
+
+    expect(error?.message).to.include('Config unset failed')
+    expect(stderr).to.include('!')
+    expect(stderr).not.to.include('done')
+  })
+
+  it('ends the action with ! when the release lookup fails', async function () {
+    api
+      .patch('/apps/myapp/config-vars', {FOO: null})
+      .reply(200, {})
+      .get('/apps/myapp/releases')
+      .reply(500, {id: 'server_error', message: 'Release lookup failed'})
+
+    const {error, stderr} = await runCommand(ConfigUnset, ['-amyapp', 'FOO'])
+
+    expect(error?.message).to.include('Release lookup failed')
+    expect(stderr).to.include('!')
+    expect(stderr).not.to.include('done')
   })
 })

--- a/test/unit/commands/pipelines/promote.unit.test.ts
+++ b/test/unit/commands/pipelines/promote.unit.test.ts
@@ -1,3 +1,4 @@
+import {prompter} from '@heroku-cli/command'
 import {runCommand} from '@heroku-cli/test-utils'
 import {expect} from 'chai'
 import nock from 'nock'
@@ -131,6 +132,30 @@ describe('pipelines:promote', function () {
     expect(stdout).to.contain('failed')
     expect(stdout).to.contain('Because reasons')
     expect(process.exitCode).to.equal(1)
+  })
+
+  it('prompts for 2fa and retries the promotion', async function () {
+    const originalIsTTY = process.stdin.isTTY
+    Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: true})
+    const promptStub = stub(prompter, 'prompt').resolves({factor: '123456'})
+    setupNock()
+    mockPromotionTargets()
+    api
+      .post('/pipeline-promotions')
+      .reply(403, {id: 'two_factor', message: 'Two-factor authentication required'})
+      .post('/pipeline-promotions')
+      .matchHeader('Heroku-Two-Factor-Code', '123456')
+      .reply(201, promotion)
+
+    try {
+      const {error} = await runCommand(Cmd, [`--app=${sourceApp.name}`])
+
+      expect(error).to.be.undefined
+      expect(promptStub.calledOnce).to.be.true
+    } finally {
+      promptStub.restore()
+      Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: originalIsTTY})
+    }
   })
 
   context('passing a `to` flag', function () {

--- a/test/unit/commands/run/index.unit.test.ts
+++ b/test/unit/commands/run/index.unit.test.ts
@@ -139,6 +139,8 @@ describe('run', function () {
   })
 
   it('prompts for 2FA via prompter and retries with Heroku-Two-Factor-Code header on 403 two_factor', async function () {
+    const originalIsTTY = process.stdin.isTTY
+    Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: true})
     const promptStub = sinon.stub(prompter, 'prompt').resolves({factor: '123456'})
 
     const api = nock('https://api.heroku.com')
@@ -161,22 +163,26 @@ describe('run', function () {
         updated_at: '2020-01-01T00:00:00Z',
       })
 
-    await runWithCliArgv([
-      '--app',
-      'myapp',
-      'echo',
-      'test',
-    ]).catch(() => {
-      // Expected to fail when trying to connect to rendezvous
-    })
+    try {
+      await runWithCliArgv([
+        '--app',
+        'myapp',
+        'echo',
+        'test',
+      ]).catch(() => {
+        // Expected to fail when trying to connect to rendezvous
+      })
 
-    expect(promptStub.calledOnce, 'prompter.prompt should be called exactly once').to.be.true
-    expect(promptStub.firstCall.args[0]).to.deep.equal([{
-      mask: '*',
-      message: 'Two-factor code',
-      name: 'factor',
-      type: 'password',
-    }])
-    expect(api.isDone(), 'all expected requests including the 2FA-retried /account should be made').to.be.true
+      expect(promptStub.calledOnce, 'prompter.prompt should be called exactly once').to.be.true
+      expect(promptStub.firstCall.args[0]).to.deep.equal([{
+        mask: '*',
+        message: 'Two-factor code',
+        name: 'factor',
+        type: 'password',
+      }])
+      expect(api.isDone(), 'all expected requests including the 2FA-retried /account should be made').to.be.true
+    } finally {
+      Object.defineProperty(process.stdin, 'isTTY', {configurable: true, value: originalIsTTY})
+    }
   })
 })


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary

Why:

config:set and config:unset could print done even when a 2FA prompt or API request failed. This made failed commands look successful.

What:

- End failed config actions with ! instead of done
- Preserve the original 2FA or API error and nonzero exit code
- Use @heroku-cli/command 13.2.0 for safe 2FA prompting
- Add coverage for success, cancellation, API failures, retries, and noninteractive use

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing

### Prerequisites

- Working 2FA factor
- The `legacy-2fa` account feature
- Permission to create and update test apps

### Setup

Install the sudo plugin and create a dedicated test app with no production data, traffic, add-ons, or collaborators:

```bash
heroku plugins:install heroku/sudo
export APP="paranoid-cli-test-$(date +%s)"
heroku apps:create "$APP"
heroku sudo -- labs:enable paranoid --app "$APP"
heroku sudo -- labs:info paranoid --app "$APP"
```

The `--` passes the remaining flags to `labs:enable` instead of the sudo command. Enter a valid 2FA factor and expect `paranoid` to be enabled. An existing approved non-production Paranoid app can be used instead by setting `APP` to its name.

Build the local CLI and prepare the test value:

```bash
npm ci
npm run build

export KEY="PARANOID_CLI_TEST"
export VALUE="manual-test-$(date +%s)"

./bin/run auth:whoami
./bin/run 2fa:preauth:clear --app "$APP"
```

### Successful set

```bash
./bin/run config:set "$KEY=$VALUE" --app "$APP"
echo "exit=$?"
```

Enter a valid factor. Expect a readable prompt, `done, vN`, and exit status `0`.

### Cancelled set

```bash
./bin/run 2fa:preauth:clear --app "$APP"
./bin/run config:set "$KEY=must-not-be-saved" --app "$APP"
```

Cancel with `Ctrl+C`, then run `echo "exit=$?"`. Expect `!`, a nonzero exit, and no `done`.

### Successful unset

```bash
./bin/run 2fa:preauth:clear --app "$APP"
./bin/run config:unset "$KEY" --app "$APP"
echo "exit=$?"
```

Enter a valid factor. Expect `done, vN` and exit status `0`.

### Teardown

If the unset test failed, remove the test key first:

```bash
./bin/run config:unset "$KEY" --app "$APP"
```

Then clear the preauthorization. If setup created a dedicated app, destroy it:

```bash
./bin/run 2fa:preauth:clear --app "$APP"
heroku apps:destroy --app "$APP" --confirm "$APP"
unset APP KEY VALUE
```

Do not destroy an existing shared test app.

## Screenshots (if applicable)

## Related Issues
GUS work item: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bIDdzYAG/view
