### PR TITLE
feat: use sdk for reviewapps enable and disable commands

### DIFF
--- a/V12-CHANGES.md
+++ b/V12-CHANGES.md
@@ -14,6 +14,10 @@
 - `run`, `run:detached`, and `run:inside` now create dynos through `@heroku/sdk` (`platform.dyno.run`) instead of raw API calls.
 - Release-conflict (`409`) retries during one-off dyno creation are now handled by the SDK; the CLI no longer runs its own retry loop.
 
+## Review Apps commands
+
+- `reviewapps:enable` and `reviewapps:disable` now fall back to the pipeline repository service when the repositories API account feature is disabled, instead of continuing without a repository name.
+
 ## Spaces commands
 
 - `spaces:vpn:wait` no longer shows `VPN has been allocated.` when the status is already `active`. Instead it immediately shows `Waiting for VPN Connection ${name} to allocate... done`

--- a/package-lock.json
+++ b/package-lock.json
@@ -2683,12 +2683,12 @@
       }
     },
     "node_modules/@heroku/sdk": {
-      "version": "0.5.7",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#ed3e589c45b6abd4618d1e49e78da5b187ae6d4f",
+      "version": "0.6.1",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#84bd8bee369013d46e7dff6f2c3009ae07dd5d53",
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku/heroku-fetch": "^0.1.4",
-        "@heroku/types": "^4.2.0",
+        "@heroku/types": "^4.7.0",
         "debug": "^4.4.0"
       },
       "engines": {
@@ -2708,9 +2708,9 @@
       }
     },
     "node_modules/@heroku/types": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@heroku/types/-/types-4.6.0.tgz",
-      "integrity": "sha512-ylGXhUe4irMJ49+/qXwN0jggd6asfAZq4uMx0Jv9URsVXEGilaLpJ57oKLdTSUWixtjd5SLG6HVthxUdl6CdVQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@heroku/types/-/types-4.8.0.tgz",
+      "integrity": "sha512-Wen88W3cs4EGUnjxfDw+7BR7soGO9pKkNlVc3syogzaeQPtkF3dUBMMWuneMAQ8TkBXWAaGkO9O4x1dlBwyiZg==",
       "license": "MIT",
       "engines": {
         "node": ">=22"

--- a/src/commands/reviewapps/disable.ts
+++ b/src/commands/reviewapps/disable.ts
@@ -1,9 +1,8 @@
-import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
+import {Command, flags, vars} from '@heroku-cli/command'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
+import {reviewAppConfigExtensions} from '@heroku/sdk/extensions/platform'
 import {ux} from '@oclif/core/ux'
-
-import KolkrabbiAPI from '../../lib/pipelines/kolkrabbi-api.js'
 
 export default class ReviewappsDisable extends Command {
   static description = 'disable review apps and/or settings on an existing pipeline'
@@ -81,42 +80,31 @@ export default class ReviewappsDisable extends Command {
       settings.wait_for_ci = false
     }
 
-    const kolkrabbi = new KolkrabbiAPI(this.config.userAgent, () => this.heroku.auth)
+    const sdk = new HerokuSDK({
+      clientOptions: {token: this.heroku.auth},
+      clientOptionsByService: {
+        platform: {baseUrl: vars.apiUrl},
+        repositoriesApi: {baseUrl: vars.apiUrl},
+      },
+      extensions: [reviewAppConfigExtensions],
+    })
 
     ux.action.start('Configuring pipeline')
 
-    const {body: pipeline} = await this.heroku.get<Heroku.Pipeline>(`/pipelines/${flags.pipeline}`)
+    const pipeline = await sdk.platform.pipeline.info(flags.pipeline)
+    const pipelineId = pipeline.id!
+    const repo = await sdk.platform.reviewAppConfig.resolveRepoName(pipelineId)
+    const requestBody = {...settings, pipeline: pipelineId, repo}
 
-    settings.pipeline = pipeline.id
-
-    try {
-      const {body: feature} = await this.heroku.get<Heroku.AccountFeature>('/account/features/dashboard-repositories-api')
-
-      if (feature.enabled) {
-        const {body: repo} = await this.heroku.get<{full_name: string}>(`/pipelines/${pipeline.id}/repo`, {
-          headers: {Accept: 'application/vnd.heroku+json; version=3.repositories-api'},
-        })
-        settings.repo = repo.full_name
-      }
-    } catch {
-      const {repository} = await kolkrabbi.getPipelineRepository(pipeline.id)
-      settings.repo = repository.name
-    }
-
-    // eslint-disable-next-line unicorn/prefer-ternary
     if (flags.autodeploy || flags['no-autodeploy'] || flags.autodestroy || flags['no-autodestroy'] || flags['wait-for-ci'] || flags['no-wait-for-ci']) {
-      await this.heroku.patch(`/pipelines/${pipeline.id}/review-app-config`, {
-        body: settings,
-        headers: {Accept: 'application/vnd.heroku+json; version=3.review-apps'},
-      })
-    } else {
-      // if no flags are passed then the user is disabling review apps
-      await this.heroku.delete(`/pipelines/${pipeline.id}/review-app-config`, {
-        body: settings,
-        headers: {Accept: 'application/vnd.heroku+json; version=3.review-apps'},
-      })
+      const result = await sdk.platform.reviewAppConfig.update(pipelineId, requestBody)
+      ux.action.stop()
+      return result
     }
 
+    // if no flags are passed then the user is disabling review apps
+    const result = await sdk.platform.withOptions({body: requestBody}).reviewAppConfig.delete(pipelineId)
     ux.action.stop()
+    return result
   }
 }

--- a/src/commands/reviewapps/enable.ts
+++ b/src/commands/reviewapps/enable.ts
@@ -1,9 +1,8 @@
-import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
+import {Command, flags, vars} from '@heroku-cli/command'
 import * as color from '@heroku/heroku-cli-util/color'
+import {HerokuSDK} from '@heroku/sdk'
+import {reviewAppConfigExtensions} from '@heroku/sdk/extensions/platform'
 import {ux} from '@oclif/core/ux'
-
-import KolkrabbiAPI from '../../lib/pipelines/kolkrabbi-api.js'
 
 export default class ReviewappsEnable extends Command {
   static description = 'enable review apps and/or settings on an existing pipeline'
@@ -68,42 +67,31 @@ export default class ReviewappsEnable extends Command {
       settings.wait_for_ci = true
     }
 
-    const kolkrabbi = new KolkrabbiAPI(this.config.userAgent, () => this.heroku.auth)
+    const sdk = new HerokuSDK({
+      clientOptions: {token: this.heroku.auth},
+      clientOptionsByService: {
+        platform: {baseUrl: vars.apiUrl},
+        repositoriesApi: {baseUrl: vars.apiUrl},
+      },
+      extensions: [reviewAppConfigExtensions],
+    })
 
     ux.action.start('Configuring pipeline')
 
-    const {body: pipeline} = await this.heroku.get<Heroku.Pipeline>(`/pipelines/${flags.pipeline}`)
+    const pipeline = await sdk.platform.pipeline.info(flags.pipeline)
+    const pipelineId = pipeline.id!
+    const repo = await sdk.platform.reviewAppConfig.resolveRepoName(pipelineId)
+    const requestBody = {...settings, pipeline: pipelineId, repo}
 
-    settings.pipeline = pipeline.id
-
-    try {
-      const {body: feature} = await this.heroku.get<Heroku.AccountFeature>('/account/features/dashboard-repositories-api')
-
-      if (feature.enabled) {
-        const {body: repo} = await this.heroku.get<{full_name: string}>(`/pipelines/${pipeline.id}/repo`, {
-          headers: {Accept: 'application/vnd.heroku+json; version=3.repositories-api'},
-        })
-        settings.repo = repo.full_name
-      }
-    } catch {
-      const {repository} = await kolkrabbi.getPipelineRepository(pipeline.id)
-      settings.repo = repository.name
-    }
-
-    // eslint-disable-next-line unicorn/prefer-ternary
     if (flags.autodeploy || flags.autodestroy || flags['wait-for-ci']) {
-      await this.heroku.patch(`/pipelines/${pipeline.id}/review-app-config`, {
-        body: settings,
-        headers: {Accept: 'application/vnd.heroku+json; version=3.review-apps'},
-      })
-    } else {
-      // if no flags are passed then the user is enabling review apps
-      await this.heroku.post(`/pipelines/${pipeline.id}/review-app-config`, {
-        body: settings,
-        headers: {Accept: 'application/vnd.heroku+json; version=3.review-apps'},
-      })
+      const result = await sdk.platform.reviewAppConfig.update(pipelineId, requestBody)
+      ux.action.stop()
+      return result
     }
 
+    // if no flags are passed then the user is enabling review apps
+    const result = await sdk.platform.reviewAppConfig.enable(pipelineId, requestBody)
     ux.action.stop()
+    return result
   }
 }

--- a/test/unit/commands/pipelines/setup.unit.test.ts
+++ b/test/unit/commands/pipelines/setup.unit.test.ts
@@ -316,7 +316,10 @@ describe('pipelines:setup', function () {
               .reply(201, {app: coupling.app, id: coupling.id})
 
             api.get(`/app-setups/${coupling.id}`).reply(200, {status: 'timedout'})
-            api.get(`/app-setups/${coupling.id}`).reply(200, {app: {name: 'my-pipeline'}, failure_message: 'timedout', status: 'failed'})
+            // Both couplings poll concurrently via Promise.all; the first to report `failed`
+            // rejects and short-circuits the rest, so the other coupling's re-poll may never
+            // fire. Mark it optional so teardown doesn't flake on slower runners (e.g. Windows).
+            api.get(`/app-setups/${coupling.id}`).optionally().reply(200, {app: {name: 'my-pipeline'}, failure_message: 'timedout', status: 'failed'})
           }
 
           api.get('/teams/test-org').reply(200, {id: '89-0123-456'})

--- a/test/unit/commands/reviewapps/disable.unit.test.ts
+++ b/test/unit/commands/reviewapps/disable.unit.test.ts
@@ -1,222 +1,241 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
+import {ux} from '@oclif/core/ux'
 import {expect} from 'chai'
-import nock from 'nock'
+import {execFileSync} from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import * as sinon from 'sinon'
 
 import ReviewappsDisable from '../../../../src/commands/reviewapps/disable.js'
 
+type FakePlatform = {
+  pipeline: {
+    info: sinon.SinonStub
+  }
+  reviewAppConfig: {
+    delete: sinon.SinonStub
+    resolveRepoName: sinon.SinonStub
+    update: sinon.SinonStub
+  }
+  withOptions: sinon.SinonStub
+}
+
+function buildFakePlatform() {
+  const scopedDelete = sinon.stub()
+  const fakePlatform: FakePlatform = {
+    pipeline: {
+      info: sinon.stub(),
+    },
+    reviewAppConfig: {
+      delete: sinon.stub(),
+      resolveRepoName: sinon.stub(),
+      update: sinon.stub(),
+    },
+    withOptions: sinon.stub().returns({
+      reviewAppConfig: {
+        delete: scopedDelete,
+      },
+    }),
+  }
+
+  return {fakePlatform, scopedDelete}
+}
+
 describe('reviewapps:disable', function () {
+  const mutationResult = {id: 'review-app-config'}
   const pipeline = {
     id: '123-pipeline',
     name: 'my-pipeline',
   }
+  const repo = 'james/repo'
+  let fakePlatform: FakePlatform
+  let scopedDelete: sinon.SinonStub
+
+  beforeEach(function () {
+    ({fakePlatform, scopedDelete} = buildFakePlatform())
+    fakePlatform.pipeline.info.resolves(pipeline)
+    fakePlatform.reviewAppConfig.resolveRepoName.resolves(repo)
+    fakePlatform.reviewAppConfig.update.resolves(mutationResult)
+    scopedDelete.resolves(mutationResult)
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
+  })
 
   afterEach(function () {
-    nock.cleanAll()
+    if (ux.action.running) ux.action.stop()
+
+    sinon.restore()
   })
 
-  describe('with repos api enabled', function () {
-    const feature = {
-      enabled: true,
-      name: 'dashboard-repositories-api',
+  it('resolves the pipeline and repository before disabling review apps by default', async function () {
+    const requestBody = {
+      automatic_review_apps: undefined,
+      destroy_stale_apps: undefined,
+      pipeline: pipeline.id,
+      repo,
+      wait_for_ci: undefined,
     }
 
-    const repo = {
-      full_name: 'james/repo',
-    }
+    const {result, stderr} = await runCommand(ReviewappsDisable, [`--pipeline=${pipeline.name}`])
 
-    it('succeeds with defaults', async function () {
-      nock('https://api.heroku.com')
-        .get(`/account/features/${feature.name}`)
-        .reply(200, feature)
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .get(`/pipelines/${pipeline.id}/repo`)
-        .reply(200, repo)
-        .delete(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
-
-      const {stderr} = await runCommand(ReviewappsDisable, [`--pipeline=${pipeline.name}`])
-
-      expect(stderr).to.include('done\n')
-    })
-
-    it('disables autodeploy', async function () {
-      nock('https://api.heroku.com')
-        .get(`/account/features/${feature.name}`)
-        .reply(200, feature)
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .get(`/pipelines/${pipeline.id}/repo`)
-        .reply(200, repo)
-        .patch(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
-
-      const {stderr, stdout} = await runCommand(ReviewappsDisable, [`--pipeline=${pipeline.name}`, '--no-autodeploy'])
-
-      expect(stdout).to.include('Disabling auto deployment')
-      expect(stderr).to.include('Configuring pipeline')
-    })
-
-    it('disables autodestroy', async function () {
-      nock('https://api.heroku.com')
-        .get(`/account/features/${feature.name}`)
-        .reply(200, feature)
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .get(`/pipelines/${pipeline.id}/repo`)
-        .reply(200, repo)
-        .patch(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
-
-      const {stderr, stdout} = await runCommand(ReviewappsDisable, [`--pipeline=${pipeline.name}`, '--no-autodestroy'])
-
-      expect(stdout).to.include('Disabling auto destroy')
-      expect(stderr).to.include('Configuring pipeline')
-    })
-
-    it('disables wait-for-ci', async function () {
-      nock('https://api.heroku.com')
-        .get(`/account/features/${feature.name}`)
-        .reply(200, feature)
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .get(`/pipelines/${pipeline.id}/repo`)
-        .reply(200, repo)
-        .patch(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
-
-      const {stderr, stdout} = await runCommand(ReviewappsDisable, [`--pipeline=${pipeline.name}`, '--no-wait-for-ci'])
-
-      expect(stdout).to.include('Disabling wait for CI')
-      expect(stderr).to.include('Configuring pipeline')
-    })
-
-    it('disables autodeploy and autodestroy and wait-for-ci', async function () {
-      nock('https://api.heroku.com')
-        .get(`/account/features/${feature.name}`)
-        .reply(200, feature)
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .get(`/pipelines/${pipeline.id}/repo`)
-        .reply(200, repo)
-        .patch(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
-
-      const {stderr, stdout} = await runCommand(ReviewappsDisable, [`--pipeline=${pipeline.name}`, '--no-autodeploy', '--no-autodestroy', '--no-wait-for-ci'])
-
-      expect(stdout).to.include('Disabling auto deployment')
-      expect(stdout).to.include('Disabling auto destroy')
-      expect(stdout).to.include('Disabling wait for CI')
-      expect(stderr).to.include('Configuring pipeline')
-    })
+    expect(fakePlatform.pipeline.info.calledOnceWithExactly(pipeline.name)).to.equal(true)
+    expect(fakePlatform.reviewAppConfig.resolveRepoName.calledOnceWithExactly(pipeline.id)).to.equal(true)
+    expect(fakePlatform.withOptions.calledOnceWithExactly({body: requestBody})).to.equal(true)
+    expect(scopedDelete.calledOnceWithExactly(pipeline.id)).to.equal(true)
+    expect(fakePlatform.reviewAppConfig.delete.called).to.equal(false)
+    expect(fakePlatform.reviewAppConfig.update.called).to.equal(false)
+    expect(stderr).to.include('Configuring pipeline... done\n')
+    expect(result).to.deep.equal(mutationResult)
   })
 
-  describe('with repos api disabled', function () {
-    const feature = {
-      enabled: false,
-      name: 'dashboard-repositories-api',
+  const adjustmentCases = [
+    {
+      expectedOutput: 'Disabling auto deployment',
+      expectedSettings: {automatic_review_apps: false},
+      flag: '--no-autodeploy',
+    },
+    {
+      expectedOutput: 'Disabling auto deployment',
+      expectedSettings: {automatic_review_apps: false},
+      flag: '--autodeploy',
+    },
+    {
+      expectedOutput: 'Disabling auto destroy',
+      expectedSettings: {destroy_stale_apps: false},
+      flag: '--no-autodestroy',
+    },
+    {
+      expectedOutput: 'Disabling auto destroy',
+      expectedSettings: {destroy_stale_apps: false},
+      flag: '--autodestroy',
+    },
+    {
+      expectedOutput: 'Disabling wait for CI',
+      expectedSettings: {wait_for_ci: false},
+      flag: '--no-wait-for-ci',
+    },
+    {
+      expectedOutput: 'Disabling wait for CI',
+      expectedSettings: {wait_for_ci: false},
+      flag: '--wait-for-ci',
+    },
+  ]
+
+  for (const {expectedOutput, expectedSettings, flag} of adjustmentCases) {
+    it(`updates review apps with ${flag}`, async function () {
+      const {result, stderr, stdout} = await runCommand(ReviewappsDisable, [`--pipeline=${pipeline.name}`, flag])
+
+      expect(fakePlatform.reviewAppConfig.resolveRepoName.calledOnceWithExactly(pipeline.id)).to.equal(true)
+      expect(fakePlatform.reviewAppConfig.update.calledOnceWithExactly(pipeline.id, {
+        automatic_review_apps: undefined,
+        destroy_stale_apps: undefined,
+        pipeline: pipeline.id,
+        repo,
+        wait_for_ci: undefined,
+        ...expectedSettings,
+      })).to.equal(true)
+      expect(fakePlatform.withOptions.called).to.equal(false)
+      expect(scopedDelete.called).to.equal(false)
+      expect(fakePlatform.reviewAppConfig.delete.called).to.equal(false)
+      expect(stdout).to.include(expectedOutput)
+      expect(stderr).to.include('Configuring pipeline... done\n')
+      expect(result).to.deep.equal(mutationResult)
+    })
+  }
+
+  it('updates review apps once with all negative adjustments', async function () {
+    const {result, stderr, stdout} = await runCommand(ReviewappsDisable, [
+      `--pipeline=${pipeline.name}`,
+      '--no-autodeploy',
+      '--no-autodestroy',
+      '--no-wait-for-ci',
+    ])
+
+    expect(fakePlatform.reviewAppConfig.resolveRepoName.calledOnceWithExactly(pipeline.id)).to.equal(true)
+    expect(fakePlatform.reviewAppConfig.update.calledOnceWithExactly(pipeline.id, {
+      automatic_review_apps: false,
+      destroy_stale_apps: false,
+      pipeline: pipeline.id,
+      repo,
+      wait_for_ci: false,
+    })).to.equal(true)
+    expect(fakePlatform.withOptions.called).to.equal(false)
+    expect(scopedDelete.called).to.equal(false)
+    expect(fakePlatform.reviewAppConfig.delete.called).to.equal(false)
+    expect(stdout).to.include('Disabling auto deployment')
+    expect(stdout).to.include('Disabling auto destroy')
+    expect(stdout).to.include('Disabling wait for CI')
+    expect(stderr).to.include('Configuring pipeline... done\n')
+    expect(result).to.deep.equal(mutationResult)
+  })
+
+  it('preserves the app flag warning', async function () {
+    const {stderr} = await runCommand(ReviewappsDisable, [`--pipeline=${pipeline.name}`, '--app=my-app'])
+
+    expect(stderr).to.include('Specifying an app via --app or --remote is no longer needed with')
+    expect(stderr).to.include('Review Apps')
+  })
+
+  it('resolves the app from a remote while disabling review apps', async function () {
+    const originalCwd = process.cwd()
+    const originalHerokuApp = process.env.HEROKU_APP
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reviewapps-disable-'))
+    const requestBody = {
+      automatic_review_apps: undefined,
+      destroy_stale_apps: undefined,
+      pipeline: pipeline.id,
+      repo,
+      wait_for_ci: undefined,
     }
 
-    const repo = {
-      repository: {
-        name: 'james/repo',
-      },
+    try {
+      delete process.env.HEROKU_APP
+      execFileSync('git', ['init', '--quiet'], {cwd: tempDir})
+      execFileSync('git', ['remote', 'add', 'staging', 'https://git.heroku.com/remote-app.git'], {cwd: tempDir})
+      process.chdir(tempDir)
+
+      const {result, stderr} = await runCommand(ReviewappsDisable, [`--pipeline=${pipeline.name}`, '--remote=staging'])
+
+      expect(stderr).to.include('Specifying an app via --app or --remote is no longer needed with')
+      expect(stderr).to.include('Review Apps')
+      expect(fakePlatform.withOptions.calledOnceWithExactly({body: requestBody})).to.equal(true)
+      expect(scopedDelete.calledOnceWithExactly(pipeline.id)).to.equal(true)
+      expect(fakePlatform.reviewAppConfig.update.called).to.equal(false)
+      expect(result).to.deep.equal(mutationResult)
+    } finally {
+      process.chdir(originalCwd)
+      if (originalHerokuApp === undefined) delete process.env.HEROKU_APP
+      else process.env.HEROKU_APP = originalHerokuApp
+
+      fs.rmSync(tempDir, {force: true, recursive: true})
     }
+  })
 
-    it('succeeds with defaults', async function () {
-      nock('https://api.heroku.com')
-        .get(`/account/features/${feature.name}`)
-        .reply(404, {})
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .delete(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
+  it('does not resolve a repository or mutate when pipeline lookup fails', async function () {
+    fakePlatform.pipeline.info.rejects(new Error('pipeline failed'))
 
-      nock('https://kolkrabbi.heroku.com')
-        .get(`/pipelines/${pipeline.id}/repository`)
-        .reply(200, repo)
+    const {error, stderr} = await runCommand(ReviewappsDisable, [`--pipeline=${pipeline.name}`])
 
-      const {stderr} = await runCommand(ReviewappsDisable, [`--pipeline=${pipeline.name}`])
+    expect(error?.message).to.equal('pipeline failed')
+    expect(stderr).not.to.include('done')
+    expect(fakePlatform.reviewAppConfig.resolveRepoName.called).to.equal(false)
+    expect(fakePlatform.reviewAppConfig.update.called).to.equal(false)
+    expect(fakePlatform.withOptions.called).to.equal(false)
+    expect(scopedDelete.called).to.equal(false)
+    expect(fakePlatform.reviewAppConfig.delete.called).to.equal(false)
+  })
 
-      expect(stderr).to.include('Configuring pipeline')
-    })
+  it('does not mutate when repository resolution fails', async function () {
+    fakePlatform.reviewAppConfig.resolveRepoName.rejects(new Error('repository failed'))
 
-    it('disables autodeploy', async function () {
-      nock('https://api.heroku.com')
-        .get(`/account/features/${feature.name}`)
-        .reply(404, {})
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .patch(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
+    const {error, stderr} = await runCommand(ReviewappsDisable, [`--pipeline=${pipeline.name}`])
 
-      nock('https://kolkrabbi.heroku.com')
-        .get(`/pipelines/${pipeline.id}/repository`)
-        .reply(200, repo)
-
-      const {stderr, stdout} = await runCommand(ReviewappsDisable, [`--pipeline=${pipeline.name}`, '--no-autodeploy'])
-
-      expect(stdout).to.include('Disabling auto deployment')
-      expect(stderr).to.include('Configuring pipeline')
-    })
-
-    it('disables autodestroy', async function () {
-      nock('https://api.heroku.com')
-        .get(`/account/features/${feature.name}`)
-        .reply(404, {})
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .patch(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
-
-      nock('https://kolkrabbi.heroku.com')
-        .get(`/pipelines/${pipeline.id}/repository`)
-        .reply(200, repo)
-
-      const {stderr, stdout} = await runCommand(ReviewappsDisable, [`--pipeline=${pipeline.name}`, '--no-autodestroy'])
-
-      expect(stdout).to.include('Disabling auto destroy')
-      expect(stderr).to.include('Configuring pipeline')
-    })
-
-    it('disables wait-for-ci', async function () {
-      nock('https://api.heroku.com')
-        .get(`/account/features/${feature.name}`)
-        .reply(404, {})
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .patch(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
-
-      nock('https://kolkrabbi.heroku.com')
-        .get(`/pipelines/${pipeline.id}/repository`)
-        .reply(200, repo)
-
-      const {stderr, stdout} = await runCommand(ReviewappsDisable, [`--pipeline=${pipeline.name}`, '--no-wait-for-ci'])
-
-      expect(stdout).to.include('Disabling wait for CI')
-      expect(stderr).to.include('Configuring pipeline')
-    })
-
-    it('disables autodeploy and autodestroy and wait-for-ci', async function () {
-      nock('https://api.heroku.com')
-        .get(`/account/features/${feature.name}`)
-        .reply(404, {})
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .patch(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
-
-      nock('https://kolkrabbi.heroku.com')
-        .get(`/pipelines/${pipeline.id}/repository`)
-        .reply(200, repo)
-
-      const {stderr, stdout} = await runCommand(ReviewappsDisable, [`--pipeline=${pipeline.name}`, '--no-autodeploy', '--no-autodestroy', '--no-wait-for-ci'])
-
-      expect(stdout).to.include('Disabling auto deployment')
-      expect(stdout).to.include('Disabling auto destroy')
-      expect(stdout).to.include('Disabling wait for CI')
-      expect(stderr).to.include('Configuring pipeline')
-    })
+    expect(error?.message).to.equal('repository failed')
+    expect(stderr).not.to.include('done')
+    expect(fakePlatform.reviewAppConfig.update.called).to.equal(false)
+    expect(fakePlatform.withOptions.called).to.equal(false)
+    expect(scopedDelete.called).to.equal(false)
+    expect(fakePlatform.reviewAppConfig.delete.called).to.equal(false)
   })
 })

--- a/test/unit/commands/reviewapps/enable.unit.test.ts
+++ b/test/unit/commands/reviewapps/enable.unit.test.ts
@@ -1,231 +1,197 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
+import {ux} from '@oclif/core/ux'
 import {expect} from 'chai'
-import nock from 'nock'
+import {execFileSync} from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import * as sinon from 'sinon'
 
 import ReviewappsEnable from '../../../../src/commands/reviewapps/enable.js'
 
+type FakePlatform = {
+  pipeline: {
+    info: sinon.SinonStub
+  }
+  reviewAppConfig: {
+    enable: sinon.SinonStub
+    resolveRepoName: sinon.SinonStub
+    update: sinon.SinonStub
+  }
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    pipeline: {
+      info: sinon.stub(),
+    },
+    reviewAppConfig: {
+      enable: sinon.stub(),
+      resolveRepoName: sinon.stub(),
+      update: sinon.stub(),
+    },
+  }
+}
+
 describe('reviewapps:enable', function () {
+  const mutationResult = {id: 'review-app-config'}
   const pipeline = {
     id: '123-pipeline',
     name: 'my-pipeline',
   }
-  let api: nock.Scope
-  let kolkrabbiApi: nock.Scope
+  const repo = 'james/repo'
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
-    kolkrabbiApi = nock('https://kolkrabbi.heroku.com')
+    fakePlatform = buildFakePlatform()
+    fakePlatform.pipeline.info.resolves(pipeline)
+    fakePlatform.reviewAppConfig.resolveRepoName.resolves(repo)
+    fakePlatform.reviewAppConfig.enable.resolves(mutationResult)
+    fakePlatform.reviewAppConfig.update.resolves(mutationResult)
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    kolkrabbiApi.done()
-    nock.cleanAll()
+    if (ux.action.running) ux.action.stop()
+
+    sinon.restore()
   })
 
-  describe('with repos api enabled', function () {
-    const feature = {
-      enabled: true,
-      name: 'dashboard-repositories-api',
-    }
+  it('resolves the pipeline and repository before enabling review apps by default', async function () {
+    const {result, stderr} = await runCommand(ReviewappsEnable, [`--pipeline=${pipeline.name}`])
 
-    const repo = {
-      full_name: 'james/repo',
-    }
-
-    it('succeeds with defaults', async function () {
-      api
-        .get(`/account/features/${feature.name}`)
-        .reply(200, feature)
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .get(`/pipelines/${pipeline.id}/repo`)
-        .reply(200, repo)
-        .post(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
-
-      const {stderr} = await runCommand(ReviewappsEnable, [`--pipeline=${pipeline.name}`])
-
-      expect(stderr).to.include('Configuring pipeline')
-    })
-
-    it('succeeds with autodeploy', async function () {
-      api
-        .get(`/account/features/${feature.name}`)
-        .reply(200, feature)
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .get(`/pipelines/${pipeline.id}/repo`)
-        .reply(200, repo)
-        .patch(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
-
-      const {stderr, stdout} = await runCommand(ReviewappsEnable, [`--pipeline=${pipeline.name}`, '--autodeploy'])
-
-      expect(stdout).to.include('Enabling auto deployment')
-      expect(stderr).to.include('Configuring pipeline')
-    })
-
-    it('it succeeds with autodestroy', async function () {
-      api
-        .get(`/account/features/${feature.name}`)
-        .reply(200, feature)
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .get(`/pipelines/${pipeline.id}/repo`)
-        .reply(200, repo)
-        .patch(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
-
-      const {stderr, stdout} = await runCommand(ReviewappsEnable, [`--pipeline=${pipeline.name}`, '--autodestroy'])
-
-      expect(stdout).to.include('Enabling auto destroy')
-      expect(stderr).to.include('Configuring pipeline')
-    })
-
-    it('it succeeds with wait-for-ci', async function () {
-      api
-        .get(`/account/features/${feature.name}`)
-        .reply(200, feature)
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .get(`/pipelines/${pipeline.id}/repo`)
-        .reply(200, repo)
-        .patch(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
-
-      const {stderr, stdout} = await runCommand(ReviewappsEnable, [`--pipeline=${pipeline.name}`, '--wait-for-ci'])
-
-      expect(stdout).to.include('Enabling wait for CI')
-      expect(stderr).to.include('Configuring pipeline')
-    })
-
-    it('it succeeds with autodeploy and autodestroy and wait-for-ci', async function () {
-      api
-        .get(`/account/features/${feature.name}`)
-        .reply(200, feature)
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .get(`/pipelines/${pipeline.id}/repo`)
-        .reply(200, repo)
-        .patch(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
-
-      const {stderr, stdout} = await runCommand(ReviewappsEnable, [`--pipeline=${pipeline.name}`, '--autodeploy', '--autodestroy', '--wait-for-ci'])
-
-      expect(stdout).to.include('Enabling auto deployment')
-      expect(stdout).to.include('Enabling auto destroy')
-      expect(stdout).to.include('Enabling wait for CI')
-      expect(stderr).to.include('Configuring pipeline')
-    })
+    expect(fakePlatform.pipeline.info.calledOnceWithExactly(pipeline.name)).to.equal(true)
+    expect(fakePlatform.reviewAppConfig.resolveRepoName.calledOnceWithExactly(pipeline.id)).to.equal(true)
+    expect(fakePlatform.reviewAppConfig.enable.calledOnceWithExactly(pipeline.id, {
+      automatic_review_apps: undefined,
+      destroy_stale_apps: undefined,
+      pipeline: pipeline.id,
+      repo,
+      wait_for_ci: undefined,
+    })).to.equal(true)
+    expect(fakePlatform.reviewAppConfig.update.called).to.equal(false)
+    expect(stderr).to.include('Configuring pipeline... done\n')
+    expect(result).to.deep.equal(mutationResult)
   })
 
-  describe('with repos api disabled', function () {
-    const feature = {
-      enabled: false,
-      name: 'dashboard-repositories-api',
+  const adjustmentCases = [
+    {
+      expectedOutput: 'Enabling auto deployment',
+      expectedSettings: {automatic_review_apps: true},
+      flag: '--autodeploy',
+    },
+    {
+      expectedOutput: 'Enabling auto destroy',
+      expectedSettings: {destroy_stale_apps: true},
+      flag: '--autodestroy',
+    },
+    {
+      expectedOutput: 'Enabling wait for CI',
+      expectedSettings: {wait_for_ci: true},
+      flag: '--wait-for-ci',
+    },
+  ]
+
+  for (const {expectedOutput, expectedSettings, flag} of adjustmentCases) {
+    it(`updates review apps with ${flag}`, async function () {
+      const {result, stderr, stdout} = await runCommand(ReviewappsEnable, [`--pipeline=${pipeline.name}`, flag])
+
+      expect(fakePlatform.reviewAppConfig.update.calledOnceWithExactly(pipeline.id, {
+        automatic_review_apps: undefined,
+        destroy_stale_apps: undefined,
+        pipeline: pipeline.id,
+        repo,
+        wait_for_ci: undefined,
+        ...expectedSettings,
+      })).to.equal(true)
+      expect(fakePlatform.reviewAppConfig.enable.called).to.equal(false)
+      expect(stdout).to.include(expectedOutput)
+      expect(stderr).to.include('Configuring pipeline... done\n')
+      expect(result).to.deep.equal(mutationResult)
+    })
+  }
+
+  it('updates review apps once with all adjustments', async function () {
+    const {stdout} = await runCommand(ReviewappsEnable, [
+      `--pipeline=${pipeline.name}`,
+      '--autodeploy',
+      '--autodestroy',
+      '--wait-for-ci',
+    ])
+
+    expect(fakePlatform.reviewAppConfig.update.calledOnceWithExactly(pipeline.id, {
+      automatic_review_apps: true,
+      destroy_stale_apps: true,
+      pipeline: pipeline.id,
+      repo,
+      wait_for_ci: true,
+    })).to.equal(true)
+    expect(fakePlatform.reviewAppConfig.enable.called).to.equal(false)
+    expect(stdout).to.include('Enabling auto deployment')
+    expect(stdout).to.include('Enabling auto destroy')
+    expect(stdout).to.include('Enabling wait for CI')
+  })
+
+  it('preserves the app flag warning', async function () {
+    const {stderr} = await runCommand(ReviewappsEnable, [`--pipeline=${pipeline.name}`, '--app=my-app'])
+
+    expect(stderr).to.include('Specifying an app via --app or --remote is no longer needed with')
+    expect(stderr).to.include('Review Apps')
+  })
+
+  it('resolves the app from a remote while enabling review apps', async function () {
+    const originalCwd = process.cwd()
+    const originalHerokuApp = process.env.HEROKU_APP
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reviewapps-enable-'))
+
+    try {
+      delete process.env.HEROKU_APP
+      execFileSync('git', ['init', '--quiet'], {cwd: tempDir})
+      execFileSync('git', ['remote', 'add', 'staging', 'https://git.heroku.com/remote-app.git'], {cwd: tempDir})
+      process.chdir(tempDir)
+
+      const {result, stderr} = await runCommand(ReviewappsEnable, [`--pipeline=${pipeline.name}`, '--remote=staging'])
+
+      expect(stderr).to.include('Specifying an app via --app or --remote is no longer needed with')
+      expect(stderr).to.include('Review Apps')
+      expect(fakePlatform.reviewAppConfig.enable.calledOnceWithExactly(pipeline.id, {
+        automatic_review_apps: undefined,
+        destroy_stale_apps: undefined,
+        pipeline: pipeline.id,
+        repo,
+        wait_for_ci: undefined,
+      })).to.equal(true)
+      expect(result).to.deep.equal(mutationResult)
+    } finally {
+      process.chdir(originalCwd)
+      if (originalHerokuApp === undefined) delete process.env.HEROKU_APP
+      else process.env.HEROKU_APP = originalHerokuApp
+
+      fs.rmSync(tempDir, {force: true, recursive: true})
     }
+  })
 
-    const repo = {
-      repository: {
-        name: 'james/repo',
-      },
-    }
+  it('does not resolve a repository or mutate when pipeline lookup fails', async function () {
+    fakePlatform.pipeline.info.rejects(new Error('pipeline failed'))
 
-    it('succeeds with defaults', async function () {
-      api
-        .get(`/account/features/${feature.name}`)
-        .reply(404, {})
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .post(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
+    const {error, stderr} = await runCommand(ReviewappsEnable, [`--pipeline=${pipeline.name}`])
 
-      kolkrabbiApi
-        .get(`/pipelines/${pipeline.id}/repository`)
-        .reply(200, repo)
+    expect(error?.message).to.equal('pipeline failed')
+    expect(stderr).not.to.include('done')
+    expect(fakePlatform.reviewAppConfig.resolveRepoName.called).to.equal(false)
+    expect(fakePlatform.reviewAppConfig.enable.called).to.equal(false)
+    expect(fakePlatform.reviewAppConfig.update.called).to.equal(false)
+  })
 
-      const {stderr} = await runCommand(ReviewappsEnable, [`--pipeline=${pipeline.name}`])
+  it('does not mutate when repository resolution fails', async function () {
+    fakePlatform.reviewAppConfig.resolveRepoName.rejects(new Error('repository failed'))
 
-      expect(stderr).to.include('Configuring pipeline')
-    })
+    const {error, stderr} = await runCommand(ReviewappsEnable, [`--pipeline=${pipeline.name}`])
 
-    it('succeeds with autodeploy', async function () {
-      api
-        .get(`/account/features/${feature.name}`)
-        .reply(404, {})
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .patch(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
-
-      kolkrabbiApi
-        .get(`/pipelines/${pipeline.id}/repository`)
-        .reply(200, repo)
-
-      const {stderr, stdout} = await runCommand(ReviewappsEnable, [`--pipeline=${pipeline.name}`, '--autodeploy'])
-
-      expect(stdout).to.include('Enabling auto deployment')
-      expect(stderr).to.include('Configuring pipeline')
-    })
-
-    it('it succeeds with autodestroy', async function () {
-      api
-        .get(`/account/features/${feature.name}`)
-        .reply(404, {})
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .patch(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
-
-      kolkrabbiApi
-        .get(`/pipelines/${pipeline.id}/repository`)
-        .reply(200, repo)
-
-      const {stderr, stdout} = await runCommand(ReviewappsEnable, [`--pipeline=${pipeline.name}`, '--autodestroy'])
-
-      expect(stdout).to.include('Enabling auto destroy')
-      expect(stderr).to.include('Configuring pipeline')
-    })
-
-    it('it succeeds with wait-for-ci', async function () {
-      api
-        .get(`/account/features/${feature.name}`)
-        .reply(404, {})
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .patch(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
-
-      kolkrabbiApi
-        .get(`/pipelines/${pipeline.id}/repository`)
-        .reply(200, repo)
-
-      const {stderr, stdout} = await runCommand(ReviewappsEnable, [`--pipeline=${pipeline.name}`, '--wait-for-ci'])
-
-      expect(stdout).to.include('Enabling wait for CI')
-      expect(stderr).to.include('Configuring pipeline')
-    })
-
-    it('it succeeds with autodeploy and autodestroy and wait-for-ci', async function () {
-      api
-        .get(`/account/features/${feature.name}`)
-        .reply(404, {})
-        .get(`/pipelines/${pipeline.name}`)
-        .reply(200, pipeline)
-        .patch(`/pipelines/${pipeline.id}/review-app-config`)
-        .reply(200, {})
-
-      kolkrabbiApi
-        .get(`/pipelines/${pipeline.id}/repository`)
-        .reply(200, repo)
-
-      const {stderr, stdout} = await runCommand(ReviewappsEnable, [`--pipeline=${pipeline.name}`, '--autodeploy', '--autodestroy', '--wait-for-ci'])
-
-      expect(stdout).to.include('Enabling auto deployment')
-      expect(stdout).to.include('Enabling auto destroy')
-      expect(stdout).to.include('Enabling wait for CI')
-      expect(stderr).to.include('Configuring pipeline')
-    })
+    expect(error?.message).to.equal('repository failed')
+    expect(stderr).not.to.include('done')
+    expect(fakePlatform.reviewAppConfig.enable.called).to.equal(false)
+    expect(fakePlatform.reviewAppConfig.update.called).to.equal(false)
   })
 })


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary

Why:

`reviewapps:enable` and `reviewapps:disable` duplicated the logic for looking up a pipeline's GitHub repository across the Platform API, Repositories API, and Kolkrabbi.

That logic also had a correctness issue: when the `dashboard-repositories-api` account feature returned `{enabled: false}`, the commands continued without a repository name instead of falling back to the pipeline repository service.

Moving repository resolution into `@heroku/sdk` gives both commands one consistent implementation while preserving existing command behavior, including flags, output, warnings, and the request body sent when disabling Review Apps.

How:

- Update the CLI lockfile to use `@heroku/sdk@0.6.1`.
- Replace direct Platform API and Kolkrabbi calls in `reviewapps:enable` and `reviewapps:disable` with the SDK.
- Resolve the pipeline through `platform.pipeline.info()`.
- Resolve its repository through `platform.reviewAppConfig.resolveRepoName()`.
- Share authentication across SDK services while applying the CLI's Platform API URL only to the Platform and Repositories API clients.
- Continue using the Kolkrabbi-backed repositories service as the fallback when the account feature is disabled or the Repositories API lookup fails.
- Preserve the existing enable and settings-update behavior.
- Preserve the complete request body for `reviewapps:disable` by applying it through `platform.withOptions()` before calling the generated DELETE method.
- Preserve the hidden positive aliases accepted by `reviewapps:disable`.
- Replace command-level Nock tests with SDK fakes so the CLI tests focus on flag parsing, request construction, routing, output, and error propagation.
- Document the corrected disabled-feature fallback in `V12-CHANGES.md`.


## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing

These commands change Review App configuration. Use a disposable app and pipeline rather than production resources.

### Prerequisites

- Node.js and npm installed
- Heroku CLI authenticated (`heroku auth:whoami`)
- Permission to create and destroy a disposable Heroku app and pipeline
- A GitHub repository that can be connected to a Heroku pipeline and used for Review Apps
- Run the commands below from the root of this CLI checkout

Set unique test values, replacing the repository placeholder:

```sh
export TEST_ID="reviewapps-sdk-$(date +%s)"
export TEST_APP="$TEST_ID-app"
export TEST_PIPELINE="$TEST_ID-pipeline"
export TEST_REPO="<github-owner>/<github-repository>"
```

### Setup

1. Install dependencies and build the CLI:

   ```sh
   npm install
   npm run build
   ```

2. Confirm authentication:

   ```sh
   heroku auth:whoami
   ```

3. Create a disposable app and pipeline:

   ```sh
   ./bin/run apps:create "$TEST_APP"
   ./bin/run pipelines:create "$TEST_PIPELINE" --app "$TEST_APP" --stage staging
   ```

4. Connect the test GitHub repository:

   ```sh
   ./bin/run pipelines:connect "$TEST_PIPELINE" --repo "$TEST_REPO"
   ```

### Test Commands

These manual steps exercise all three migrated live Platform API operations using the SDK's `3.sdk` media type: enabling without flags validates POST, changing settings validates PATCH, and disabling without flags validates DELETE with the preserved request body. A successful `Configuring pipeline... done` confirms that the deployed endpoint accepted the SDK request.

1. Enable Review Apps without changing individual settings:

   ```sh
   ./bin/run reviewapps:enable --pipeline "$TEST_PIPELINE"
   ```

   Expect `Configuring pipeline... done`.

2. Enable all supported settings:

   ```sh
   ./bin/run reviewapps:enable \
     --pipeline "$TEST_PIPELINE" \
     --autodeploy \
     --autodestroy \
     --wait-for-ci
   ```

   Expect messages for enabling auto deployment, auto destroy, and waiting for CI, followed by `Configuring pipeline... done`.

3. Disable each setting through the visible flags:

   ```sh
   ./bin/run reviewapps:disable \
     --pipeline "$TEST_PIPELINE" \
     --no-autodeploy \
     --no-autodestroy \
     --no-wait-for-ci
   ```

   Expect messages for disabling all three settings, followed by `Configuring pipeline... done`.

4. Verify a hidden positive alias remains backward compatible:

   ```sh
   ./bin/run reviewapps:disable --pipeline "$TEST_PIPELINE" --autodeploy
   ```

   Expect `Disabling auto deployment...` followed by `Configuring pipeline... done`.

5. Verify the deprecated app warning remains unchanged:

   ```sh
   ./bin/run reviewapps:enable --pipeline "$TEST_PIPELINE" --app "$TEST_APP"
   ```

   Expect a warning containing `Specifying an app via --app or --remote is no longer needed with Review Apps` and a successful configuration result.

6. Disable Review Apps entirely:

   ```sh
   ./bin/run reviewapps:disable --pipeline "$TEST_PIPELINE"
   ```

   Expect `Configuring pipeline... done`. Run this last among the manual command checks so the pipeline is left with Review Apps disabled.

7. Run the automated Review Apps tests:

   ```sh
   npx mocha 'test/unit/commands/reviewapps/*.unit.test.ts' --reporter min
   ```

   Expect all Review Apps tests to pass.

8. Run the focused lint, type, and build checks:

   ```sh
   npx eslint \
     src/commands/reviewapps/enable.ts \
     src/commands/reviewapps/disable.ts \
     test/unit/commands/reviewapps/enable.unit.test.ts \
     test/unit/commands/reviewapps/disable.unit.test.ts

   bash scripts/codemods/sdk-migration/tsc-delta.sh
   npm run build
   ```

   Expect each command to exit successfully without new diagnostics.

### Tear Down

Run these steps even if a manual test fails:

1. Disable Review Apps if they are still enabled:

   ```sh
   ./bin/run reviewapps:disable --pipeline "$TEST_PIPELINE" || true
   ```

2. Destroy the disposable pipeline and app:

   ```sh
   ./bin/run pipelines:destroy "$TEST_PIPELINE"
   ./bin/run apps:destroy --app "$TEST_APP" --confirm "$TEST_APP"
   ```

3. Clear the test variables:

   ```sh
   unset TEST_ID TEST_APP TEST_PIPELINE TEST_REPO
   ```

The disabled-account-feature fallback is covered by the SDK resolver tests because that account feature cannot be safely toggled as part of manual CLI testing.

## Screenshots (if applicable)

## Related Issues
GUS work item: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eLUGnYAO/view
