### PR TITLE
feat(data): manage Postgres Advanced logical replication

### DIFF
--- a/src/commands/data/pg/logical-replication/publications/create.ts
+++ b/src/commands/data/pg/logical-replication/publications/create.ts
@@ -1,0 +1,63 @@
+import {flags as Flags} from '@heroku-cli/command'
+import {color} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+
+import BaseCommand from '../../../../../lib/data/base-command.js'
+import {PublicationTarget, resolveAdvancedDatabase} from '../../../../../lib/data/logical-replication.js'
+
+export default class DataPgLogicalReplicationPublicationsCreate extends BaseCommand {
+  static args = {
+    database: Args.string({
+      description: 'database name, database attachment name, or related config var on an app',
+      required: true,
+    }),
+  }
+  static description = 'create a logical replication publication on a Postgres Advanced database'
+  static examples = [
+    '<%= config.bin %> <%= command.id %> DATABASE --name orders --table public.orders --app example-app',
+    '<%= config.bin %> <%= command.id %> DATABASE --name application --schema public --app example-app',
+    '<%= config.bin %> <%= command.id %> DATABASE --name application --all-schemas --app example-app',
+  ]
+  static flags = {
+    'all-schemas': Flags.boolean({
+      description: 'include all current customer schemas',
+      exclusive: ['schema', 'table'],
+    }),
+    app: Flags.app({required: true}),
+    name: Flags.string({description: 'lowercase name for the publication', required: true}),
+    remote: Flags.remote(),
+    schema: Flags.string({description: 'schema to include, including new tables created in the schema', multiple: true}),
+    table: Flags.string({description: 'fully-qualified table to include', multiple: true}),
+  }
+
+  async run(): Promise<void> {
+    const {args, flags} = await this.parse(DataPgLogicalReplicationPublicationsCreate)
+    const addon = await resolveAdvancedDatabase(this, args.database, flags.app)
+    const target = this.publicationTarget(flags['all-schemas'], flags.table, flags.schema)
+
+    try {
+      ux.action.start(`Creating publication ${color.name(flags.name)} on ${color.datastore(addon.name)}`)
+      await this.dataApi.post(`/data/postgres/v1/${addon.id}/logical-replication/publications`, {body: {name: flags.name, target}})
+      ux.action.stop()
+      if (flags['all-schemas']) {
+        ux.stdout('The publication includes all current customer schemas. Tables created later and new schemas are not added automatically.')
+      }
+    } catch (error) {
+      ux.action.stop(color.red('!'))
+      throw error
+    }
+  }
+
+  private publicationTarget(allSchemas: boolean, tables?: string[], schemas?: string[]): PublicationTarget {
+    if (allSchemas) return {type: 'all_customer_schemas'}
+
+    if (tables && schemas) {
+      ux.error('Specify either --table or --schema, not both.')
+    }
+
+    if (tables) return {tables, type: 'tables'}
+    if (schemas) return {schemas, type: 'schemas'}
+
+    ux.error('Specify --all-schemas, at least one --table, or at least one --schema.')
+  }
+}

--- a/src/commands/data/pg/logical-replication/publications/create.ts
+++ b/src/commands/data/pg/logical-replication/publications/create.ts
@@ -6,6 +6,7 @@ import BaseCommand from '../../../../../lib/data/base-command.js'
 import {PublicationTarget, resolveAdvancedDatabase} from '../../../../../lib/data/logical-replication.js'
 
 export default class DataPgLogicalReplicationPublicationsCreate extends BaseCommand {
+  static aliases = ['data:pg:lr:publications:create']
   static args = {
     database: Args.string({
       description: 'database name, database attachment name, or related config var on an app',

--- a/src/commands/data/pg/logical-replication/publications/destroy.ts
+++ b/src/commands/data/pg/logical-replication/publications/destroy.ts
@@ -6,6 +6,7 @@ import BaseCommand from '../../../../../lib/data/base-command.js'
 import {resolveAdvancedDatabase} from '../../../../../lib/data/logical-replication.js'
 
 export default class DataPgLogicalReplicationPublicationsDestroy extends BaseCommand {
+  static aliases = ['data:pg:lr:publications:destroy']
   static args = {
     database: Args.string({
       description: 'database name, database attachment name, or related config var on an app',

--- a/src/commands/data/pg/logical-replication/publications/destroy.ts
+++ b/src/commands/data/pg/logical-replication/publications/destroy.ts
@@ -1,0 +1,40 @@
+import {flags as Flags} from '@heroku-cli/command'
+import {color, hux} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+
+import BaseCommand from '../../../../../lib/data/base-command.js'
+import {resolveAdvancedDatabase} from '../../../../../lib/data/logical-replication.js'
+
+export default class DataPgLogicalReplicationPublicationsDestroy extends BaseCommand {
+  static args = {
+    database: Args.string({
+      description: 'database name, database attachment name, or related config var on an app',
+      required: true,
+    }),
+  }
+  static description = 'destroy a logical replication publication'
+  static examples = [
+    '<%= config.bin %> <%= command.id %> DATABASE --name orders --app example-app --confirm example-app',
+  ]
+  static flags = {
+    app: Flags.app({required: true}),
+    confirm: Flags.string({char: 'c', description: 'pass in the app name to skip confirmation prompts'}),
+    name: Flags.string({description: 'name of the publication', required: true}),
+    remote: Flags.remote(),
+  }
+
+  async run(): Promise<void> {
+    const {args, flags} = await this.parse(DataPgLogicalReplicationPublicationsDestroy)
+    const addon = await resolveAdvancedDatabase(this, args.database, flags.app)
+    await hux.confirmCommand({comparison: flags.app, confirmation: flags.confirm})
+
+    try {
+      ux.action.start(`Destroying publication ${color.name(flags.name)} on ${color.datastore(addon.name)}`)
+      await this.dataApi.delete(`/data/postgres/v1/${addon.id}/logical-replication/publications/${encodeURIComponent(flags.name)}`)
+      ux.action.stop()
+    } catch (error) {
+      ux.action.stop(color.red('!'))
+      throw error
+    }
+  }
+}

--- a/src/commands/data/pg/logical-replication/publications/index.ts
+++ b/src/commands/data/pg/logical-replication/publications/index.ts
@@ -1,0 +1,47 @@
+import {flags as Flags} from '@heroku-cli/command'
+import {hux} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+
+import BaseCommand from '../../../../../lib/data/base-command.js'
+import {LogicalReplicationPublicationsResponse, resolveAdvancedDatabase} from '../../../../../lib/data/logical-replication.js'
+import {huxTableNoWrapOptions} from '../../../../../lib/utils/table-utils.js'
+
+export default class DataPgLogicalReplicationPublicationsIndex extends BaseCommand {
+  static args = {
+    database: Args.string({
+      description: 'database name, database attachment name, or related config var on an app',
+      required: true,
+    }),
+  }
+  static description = 'list logical replication publications on a Postgres Advanced database'
+  static examples = [
+    '<%= config.bin %> <%= command.id %> DATABASE --app example-app',
+  ]
+  static flags = {
+    app: Flags.app({required: true}),
+    'no-wrap': Flags.noWrap(),
+    remote: Flags.remote(),
+  }
+
+  async run(): Promise<void> {
+    const {args, flags} = await this.parse(DataPgLogicalReplicationPublicationsIndex)
+    const addon = await resolveAdvancedDatabase(this, args.database, flags.app)
+    const {body: {publications}} = await this.dataApi.get<LogicalReplicationPublicationsResponse>(`/data/postgres/v1/${addon.id}/logical-replication/publications`)
+
+    if (publications.length === 0) {
+      ux.stdout(`No logical replication publications exist on ${addon.name}.`)
+      return
+    }
+
+    hux.table(publications, {
+      Name: {get: publication => publication.name},
+      'New Tables': {get: publication => publication.target.automatically_includes_new_tables ? 'included' : 'not included'},
+      Owner: {get: publication => publication.owner},
+      Target: {
+        get: publication => publication.target.type === 'schemas'
+          ? `schemas: ${publication.target.schemas.join(', ')}`
+          : `tables: ${publication.current_tables.join(', ')}`,
+      },
+    }, huxTableNoWrapOptions(flags['no-wrap']))
+  }
+}

--- a/src/commands/data/pg/logical-replication/publications/index.ts
+++ b/src/commands/data/pg/logical-replication/publications/index.ts
@@ -7,6 +7,7 @@ import {LogicalReplicationPublicationsResponse, resolveAdvancedDatabase} from '.
 import {huxTableNoWrapOptions} from '../../../../../lib/utils/table-utils.js'
 
 export default class DataPgLogicalReplicationPublicationsIndex extends BaseCommand {
+  static aliases = ['data:pg:lr:publications']
   static args = {
     database: Args.string({
       description: 'database name, database attachment name, or related config var on an app',
@@ -26,14 +27,14 @@ export default class DataPgLogicalReplicationPublicationsIndex extends BaseComma
   async run(): Promise<void> {
     const {args, flags} = await this.parse(DataPgLogicalReplicationPublicationsIndex)
     const addon = await resolveAdvancedDatabase(this, args.database, flags.app)
-    const {body: {publications}} = await this.dataApi.get<LogicalReplicationPublicationsResponse>(`/data/postgres/v1/${addon.id}/logical-replication/publications`)
+    const {body: {items}} = await this.dataApi.get<LogicalReplicationPublicationsResponse>(`/data/postgres/v1/${addon.id}/logical-replication/publications`)
 
-    if (publications.length === 0) {
+    if (items.length === 0) {
       ux.stdout(`No logical replication publications exist on ${addon.name}.`)
       return
     }
 
-    hux.table(publications, {
+    hux.table(items, {
       Name: {get: publication => publication.name},
       'New Tables': {get: publication => publication.target.automatically_includes_new_tables ? 'included' : 'not included'},
       Owner: {get: publication => publication.owner},

--- a/src/commands/data/pg/logical-replication/publications/info.ts
+++ b/src/commands/data/pg/logical-replication/publications/info.ts
@@ -1,0 +1,39 @@
+import {flags as Flags} from '@heroku-cli/command'
+import {hux} from '@heroku/heroku-cli-util'
+import {Args} from '@oclif/core'
+
+import BaseCommand from '../../../../../lib/data/base-command.js'
+import {LogicalReplicationPublicationResponse, resolveAdvancedDatabase} from '../../../../../lib/data/logical-replication.js'
+
+export default class DataPgLogicalReplicationPublicationsInfo extends BaseCommand {
+  static args = {
+    database: Args.string({
+      description: 'database name, database attachment name, or related config var on an app',
+      required: true,
+    }),
+  }
+  static description = 'show a logical replication publication on a Postgres Advanced database'
+  static examples = [
+    '<%= config.bin %> <%= command.id %> DATABASE --name orders --app example-app',
+  ]
+  static flags = {
+    app: Flags.app({required: true}),
+    name: Flags.string({description: 'name of the publication', required: true}),
+    remote: Flags.remote(),
+  }
+
+  async run(): Promise<void> {
+    const {args, flags} = await this.parse(DataPgLogicalReplicationPublicationsInfo)
+    const addon = await resolveAdvancedDatabase(this, args.database, flags.app)
+    const {body: {publication}} = await this.dataApi.get<LogicalReplicationPublicationResponse>(`/data/postgres/v1/${addon.id}/logical-replication/publications/${encodeURIComponent(flags.name)}`)
+    const target = publication.target.type === 'schemas' ? publication.target.schemas.join(', ') : publication.current_tables.join(', ')
+
+    hux.styledObject({
+      'Current Tables': publication.current_tables.join(', '),
+      'Includes New Tables': publication.target.automatically_includes_new_tables ? 'yes' : 'no',
+      Name: publication.name,
+      Owner: publication.owner,
+      Target: `${publication.target.type}: ${target}`,
+    }, ['Name', 'Owner', 'Target', 'Current Tables', 'Includes New Tables'])
+  }
+}

--- a/src/commands/data/pg/logical-replication/publications/info.ts
+++ b/src/commands/data/pg/logical-replication/publications/info.ts
@@ -3,9 +3,10 @@ import {hux} from '@heroku/heroku-cli-util'
 import {Args} from '@oclif/core'
 
 import BaseCommand from '../../../../../lib/data/base-command.js'
-import {LogicalReplicationPublicationResponse, resolveAdvancedDatabase} from '../../../../../lib/data/logical-replication.js'
+import {LogicalReplicationPublication, resolveAdvancedDatabase} from '../../../../../lib/data/logical-replication.js'
 
 export default class DataPgLogicalReplicationPublicationsInfo extends BaseCommand {
+  static aliases = ['data:pg:lr:publications:info']
   static args = {
     database: Args.string({
       description: 'database name, database attachment name, or related config var on an app',
@@ -25,7 +26,7 @@ export default class DataPgLogicalReplicationPublicationsInfo extends BaseComman
   async run(): Promise<void> {
     const {args, flags} = await this.parse(DataPgLogicalReplicationPublicationsInfo)
     const addon = await resolveAdvancedDatabase(this, args.database, flags.app)
-    const {body: {publication}} = await this.dataApi.get<LogicalReplicationPublicationResponse>(`/data/postgres/v1/${addon.id}/logical-replication/publications/${encodeURIComponent(flags.name)}`)
+    const {body: publication} = await this.dataApi.get<LogicalReplicationPublication>(`/data/postgres/v1/${addon.id}/logical-replication/publications/${encodeURIComponent(flags.name)}`)
     const target = publication.target.type === 'schemas' ? publication.target.schemas.join(', ') : publication.current_tables.join(', ')
 
     hux.styledObject({

--- a/src/commands/data/pg/logical-replication/publications/update.ts
+++ b/src/commands/data/pg/logical-replication/publications/update.ts
@@ -6,6 +6,7 @@ import BaseCommand from '../../../../../lib/data/base-command.js'
 import {PublicationTarget, resolveAdvancedDatabase} from '../../../../../lib/data/logical-replication.js'
 
 export default class DataPgLogicalReplicationPublicationsUpdate extends BaseCommand {
+  static aliases = ['data:pg:lr:publications:update']
   static args = {
     database: Args.string({
       description: 'database name, database attachment name, or related config var on an app',

--- a/src/commands/data/pg/logical-replication/publications/update.ts
+++ b/src/commands/data/pg/logical-replication/publications/update.ts
@@ -1,0 +1,53 @@
+import {flags as Flags} from '@heroku-cli/command'
+import {color} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+
+import BaseCommand from '../../../../../lib/data/base-command.js'
+import {PublicationTarget, resolveAdvancedDatabase} from '../../../../../lib/data/logical-replication.js'
+
+export default class DataPgLogicalReplicationPublicationsUpdate extends BaseCommand {
+  static args = {
+    database: Args.string({
+      description: 'database name, database attachment name, or related config var on an app',
+      required: true,
+    }),
+  }
+  static description = 'replace the target of a logical replication publication'
+  static examples = [
+    '<%= config.bin %> <%= command.id %> DATABASE --name orders --table public.orders --app example-app',
+    '<%= config.bin %> <%= command.id %> DATABASE --name application --schema public --app example-app',
+  ]
+  static flags = {
+    app: Flags.app({required: true}),
+    name: Flags.string({description: 'name of the publication', required: true}),
+    remote: Flags.remote(),
+    schema: Flags.string({description: 'schema to include, including new tables created in the schema', multiple: true}),
+    table: Flags.string({description: 'fully-qualified table to include', multiple: true}),
+  }
+
+  async run(): Promise<void> {
+    const {args, flags} = await this.parse(DataPgLogicalReplicationPublicationsUpdate)
+    const addon = await resolveAdvancedDatabase(this, args.database, flags.app)
+    const target = this.publicationTarget(flags.table, flags.schema)
+
+    try {
+      ux.action.start(`Updating publication ${color.name(flags.name)} on ${color.datastore(addon.name)}`)
+      await this.dataApi.put(`/data/postgres/v1/${addon.id}/logical-replication/publications/${encodeURIComponent(flags.name)}`, {body: {target}})
+      ux.action.stop()
+    } catch (error) {
+      ux.action.stop(color.red('!'))
+      throw error
+    }
+  }
+
+  private publicationTarget(tables?: string[], schemas?: string[]): PublicationTarget {
+    if (tables && schemas) {
+      ux.error('Specify either --table or --schema, not both.')
+    }
+
+    if (tables) return {tables, type: 'tables'}
+    if (schemas) return {schemas, type: 'schemas'}
+
+    ux.error('Specify at least one --table or --schema.')
+  }
+}

--- a/src/commands/data/pg/logical-replication/publishing/enable.ts
+++ b/src/commands/data/pg/logical-replication/publishing/enable.ts
@@ -6,6 +6,7 @@ import BaseCommand from '../../../../../lib/data/base-command.js'
 import {resolveAdvancedDatabase} from '../../../../../lib/data/logical-replication.js'
 
 export default class DataPgLogicalReplicationPublishingEnable extends BaseCommand {
+  static aliases = ['data:pg:lr:publishing:enable']
   static args = {
     database: Args.string({
       description: 'database name, database attachment name, or related config var on an app',

--- a/src/commands/data/pg/logical-replication/publishing/enable.ts
+++ b/src/commands/data/pg/logical-replication/publishing/enable.ts
@@ -1,0 +1,38 @@
+import {flags as Flags} from '@heroku-cli/command'
+import {color} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+
+import BaseCommand from '../../../../../lib/data/base-command.js'
+import {resolveAdvancedDatabase} from '../../../../../lib/data/logical-replication.js'
+
+export default class DataPgLogicalReplicationPublishingEnable extends BaseCommand {
+  static args = {
+    database: Args.string({
+      description: 'database name, database attachment name, or related config var on an app',
+      required: true,
+    }),
+  }
+  static description = 'enable logical replication publishing for a Postgres Advanced database'
+  static examples = [
+    '<%= config.bin %> <%= command.id %> DATABASE --app example-app',
+  ]
+  static flags = {
+    app: Flags.app({required: true}),
+    remote: Flags.remote(),
+  }
+
+  async run(): Promise<void> {
+    const {args, flags} = await this.parse(DataPgLogicalReplicationPublishingEnable)
+    const addon = await resolveAdvancedDatabase(this, args.database, flags.app)
+
+    try {
+      ux.action.start(`Enabling logical replication publishing for ${color.datastore(addon.name)}`)
+      await this.dataApi.post(`/data/postgres/v1/${addon.id}/logical-replication/publishing/enable`)
+      ux.action.stop('requested')
+      ux.stdout(`Wait for ${color.datastore(addon.name)} to finish updating before creating publications. Use ${color.code(`heroku data:pg:info ${addon.name} --app ${flags.app}`)} to track progress.`)
+    } catch (error) {
+      ux.action.stop(color.red('!'))
+      throw error
+    }
+  }
+}

--- a/src/commands/data/pg/logical-replication/subscribing/enable.ts
+++ b/src/commands/data/pg/logical-replication/subscribing/enable.ts
@@ -1,0 +1,39 @@
+import {flags as Flags} from '@heroku-cli/command'
+import {color} from '@heroku/heroku-cli-util'
+import {Args, ux} from '@oclif/core'
+
+import BaseCommand from '../../../../../lib/data/base-command.js'
+import {resolveAdvancedDatabase} from '../../../../../lib/data/logical-replication.js'
+
+export default class DataPgLogicalReplicationSubscribingEnable extends BaseCommand {
+  static args = {
+    database: Args.string({
+      description: 'database name, database attachment name, or related config var on an app',
+      required: true,
+    }),
+  }
+  static description = 'enable logical replication subscribing for a Postgres Advanced database'
+  static examples = [
+    '<%= config.bin %> <%= command.id %> DATABASE --app example-app',
+  ]
+  static flags = {
+    app: Flags.app({required: true}),
+    remote: Flags.remote(),
+  }
+
+  async run(): Promise<void> {
+    const {args, flags} = await this.parse(DataPgLogicalReplicationSubscribingEnable)
+    const addon = await resolveAdvancedDatabase(this, args.database, flags.app)
+
+    try {
+      ux.action.start(`Enabling logical replication subscribing for ${color.datastore(addon.name)}`)
+      await this.dataApi.post(`/data/postgres/v1/${addon.id}/logical-replication/subscribing/enable`)
+      ux.action.stop('requested')
+      ux.stdout(`Wait for ${color.datastore(addon.name)} to finish updating before creating subscriptions. `
+        + `Use ${color.code(`heroku data:pg:info ${addon.name} --app ${flags.app}`)} to track progress.`)
+    } catch (error) {
+      ux.action.stop(color.red('!'))
+      throw error
+    }
+  }
+}

--- a/src/commands/data/pg/logical-replication/subscribing/enable.ts
+++ b/src/commands/data/pg/logical-replication/subscribing/enable.ts
@@ -6,6 +6,7 @@ import BaseCommand from '../../../../../lib/data/base-command.js'
 import {resolveAdvancedDatabase} from '../../../../../lib/data/logical-replication.js'
 
 export default class DataPgLogicalReplicationSubscribingEnable extends BaseCommand {
+  static aliases = ['data:pg:lr:subscribing:enable']
   static args = {
     database: Args.string({
       description: 'database name, database attachment name, or related config var on an app',

--- a/src/lib/data/logical-replication.ts
+++ b/src/lib/data/logical-replication.ts
@@ -1,0 +1,51 @@
+import type {pg} from '@heroku/heroku-cli-util'
+
+import {color, utils} from '@heroku/heroku-cli-util'
+import {ux} from '@oclif/core'
+
+import type BaseCommand from './base-command.js'
+
+export type PublicationTarget
+  = | {schemas: string[], type: 'schemas'}
+    | {tables: string[], type: 'tables'}
+    | {type: 'all_customer_schemas'}
+
+type PublicationResponseTarget
+  = | {
+    automatically_includes_new_schemas: boolean
+    automatically_includes_new_tables: boolean
+    schemas: string[]
+    type: 'schemas'
+  }
+    | {
+      automatically_includes_new_schemas: boolean
+      automatically_includes_new_tables: boolean
+      tables: string[]
+      type: 'tables'
+    }
+
+export type LogicalReplicationPublication = {
+  current_tables: string[]
+  name: string
+  owner: string
+  target: PublicationResponseTarget
+}
+
+export type LogicalReplicationPublicationsResponse = {
+  publications: LogicalReplicationPublication[]
+}
+
+export type LogicalReplicationPublicationResponse = {
+  publication: LogicalReplicationPublication
+}
+
+export async function resolveAdvancedDatabase(command: BaseCommand, database: string, app: string): Promise<pg.ExtendedAddon> {
+  const addonResolver = new utils.AddonResolver(command.heroku)
+  const addon = await addonResolver.resolve(database, app, utils.pg.addonService())
+
+  if (!utils.pg.isAdvancedDatabase(addon)) {
+    ux.error(`You can only use this command on Advanced-tier databases.\nUse ${color.code(`heroku data:pg:info ${database} --app ${app}`)} to inspect an Advanced database.`)
+  }
+
+  return addon
+}

--- a/src/lib/data/logical-replication.ts
+++ b/src/lib/data/logical-replication.ts
@@ -32,11 +32,9 @@ export type LogicalReplicationPublication = {
 }
 
 export type LogicalReplicationPublicationsResponse = {
-  publications: LogicalReplicationPublication[]
-}
-
-export type LogicalReplicationPublicationResponse = {
-  publication: LogicalReplicationPublication
+  count: number
+  items: LogicalReplicationPublication[]
+  limit: number
 }
 
 export async function resolveAdvancedDatabase(command: BaseCommand, database: string, app: string): Promise<pg.ExtendedAddon> {

--- a/test/unit/commands/data/pg/logical-replication.unit.test.ts
+++ b/test/unit/commands/data/pg/logical-replication.unit.test.ts
@@ -1,0 +1,176 @@
+import {runCommand} from '@heroku-cli/test-utils'
+import ansis from 'ansis'
+import {expect} from 'chai'
+import nock from 'nock'
+
+import DataPgLogicalReplicationPublicationsCreate from '../../../../../src/commands/data/pg/logical-replication/publications/create.js'
+import DataPgLogicalReplicationPublicationsDestroy from '../../../../../src/commands/data/pg/logical-replication/publications/destroy.js'
+import DataPgLogicalReplicationPublicationsIndex from '../../../../../src/commands/data/pg/logical-replication/publications/index.js'
+import DataPgLogicalReplicationPublicationsInfo from '../../../../../src/commands/data/pg/logical-replication/publications/info.js'
+import DataPgLogicalReplicationPublicationsUpdate from '../../../../../src/commands/data/pg/logical-replication/publications/update.js'
+import DataPgLogicalReplicationPublishingEnable from '../../../../../src/commands/data/pg/logical-replication/publishing/enable.js'
+import DataPgLogicalReplicationSubscribingEnable from '../../../../../src/commands/data/pg/logical-replication/subscribing/enable.js'
+import {addon} from '../../../../fixtures/data/pg/fixtures.js'
+import removeAllWhitespace from '../../../../helpers/utils/remove-whitespaces.js'
+
+const publicationsResponse = {
+  publications: [{
+    current_tables: ['public.orders'],
+    name: 'orders',
+    owner: 'u12345',
+    target: {
+      automatically_includes_new_schemas: false,
+      automatically_includes_new_tables: false,
+      tables: ['public.orders'],
+      type: 'tables',
+    },
+  }],
+}
+
+const resolveAddon = () => nock('https://api.heroku.com')
+  .post('/actions/addons/resolve')
+  .reply(200, [{...addon, addon_service: {...addon.addon_service, name: 'heroku-postgresql'}}])
+
+describe('data:pg:logical-replication', function () {
+  it('enables publishing and explains how to track the asynchronous operation', async function () {
+    const herokuApi = resolveAddon()
+    const dataApi = nock('https://api.data.heroku.com')
+      .post(`/data/postgres/v1/${addon.id}/logical-replication/publishing/enable`)
+      .reply(202)
+
+    const {error, stderr, stdout} = await runCommand(DataPgLogicalReplicationPublishingEnable, ['DATABASE', '--app=myapp'])
+
+    expect(error).to.be.undefined
+    herokuApi.done()
+    dataApi.done()
+    expect(ansis.strip(stderr)).to.include('Enabling logical replication publishing for')
+    expect(ansis.strip(stderr)).to.include('advanced-horizontal-01234... requested')
+    expect(ansis.strip(stdout)).to.include('to finish updating before creating publications.')
+  })
+
+  it('enables subscribing and explains how to track the asynchronous operation', async function () {
+    const herokuApi = resolveAddon()
+    const dataApi = nock('https://api.data.heroku.com')
+      .post(`/data/postgres/v1/${addon.id}/logical-replication/subscribing/enable`)
+      .reply(202)
+
+    const {stderr, stdout} = await runCommand(DataPgLogicalReplicationSubscribingEnable, ['DATABASE', '--app=myapp'])
+
+    herokuApi.done()
+    dataApi.done()
+    expect(ansis.strip(stderr)).to.include('Enabling logical replication subscribing for')
+    expect(ansis.strip(stderr)).to.include('advanced-horizontal-01234... requested')
+    expect(ansis.strip(stdout)).to.include('to finish updating before creating subscriptions.')
+  })
+
+  it('creates table-scoped publications', async function () {
+    const herokuApi = resolveAddon()
+    const dataApi = nock('https://api.data.heroku.com')
+      .post(`/data/postgres/v1/${addon.id}/logical-replication/publications`, {
+        name: 'orders', target: {tables: ['public.orders', 'public.order_items'], type: 'tables'},
+      })
+      .reply(201)
+
+    const {stderr} = await runCommand(DataPgLogicalReplicationPublicationsCreate, [
+      'DATABASE', '--app=myapp', '--name=orders', '--table=public.orders', '--table=public.order_items',
+    ])
+
+    herokuApi.done()
+    dataApi.done()
+    expect(ansis.strip(stderr)).to.include('Creating publication orders on')
+    expect(ansis.strip(stderr)).to.include('advanced-horizontal-01234... done')
+  })
+
+  it('requires exactly one publication target type', async function () {
+    const herokuApi = resolveAddon()
+    const {error} = await runCommand(DataPgLogicalReplicationPublicationsCreate, [
+      'DATABASE', '--app=myapp', '--name=orders', '--table=public.orders', '--schema=public',
+    ])
+
+    herokuApi.done()
+    expect((error as Error).message).to.equal('Specify either --table or --schema, not both.')
+  })
+
+  it('creates a publication for all current customer schemas', async function () {
+    const herokuApi = resolveAddon()
+    const dataApi = nock('https://api.data.heroku.com')
+      .post(`/data/postgres/v1/${addon.id}/logical-replication/publications`, {
+        name: 'application', target: {type: 'all_customer_schemas'},
+      })
+      .reply(201)
+
+    const {stdout} = await runCommand(DataPgLogicalReplicationPublicationsCreate, [
+      'DATABASE', '--app=myapp', '--name=application', '--all-schemas',
+    ])
+
+    herokuApi.done()
+    dataApi.done()
+    expect(ansis.strip(stdout)).to.equal('The publication includes all current customer schemas. Tables created later and new schemas are not added automatically.\n')
+  })
+
+  it('lists publications', async function () {
+    const herokuApi = resolveAddon()
+    const dataApi = nock('https://api.data.heroku.com')
+      .get(`/data/postgres/v1/${addon.id}/logical-replication/publications`)
+      .reply(200, publicationsResponse)
+
+    const {stdout} = await runCommand(DataPgLogicalReplicationPublicationsIndex, ['DATABASE', '--app=myapp'])
+
+    herokuApi.done()
+    dataApi.done()
+    const actual = removeAllWhitespace(stdout)
+    expect(actual).to.include(removeAllWhitespace('Name New Tables Owner Target'))
+    expect(actual).to.include(removeAllWhitespace('orders not included u12345 tables: public.orders'))
+  })
+
+  it('shows publication details', async function () {
+    const herokuApi = resolveAddon()
+    const dataApi = nock('https://api.data.heroku.com')
+      .get(`/data/postgres/v1/${addon.id}/logical-replication/publications/orders`)
+      .reply(200, {publication: publicationsResponse.publications[0]})
+
+    const {stdout} = await runCommand(DataPgLogicalReplicationPublicationsInfo, [
+      'DATABASE', '--app=myapp', '--name=orders',
+    ])
+
+    herokuApi.done()
+    dataApi.done()
+    const actual = removeAllWhitespace(stdout)
+    expect(actual).to.include(removeAllWhitespace('Name: orders'))
+    expect(actual).to.include(removeAllWhitespace('Target: tables: public.orders'))
+  })
+
+  it('replaces a publication target', async function () {
+    const herokuApi = resolveAddon()
+    const dataApi = nock('https://api.data.heroku.com')
+      .put(`/data/postgres/v1/${addon.id}/logical-replication/publications/orders`, {
+        target: {schemas: ['public'], type: 'schemas'},
+      })
+      .reply(204)
+
+    const {stderr} = await runCommand(DataPgLogicalReplicationPublicationsUpdate, [
+      'DATABASE', '--app=myapp', '--name=orders', '--schema=public',
+    ])
+
+    herokuApi.done()
+    dataApi.done()
+    expect(ansis.strip(stderr)).to.include('Updating publication orders on')
+    expect(ansis.strip(stderr)).to.include('advanced-horizontal-01234... done')
+  })
+
+  it('destroys a publication with explicit confirmation', async function () {
+    const herokuApi = resolveAddon()
+    const dataApi = nock('https://api.data.heroku.com')
+      .delete(`/data/postgres/v1/${addon.id}/logical-replication/publications/orders`)
+      .reply(204)
+
+    const {stderr} = await runCommand(DataPgLogicalReplicationPublicationsDestroy, [
+      'DATABASE', '--app=myapp', '--name=orders', '--confirm=myapp',
+    ])
+
+    herokuApi.done()
+    dataApi.done()
+    expect(ansis.strip(stderr)).to.include('Destroying publication orders on')
+    expect(ansis.strip(stderr)).to.include('advanced-horizontal-01234... done')
+  })
+})

--- a/test/unit/commands/data/pg/logical-replication.unit.test.ts
+++ b/test/unit/commands/data/pg/logical-replication.unit.test.ts
@@ -14,7 +14,8 @@ import {addon} from '../../../../fixtures/data/pg/fixtures.js'
 import removeAllWhitespace from '../../../../helpers/utils/remove-whitespaces.js'
 
 const publicationsResponse = {
-  publications: [{
+  count: 1,
+  items: [{
     current_tables: ['public.orders'],
     name: 'orders',
     owner: 'u12345',
@@ -25,6 +26,7 @@ const publicationsResponse = {
       type: 'tables',
     },
   }],
+  limit: 50,
 }
 
 const resolveAddon = () => nock('https://api.heroku.com')
@@ -127,7 +129,7 @@ describe('data:pg:logical-replication', function () {
     const herokuApi = resolveAddon()
     const dataApi = nock('https://api.data.heroku.com')
       .get(`/data/postgres/v1/${addon.id}/logical-replication/publications/orders`)
-      .reply(200, {publication: publicationsResponse.publications[0]})
+      .reply(200, publicationsResponse.items[0])
 
     const {stdout} = await runCommand(DataPgLogicalReplicationPublicationsInfo, [
       'DATABASE', '--app=myapp', '--name=orders',


### PR DESCRIPTION
## Summary

Add commands to enable logical replication publishing and subscribing on Postgres Advanced databases.

Add publication list, info, create, update, and destroy operations with table and schema scoped targets. Include --all-schemas as an opinionated setup path for all current customer schemas, while making its non-continuous behavior explicit.

Resolve and reject non-Advanced databases before contacting the Data API, preserve destructive confirmation for publication removal, and cover the command flows with unit tests.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
<!-- Add any context/setup necessary for testing. -->

```
❯ heroku data:pg:logical-replication:publications postgresql-justin-animated-23578 -a justin-lr-test
  Name      New Tables     Owner            Target
 ───────────────────────────────────────────────────────────
  onepub    included       ubitise4r2c94d   schemas: one
  testpub   included       ubitise4r2c94d   schemas: public
  twopub    not included   ubitise4r2c94d   tables: two.foo
  
❯ heroku data:pg:logical-replication:publications:info --name testpub postgresql-justin-animated-23578 -a justin-lr-test
Name:                testpub
Owner:               ubitise4r2c94d
Target:              schemas: public
Current Tables:      public.bar, public.baz, public.foo, public.pgbench_accounts, public.pgbench_branches, public.pgbench_history, public.pgbench_tellers, public.test
Includes New Tables: yes
```

**Steps**:
1. Replace this text with a list of steps used to validate changes or type 'Passing CI suffices'.
2. ...

## Screenshots (if applicable)

## Related Issues
GitHub issue: #[GitHub issue number]
GUS work item: [W-24080815](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002jc8r1YAA/view)