### PR TITLE
refactor: use @heroku/sdk for regions command

### DIFF
--- a/src/commands/regions.ts
+++ b/src/commands/regions.ts
@@ -1,6 +1,6 @@
 import {Command, flags} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
 import {color, hux} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
 
 export default class Regions extends Command {
   static description = 'list available regions for deployment'
@@ -12,8 +12,9 @@ export default class Regions extends Command {
   static topic = 'regions'
 
   async run() {
+    const {platform} = new HerokuSDK()
     const {flags} = await this.parse(Regions)
-    let {body: regions} = await this.heroku.get<Heroku.Region[]>('/regions')
+    let regions = await platform.region.list()
     if (flags.private) {
       regions = regions.filter((region: any) => region.private_capable)
     } else if (flags.common) {
@@ -47,5 +48,7 @@ export default class Regions extends Command {
       })
       /* eslint-enable perfectionist/sort-objects */
     }
+
+    return regions
   }
 }

--- a/test/unit/commands/regions.unit.test.ts
+++ b/test/unit/commands/regions.unit.test.ts
@@ -1,9 +1,20 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
+import * as sinon from 'sinon'
 
 import Regions from '../../../src/commands/regions.js'
 import removeAllWhitespace from '../../helpers/utils/remove-whitespaces.js'
+
+type FakePlatform = {
+  region: {list: sinon.SinonStub}
+}
+
+function buildFakePlatform(): FakePlatform {
+  return {
+    region: {list: sinon.stub()},
+  }
+}
 
 describe('regions', function () {
   const regionData = [
@@ -11,33 +22,30 @@ describe('regions', function () {
     {description: 'United States', name: 'us', private_capable: false},
     {description: 'Oregon, United States', name: 'oregon', private_capable: true},
   ]
-  let api: nock.Scope
+  let fakePlatform: FakePlatform
 
   beforeEach(function () {
-    api = nock('https://api.heroku.com')
+    fakePlatform = buildFakePlatform()
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
   })
 
   afterEach(function () {
-    api.done()
-    nock.cleanAll()
+    sinon.restore()
   })
 
   it('list regions', async function () {
-    api
-      .get('/regions')
-      .reply(200, regionData)
+    fakePlatform.region.list.resolves(regionData)
 
     const {stdout} = await runCommand(Regions, [])
 
     expect(removeAllWhitespace(stdout)).to.include(removeAllWhitespace('ID       Location                Runtime'))
     expect(removeAllWhitespace(stdout)).to.include(removeAllWhitespace('eu       Europe                  Common Runtime'))
     expect(removeAllWhitespace(stdout)).to.include(removeAllWhitespace('us       United States           Common Runtime'))
+    expect(fakePlatform.region.list.calledOnceWithExactly()).to.equal(true)
   })
 
   it('--private', async function () {
-    api
-      .get('/regions')
-      .reply(200, regionData)
+    fakePlatform.region.list.resolves(regionData)
 
     const {stdout} = await runCommand(Regions, ['--private'])
 
@@ -46,9 +54,7 @@ describe('regions', function () {
   })
 
   it('--common', async function () {
-    api
-      .get('/regions')
-      .reply(200, regionData)
+    fakePlatform.region.list.resolves(regionData)
 
     const {stdout} = await runCommand(Regions, ['--common'])
 
@@ -58,9 +64,7 @@ describe('regions', function () {
   })
 
   it('--json', async function () {
-    api
-      .get('/regions')
-      .reply(200, regionData)
+    fakePlatform.region.list.resolves(regionData)
 
     const {stdout} = await runCommand(Regions, ['--json'])
 


### PR DESCRIPTION
## Summary
Migrates the `regions` command from a raw Platform API call (`this.heroku.get('/regions')` via the deprecated `@heroku-cli/schema`) to `@heroku/sdk`'s `platform.region.list()`. Part of **W-23384760** — adopt `@heroku/sdk` in root-level standalone commands (v12).

- Source: `const {platform} = new HerokuSDK()` + `platform.region.list()`; drop the `@heroku-cli/schema` import; `run()` now returns the region list (SDK return-value contract).
- Tests: stub `HerokuSDK.prototype.platform` directly via sinon; drop `nock`.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [x] **test**: Add/update/remove tests

## Testing
**Notes**:
Verified with `bin/run` against the live Platform API (authenticated).

**Steps**:
1. `./bin/run regions` — lists regions in a table (ID / Location / Runtime), common runtime first.
2. `./bin/run regions --private` — shows only private-space-capable regions.
3. `./bin/run regions --common` — shows only common-runtime regions (eu, us).
4. `./bin/run regions --json` — emits valid JSON of the full region list.

## Screenshots (if applicable)

## Related Issues
GitHub issue: #N/A
GUS work item: W-23384760
