### PR TITLE
refactor(features): use @heroku/sdk

### DIFF
--- a/src/commands/features/disable.ts
+++ b/src/commands/features/disable.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 
 export default class Disable extends Command {
@@ -14,20 +14,19 @@ export default class Disable extends Command {
   }
 
   async run() {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Disable)
 
     const {app} = flags
     const {feature} = args
 
     ux.action.start(`Disabling ${color.name(feature)} for ${color.app(app)}`)
-    const {body: f} = await this.heroku.get<Heroku.AppFeature>(`/apps/${app}/features/${feature}`)
+    const f = await platform.appFeature.info(app, feature)
     if (!f.enabled) {
       throw new Error(`${color.name(feature)} is already disabled.`)
     }
 
-    await this.heroku.patch(`/apps/${app}/features/${feature}`, {
-      body: {enabled: false},
-    })
+    await platform.appFeature.update(app, feature, {enabled: false})
 
     ux.action.stop()
   }

--- a/src/commands/features/enable.ts
+++ b/src/commands/features/enable.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 
 export default class Enable extends Command {
@@ -14,18 +14,17 @@ export default class Enable extends Command {
   }
 
   async run() {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Enable)
 
     const {app} = flags
     const {feature} = args
 
     ux.action.start(`Enabling ${color.name(feature)} for ${color.app(app)}`)
-    const {body: f} = await this.heroku.get<Heroku.AppFeature>(`/apps/${app}/features/${feature}`)
+    const f = await platform.appFeature.info(app, feature)
     if (f.enabled) throw new Error(`${color.name(feature)} is already enabled.`)
 
-    await this.heroku.patch(`/apps/${app}/features/${feature}`, {
-      body: {enabled: true},
-    })
+    await platform.appFeature.update(app, feature, {enabled: true})
     ux.action.stop()
   }
 }

--- a/src/commands/features/info.ts
+++ b/src/commands/features/info.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import {color, hux} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args} from '@oclif/core'
 
 export default class Info extends Command {
@@ -15,10 +15,11 @@ export default class Info extends Command {
   }
 
   async run() {
+    const {platform} = new HerokuSDK()
     const {args, flags} = await this.parse(Info)
 
     const {app, json} = flags
-    const {body: feature} = await this.heroku.get<Heroku.AppFeature>(`/apps/${app}/features/${args.feature}`)
+    const feature = await platform.appFeature.info(app, args.feature)
 
     if (json) {
       hux.styledJSON(feature)

--- a/test/unit/commands/features/disable.unit.test.ts
+++ b/test/unit/commands/features/disable.unit.test.ts
@@ -1,28 +1,42 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import ansis from 'ansis'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import FeaturesDisable from '../../../../src/commands/features/disable.js'
 
-describe('features:disable',  function () {
-  let api: nock.Scope
+type FakePlatform = {
+  appFeature: {
+    info: sinon.SinonStub,
+    update: sinon.SinonStub,
+  },
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    appFeature: {
+      info: sinon.stub(),
+      update: sinon.stub(),
+    },
+  }
+}
+
+describe('features:disable', function () {
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('disables an app feature', async function () {
-    api
-      .get('/apps/myapp/features/feature-a')
-      .reply(200, {enabled: true})
-      .patch('/apps/myapp/features/feature-a', {enabled: false})
-      .reply(200)
+    fakePlatform.appFeature.info.resolves({enabled: true})
+    fakePlatform.appFeature.update.resolves({enabled: false})
 
     const {stderr, stdout} = await runCommand(FeaturesDisable, ['-a', 'myapp', 'feature-a'])
 
@@ -30,15 +44,16 @@ describe('features:disable',  function () {
     expect(stderr).to.include('myapp')
     expect(stderr).to.include('done')
     expect(stdout).to.equal('')
+    expect(fakePlatform.appFeature.info.calledOnceWithExactly('myapp', 'feature-a')).to.equal(true)
+    expect(fakePlatform.appFeature.update.calledOnceWithExactly('myapp', 'feature-a', {enabled: false})).to.equal(true)
   })
 
   it('errors if feature is already disabled', async function () {
-    api
-      .get('/apps/myapp/features/feature-a')
-      .reply(200, {enabled: false})
+    fakePlatform.appFeature.info.resolves({enabled: false})
 
     const {error} = await runCommand(FeaturesDisable, ['-a', 'myapp', 'feature-a'])
 
     expect(ansis.strip(error?.message || '')).to.equal('feature-a is already disabled.')
+    expect(fakePlatform.appFeature.update.called).to.equal(false)
   })
 })

--- a/test/unit/commands/features/enable.unit.test.ts
+++ b/test/unit/commands/features/enable.unit.test.ts
@@ -1,28 +1,42 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import ansis from 'ansis'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import FeaturesEnable from '../../../../src/commands/features/enable.js'
 
+type FakePlatform = {
+  appFeature: {
+    info: sinon.SinonStub,
+    update: sinon.SinonStub,
+  },
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    appFeature: {
+      info: sinon.stub(),
+      update: sinon.stub(),
+    },
+  }
+}
+
 describe('features:enable', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('enables an app feature', async function () {
-    api
-      .get('/apps/myapp/features/feature-a')
-      .reply(200, {enabled: false})
-      .patch('/apps/myapp/features/feature-a', {enabled: true})
-      .reply(200)
+    fakePlatform.appFeature.info.resolves({enabled: false})
+    fakePlatform.appFeature.update.resolves({enabled: true})
 
     const {stderr, stdout} = await runCommand(FeaturesEnable, ['feature-a', '--app', 'myapp'])
 
@@ -30,15 +44,16 @@ describe('features:enable', function () {
     expect(stderr).to.contain('Enabling feature-a for')
     expect(stderr).to.contain('myapp')
     expect(stderr).to.contain('done')
+    expect(fakePlatform.appFeature.info.calledOnceWithExactly('myapp', 'feature-a')).to.equal(true)
+    expect(fakePlatform.appFeature.update.calledOnceWithExactly('myapp', 'feature-a', {enabled: true})).to.equal(true)
   })
 
   it('errors if feature is already enabled', async function () {
-    api
-      .get('/apps/myapp/features/feature-a')
-      .reply(200, {enabled: true})
+    fakePlatform.appFeature.info.resolves({enabled: true})
 
     const {error} = await runCommand(FeaturesEnable, ['-a', 'myapp', 'feature-a'])
 
     expect(ansis.strip(error?.message || '')).to.equal('feature-a is already enabled.')
+    expect(fakePlatform.appFeature.update.called).to.equal(false)
   })
 })

--- a/test/unit/commands/features/info.unit.test.ts
+++ b/test/unit/commands/features/info.unit.test.ts
@@ -1,31 +1,43 @@
-
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import FeaturesInfo from '../../../../src/commands/features/info.js'
 
+type FakePlatform = {
+  appFeature: {
+    info: sinon.SinonStub,
+  },
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    appFeature: {
+      info: sinon.stub(),
+    },
+  }
+}
+
 describe('features:info', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('shows feature info', async function () {
-    api
-      .get('/apps/myapp/features/feature-a')
-      .reply(200, {
-        description: 'the description',
-        doc_url: 'https://devcenter.heroku.com',
-        enabled: true,
-        name: 'myfeature',
-      })
+    fakePlatform.appFeature.info.resolves({
+      description: 'the description',
+      doc_url: 'https://devcenter.heroku.com',
+      enabled: true,
+      name: 'myfeature',
+    })
 
     const {stderr, stdout} = await runCommand(FeaturesInfo, ['-a', 'myapp', 'feature-a'])
 
@@ -36,5 +48,6 @@ Docs:        https://devcenter.heroku.com
 Enabled:     true
 `)
     expect(stderr).to.equal('')
+    expect(fakePlatform.appFeature.info.calledOnceWithExactly('myapp', 'feature-a')).to.equal(true)
   })
 })


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
This PR migrates the following `features` commands to use `@heroku/sdk`:

- `features:disable`
- `features:enable`
- `features:info`

**Details:**
- Replaced direct API calls with the SDK
- Rewrote tests to stub the SDK directly instead of using nock

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
<!-- Add any context/setup necessary for testing. -->
The SDK uses `heroku-fetch` to make API calls, which looks for a netrc file. Therefore, we must log in with `HEROKU_NETRC_WRITE=true`.

**Setup**:
- Pull down this branch
- `npm i && npm run build`
- `heroku logout`
- `HEROKU_NETRC_WRITE=true ./bin/run login`

**Steps**:
```bash
# List available app features
./bin/run features --app APP

# Enable app feature
./bin/run features:enable FEATURE --app APP

# Display information about the above feature - should be `Enabled: true`
./bin/run features:info FEATURE --app APP

# Disable app feature
./bin/run features:disable FEATURE --app APP

# Display information about the above feature - should  be `Enabled: false`
./bin/run features:info FEATURE --app APP
```

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-23388645](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eMyvAYAS/view)