### PR TITLE
refactor(config): use @heroku/sdk

### DIFF
--- a/src/commands/config/edit.ts
+++ b/src/commands/config/edit.ts
@@ -1,11 +1,13 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import {color, hux} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args, ux} from '@oclif/core'
 
 import {parse, quote} from '../../lib/config/quote.js'
 import {EditorFactory} from '../../lib/config/util.js'
 import {lazyModuleLoader} from '../../lib/lazy-module-loader.js'
+
+type Platform = HerokuSDK['platform']
 
 interface Config {
   [key: string]: string;
@@ -38,12 +40,13 @@ ${color.command('VISUAL="atom --wait" heroku config:edit')}`,
   app!: string
 
   async run() {
+    const {platform} = new HerokuSDK()
     const _ = await lazyModuleLoader.loadLodash()
 
     const {args: {key}, flags: {app}} = await this.parse(ConfigEdit)
     this.app = app
     ux.action.start('Fetching config')
-    const original = await this.fetchLatestConfig()
+    const original = await this.fetchLatestConfig(platform)
     ux.action.stop()
     let newConfig = {...original}
     const prefix = `heroku-${app}-config-`
@@ -58,10 +61,10 @@ ${color.command('VISUAL="atom --wait" heroku config:edit')}`,
 
     if (!await this.diffPrompt(original, newConfig, _)) return
     ux.action.start('Verifying new config')
-    await this.verifyUnchanged(original, _)
+    await this.verifyUnchanged(original, _, platform)
     ux.action.start('Updating config')
     removeDeleted(newConfig, original)
-    await this.updateConfig(newConfig)
+    await this.updateConfig(newConfig, platform)
     ux.action.stop()
   }
 
@@ -78,19 +81,17 @@ ${color.command('VISUAL="atom --wait" heroku config:edit')}`,
     return hux.confirm(`Update config on ${color.app(this.app)} with these values?`)
   }
 
-  private async fetchLatestConfig() {
-    const {body: original} = await this.heroku.get<Heroku.ConfigVars>(`/apps/${this.app}/config-vars`)
+  private async fetchLatestConfig(platform: Platform) {
+    const original = await platform.configVar.infoForApp(this.app)
     return original
   }
 
-  private async updateConfig(newConfig: UploadConfig) {
-    await this.heroku.patch(`/apps/${this.app}/config-vars`, {
-      body: newConfig,
-    })
+  private async updateConfig(newConfig: UploadConfig, platform: Platform) {
+    await platform.configVar.update(this.app, newConfig)
   }
 
-  private async verifyUnchanged(original: Config, _: any) {
-    const latest = await this.fetchLatestConfig()
+  private async verifyUnchanged(original: Config, _: any, platform: Platform) {
+    const latest = await this.fetchLatestConfig(platform)
     if (!_.isEqual(original, latest)) {
       throw new Error('Config changed on server. Refusing to update.')
     }

--- a/src/commands/config/get.ts
+++ b/src/commands/config/get.ts
@@ -1,7 +1,7 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import {hux} from '@heroku/heroku-cli-util'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {Args} from '@oclif/core'
 
 import {quote} from '../../lib/config/quote.js'
@@ -23,8 +23,9 @@ production`)}`
   static usage = 'config:get KEY...'
 
   async run() {
+    const {platform} = new HerokuSDK()
     const {argv, flags} = await this.parse(ConfigGet)
-    const {body: config} = await this.heroku.get<Heroku.ConfigVars>(`/apps/${flags.app}/config-vars`)
+    const config = await platform.configVar.infoForApp(flags.app)
 
     if (flags.json) {
       const results = (argv as string[]).map(key => {

--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import {color, hux} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
 import {ux} from '@oclif/core/ux'
 
 import {quote} from '../../lib/config/quote.js'
@@ -15,8 +15,9 @@ export class ConfigIndex extends Command {
   }
 
   async run() {
+    const {platform} = new HerokuSDK()
     const {flags} = await this.parse(ConfigIndex)
-    const {body: config} = await this.heroku.get<Heroku.ConfigVars>(`/apps/${flags.app}/config-vars`)
+    const config = await platform.configVar.infoForApp(flags.app)
     if (flags.shell) {
       for (const [k, v] of Object.entries(config)) ux.stdout(`${k}=${quote(v)}`)
     } else if (flags.json) {

--- a/src/commands/config/set.ts
+++ b/src/commands/config/set.ts
@@ -1,17 +1,17 @@
-import {APIClient, Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
+import {Command, flags} from '@heroku-cli/command'
 import {color, hux} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
 import {ux} from '@oclif/core/ux'
 import tsheredoc from 'tsheredoc'
 
 const heredoc = tsheredoc.default
 
-const lastRelease = async (client: APIClient, app: string) => {
-  const {body: releases} = await client.get<Heroku.Release[]>(`/apps/${app}/releases`, {
-    headers: {Range: 'version ..; order=desc,max=1'},
-    method: 'GET',
-    partial: true,
-  })
+type Platform = HerokuSDK['platform']
+
+const lastRelease = async (platform: Platform, app: string) => {
+  const releases = await platform
+    .withHeaders({Range: 'version ..; order=desc,max=1'})
+    .release.list(app)
   return releases[0]
 }
 
@@ -33,6 +33,7 @@ RACK_ENV:  staging`)]
   static strict = false
 
   async run() {
+    const {platform} = new HerokuSDK()
     const {argv: _argv, flags} = await this.parse(Set)
     const argv = _argv as string[]
 
@@ -53,10 +54,8 @@ RACK_ENV:  staging`)]
     const varsCopy = argv.map((v: string) => color.name(v.split('=')[0])).join(', ')
     ux.action.start(`Setting ${varsCopy} and restarting ${color.app(flags.app)}`)
 
-    let {body: config} = await this.heroku.patch<Heroku.ConfigVars>(`/apps/${flags.app}/config-vars`, {
-      body: vars,
-    })
-    const release = await lastRelease(this.heroku, flags.app)
+    let config = await platform.configVar.update(flags.app, vars)
+    const release = await lastRelease(platform, flags.app)
     ux.action.stop(`done, ${color.name('v' + release.version)}`)
 
     config = Object.fromEntries(Object.entries(config)

--- a/src/commands/config/unset.ts
+++ b/src/commands/config/unset.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
 import {ux} from '@oclif/core/ux'
 import tsheredoc from 'tsheredoc'
 
@@ -23,14 +23,14 @@ Unsetting RAILS_ENV, RACK_ENV and restarting example... done, v10`)]
   static strict = false
 
   async run() {
+    const {platform} = new HerokuSDK()
     const parsed = await this.parse(ConfigUnset)
     const {flags} = parsed
     const argv = parsed.argv as string[]
     const lastRelease = async () => {
-      const {body: releases} = await this.heroku.get<Heroku.Release[]>(`/apps/${flags.app}/releases`, {
-        headers: {Range: 'version ..; order=desc,max=1'},
-        partial: true,
-      })
+      const releases = await platform
+        .withHeaders({Range: 'version ..; order=desc,max=1'})
+        .release.list(flags.app)
       return releases[0]
     }
 
@@ -41,10 +41,8 @@ Unsetting RAILS_ENV, RACK_ENV and restarting example... done, v10`)]
     const vars = argv.map(v => color.name(v)).join(', ')
 
     ux.action.start(`Unsetting ${vars} and restarting ${color.app(flags.app)}`)
-    await this.heroku.patch(`/apps/${flags.app}/config-vars`, {
-      // body will be like {FOO: null, BAR: null}
-      body: Object.fromEntries(argv.map(v => [v, null])),
-    })
+    // body will be like {FOO: null, BAR: null}
+    await platform.configVar.update(flags.app, Object.fromEntries(argv.map(v => [v, null])))
     const release = await lastRelease()
     ux.action.stop('done, ' + color.name(`v${release.version}`))
   }

--- a/test/unit/commands/config/edit.unit.test.ts
+++ b/test/unit/commands/config/edit.unit.test.ts
@@ -1,26 +1,41 @@
 import {runCommand} from '@heroku-cli/test-utils'
 import {hux} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
 import {restore, SinonStub, stub} from 'sinon'
 
 import Cmd, {stringToConfig} from '../../../../src/commands/config/edit.js'
 import {EditorFactory} from '../../../../src/lib/config/util.js'
 
+type FakePlatform = {
+  configVar: {
+    infoForApp: SinonStub
+    update: SinonStub
+  }
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    configVar: {
+      infoForApp: stub(),
+      update: stub(),
+    },
+  }
+}
+
 describe('config:edit', function () {
-  let updated: Record<string, unknown> | string
   let editedConfig = ''
   let createEditorStub: SinonStub
   let editorEditStub: SinonStub
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    restore()
   })
 
   describe('stringToConfig', function () {
@@ -50,16 +65,8 @@ describe('config:edit', function () {
       it('nulls out vars to delete', async function () {
         editedConfig = '\n'
 
-        api
-          .get('/apps/myapp/config-vars')
-          .reply(200, {NOT_BLANK: 'not blank'})
-          .get('/apps/myapp/config-vars')
-          .reply(200, {NOT_BLANK: 'not blank'})
-          .patch('/apps/myapp/config-vars')
-          .reply(function (_uri, requestBody) {
-            updated = requestBody as Record<string, unknown>
-            return [200, {}]
-          })
+        fakePlatform.configVar.infoForApp.resolves({NOT_BLANK: 'not blank'})
+        fakePlatform.configVar.update.resolves({})
 
         await runCommand(Cmd, ['--app=myapp'])
 
@@ -69,24 +76,16 @@ describe('config:edit', function () {
           postfix: '.sh',
           prefix: 'heroku-myapp-config-',
         })).to.be.true
-        expect(updated).to.deep.equal({NOT_BLANK: null})
+        expect(fakePlatform.configVar.infoForApp.calledTwice).to.equal(true)
+        expect(fakePlatform.configVar.update.calledOnceWithExactly('myapp', {NOT_BLANK: null})).to.equal(true)
       })
     })
 
     describe('setting config var to blank', function () {
       it('updates the values with blanks', async function () {
         editedConfig = "BLANK=\nNOT_BLANK=''\n"
-
-        api
-          .get('/apps/myapp/config-vars')
-          .reply(200, {NOT_BLANK: 'not blank'})
-          .get('/apps/myapp/config-vars')
-          .reply(200, {NOT_BLANK: 'not blank'})
-          .patch('/apps/myapp/config-vars')
-          .reply(function (_uri, requestBody) {
-            updated = requestBody as Record<string, unknown>
-            return [200, {BLANK: '', NOT_BLANK: 'not blank'}]
-          })
+        fakePlatform.configVar.infoForApp.resolves({NOT_BLANK: 'not blank'})
+        fakePlatform.configVar.update.resolves({BLANK: '', NOT_BLANK: 'not blank'})
 
         await runCommand(Cmd, ['--app=myapp'])
 
@@ -96,24 +95,15 @@ describe('config:edit', function () {
           postfix: '.sh',
           prefix: 'heroku-myapp-config-',
         })).to.be.true
-        expect(updated).to.deep.equal({BLANK: '', NOT_BLANK: ''})
+        expect(fakePlatform.configVar.update.calledOnceWithExactly('myapp', {BLANK: '', NOT_BLANK: ''})).to.be.true
       })
     })
 
     describe('setting specific var', function () {
       it('updates the values with blanks', async function () {
         editedConfig = 'a'
-
-        api
-          .get('/apps/myapp/config-vars')
-          .reply(200, {FIRST: '1', SECOND: '2'})
-          .get('/apps/myapp/config-vars')
-          .reply(200, {FIRST: '1', SECOND: '2'})
-          .patch('/apps/myapp/config-vars')
-          .reply(function (_uri, requestBody) {
-            updated = requestBody as Record<string, unknown>
-            return [200, {DOES_NOT: 'matter'}]
-          })
+        fakePlatform.configVar.infoForApp.resolves({FIRST: '1', SECOND: '2'})
+        fakePlatform.configVar.update.resolves({DOES_NOT: 'matter'})
 
         await runCommand(Cmd, ['--app=myapp', 'FIRST'])
 
@@ -122,7 +112,7 @@ describe('config:edit', function () {
         expect(editorEditStub.calledWith('1', {
           prefix: 'heroku-myapp-config-',
         })).to.be.true
-        expect(updated).to.deep.equal({FIRST: 'a', SECOND: '2'})
+        expect(fakePlatform.configVar.update.calledOnceWithExactly('myapp', {FIRST: 'a', SECOND: '2'})).to.be.true
       })
     })
   })

--- a/test/unit/commands/config/get.unit.test.ts
+++ b/test/unit/commands/config/get.unit.test.ts
@@ -1,35 +1,47 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import {ConfigGet} from '../../../../src/commands/config/get.js'
 
+type FakePlatform = {
+  configVar: {
+    infoForApp: sinon.SinonStub
+  }
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    configVar: {
+      infoForApp: sinon.stub(),
+    },
+  }
+}
+
 describe('config', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('shows config vars', async function () {
-    api
-      .get('/apps/myapp/config-vars')
-      .reply(200, {LANG: 'en_US.UTF-8', RACK_ENV: 'production'})
+    fakePlatform.configVar.infoForApp.resolves({LANG: 'en_US.UTF-8', RACK_ENV: 'production'})
 
     const {stdout} = await runCommand(ConfigGet, ['--app=myapp', 'RACK_ENV'])
 
     expect(stdout).to.equal('production\n')
+    expect(fakePlatform.configVar.infoForApp.calledOnceWithExactly('myapp')).to.equal(true)
   })
 
   it('--shell', async function () {
-    api
-      .get('/apps/myapp/config-vars')
-      .reply(200, {LANG: 'en_US.UTF-8', RACK_ENV: 'production'})
+    fakePlatform.configVar.infoForApp.resolves({LANG: 'en_US.UTF-8', RACK_ENV: 'production'})
 
     const {stdout} = await runCommand(ConfigGet, ['--app=myapp', '-s', 'RACK_ENV'])
 
@@ -37,9 +49,7 @@ describe('config', function () {
   })
 
   it('missing', async function () {
-    api
-      .get('/apps/myapp/config-vars')
-      .reply(200, {LANG: 'en_US.UTF-8', RACK_ENV: 'production'})
+    fakePlatform.configVar.infoForApp.resolves({LANG: 'en_US.UTF-8', RACK_ENV: 'production'})
 
     const {stdout} = await runCommand(ConfigGet, ['--app=myapp', 'MISSING'])
 
@@ -47,9 +57,7 @@ describe('config', function () {
   })
 
   it('--json with unset var', async function () {
-    api
-      .get('/apps/myapp/config-vars')
-      .reply(200, {EMPTY_VAR: '', RACK_ENV: 'production'})
+    fakePlatform.configVar.infoForApp.resolves({EMPTY_VAR: '', RACK_ENV: 'production'})
 
     const {stdout} = await runCommand(ConfigGet, ['--app=myapp', '--json', 'MISSING'])
 
@@ -57,9 +65,7 @@ describe('config', function () {
   })
 
   it('--json with empty string var', async function () {
-    api
-      .get('/apps/myapp/config-vars')
-      .reply(200, {EMPTY_VAR: '', RACK_ENV: 'production'})
+    fakePlatform.configVar.infoForApp.resolves({EMPTY_VAR: '', RACK_ENV: 'production'})
 
     const {stdout} = await runCommand(ConfigGet, ['--app=myapp', '--json', 'EMPTY_VAR'])
 
@@ -67,9 +73,7 @@ describe('config', function () {
   })
 
   it('--json with normal var', async function () {
-    api
-      .get('/apps/myapp/config-vars')
-      .reply(200, {LANG: 'en_US.UTF-8', RACK_ENV: 'production'})
+    fakePlatform.configVar.infoForApp.resolves({LANG: 'en_US.UTF-8', RACK_ENV: 'production'})
 
     const {stdout} = await runCommand(ConfigGet, ['--app=myapp', '--json', 'RACK_ENV'])
 
@@ -77,9 +81,7 @@ describe('config', function () {
   })
 
   it('--json with multiple vars', async function () {
-    api
-      .get('/apps/myapp/config-vars')
-      .reply(200, {EMPTY_VAR: '', RACK_ENV: 'production'})
+    fakePlatform.configVar.infoForApp.resolves({EMPTY_VAR: '', RACK_ENV: 'production'})
 
     const {stdout} = await runCommand(ConfigGet, ['--app=myapp', '--json', 'MISSING', 'EMPTY_VAR', 'RACK_ENV'])
 

--- a/test/unit/commands/config/index.unit.test.ts
+++ b/test/unit/commands/config/index.unit.test.ts
@@ -1,35 +1,47 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import {ConfigIndex} from '../../../../src/commands/config/index.js'
 
+type FakePlatform = {
+  configVar: {
+    infoForApp: sinon.SinonStub
+  }
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    configVar: {
+      infoForApp: sinon.stub(),
+    },
+  }
+}
+
 describe('config', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('shows config vars', async function () {
-    api
-      .get('/apps/myapp/config-vars')
-      .reply(200, {LANG: 'en_US.UTF-8', RACK_ENV: 'production'})
+    fakePlatform.configVar.infoForApp.resolves({LANG: 'en_US.UTF-8', RACK_ENV: 'production'})
 
     const {stdout} = await runCommand(ConfigIndex, ['--app=myapp'])
 
     expect(stdout).to.equal('=== ⬢ myapp Config Vars\n\nLANG:     en_US.UTF-8\nRACK_ENV: production\n')
+    expect(fakePlatform.configVar.infoForApp.calledOnceWithExactly('myapp')).to.equal(true)
   })
 
   it('--json', async function () {
-    api
-      .get('/apps/myapp/config-vars')
-      .reply(200, {LANG: 'en_US.UTF-8', RACK_ENV: 'production'})
+    fakePlatform.configVar.infoForApp.resolves({LANG: 'en_US.UTF-8', RACK_ENV: 'production'})
 
     const {stdout} = await runCommand(ConfigIndex, ['--app=myapp', '-j'])
 
@@ -37,9 +49,7 @@ describe('config', function () {
   })
 
   it('--shell', async function () {
-    api
-      .get('/apps/myapp/config-vars')
-      .reply(200, {LANG: 'en_US.UTF-8', RACK_ENV: 'production'})
+    fakePlatform.configVar.infoForApp.resolves({LANG: 'en_US.UTF-8', RACK_ENV: 'production'})
 
     const {stdout} = await runCommand(ConfigIndex, ['--app=myapp', '-s'])
 

--- a/test/unit/commands/config/set.unit.test.ts
+++ b/test/unit/commands/config/set.unit.test.ts
@@ -1,48 +1,71 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import ansis from 'ansis'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import ConfigSet from '../../../../src/commands/config/set.js'
 
+type FakePlatform = {
+  configVar: {
+    update: sinon.SinonStub
+  }
+  release: {
+    list: sinon.SinonStub
+  }
+  withHeaders: sinon.SinonStub
+}
+
+function buildFakePlatform(): FakePlatform {
+  const platform: FakePlatform = {
+    configVar: {
+      update: sinon.stub(),
+    },
+    release: {
+      list: sinon.stub(),
+    },
+    withHeaders: sinon.stub(),
+  }
+  platform.withHeaders.returns(platform)
+  return platform
+}
+
 describe('config:set', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('sets a config var', async function () {
-    api
-      .patch('/apps/myapp/config-vars', {RACK_ENV: 'production'})
-      .reply(200, {RACK_ENV: 'production', RAILS_ENV: 'production'})
-      .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
+    fakePlatform.configVar.update.resolves({RACK_ENV: 'production', RAILS_ENV: 'production'})
+    fakePlatform.release.list.resolves([{version: 10}])
 
     const {stderr, stdout} = await runCommand(ConfigSet, ['RACK_ENV=production', '--app', 'myapp'])
 
     expect(stdout).to.equal('RACK_ENV: production\n')
     expect(stderr).to.include('Setting RACK_ENV and restarting ⬢ myapp')
     expect(stderr).to.include('done, v10')
+    expect(fakePlatform.configVar.update.calledOnceWithExactly('myapp', {RACK_ENV: 'production'})).to.equal(true)
+    expect(fakePlatform.withHeaders.calledOnceWithExactly({Range: 'version ..; order=desc,max=1'})).to.equal(true)
+    expect(fakePlatform.release.list.calledOnceWithExactly('myapp')).to.equal(true)
   })
 
   it('sets a config var with an "=" in it', async function () {
-    api
-      .patch('/apps/myapp/config-vars', {RACK_ENV: 'production=foo'})
-      .reply(200)
-      .get('/apps/myapp/releases')
-      .reply(200, [{version: 10}])
+    fakePlatform.configVar.update.resolves({})
+    fakePlatform.release.list.resolves([{version: 10}])
 
     const {stderr, stdout} = await runCommand(ConfigSet, ['RACK_ENV=production=foo', '--app', 'myapp'])
 
     expect(stdout).to.equal('\n')
     expect(stderr).to.include('Setting RACK_ENV and restarting ⬢ myapp')
     expect(stderr).to.include('done, v10')
+    expect(fakePlatform.configVar.update.calledOnceWithExactly('myapp', {RACK_ENV: 'production=foo'})).to.equal(true)
   })
 
   it('errors without args', async function () {

--- a/test/unit/commands/config/unset.unit.test.ts
+++ b/test/unit/commands/config/unset.unit.test.ts
@@ -1,30 +1,57 @@
 import {runCommand} from '@heroku-cli/test-utils'
-import nock from 'nock'
+import {HerokuSDK} from '@heroku/sdk'
+import {expect} from 'chai'
+import * as sinon from 'sinon'
 
 import {ConfigUnset} from '../../../../src/commands/config/unset.js'
 
+type FakePlatform = {
+  configVar: {
+    update: sinon.SinonStub
+  }
+  release: {
+    list: sinon.SinonStub
+  }
+  withHeaders: sinon.SinonStub
+}
+
+function buildFakePlatform(): FakePlatform {
+  const platform: FakePlatform = {
+    configVar: {
+      update: sinon.stub(),
+    },
+    release: {
+      list: sinon.stub(),
+    },
+    withHeaders: sinon.stub(),
+  }
+  platform.withHeaders.returns(platform)
+  return platform
+}
+
 describe('config', function () {
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('removes 2 config vars', async function () {
-    api
-      .patch('/apps/myapp/config-vars', {
-        FOO: null,
-        RACK_ENV: null,
-      })
-      .reply(200, {})
-      .get('/apps/myapp/releases')
-      .reply(200, [{version: 1}])
+    fakePlatform.configVar.update.resolves({})
+    fakePlatform.release.list.resolves([{version: 1}])
 
     await runCommand(ConfigUnset, ['-amyapp', 'FOO', 'RACK_ENV'])
+
+    expect(fakePlatform.configVar.update.calledOnceWithExactly('myapp', {
+      FOO: null,
+      RACK_ENV: null,
+    })).to.equal(true)
+    expect(fakePlatform.withHeaders.calledOnceWithExactly({Range: 'version ..; order=desc,max=1'})).to.equal(true)
+    expect(fakePlatform.release.list.calledOnceWithExactly('myapp')).to.equal(true)
   })
 })


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->
This PR migrates the following `config` commands to use @heroku/sdk:

- `config/edit`
- `config/get`
- `config/index`
- `config/set`
- `config/unset`

**Details:**
- Replaced direct API calls with the SDK
- Rewrote tests to stub the SDK directly instead of using nock

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
<!-- Add any context/setup necessary for testing. -->
The SDK uses `heroku-fetch` to make API calls, which looks for a netrc file. Therefore, we must log in with `HEROKU_NETRC_WRITE=true`.

**Setup**:
- Pull down this branch
- `npm i && npm run build`
- `heroku logout`
- `HEROKU_NETRC_WRITE=true ./bin/run login`

**Steps**:
```bash
# Sets config vars
./bin/run config:set TEST_ONE=test1 TEST_TWO=test2 --app $APP

# Lists new config vars
./bin/run config --app $APP

# Opens an editor for config var updates (update the value of TEST_ONE only)
./bin/run config:edit --app $APP

# Gets config vars (TEST_ONE should be updated, TEST_TWO should be the same)
./bin/run config:get TEST_ONE TEST_TWO --app $APP

#Unset config vars
./bin/run config:unset TEST_ONE TEST_TWO --app $APP
```

**Cleanup:**
- `./bin/run logout`

## Screenshots (if applicable)

## Related Issues
GUS work item: [W-23387800](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eMfMZYA0/view)