### PR TITLE
fix(deps): bump fast-uri to 3.1.7 (closes 4 advisories)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12582,9 +12582,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Refreshes the committed `package-lock.json` entry for **`fast-uri`** from the vulnerable `3.1.5` to the patched `3.1.7`, resolving four high-severity Dependabot advisories that all share the same upstream fix.

`fast-uri` is a deeply transitive, runtime dependency (`@heroku/mcp-server` → `@modelcontextprotocol/sdk` → `ajv` → `fast-uri`). `ajv@8.20.0` already declares `"fast-uri": "^3.0.1"`, a range that permits the patched `3.1.6`/`3.1.7` — the lockfile was simply stale at `3.1.5`. This is a **lockfile-only refresh**: no `package.json`, parent-version, or `overrides` change (`git diff package.json` is empty), and only the `fast-uri` entry moved (3 lines).

The four advisories are distinct URI parsing/normalization bugs (skipped IDN canonicalization on scheme-relative refs, double percent-decoding of the host, unvalidated scheme percent-decoding, and malformed-IPv6 truncation), all fixed in `fast-uri` 3.1.6.

## Type of Change

### Patch Updates (patch semver update)
- [x] **deps**: Dependency upgrade

## Testing
**Notes**:
Lockfile-only transitive dependency bump; `fast-uri` is used internally by `ajv` for URI-format schema validation and is not imported directly anywhere in this repo.

**Steps**:
1. `npm ls fast-uri --all` shows the single path resolving to `fast-uri@3.1.7` (≥ 3.1.6, patched).
2. `git diff package.json` is empty (no direct-dependency or overrides change).
3. `npm run lint` — 0 errors.
4. `npm test` — 2340 passing, 0 failing.
5. Passing CI suffices.

## Related Issues
### Dependabot alerts

Closes all four advisories (same `fast-uri` fix):

- GHSA-5jgf-p345-68v8 — https://github.com/heroku/cli/security/dependabot/391
- GHSA-fph4-wmhf-6fwf — https://github.com/heroku/cli/security/dependabot/392
- GHSA-jqff-g426-hqxp — https://github.com/heroku/cli/security/dependabot/399
- GHSA-f65p-4m7j-42xc — https://github.com/heroku/cli/security/dependabot/400
