### PR TITLE
refactor(releases): use @heroku/sdk

### DIFF
--- a/src/commands/releases/index.ts
+++ b/src/commands/releases/index.ts
@@ -1,6 +1,8 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import {color, hux} from '@heroku/heroku-cli-util'
+import {HerokuApiClient} from '@heroku/heroku-fetch'
+import {HerokuSDK} from '@heroku/sdk'
+import {Release} from '@heroku/types/3.sdk'
 import {ux} from '@oclif/core/ux'
 import ansis from 'ansis'
 
@@ -8,13 +10,20 @@ import {lazyModuleLoader} from '../../lib/lazy-module-loader.js'
 import * as statusHelper from '../../lib/releases/status-helper.js'
 import * as time from '../../lib/time.js'
 
+type ExtendedRelease = Release & {
+  extended?: {
+    slug_id?: string,
+    slug_uuid?: string,
+  }
+}
+
 type ColumnConfig = {
   extended?: boolean
-  get?: (row: Heroku.Release) => number | string | undefined
+  get?: (row: ExtendedRelease) => number | string | undefined
   header?: string
 }
 
-const getDescriptionTruncation = function (releases: Heroku.Release[], columns: Record<string, ColumnConfig>, optimizeKey: string) {
+export const getDescriptionTruncation = function (releases: ExtendedRelease[], columns: Record<string, ColumnConfig>, optimizeKey: string) {
   // width management here is quite opaque.
   // This entire function is to determine how much of Formation.description should be truncated to accommodate for Formation.status. They both go in the same column.
   // Nothing else is truncated and the table is passed `'no-truncate': true` in options.
@@ -39,7 +48,7 @@ const getDescriptionTruncation = function (releases: Heroku.Release[], columns: 
 
         let colValue = row
         for (const part of parts) {
-          colValue = colValue[part]
+          colValue = (colValue as any)[part]
         }
 
         const formattedValue = col.get ? col.get(row) : colValue.toString()
@@ -82,22 +91,30 @@ export default class Index extends Command {
   public async run(): Promise<void> {
     const _ = await lazyModuleLoader.loadLodash()
 
+    const {platform} = new HerokuSDK()
     const {flags} = await this.parse(Index)
     const {app, extended, json, num} = flags
+    const range = `version ..; max=${num || 15}, order=desc`
 
-    const url = `/apps/${app}/releases${extended ? '?extended=true' : ''}`
-
-    const {body: releases} = await this.heroku.request<Heroku.Release[]>(url, {
-      headers: {
-        Accept: 'application/vnd.heroku+json; version=3.sdk',
-        Range: `version ..; max=${num || 15}, order=desc`,
-      },
-      partial: true,
-    })
+    let releases: ExtendedRelease[]
+    if (extended) {
+      const client = new HerokuApiClient()
+      const response = await client.get(`/apps/${app}/releases?extended=true`, {
+        headers: {
+          Accept: 'application/vnd.heroku+json; version=3.sdk',
+          Range: range,
+        },
+      })
+      releases = await response.json() as ExtendedRelease[]
+    } else {
+      releases = await platform
+        .withHeaders({Range: range})
+        .release.list(app)
+    }
 
     let optimizationWidth = 0
 
-    const descriptionWithStatus = function (release: Heroku.Release) {
+    const descriptionWithStatus = function (release: ExtendedRelease) {
       const {description} = release
       const width = () => process.stdout?.columns && process.stdout.columns > 80 ? process.stdout.columns : 80
       const trunc = (l: number, s?: string) => {
@@ -143,7 +160,7 @@ export default class Index extends Command {
       return trunc(0, description)
     }
 
-    const getVersionColor = (release: Heroku.Release) => {
+    const getVersionColor = (release: ExtendedRelease) => {
       const statusColor = statusHelper.color(release.status)
       if (statusColor === 'red') return color.failure('v' + release.version)
       if (statusColor === 'yellow') return color.warning('v' + release.version)
@@ -184,7 +201,7 @@ export default class Index extends Command {
 
       hux.styledHeader(header)
       const sortedReleases = releases.sort((a, b) => (b.version ?? 0) - (a.version ?? 0))
-      hux.table(sortedReleases, columns, {extended})
+      hux.table(sortedReleases as any, columns as any, {extended})
     }
   }
 }

--- a/src/commands/releases/index.ts
+++ b/src/commands/releases/index.ts
@@ -23,7 +23,7 @@ type ColumnConfig = {
   header?: string
 }
 
-export const getDescriptionTruncation = function (releases: ExtendedRelease[], columns: Record<string, ColumnConfig>, optimizeKey: string) {
+const getDescriptionTruncation = function (releases: ExtendedRelease[], columns: Record<string, ColumnConfig>, optimizeKey: string) {
   // width management here is quite opaque.
   // This entire function is to determine how much of Formation.description should be truncated to accommodate for Formation.status. They both go in the same column.
   // Nothing else is truncated and the table is passed `'no-truncate': true` in options.

--- a/src/commands/releases/info.ts
+++ b/src/commands/releases/info.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import {color, hux} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 
 import {quote} from '../../lib/config/quote.js'
@@ -21,9 +21,10 @@ export default class Info extends Command {
   static topic = 'releases'
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Info)
     const {app, json, shell} = flags
-    const release = await findByLatestOrId(this.heroku, app, args.release)
+    const release = await findByLatestOrId(platform, app, args.release)
 
     if (json) {
       hux.styledJSON(release)
@@ -32,7 +33,7 @@ export default class Info extends Command {
       const status = description(release)
       const statusColor = getStatusColor(release.status)
       const userEmail = color.user(release?.user?.email ?? '')
-      const {body: config} = await this.heroku.get<Heroku.ConfigVars>(`/apps/${app}/releases/${release.version}/config-vars`)
+      const config = await platform.configVar.infoForAppRelease(app, release.version)
 
       if (status) {
         let colorFn: (s: string) => string

--- a/src/commands/releases/output.ts
+++ b/src/commands/releases/output.ts
@@ -1,4 +1,5 @@
 import {Command, flags} from '@heroku-cli/command'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 
 import {stream} from '../../lib/releases/output.js'
@@ -16,9 +17,10 @@ export default class Output extends Command {
   static topic = 'releases'
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Output)
     const {app} = flags
-    const release = await findByLatestOrId(this.heroku, app, args.release)
+    const release = await findByLatestOrId(platform, app, args.release)
     const streamUrl = release.output_stream_url
 
     if (!streamUrl) {

--- a/src/commands/releases/retry.ts
+++ b/src/commands/releases/retry.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {ux} from '@oclif/core/ux'
 
 import {stream} from '../../lib/releases/output.js'
@@ -16,10 +16,11 @@ export default class Retry extends Command {
   static topic = 'releases'
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {flags} = await this.parse(Retry)
     const {app} = flags
-    const release = await findByLatestOrId(this.heroku, app)
-    const {body: formations} = await this.heroku.get<Heroku.Formation[]>(`/apps/${app}/formation`)
+    const release = await findByLatestOrId(platform, app)
+    const formations = await platform.formation.list(app)
     const releasePhase = formations.filter(formation => formation.type === 'release')
 
     if (!release) {
@@ -32,11 +33,9 @@ export default class Retry extends Command {
 
     ux.action.start(`Retrying ${color.name('v' + release.version)} on ${color.app(app)}`)
 
-    const {body: retry} = await this.heroku.post<Heroku.Release>(`/apps/${app}/releases`, {
-      body: {
-        description: `Retry of v${release.version}: ${release.description}`,
-        slug: release?.slug?.id,
-      },
+    const retry = await platform.release.create(app, {
+      description: `Retry of v${release.version}: ${release.description}`,
+      slug: release?.slug?.id,
     })
 
     ux.action.stop(`done, ${color.name('v' + retry.version)}`)

--- a/src/commands/releases/rollback.ts
+++ b/src/commands/releases/rollback.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 
 import {stream} from '../../lib/releases/output.js'
@@ -22,23 +22,17 @@ export default class Rollback extends Command {
   static topic = 'releases'
 
   public async run(): Promise<void> {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Rollback)
     const {app} = flags
-    const release = await findByPreviousOrId(this.heroku, app, args.release)
+    const release = await findByPreviousOrId(platform, app, args.release)
 
     if (!release) {
       ux.error(`No eligible release found for ${color.app(app)} to roll back to.`)
     }
 
     ux.action.start(`Rolling back ${color.app(app)} to ${color.green('v' + release.version)}`)
-    const {body: latest} = await this.heroku.post<Heroku.Release>(`/apps/${app}/releases`, {
-      body: {
-        release: release.id,
-      },
-      headers: {
-        Accept: 'application/vnd.heroku+json; version=3.sdk',
-      },
-    })
+    const latest = await platform.release.rollback(app, {release: release.id})
     const streamUrl = latest.output_stream_url
     ux.action.stop(`done, ${color.green('v' + latest.version)}`)
     ux.warn("Rollback affects code and config vars; it doesn't add or remove addons.")

--- a/src/lib/releases/releases.ts
+++ b/src/lib/releases/releases.ts
@@ -1,43 +1,36 @@
-import {APIClient} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
+import {HerokuSDK} from '@heroku/sdk'
+import {Release} from '@heroku/types/3.sdk'
 
-export const findRelease = async function (heroku: APIClient, app: string, search: (releases: Heroku.Release[]) => Heroku.Release) {
-  const {body: releases} = await heroku.request<Heroku.Release[]>(`/apps/${app}/releases`, {
-    headers: {
-      Accept: 'application/vnd.heroku+json; version=3.sdk',
-      Range: 'version ..; max=10, order=desc',
-    },
-    partial: true,
-  })
+type Platform = HerokuSDK['platform']
+
+export const findRelease = async function (platform: Platform, app: string, search: (releases: Release[]) => Release) {
+  const releases = await platform
+    .withHeaders({Range: 'version ..; max=10, order=desc'})
+    .release.list(app)
 
   return search(releases)
 }
 
-export const getRelease = async function (heroku: APIClient, app: string, release: string) {
+export const getRelease = async function (platform: Platform, app: string, release: string) {
   let id = release.toLowerCase()
   id = id.startsWith('v') ? id.slice(1) : id
 
-  const {body: releaseResponse} = await heroku.get<Heroku.Release>(`/apps/${app}/releases/${id}`, {
-    headers: {
-      Accept: 'application/vnd.heroku+json; version=3.sdk',
-    },
-  })
-
+  const releaseResponse = platform.release.info(app, id)
   return releaseResponse
 }
 
-export const findByLatestOrId = async function (heroku: APIClient, app: string, release = 'current') {
+export const findByLatestOrId = async function (platform: Platform, app: string, release = 'current') {
   if (release === 'current') {
-    return findRelease(heroku, app, releases => releases[0])
+    return findRelease(platform, app, releases => releases[0])
   }
 
-  return getRelease(heroku, app, release)
+  return getRelease(platform, app, release)
 }
 
-export const findByPreviousOrId = async function (heroku: APIClient, app: string, release = 'previous') {
+export const findByPreviousOrId = async function (platform: Platform, app: string, release = 'previous') {
   if (release === 'previous') {
-    return findRelease(heroku, app, releases => releases.filter(r => r.eligible_for_rollback)[1])
+    return findRelease(platform, app, releases => releases.filter(r => r.eligible_for_rollback)[1])
   }
 
-  return getRelease(heroku, app, release)
+  return getRelease(platform, app, release)
 }

--- a/test/unit/commands/releases/index.unit.test.ts
+++ b/test/unit/commands/releases/index.unit.test.ts
@@ -1,14 +1,35 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuApiClient} from '@heroku/heroku-fetch'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Cmd from '../../../../src/commands/releases/index.js'
 import removeAllWhitespace from '../../../helpers/utils/remove-whitespaces.js'
 
+type FakePlatform = {
+  release: {
+    list: sinon.SinonStub,
+  }
+  withHeaders: sinon.SinonStub,
+}
+
+function buildFakePlatform(): FakePlatform {
+  const platform: FakePlatform = {
+    release: {
+      list: sinon.stub(),
+    },
+    withHeaders: sinon.stub(),
+  }
+  platform.withHeaders.returns(platform)
+  return platform
+}
+
 describe('releases', function () {
   let originalColumns: number | undefined
   let originalIsTTY: boolean | undefined
-  let api: nock.Scope
+  let api: sinon.SinonStub
+  let fakePlatform: FakePlatform
 
   before(function () {
     process.env.TZ = 'UTC' // Use UTC time always
@@ -17,7 +38,9 @@ describe('releases', function () {
   beforeEach(function () {
     originalColumns = process.stdout.columns
     originalIsTTY = process.stdout.isTTY
-    api = nock('https://api.heroku.com')
+    api = sinon.stub(HerokuApiClient.prototype, 'get')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
@@ -34,7 +57,7 @@ describe('releases', function () {
       process.stdout.columns = originalColumns
     }
 
-    api.done()
+    sinon.restore()
   })
 
   const releases = [
@@ -106,9 +129,17 @@ describe('releases', function () {
   ]
   const releasesNoSlug = [
     {
-      created_at: '2015-11-18T01:36:38Z', current: false, description: 'first commit', id: '86b20c9f-f5de-4876-aa36-d3dcb1d60f6a', slug: null, status: 'pending', updated_at: '2015-11-18T01:36:38Z', user: {
+      created_at: '2015-11-18T01:36:38Z',
+      current: false,
+      description: 'first commit',
+      id: '86b20c9f-f5de-4876-aa36-d3dcb1d60f6a',
+      slug: null,
+      status: 'pending',
+      updated_at: '2015-11-18T01:36:38Z',
+      user: {
         email: 'rdagg@heroku.com', id: '5985f8c9-a63f-42a2-bec7-40b875bb986f',
-      }, version: 1,
+      },
+      version: 1,
     },
   ]
   const extended = [
@@ -126,9 +157,7 @@ describe('releases', function () {
   it('shows releases', async function () {
     process.stdout.isTTY = true
     process.stdout.columns = 80
-    api
-      .get('/apps/myapp/releases')
-      .reply(200, releases)
+    fakePlatform.release.list.resolves(releases)
 
     const {stdout} = await runCommand(Cmd, [
       '--app',
@@ -142,14 +171,14 @@ describe('releases', function () {
     expect(actual).to.include(removeAllWhitespace('releasecomman…'))
     expect(actual).to.include(removeAllWhitespace('v40   Set foo config vars   rdagg@heroku.com'))
     expect(actual).to.include(removeAllWhitespace('v37   first commit   rdagg@heroku.com'))
+    expect(fakePlatform.withHeaders.calledOnceWithExactly({Range: 'version ..; max=15, order=desc'})).to.equal(true)
+    expect(fakePlatform.release.list.calledOnceWithExactly('myapp')).to.equal(true)
   })
 
   it('shows successful releases', async function () {
     process.stdout.isTTY = true
     process.stdout.columns = 80
-    api
-      .get('/apps/myapp/releases')
-      .reply(200, onlySuccessfulReleases)
+    fakePlatform.release.list.resolves(onlySuccessfulReleases)
 
     const {stdout} = await runCommand(Cmd, [
       '--app',
@@ -166,9 +195,7 @@ describe('releases', function () {
   it('shows releases in wider terminal', async function () {
     process.stdout.isTTY = true
     process.stdout.columns = 100
-    api
-      .get('/apps/myapp/releases')
-      .reply(200, releases)
+    fakePlatform.release.list.resolves(releases)
 
     const {stdout} = await runCommand(Cmd, [
       '--app',
@@ -185,9 +212,7 @@ describe('releases', function () {
   it('shows successful releases in wider terminal', async function () {
     process.stdout.isTTY = true
     process.stdout.columns = 100
-    api
-      .get('/apps/myapp/releases')
-      .reply(200, onlySuccessfulReleases)
+    fakePlatform.release.list.resolves(onlySuccessfulReleases)
 
     const {stdout} = await runCommand(Cmd, [
       '--app',
@@ -204,9 +229,7 @@ describe('releases', function () {
   it('shows releases in narrow terminal', async function () {
     process.stdout.isTTY = true
     process.stdout.columns = 65
-    api
-      .get('/apps/myapp/releases')
-      .reply(200, releases)
+    fakePlatform.release.list.resolves(releases)
 
     const {stdout} = await runCommand(Cmd, [
       '--app',
@@ -225,9 +248,7 @@ describe('releases', function () {
   it('shows pending releases without release phase', async function () {
     process.stdout.isTTY = true
     process.stdout.columns = 80
-    api
-      .get('/apps/myapp/releases')
-      .reply(200, releases)
+    fakePlatform.release.list.resolves(releases)
 
     const {stdout} = await runCommand(Cmd, [
       '--app',
@@ -246,9 +267,7 @@ describe('releases', function () {
   it('shows pending releases without a slug', async function () {
     process.stdout.isTTY = true
     process.stdout.columns = 80
-    api
-      .get('/apps/myapp/releases')
-      .reply(200, releasesNoSlug)
+    fakePlatform.release.list.resolves(releasesNoSlug)
 
     const {stdout} = await runCommand(Cmd, [
       '--app',
@@ -263,9 +282,7 @@ describe('releases', function () {
   })
 
   it('shows releases as json', async function () {
-    api
-      .get('/apps/myapp/releases')
-      .reply(200, releases)
+    fakePlatform.release.list.resolves(releases)
 
     const {stdout} = await runCommand(Cmd, [
       '--app',
@@ -277,9 +294,7 @@ describe('releases', function () {
   })
 
   it('shows message if no releases', async function () {
-    api
-      .get('/apps/myapp/releases')
-      .reply(200, [])
+    fakePlatform.release.list.resolves([])
 
     const {stdout} = await runCommand(Cmd, [
       '--app',
@@ -290,9 +305,7 @@ describe('releases', function () {
   })
 
   it('shows extended info', async function () {
-    api
-      .get('/apps/myapp/releases?extended=true')
-      .reply(200, extended)
+    api.withArgs('/apps/myapp/releases?extended=true').resolves({json: async () => extended})
 
     const {stdout} = await runCommand(Cmd, [
       '--app',
@@ -309,15 +322,15 @@ describe('releases', function () {
     expect(actual).to.include(removeAllWhitespace('rdagg@heroku.com'))
     expect(actual).to.include(removeAllWhitespace('1'))
     expect(actual).to.include(removeAllWhitespace('uuid'))
+    expect(api.calledOnce).to.equal(true)
+    expect(fakePlatform.release.list.called).to.equal(false)
     // stderr may contain warnings from other plugins in test environment
   })
 
   it('shows extended info in wider terminal', async function () {
     process.stdout.isTTY = true
     process.stdout.columns = 100
-    api
-      .get('/apps/myapp/releases?extended=true')
-      .reply(200, extended)
+    api.withArgs('/apps/myapp/releases?extended=true').resolves({json: async () => extended})
 
     const {stdout} = await runCommand(Cmd, [
       '--app',
@@ -344,9 +357,7 @@ describe('releases', function () {
     // Create a copy to avoid mutating the shared releases array
     const releasesCopy = releases.map(r => ({...r}))
     releasesCopy.at(-1)!.current = false
-    api
-      .get('/apps/myapp/releases')
-      .reply(200, releasesCopy)
+    fakePlatform.release.list.resolves(releasesCopy)
 
     const {stdout} = await runCommand(Cmd, [
       '--app',

--- a/test/unit/commands/releases/info.unit.test.ts
+++ b/test/unit/commands/releases/info.unit.test.ts
@@ -1,21 +1,56 @@
 import {expectOutput, runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 import tsheredoc from 'tsheredoc'
 
 import Cmd from '../../../../src/commands/releases/info.js'
 
 const heredoc = tsheredoc.default
 
-const d = new Date(2000, 1, 1)
+const createdAt = new Date(2000, 1, 1).toISOString()
+
+type FakePlatform = {
+  configVar: {
+    infoForAppRelease: sinon.SinonStub,
+  }
+  release: {
+    info: sinon.SinonStub,
+    list: sinon.SinonStub,
+  }
+  withHeaders: sinon.SinonStub,
+}
+
+function buildFakePlatform(): FakePlatform {
+  const platform: FakePlatform = {
+    configVar: {
+      infoForAppRelease: sinon.stub(),
+    },
+    release: {
+      info: sinon.stub(),
+      list: sinon.stub(),
+    },
+    withHeaders: sinon.stub(),
+  }
+  platform.withHeaders.returns(platform)
+  return platform
+}
+
 describe('releases:info', function () {
+  let fakePlatform: FakePlatform
+
+  beforeEach(function () {
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
+  })
+
   afterEach(function () {
-    return nock.cleanAll()
+    sinon.restore()
   })
 
   const release = {
     addon_plan_names: ['addon1', 'addon2'],
-    created_at: d,
+    created_at: createdAt,
     description: 'something changed',
     eligible_for_rollback: true,
     user: {
@@ -28,11 +63,8 @@ describe('releases:info', function () {
   const configVars = {FOO: 'foo', BAR: 'bar'}
 
   it('shows most recent release info', async function () {
-    nock('https://api.heroku.com')
-      .get('/apps/myapp/releases')
-      .reply(200, [release])
-      .get('/apps/myapp/releases/10/config-vars')
-      .reply(200, configVars)
+    fakePlatform.release.list.resolves([release])
+    fakePlatform.configVar.infoForAppRelease.resolves(configVars)
     const {stdout} = await runCommand(Cmd, [
       '--app',
       'myapp',
@@ -44,21 +76,20 @@ describe('releases:info', function () {
       By:                     foo@foo.com
       Change:                 something changed
       Eligible for Rollback?: Yes
-      When:                   ${d.toISOString()}
+      When:                   ${createdAt}
 
       === v10 Config vars
 
       FOO: foo
       BAR: bar
     `))
+    expect(fakePlatform.release.list.calledOnceWithExactly('myapp')).to.equal(true)
+    expect(fakePlatform.configVar.infoForAppRelease.calledOnceWithExactly('myapp', 10)).to.equal(true)
   })
 
   it('shows most recent release info config vars as shell', async function () {
-    nock('https://api.heroku.com')
-      .get('/apps/myapp/releases')
-      .reply(200, [release])
-      .get('/apps/myapp/releases/10/config-vars')
-      .reply(200, configVars)
+    fakePlatform.release.list.resolves([release])
+    fakePlatform.configVar.infoForAppRelease.resolves(configVars)
     const {stdout} = await runCommand(Cmd, [
       '--app',
       'myapp',
@@ -71,7 +102,7 @@ describe('releases:info', function () {
       By:                     foo@foo.com
       Change:                 something changed
       Eligible for Rollback?: Yes
-      When:                   ${d.toISOString()}
+      When:                   ${createdAt}
 
       === v10 Config vars
 
@@ -81,11 +112,8 @@ describe('releases:info', function () {
   })
 
   it('shows release info by id', async function () {
-    nock('https://api.heroku.com')
-      .get('/apps/myapp/releases/10')
-      .reply(200, release)
-      .get('/apps/myapp/releases/10/config-vars')
-      .reply(200, configVars)
+    fakePlatform.release.info.resolves(release)
+    fakePlatform.configVar.infoForAppRelease.resolves(configVars)
     const {stdout} = await runCommand(Cmd, [
       '--app',
       'myapp',
@@ -98,19 +126,19 @@ describe('releases:info', function () {
       By:                     foo@foo.com
       Change:                 something changed
       Eligible for Rollback?: Yes
-      When:                   ${d.toISOString()}
+      When:                   ${createdAt}
 
       === v10 Config vars
 
       FOO: foo
       BAR: bar
     `))
+    expect(fakePlatform.release.info.calledOnceWithExactly('myapp', '10')).to.equal(true)
+    expect(fakePlatform.configVar.infoForAppRelease.calledOnceWithExactly('myapp', 10)).to.equal(true)
   })
 
   it('shows recent release as json', async function () {
-    nock('https://api.heroku.com')
-      .get('/apps/myapp/releases/10')
-      .reply(200, release)
+    fakePlatform.release.info.resolves(release)
     const {stdout} = await runCommand(Cmd, [
       '--app',
       'myapp',
@@ -118,21 +146,20 @@ describe('releases:info', function () {
       'v10',
     ])
     expect(stdout).to.contain('"version": 10')
+    expect(fakePlatform.release.info.calledOnceWithExactly('myapp', '10')).to.equal(true)
+    expect(fakePlatform.configVar.infoForAppRelease.called).to.equal(false)
   })
 
   it('shows a failed release info', async function () {
-    nock('https://api.heroku.com')
-      .get('/apps/myapp/releases')
-      .reply(200, [{
-        created_at: d,
-        description: 'something changed',
-        eligible_for_rollback: false,
-        status: 'failed',
-        user: {email: 'foo@foo.com'},
-        version: 10,
-      }])
-      .get('/apps/myapp/releases/10/config-vars')
-      .reply(200, configVars)
+    fakePlatform.release.list.resolves([{
+      created_at: createdAt,
+      description: 'something changed',
+      eligible_for_rollback: false,
+      status: 'failed',
+      user: {email: 'foo@foo.com'},
+      version: 10,
+    }])
+    fakePlatform.configVar.infoForAppRelease.resolves(configVars)
     const {stdout} = await runCommand(Cmd, [
       '--app',
       'myapp',
@@ -142,7 +169,7 @@ describe('releases:info', function () {
       By:                     foo@foo.com
       Change:                 something changed (release command failed)
       Eligible for Rollback?: No
-      When:                   ${d.toISOString()}
+      When:                   ${createdAt}
 
       === v10 Config vars
 
@@ -152,19 +179,16 @@ describe('releases:info', function () {
   })
 
   it('shows a pending release info', async function () {
-    nock('https://api.heroku.com')
-      .get('/apps/myapp/releases')
-      .reply(200, [{
-        addon_plan_names: ['addon1', 'addon2'],
-        created_at: d,
-        description: 'something changed',
-        eligible_for_rollback: false,
-        status: 'pending',
-        user: {email: 'foo@foo.com'},
-        version: 10,
-      }])
-      .get('/apps/myapp/releases/10/config-vars')
-      .reply(200, configVars)
+    fakePlatform.release.list.resolves([{
+      addon_plan_names: ['addon1', 'addon2'],
+      created_at: createdAt,
+      description: 'something changed',
+      eligible_for_rollback: false,
+      status: 'pending',
+      user: {email: 'foo@foo.com'},
+      version: 10,
+    }])
+    fakePlatform.configVar.infoForAppRelease.resolves(configVars)
     const {stdout} = await runCommand(Cmd, [
       '--app',
       'myapp',
@@ -176,7 +200,7 @@ describe('releases:info', function () {
       By:                     foo@foo.com
       Change:                 something changed (release command executing)
       Eligible for Rollback?: No
-      When:                   ${d.toISOString()}
+      When:                   ${createdAt}
 
       === v10 Config vars
 
@@ -186,18 +210,15 @@ describe('releases:info', function () {
   })
 
   it("shows an expired release's info", async function () {
-    nock('https://api.heroku.com')
-      .get('/apps/myapp/releases')
-      .reply(200, [{
-        created_at: d,
-        description: 'something changed',
-        eligible_for_rollback: false,
-        status: 'expired',
-        user: {email: 'foo@foo.com'},
-        version: 10,
-      }])
-      .get('/apps/myapp/releases/10/config-vars')
-      .reply(200, configVars)
+    fakePlatform.release.list.resolves([{
+      created_at: createdAt,
+      description: 'something changed',
+      eligible_for_rollback: false,
+      status: 'expired',
+      user: {email: 'foo@foo.com'},
+      version: 10,
+    }])
+    fakePlatform.configVar.infoForAppRelease.resolves(configVars)
     const {stdout} = await runCommand(Cmd, [
       '--app',
       'myapp',
@@ -207,7 +228,7 @@ describe('releases:info', function () {
       By:                     foo@foo.com
       Change:                 something changed (release expired)
       Eligible for Rollback?: No
-      When:                   ${d.toISOString()}
+      When:                   ${createdAt}
 
       === v10 Config vars
 

--- a/test/unit/commands/releases/output.unit.test.ts
+++ b/test/unit/commands/releases/output.unit.test.ts
@@ -1,15 +1,47 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
 import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Cmd from '../../../../src/commands/releases/output.js'
 import {unwrap} from '../../../helpers/utils/unwrap.js'
 
+type FakePlatform = {
+  release: {
+    info: sinon.SinonStub,
+    list: sinon.SinonStub,
+  }
+  withHeaders: sinon.SinonStub,
+}
+
+function buildFakePlatform(): FakePlatform {
+  const platform: FakePlatform = {
+    release: {
+      info: sinon.stub(),
+      list: sinon.stub(),
+    },
+    withHeaders: sinon.stub(),
+  }
+  platform.withHeaders.returns(platform)
+  return platform
+}
+
 describe('releases:output', function () {
+  let fakePlatform: FakePlatform
+
+  beforeEach(function () {
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
+  })
+
+  afterEach(function () {
+    sinon.restore()
+    nock.cleanAll()
+  })
+
   it('warns if there is no output available', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/myapp/releases/10')
-      .reply(200, {version: 40})
+    fakePlatform.release.info.resolves({version: 40})
 
     const {stderr, stdout} = await runCommand(Cmd, [
       '--app',
@@ -18,16 +50,14 @@ describe('releases:output', function () {
     ])
     expect(stdout).to.equal('')
     expect(unwrap(stderr)).to.contain('Release v40 has no release output available.\n')
-    api.done()
+    expect(fakePlatform.release.info.calledOnceWithExactly('myapp', '10')).to.equal(true)
   })
 
   it('shows the output from a specific release', async function () {
     const busl = nock('https://busl.test:443')
       .get('/streams/release.log')
       .reply(200, 'Release Output Content')
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/myapp/releases/10')
-      .reply(200, {output_stream_url: 'https://busl.test/streams/release.log', version: 40})
+    fakePlatform.release.info.resolves({output_stream_url: 'https://busl.test/streams/release.log', version: 40})
 
     const {stderr, stdout} = await runCommand(Cmd, [
       '--app',
@@ -35,44 +65,37 @@ describe('releases:output', function () {
       'v10',
     ])
     busl.done()
-    api.done()
     expect(stdout).to.equal('Release Output Content')
     expect(stderr).to.equal('')
+    expect(fakePlatform.release.info.calledOnceWithExactly('myapp', '10')).to.equal(true)
   })
 
   it('shows the output from the latest release', async function () {
     const busl = nock('https://busl.test:443')
       .get('/streams/release.log')
       .reply(200, 'Release Output Content')
-
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/myapp/releases')
-      .reply(200, [{output_stream_url: 'https://busl.test/streams/release.log', version: 40}])
+    fakePlatform.release.list.resolves([{output_stream_url: 'https://busl.test/streams/release.log', version: 40}])
 
     const {stderr, stdout} = await runCommand(Cmd, [
       '--app',
       'myapp',
     ])
     busl.done()
-    api.done()
     expect(stdout).to.equal('Release Output Content')
     expect(stderr).to.equal('')
+    expect(fakePlatform.release.list.calledOnceWithExactly('myapp')).to.equal(true)
   })
 
-  it('has a missing output', async function () {
+  it('has a missing output when the stream returns 404', async function () {
     const busl = nock('https://busl.test:443')
       .get('/streams/release.log')
       .reply(404, '')
-
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/myapp/releases')
-      .reply(200, [{output_stream_url: 'https://busl.test/streams/release.log', version: 40}])
+    fakePlatform.release.list.resolves([{output_stream_url: 'https://busl.test/streams/release.log', version: 40}])
 
     const {stderr, stdout} = await runCommand(Cmd, [
       '--app',
       'myapp',
     ])
-    api.done()
     busl.done()
     expect(stdout).to.equal('')
     expect(stderr).to.contain('Warning: Release command not started yet. Please try again in a few')

--- a/test/unit/commands/releases/retry.unit.test.ts
+++ b/test/unit/commands/releases/retry.unit.test.ts
@@ -1,19 +1,48 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import ansis from 'ansis'
 import {expect} from 'chai'
 import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Cmd from '../../../../src/commands/releases/retry.js'
 
+type FakePlatform = {
+  formation: {
+    list: sinon.SinonStub,
+  }
+  release: {
+    create: sinon.SinonStub,
+    list: sinon.SinonStub,
+  }
+  withHeaders: sinon.SinonStub,
+}
+
+function buildFakePlatform(): FakePlatform {
+  const platform: FakePlatform = {
+    formation: {
+      list: sinon.stub(),
+    },
+    release: {
+      create: sinon.stub(),
+      list: sinon.stub(),
+    },
+    withHeaders: sinon.stub(),
+  }
+  platform.withHeaders.returns(platform)
+  return platform
+}
+
 describe('releases:retry', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
+    sinon.restore()
     nock.cleanAll()
   })
 
@@ -42,11 +71,8 @@ describe('releases:retry', function () {
   }
 
   it('errors when there are no releases yet', async function () {
-    api
-      .get('/apps/myapp/releases')
-      .reply(200, [])
-      .get('/apps/myapp/formation')
-      .reply(200, [])
+    fakePlatform.release.list.resolves([])
+    fakePlatform.formation.list.resolves([])
 
     await runCommand(Cmd, [
       '--app',
@@ -54,21 +80,19 @@ describe('releases:retry', function () {
     ]).catch((error: Error) => {
       expect(ansis.strip(error.message)).to.eq('No release found for ⬢ myapp.')
     })
+    expect(fakePlatform.release.list.calledOnceWithExactly('myapp')).to.equal(true)
+    expect(fakePlatform.formation.list.calledOnceWithExactly('myapp')).to.equal(true)
   })
 
   it('retries the release', async function () {
-    api
-      .get('/apps/myapp/releases')
-      .reply(200, release)
-      .get('/apps/myapp/formation')
-      .reply(200, formationWithReleasePhase)
-      .post('/apps/myapp/releases', releaseRetry)
-      .reply(200, {})
-
+    fakePlatform.release.list.resolves(release)
+    fakePlatform.formation.list.resolves(formationWithReleasePhase)
+    fakePlatform.release.create.resolves({})
     await runCommand(Cmd, [
       '--app',
       'myapp',
     ])
+    expect(fakePlatform.release.create.calledOnceWithExactly('myapp', releaseRetry)).to.equal(true)
   })
 
   it('shows the output from the latest release', async function () {
@@ -76,13 +100,9 @@ describe('releases:retry', function () {
       .get('/streams/release.log')
       .reply(200, 'Release Output Content')
 
-    api
-      .get('/apps/myapp/releases')
-      .reply(200, release)
-      .get('/apps/myapp/formation')
-      .reply(200, formationWithReleasePhase)
-      .post('/apps/myapp/releases', releaseRetry)
-      .reply(200, {output_stream_url: 'https://busl.test/streams/release.log'})
+    fakePlatform.release.list.resolves(release)
+    fakePlatform.formation.list.resolves(formationWithReleasePhase)
+    fakePlatform.release.create.resolves({output_stream_url: 'https://busl.test/streams/release.log'})
 
     const {stderr, stdout} = await runCommand(Cmd, [
       '--app',
@@ -92,14 +112,12 @@ describe('releases:retry', function () {
     expect(stderr).to.contain('Retrying v40 on')
     expect(stderr).to.contain('myapp')
     expect(stdout).to.contain('Release Output Content')
+    expect(fakePlatform.release.create.calledOnceWithExactly('myapp', releaseRetry)).to.equal(true)
   })
 
   it('errors if app does not use release-phase', async function () {
-    api
-      .get('/apps/myapp/releases')
-      .reply(200, release)
-      .get('/apps/myapp/formation')
-      .reply(200, formationWithoutReleasePhase)
+    fakePlatform.release.list.resolves(release)
+    fakePlatform.formation.list.resolves(formationWithoutReleasePhase)
 
     await runCommand(Cmd, [
       '--app',
@@ -107,5 +125,6 @@ describe('releases:retry', function () {
     ]).catch((error: Error) => {
       expect(error.message).to.eq('App must have a release-phase command to use this command.')
     })
+    expect(fakePlatform.release.create.called).to.equal(false)
   })
 })

--- a/test/unit/commands/releases/rollback.unit.test.ts
+++ b/test/unit/commands/releases/rollback.unit.test.ts
@@ -1,21 +1,50 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
 import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Cmd from '../../../../src/commands/releases/rollback.js'
 import {unwrap} from '../../../helpers/utils/unwrap.js'
 
+type FakePlatform = {
+  release: {
+    info: sinon.SinonStub,
+    list: sinon.SinonStub,
+    rollback: sinon.SinonStub,
+  }
+  withHeaders: sinon.SinonStub,
+}
+
+function buildFakePlatform(): FakePlatform {
+  const platform: FakePlatform = {
+    release: {
+      info: sinon.stub(),
+      list: sinon.stub(),
+      rollback: sinon.stub(),
+    },
+    withHeaders: sinon.stub(),
+  }
+  platform.withHeaders.returns(platform)
+  return platform
+}
+
 describe('releases:rollback', function () {
+  let fakePlatform: FakePlatform
+
+  beforeEach(function () {
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
+  })
+
   afterEach(function () {
-    return nock.cleanAll()
+    sinon.restore()
+    nock.cleanAll()
   })
 
   it('rolls back the release', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/myapp/releases/10')
-      .reply(200, {id: '5efa3510-e8df-4db0-a176-83ff8ad91eb5', version: 40})
-      .post('/apps/myapp/releases', {release: '5efa3510-e8df-4db0-a176-83ff8ad91eb5'})
-      .reply(200, {})
+    fakePlatform.release.info.resolves({id: '5efa3510-e8df-4db0-a176-83ff8ad91eb5', version: 40})
+    fakePlatform.release.rollback.resolves({})
 
     await runCommand(Cmd, [
       '--app',
@@ -23,58 +52,51 @@ describe('releases:rollback', function () {
       'v10',
     ])
 
-    api.done()
+    expect(fakePlatform.release.info.calledOnceWithExactly('myapp', '10')).to.equal(true)
+    expect(fakePlatform.release.rollback.calledOnceWithExactly('myapp', {release: '5efa3510-e8df-4db0-a176-83ff8ad91eb5'})).to.equal(true)
   })
 
   it('rolls back to the latest release', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/myapp/releases')
-      .reply(200, [{
-        eligible_for_rollback: true, id: 'current_release', status: 'succeeded', version: 41,
-      }, {
-        eligible_for_rollback: true, id: 'previous_release', status: 'succeeded', version: 40,
-      }])
-      .post('/apps/myapp/releases', {release: 'previous_release'})
-      .reply(200, {})
+    fakePlatform.release.list.resolves([{
+      eligible_for_rollback: true, id: 'current_release', status: 'succeeded', version: 41,
+    }, {
+      eligible_for_rollback: true, id: 'previous_release', status: 'succeeded', version: 40,
+    }])
+    fakePlatform.release.rollback.resolves({})
 
     await runCommand(Cmd, [
       '--app',
       'myapp',
     ])
 
-    api.done()
+    expect(fakePlatform.release.list.calledOnceWithExactly('myapp')).to.equal(true)
+    expect(fakePlatform.release.rollback.calledOnceWithExactly('myapp', {release: 'previous_release'})).to.equal(true)
   })
 
   it('does not roll back to a failed release', async function () {
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/myapp/releases')
-      .reply(200, [{
-        eligible_for_rollback: true, id: 'current_release', status: 'succeeded', version: 41,
-      }, {
-        eligible_for_rollback: false, id: 'failed_release', status: 'failed', version: 40,
-      }, {
-        eligible_for_rollback: true, id: 'succeeded_release', status: 'succeeded', version: 39,
-      }])
-      .post('/apps/myapp/releases', {release: 'succeeded_release'})
-      .reply(200, {})
+    fakePlatform.release.list.resolves([{
+      eligible_for_rollback: true, id: 'current_release', status: 'succeeded', version: 41,
+    }, {
+      eligible_for_rollback: false, id: 'failed_release', status: 'failed', version: 40,
+    }, {
+      eligible_for_rollback: true, id: 'succeeded_release', status: 'succeeded', version: 39,
+    }])
+    fakePlatform.release.rollback.resolves({})
 
     await runCommand(Cmd, [
       '--app',
       'myapp',
     ])
 
-    api.done()
+    expect(fakePlatform.release.rollback.calledOnceWithExactly('myapp', {release: 'succeeded_release'})).to.equal(true)
   })
 
   it('streams the release command output', async function () {
     const busl = nock('https://busl.test:443')
       .get('/streams/release.log')
       .reply(200, 'Release Output Content')
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/myapp/releases/10')
-      .reply(200, {id: '5efa3510-e8df-4db0-a176-83ff8ad91eb5', version: 40})
-      .post('/apps/myapp/releases', {release: '5efa3510-e8df-4db0-a176-83ff8ad91eb5'})
-      .reply(200, {output_stream_url: 'https://busl.test/streams/release.log', version: 40})
+    fakePlatform.release.info.resolves({id: '5efa3510-e8df-4db0-a176-83ff8ad91eb5', version: 40})
+    fakePlatform.release.rollback.resolves({output_stream_url: 'https://busl.test/streams/release.log', version: 40})
 
     const {stderr, stdout} = await runCommand(Cmd, [
       '--app',
@@ -82,7 +104,6 @@ describe('releases:rollback', function () {
       'v10',
     ])
     busl.done()
-    api.done()
 
     const stderr_output = unwrap(stderr)
     expect(stderr_output).to.contain('Rolling back ⬢ myapp to v40... done, v40')
@@ -91,15 +112,12 @@ describe('releases:rollback', function () {
     expect(stdout).to.equal('Running release command...\nRelease Output Content')
   })
 
-  it('has a missing output', async function () {
+  it('has a missing output when the stream returns 404', async function () {
     const busl = nock('https://busl.test:443')
       .get('/streams/release.log')
       .reply(404, '')
-    const api = nock('https://api.heroku.com:443')
-      .get('/apps/myapp/releases/10')
-      .reply(200, {id: '5efa3510-e8df-4db0-a176-83ff8ad91eb5', version: 40})
-      .post('/apps/myapp/releases', {release: '5efa3510-e8df-4db0-a176-83ff8ad91eb5'})
-      .reply(200, {output_stream_url: 'https://busl.test/streams/release.log', version: 40})
+    fakePlatform.release.info.resolves({id: '5efa3510-e8df-4db0-a176-83ff8ad91eb5', version: 40})
+    fakePlatform.release.rollback.resolves({output_stream_url: 'https://busl.test/streams/release.log', version: 40})
 
     const {stderr, stdout} = await runCommand(Cmd, [
       '--app',
@@ -107,7 +125,6 @@ describe('releases:rollback', function () {
       'v10',
     ])
     busl.done()
-    api.done()
 
     expect(stdout).to.equal('Running release command...\n')
     expect(unwrap(stderr)).to.contain('Release command starting. Use `heroku releases:output` to view the log.')


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
This PR migrates the following `releases` commands to use `@heroku/sdk`:

- `releases/index`
- `releases/info`
- `releases/output`
- `releases/retry`
- `releases/rollback`

**Details:**
- Replaced direct API calls with the SDK
- Rewrote tests to stub the SDK directly instead of using nock

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
<!-- Add any context/setup necessary for testing. -->
The SDK uses `heroku-fetch` to make API calls, which looks for a netrc file. Therefore, we must log in with `HEROKU_NETRC_WRITE=true`. Requires an app with a release-phase command. The `test-app-release-phase` app should work.

**Setup**:
- Pull down this branch
- `npm i && npm run build`
- `heroku logout`
- `HEROKU_NETRC_WRITE=true ./bin/run login`

**Steps**:
```bash
# List releases
./bin/run releases --app $APP

# View latest release info
./bin/run releases:info --app $APP

# View latest release output
./bin/run releases:output --app $APP

# Retry latest release
./bin/run releases:retry --app $APP

# Confirm retried release
./bin/run releases --app $APP

# Rollback to previous release
./bin/run releases:rollback --app $APP

# Confirm rollback
./bin/run releases --app $APP
```

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-23387919](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eMBPAYA4/view)