### PR TITLE
fix(ps): render ps --extended as vertical detail blocks

### DIFF
--- a/docs/ps.md
+++ b/docs/ps.md
@@ -30,7 +30,6 @@ FLAGS
   -a, --app=<value>     (required) [env: HEROKU_APP] app to run command against
   -r, --remote=<value>  git remote of app to use
       --json            display as json
-      --no-wrap         disable wrapped table cells for easier copy/paste
 
 GLOBAL FLAGS
   --prompt  interactively prompt for command arguments and flags

--- a/src/commands/ps/index.ts
+++ b/src/commands/ps/index.ts
@@ -8,7 +8,6 @@ import {AccountQuota} from '../../lib/types/account-quota.js'
 import {AppProcessTier} from '../../lib/types/app-process-tier.js'
 import {DynoExtended} from '../../lib/types/dyno-extended.js'
 import {Account} from '../../lib/types/fir.js'
-import {huxTableNoWrapOptions} from '../../lib/utils/table-utils.js'
 
 const heredoc = tsheredoc.default
 
@@ -29,7 +28,6 @@ export default class Index extends Command {
     app: flags.app({required: true}),
     extended: flags.boolean({char: 'x', hidden: true}), // only works with sudo privileges
     json: flags.boolean({description: 'display as json'}),
-    'no-wrap': flags.noWrap(),
     remote: flags.remote(),
   }
   static strict = false
@@ -77,7 +75,7 @@ export default class Index extends Command {
     if (json)
       hux.styledJSON(selectedDynos)
     else if (extended)
-      printExtended(selectedDynos, flags['no-wrap'])
+      printExtended(selectedDynos)
     else {
       await printAccountQuota(this.heroku, appInfo, accountInfo)
       if (selectedDynos.length === 0)
@@ -205,35 +203,31 @@ function printDynos(dynos: DynoExtended[]) : void {
   }
 }
 
-function printExtended(dynos: DynoExtended[], noWrap = false) {
+function printExtended(dynos: DynoExtended[]) {
   const sortedDynos = dynos.sort(byProcessTypeAndNumber)
 
-  /* eslint-disable perfectionist/sort-objects */
-  hux.table<DynoExtended>(
-    sortedDynos,
-    {
-      ID: {get: (dyno: DynoExtended) => dyno.id},
-      Process: {get: (dyno: DynoExtended) => dyno.name},
-      State: {get: (dyno: DynoExtended) => `${dyno.state} ${ago(new Date(dyno.updated_at))}`},
-      Region: {get: (dyno: DynoExtended) => dyno.extended?.region ?? ''},
-      'Execution Plane': {get: (dyno: DynoExtended) => dyno.extended?.execution_plane ?? ''},
-      Fleet: {get: (dyno: DynoExtended) => dyno.extended?.fleet ?? ''},
-      Instance: {get: (dyno: DynoExtended) => dyno.extended?.instance ?? ''},
-      IP: {get: (dyno: DynoExtended) => dyno.extended?.ip ?? ''},
-      Port: {get: (dyno: DynoExtended) => dyno.extended?.port?.toString() ?? ''},
-      AZ: {get: (dyno: DynoExtended) => dyno.extended?.az ?? ''},
-      Release: {get: (dyno: DynoExtended) => dyno.release.version},
-      Command: {get: (dyno: DynoExtended) => truncate(dyno.command)},
-      Route: {get: (dyno: DynoExtended) => dyno.extended?.route ?? ''},
-      Size: {get: (dyno: DynoExtended) => dyno.size},
-    },
-    huxTableNoWrapOptions(noWrap),
-  )
-  /* eslint-enable perfectionist/sort-objects */
-}
+  for (const dyno of sortedDynos) {
+    const ext = dyno.extended ?? {}
 
-function truncate(s: string) {
-  return s.length > 35 ? `${s.slice(0, 34)}…` : s
+    hux.styledHeader(`${color.label(dyno.name)} (${color.info(dyno.size)})`)
+    /* eslint-disable perfectionist/sort-objects */
+    hux.styledObject({
+      ID: dyno.id,
+      State: `${dyno.state} ${ago(new Date(dyno.updated_at))}`,
+      Release: dyno.release.version,
+      Command: dyno.command,
+      Region: ext.region,
+      'Execution Plane': ext.execution_plane,
+      Fleet: ext.fleet,
+      Instance: ext.instance,
+      IP: ext.ip,
+      Port: ext.port,
+      AZ: ext.az,
+      Route: ext.route,
+    })
+    /* eslint-enable perfectionist/sort-objects */
+    ux.stdout()
+  }
 }
 
 function uniqueValues(value: string, index: number, self: string[]) : boolean {

--- a/test/unit/commands/ps/index.unit.test.ts
+++ b/test/unit/commands/ps/index.unit.test.ts
@@ -1,9 +1,8 @@
 import {runCommand} from '@heroku-cli/test-utils'
-import {hux} from '@heroku/heroku-cli-util'
 import ansis from 'ansis'
 import {expect} from 'chai'
 import nock from 'nock'
-import {restore, stub} from 'sinon'
+import {restore} from 'sinon'
 import strftime from 'strftime'
 import tsheredoc from 'tsheredoc'
 
@@ -269,48 +268,35 @@ describe('ps', function () {
     api.done()
 
     expect(normalizeTableOutput(stdout)).to.equal(normalizeTableOutput(`
-      Id  Process State                                   Region Execution plane Fleet Instance Ip       Port Az      Release Command   Route    Size
-      ─── ─────── ─────────────────────────────────────── ────── ─────────────── ───── ──────── ──────── ──── ─────── ─────── ───────── ──────── ────
-      101 run.1   up ${hourAgoStr} (~ 1h ago) us     execution_plane fleet instance 10.0.0.2 8000 us-east 40      bash      da route Eco
-      100 web.1   up ${hourAgoStr} (~ 1h ago) us     execution_plane fleet instance 10.0.0.1 8000 us-east 40      npm start da route Eco
+      === run.1 (Eco)
+      ID:              101
+      State:           up ${hourAgoStr} (~ 1h ago)
+      Release:         40
+      Command:         bash
+      Region:          us
+      Execution Plane: execution_plane
+      Fleet:           fleet
+      Instance:        instance
+      IP:              10.0.0.2
+      Port:            8000
+      AZ:              us-east
+      Route:           da route
+      === web.1 (Eco)
+      ID:              100
+      State:           up ${hourAgoStr} (~ 1h ago)
+      Release:         40
+      Command:         npm start
+      Region:          us
+      Execution Plane: execution_plane
+      Fleet:           fleet
+      Instance:        instance
+      IP:              10.0.0.1
+      Port:            8000
+      AZ:              us-east
+      Route:           da route
     `))
 
     expect(stderr).to.equal('')
-  })
-
-  it('passes no-wrap option through to extended table rendering', async function () {
-    nock('https://api.heroku.com', {reqheaders: {accept: 'application/vnd.heroku+json; version=3.sdk'}})
-      .get('/account')
-      .reply(200, {id: '1234'})
-      .get('/apps/myapp')
-      .reply(200, {name: 'myapp'})
-      .get('/apps/myapp/dynos?extended=true')
-      .reply(200, [{
-        command: 'npm start',
-        extended: {
-          az: 'us-east',
-          execution_plane: 'execution_plane',
-          fleet: 'fleet',
-          instance: 'instance',
-          ip: '10.0.0.1',
-          port: 8000,
-          region: 'us',
-          route: 'da route',
-        },
-        id: '100',
-        name: 'web.1',
-        release: {id: '10', version: '40'},
-        size: 'Eco',
-        state: 'up',
-        type: 'web',
-        updated_at: hourAgo,
-      }])
-
-    const tableStub = stub(hux, 'table')
-    await runCommand(Cmd, ['--app', 'myapp', '--extended', '--no-wrap'])
-
-    const callArgs = tableStub.firstCall.args
-    expect(callArgs[2]).to.include({maxWidth: 'none', overflow: 'truncate'})
   })
 
   it('shows extended info for Private Space app', async function () {
@@ -369,10 +355,22 @@ describe('ps', function () {
     api.done()
 
     expect(normalizeTableOutput(stdout)).to.equal(normalizeTableOutput(`
-      Id  Process State                                   Region Execution plane Fleet Instance Ip       Port Az Release Command   Route Size
-      ─── ─────── ─────────────────────────────────────── ────── ─────────────── ───── ──────── ──────── ──── ── ─────── ───────── ───── ────
-      101 run.1   up ${hourAgoStr} (~ 1h ago) us                           instance 10.0.0.1         40      bash            Eco
-      100 web.1   up ${hourAgoStr} (~ 1h ago) us                           instance 10.0.0.1         40      npm start       Eco
+      === run.1 (Eco)
+      ID:       101
+      State:    up ${hourAgoStr} (~ 1h ago)
+      Release:  40
+      Command:  bash
+      Region:   us
+      Instance: instance
+      IP:       10.0.0.1
+      === web.1 (Eco)
+      ID:       100
+      State:    up ${hourAgoStr} (~ 1h ago)
+      Release:  40
+      Command:  npm start
+      Region:   us
+      Instance: instance
+      IP:       10.0.0.1
     `))
     expect(stderr).to.equal('')
   })
@@ -419,10 +417,32 @@ describe('ps', function () {
     api.done()
 
     expect(normalizeTableOutput(stdout)).to.equal(normalizeTableOutput(`
-      Id  Process State                                   Region Execution plane Fleet Instance Ip       Port Az      Release Command   Route    Size
-      ─── ─────── ─────────────────────────────────────── ────── ─────────────── ───── ──────── ──────── ──── ─────── ─────── ───────── ──────── ────────
-      101 run.1   up ${hourAgoStr} (~ 1h ago) us     execution_plane fleet instance 10.0.0.2 8000 us-east 40      bash      da route Shield-L
-      100 web.1   up ${hourAgoStr} (~ 1h ago) us     execution_plane fleet instance 10.0.0.1 8000 us-east 40      npm start da route Shield-M
+      === run.1 (Shield-L)
+      ID:              101
+      State:           up ${hourAgoStr} (~ 1h ago)
+      Release:         40
+      Command:         bash
+      Region:          us
+      Execution Plane: execution_plane
+      Fleet:           fleet
+      Instance:        instance
+      IP:              10.0.0.2
+      Port:            8000
+      AZ:              us-east
+      Route:           da route
+      === web.1 (Shield-M)
+      ID:              100
+      State:           up ${hourAgoStr} (~ 1h ago)
+      Release:         40
+      Command:         npm start
+      Region:          us
+      Execution Plane: execution_plane
+      Fleet:           fleet
+      Instance:        instance
+      IP:              10.0.0.1
+      Port:            8000
+      AZ:              us-east
+      Route:           da route
     `))
     expect(stderr).to.equal('')
   })


### PR DESCRIPTION
## Problem

The extended `ps -x` output rendered a wide **14-column** `hux.table`. On any terminal narrower than the full table width — which is nearly always, given it packs dyno UUIDs, timestamps, IPs, routes, and a new `Fleet` column — every cell wrapped down to a few characters, shredding each value vertically:

```
  ID   Process   State   Region   Execution     Fleet   Instance   IP   Port   AZ   Release   Command   Route   Size
                                  Plane
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  00   web.1     up      us       ex01          exam    0000000    10   0000   us   1         example   0000a   Stan
  00             0000/                          ple-1              .0   0      -e             -comman   000-0   dard
  ...
```

The existing `--no-wrap` flag only truncated instead of wrapping, and it was opt-in — so the default experience stayed unreadable.

## Fix

Render one **vertical detail block per dyno** using `hux.styledObject` under a styled header — the same pattern as `releases:info` and other detail views:

```
=== web.1 (Standard-1X)
ID:              00000000-0000-0000-0000-000000000000
State:           up 0000/00/00 00:00 (~00m ago)
Release:         1
Command:         example-command as t-0000
Region:          us
Execution Plane: example-plane
Fleet:           standard-1x
Instance:        0000000.0.0.00
IP:              10.0.0.0
Port:            00000
AZ:              us-example-0a
Route:           00000000-0000-...
```

Benefits:
- **Never wraps** at any terminal width.
- **Full command** shown rather than truncated to 35 chars.
- **Null fields omitted** — Private Space dynos without an AZ/route/port no longer print empty columns; those keys simply don't appear.

## Removed `--no-wrap` from `ps`

That flag existed only to mitigate this table's wrapping and was passed solely to the extended renderer. With vertical blocks it's dead code on this command, so it's removed here (along with the now-unused `truncate` helper). The flag remains available on the other commands that use it (`addons`, `domains`, `pg:credentials`, `data:pg:credentials`).

## Testing

- Updated the three extended-output assertions in `test/unit/commands/ps/index.unit.test.ts` to the block format, and removed the obsolete `--no-wrap` pass-through test. All 18 `ps` unit tests pass.
- `npm run build`, `tsc --noEmit`, and `eslint` are clean (one pre-existing lint warning on unrelated `printDynos` code).
- Regenerated `docs/ps.md` via `oclif readme`.

## Note

This targets the `ps` command in this repo.
