### PR TITLE
refactor: use @heroku/sdk for dashboard command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@heroku/heroku-fetch": "^0.1.1-beta",
         "@heroku/http-call": "^5.5.1",
         "@heroku/mcp-server": "^1.2.5",
-        "@heroku/sdk": "^0.6.1",
+        "@heroku/sdk": "^0.6.2",
         "@heroku/socksv5": "^0.0.9",
         "@heroku/types": "^4.6.0",
         "@inquirer/prompts": "^8.7",
@@ -3460,13 +3460,13 @@
       }
     },
     "node_modules/@heroku/sdk": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@heroku/sdk/-/sdk-0.6.1.tgz",
-      "integrity": "sha512-iP1FP8h0GzfqgvrVLenEWazv+WhtYX5jNCRCundpCNXq5y/pJQHVnYKC+yzYkjxmYcngaVsXdVItAXBWWLC7Qw==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@heroku/sdk/-/sdk-0.6.2.tgz",
+      "integrity": "sha512-+GdNZ0uioedNaFf4tFR09kCbXyWV7VMiEdOdodYo+nnAyheGNrLhOyB33wwsvuoo6vDKAiheb56Dly31YQX/0A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku/heroku-fetch": "^0.1.4",
-        "@heroku/types": "^4.7.0",
+        "@heroku/types": "^4.8.0",
         "debug": "^4.4.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@heroku/heroku-fetch": "^0.1.1-beta",
     "@heroku/http-call": "^5.5.1",
     "@heroku/mcp-server": "^1.2.5",
-    "@heroku/sdk": "^0.6.1",
+    "@heroku/sdk": "^0.6.2",
     "@heroku/socksv5": "^0.0.9",
     "@heroku/types": "^4.6.0",
     "@inquirer/prompts": "^8.7",

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -1,8 +1,9 @@
-import {APIClient, Command} from '@heroku-cli/command'
-import * as Heroku from '@heroku-cli/schema'
+import {Command} from '@heroku-cli/command'
 import {color, hux} from '@heroku/heroku-cli-util'
+import {HerokuSDK} from '@heroku/sdk'
+import {App, Formation, PipelineCoupling} from '@heroku/types/3.sdk'
 import {ux} from '@oclif/core/ux'
-import {execSync} from 'node:child_process'
+import {execFileSync} from 'node:child_process'
 import path from 'node:path'
 import * as process from 'node:process'
 import {fileURLToPath} from 'node:url'
@@ -16,10 +17,19 @@ import {sparkline} from '../lib/utils/sparkline.js'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
+type Metrics = HerokuSDK['metrics']
+
+// `GET /apps/{id}/pipeline-couplings` returns the coupled pipeline's name, but
+// the strict @heroku/types schema only declares `pipeline.id`. Widen it here
+// until the upstream type catches up (see V12 SDK migration).
+type PipelineCouplingWithName = Omit<PipelineCoupling, 'pipeline'> & {
+  pipeline?: {id?: string; name?: string}
+}
+
 type AppsWithMoreInfo = {
-  app: Heroku.App
-  formation: Heroku.Formation
-  pipeline?: Heroku.PipelineCoupling
+  app: App
+  formation: Formation[]
+  pipeline?: PipelineCouplingWithName
 }
 
 type FetchMetricsResponse =  {
@@ -49,10 +59,10 @@ function displayErrors(metrics: FetchMetricsResponse[0], _: any) {
     ux.stdout(`  ${label('Errors:')} ${errors.join(dim(', '))} (see details with ${color.code('heroku apps:errors')})`)
 }
 
-function displayFormation(formation: Heroku.Formation, _: any) {
-  formation = _.groupBy(formation, 'size')
-  formation = _.map(formation, (p: any, size: string) => `${bold(_.sumBy(p, 'quantity').toString())} | ${size}`)
-  ux.stdout(`  ${label('Dynos:')} ${formation.join(', ')}`)
+function displayFormation(formation: Formation[], _: any) {
+  const grouped = _.groupBy(formation, 'size')
+  const sizes = _.map(grouped, (p: any, size: string) => `${bold(_.sumBy(p, 'quantity').toString())} | ${size}`)
+  ux.stdout(`  ${label('Dynos:')} ${sizes.join(', ')}`)
 }
 
 function displayMetrics(metrics: FetchMetricsResponse[0], _: any) {
@@ -100,27 +110,28 @@ const dim = (s: string) => color.gray(s)
 const bold = (s: string) => color.bold(s)
 const label = (s: string) => color.label(s)
 
-const fetchMetrics = async (apps: Heroku.App[], heroku: APIClient): Promise<FetchMetricsResponse> => {
+const fetchMetrics = async (apps: AppsWithMoreInfo[], metrics: Metrics): Promise<FetchMetricsResponse> => {
   const NOW = new Date().toISOString()
   const YESTERDAY = new Date(Date.now() - (24 * 60 * 60 * 1000)).toISOString()
-  const date = `start_time=${YESTERDAY}&end_time=${NOW}&step=1h`
+  const query = {end_time: NOW, start_time: YESTERDAY, step: '1h'}
 
   const metricsData = await Promise.all(apps.map(app => {
-    const types = app.formation.map((p: Heroku.Formation) => p.type)
-    const dynoErrorsPromise: Promise<(AppErrors | undefined)[]> = Promise.all(types.map((type: string) => heroku.get<AppErrors>(
-      `/apps/${app.app.name}/formation/${type}/metrics/errors?${date}`,
-      {hostname: 'api.metrics.herokai.com'},
-    ).catch(() => {})))
+    const types = app.formation.map(p => p.type)
+    const dynoErrorsPromise = Promise.all(types.map(type =>
+      metrics.formationMetric.errors(app.app.name, type, query).catch(() => {})))
     return Promise.all([
       dynoErrorsPromise,
-      heroku.get<AppErrors>(`/apps/${app.app.name}/router-metrics/latency?${date}&process_type=${types[0]}`, {hostname: 'api.metrics.herokai.com'}).catch(() => {}),
-      heroku.get<AppErrors>(`/apps/${app.app.name}/router-metrics/errors?${date}&process_type=${types[0]}`, {hostname: 'api.metrics.herokai.com'}).catch(() => {}),
-      heroku.get<AppErrors>(`/apps/${app.app.name}/router-metrics/status?${date}&process_type=${types[0]}`, {hostname: 'api.metrics.herokai.com'}).catch(() => {}),
+      metrics.routerMetric.latency(app.app.name, {...query, process_type: types[0]}).catch(() => {}),
+      metrics.routerMetric.errors(app.app.name, {...query, process_type: types[0]}).catch(() => {}),
+      metrics.routerMetric.status(app.app.name, {...query, process_type: types[0]}).catch(() => {}),
     ])
   }))
 
   return metricsData.map(([dynoErrors, routerLatency, routerErrors, routerStatus]) => ({
-    dynoErrors, routerErrors: routerErrors?.body, routerLatency: routerLatency?.body, routerStatus: routerStatus?.body,
+    dynoErrors: dynoErrors as (AppErrors | undefined)[],
+    routerErrors: routerErrors as AppErrors | undefined,
+    routerLatency: routerLatency as AppErrors | undefined,
+    routerStatus: routerStatus as AppErrors | undefined,
   }))
 }
 
@@ -131,19 +142,18 @@ export default class Dashboard extends Command {
   static promptFlagActive = false
   static topic = 'dashboard'
 
-  public async run(): Promise<void> {
+  public async run(): Promise<AppsWithMoreInfo[] | void> {
+    const {dashboardBackend, metrics, notifications, platform} = new HerokuSDK()
     const _ = await lazyModuleLoader.loadLodash()
 
     if (!this.heroku.auth && process.env.IS_HEROKU_TEST_ENV !== 'true') {
-      execSync('heroku help', {stdio: 'inherit'})
+      execFileSync('heroku', ['help'], {stdio: 'inherit'})
       return
     }
 
     const favoriteApps = async () => {
-      const {body: apps} = await this.heroku.get<Heroku.App[]>('/favorites?type=app', {
-        hostname: 'particleboard.heroku.com',
-      })
-      return apps.map(app => app.resource_name)
+      const favorites = await dashboardBackend.favorite.list({type: 'app'})
+      return favorites.map(favorite => favorite.resource_name)
     }
 
     try {
@@ -164,27 +174,26 @@ export default class Dashboard extends Command {
 
     ux.action.start('Loading')
     const apps = await favoriteApps()
-    const [{body: teams}, notificationsResponse, appsWithMoreInfo] = await Promise.all([
-      this.heroku.get<Heroku.Team[]>('/teams'),
-      this.heroku.get<{read: boolean}[]>('/user/notifications', {hostname: 'telex.heroku.com'})
-        .catch(() => null),
+    const [teams, notificationsResponse, appsWithMoreInfo] = await Promise.all([
+      platform.team.list(),
+      notifications.notification.list().catch(() => null),
       Promise.all(apps.map(async appID => {
-        const [{body: app}, {body: formation}, pipelineResponse] = await Promise.all([
-          this.heroku.get<Heroku.App>(`/apps/${appID}`),
-          this.heroku.get<Heroku.Formation>(`/apps/${appID}/formation`),
-          this.heroku.get<Heroku.PipelineCoupling>(`/apps/${appID}/pipeline-couplings`)
+        const [app, formation, pipeline] = await Promise.all([
+          platform.app.info(appID),
+          platform.formation.list(appID),
+          platform.pipelineCoupling.infoByApp(appID)
             .catch(() => null),
         ])
         return {
-          app, formation, pipeline: pipelineResponse?.body,
+          app, formation, pipeline: pipeline ?? undefined,
         }
       })),
     ])
 
-    const metrics = await fetchMetrics(appsWithMoreInfo, this.heroku)
+    const metricsData = await fetchMetrics(appsWithMoreInfo, metrics)
     ux.action.stop()
     if (apps.length > 0)
-      displayApps(appsWithMoreInfo, metrics, _)
+      displayApps(appsWithMoreInfo, metricsData, _)
     else
       ux.warn(`Add apps to this dashboard by favoriting them with ${color.code('heroku apps:favorites:add')}`)
     ux.stdout(`See all add-ons with ${color.code('heroku addons')}`)
@@ -192,13 +201,15 @@ export default class Dashboard extends Command {
     if (sampleTeam)
       ux.stdout(`See all apps in ${color.team(sampleTeam.name || '')} with ${color.code('heroku apps --team ' + sampleTeam.name)}`)
     ux.stdout(`See all apps with ${color.code('heroku apps --all')}`)
-    displayNotifications(notificationsResponse?.body)
+    displayNotifications(notificationsResponse ?? undefined)
     ux.stdout(`\nSee other CLI commands with ${color.code('heroku help')}\n`)
+
+    return appsWithMoreInfo
   }
 }
 
 function displayApps(apps: AppsWithMoreInfo[], appsMetrics: FetchMetricsResponse, _: any) {
-  const getOwner = (owner: Heroku.App['owner']) => owner?.email?.endsWith('@herokumanager.com') ? owner.email.split('@')[0] : owner?.email
+  const getOwner = (owner: App['owner']) => owner?.email?.endsWith('@herokumanager.com') ? owner.email.split('@')[0] : owner?.email
   const zipped = _.zip(apps, appsMetrics) as [AppsWithMoreInfo, FetchMetricsResponse[0]][]
   for (const a of zipped) {
     const app = a[0]

--- a/test/unit/commands/dashboard.unit.test.ts
+++ b/test/unit/commands/dashboard.unit.test.ts
@@ -1,8 +1,8 @@
 import {runCommand} from '@heroku-cli/test-utils'
+import {HerokuSDK} from '@heroku/sdk'
 import {expect} from 'chai'
-import nock from 'nock'
 import os from 'node:os'
-import {useFakeTimers} from 'sinon'
+import * as sinon from 'sinon'
 import tsheredoc from 'tsheredoc'
 
 import Cmd from '../../../src/commands/dashboard.js'
@@ -10,6 +10,26 @@ import {ago} from '../../../src/lib/time.js'
 import {unwrap} from '../../helpers/utils/unwrap.js'
 
 const heredoc = tsheredoc.default
+
+type FakePlatform = {
+  app: {info: sinon.SinonStub}
+  formation: {list: sinon.SinonStub}
+  pipelineCoupling: {infoByApp: sinon.SinonStub}
+  team: {list: sinon.SinonStub}
+}
+
+type FakeDashboardBackend = {
+  favorite: {list: sinon.SinonStub}
+}
+
+type FakeMetrics = {
+  formationMetric: {errors: sinon.SinonStub}
+  routerMetric: {errors: sinon.SinonStub; latency: sinon.SinonStub; status: sinon.SinonStub}
+}
+
+type FakeNotifications = {
+  notification: {list: sinon.SinonStub}
+}
 
 describe('dashboard', function () {
   if (os.platform() === 'win32') {
@@ -19,20 +39,43 @@ describe('dashboard', function () {
     return
   }
 
-  let clock: any
+  let clock: sinon.SinonFakeTimers
   let now: Date
+  let fakePlatform: FakePlatform
+  let fakeDashboardBackend: FakeDashboardBackend
+  let fakeMetrics: FakeMetrics
+  let fakeNotifications: FakeNotifications
 
   beforeEach(function () {
-    clock = useFakeTimers({
+    clock = sinon.useFakeTimers({
       now: new Date(2024, 1, 1, 0, 0),
       shouldAdvanceTime: true,
       toFake: ['Date'],
     })
     now = new Date()
+
+    fakePlatform = {
+      app: {info: sinon.stub()},
+      formation: {list: sinon.stub()},
+      pipelineCoupling: {infoByApp: sinon.stub()},
+      team: {list: sinon.stub().resolves([])},
+    }
+    fakeDashboardBackend = {favorite: {list: sinon.stub().resolves([])}}
+    fakeMetrics = {
+      formationMetric: {errors: sinon.stub()},
+      routerMetric: {errors: sinon.stub(), latency: sinon.stub(), status: sinon.stub()},
+    }
+    fakeNotifications = {notification: {list: sinon.stub().resolves([])}}
+
+    sinon.stub(HerokuSDK.prototype, 'platform').get(() => fakePlatform)
+    sinon.stub(HerokuSDK.prototype, 'dashboardBackend').get(() => fakeDashboardBackend)
+    sinon.stub(HerokuSDK.prototype, 'metrics').get(() => fakeMetrics)
+    sinon.stub(HerokuSDK.prototype, 'notifications').get(() => fakeNotifications)
   })
 
-  this.afterEach(() => {
+  afterEach(function () {
     clock.restore()
+    sinon.restore()
   })
 
   const pipeline = {pipeline: {name: 'foobar'}}
@@ -70,16 +113,6 @@ describe('dashboard', function () {
 
   describe('with no favorites', function () {
     it('shows the dashboard', async function () {
-      nock('https://particleboard.heroku.com:443')
-        .get('/favorites?type=app')
-        .reply(200, [])
-      nock('https://api.heroku.com:443')
-        .get('/teams')
-        .reply(200, [])
-      nock('https://telex.heroku.com:443')
-        .get('/user/notifications')
-        .reply(200, [])
-
       const {stderr, stdout} = await runCommand(Cmd)
       expect(stdout).to.contain(heredoc(`
         See all add-ons with heroku addons
@@ -88,20 +121,13 @@ describe('dashboard', function () {
         See other CLI commands with heroku help
       `))
       expect(unwrap(stderr)).to.contain('Loading... doneWarning: Add apps to this dashboard by favoriting them with heroku apps:favorites:add\n')
+      expect(fakeDashboardBackend.favorite.list.calledOnceWithExactly({type: 'app'})).to.equal(true)
     })
   })
 
   describe('with no telex', function () {
     it('shows the dashboard', async function () {
-      nock('https://particleboard.heroku.com:443')
-        .get('/favorites?type=app')
-        .reply(200, [])
-      nock('https://api.heroku.com:443')
-        .get('/teams')
-        .reply(200, [])
-      nock('https://telex.heroku.com:443')
-        .get('/user/notifications')
-        .reply(401, [])
+      fakeNotifications.notification.list.rejects(new Error('unauthorized'))
 
       const {stderr, stdout} = await runCommand(Cmd, [])
       expect(stdout).to.contain(heredoc(`
@@ -116,15 +142,8 @@ describe('dashboard', function () {
 
   describe('with notifications', function () {
     it('shows the dashboard', async function () {
-      nock('https://particleboard.heroku.com:443')
-        .get('/favorites?type=app')
-        .reply(200, [])
-      nock('https://api.heroku.com:443')
-        .get('/teams')
-        .reply(200, [])
-      nock('https://telex.heroku.com:443')
-        .get('/user/notifications')
-        .reply(200, [{read: false}])
+      fakeNotifications.notification.list.resolves([{read: false}])
+
       const {stdout} = await runCommand(Cmd, [])
       expect(stdout).to.contain(heredoc(`
         See all add-ons with heroku addons
@@ -139,38 +158,16 @@ describe('dashboard', function () {
 
   describe('with a favorite app', function () {
     it('shows the dashboard', async function () {
-      nock('https://particleboard.heroku.com:443')
-        .get('/favorites?type=app')
-        .reply(200, [{resource_name: 'myapp'}])
-      nock('https://api.heroku.com:443')
-        .get('/teams')
-        .reply(200, [])
-        .get('/apps/myapp')
-        .reply(200, {
-          name: 'myapp', owner: {email: 'foo@bar.com'}, released_at: now.toString(),
-        })
-        .get('/apps/myapp/formation')
-        .reply(200, formation)
-      nock('https://telex.heroku.com:443')
-        .get('/user/notifications')
-        .reply(200, [])
-      nock('https://api.metrics.herokai.com:443')
-        .get('/apps/myapp/router-metrics/status')
-        // `.query` calls used below to avoid getting mocked time to match exactly for `start_time` and `end_time`
-        .query((params: any) => params.step === '1h' && params.process_type === 'web')
-        .reply(200, router.status)
-        .get('/apps/myapp/router-metrics/latency')
-        .query((params: any) => params.step === '1h' && params.process_type === 'web')
-        .reply(200, router.latency)
-        .get('/apps/myapp/router-metrics/errors')
-        .query((params: any) => params.step === '1h' && params.process_type === 'web')
-        .reply(200, router.errors)
-        .get('/apps/myapp/formation/node/metrics/errors')
-        .query((params: any) => params.step === '1h')
-        .reply(200, {data: {}})
-        .get('/apps/myapp/formation/web/metrics/errors')
-        .query((params: any) => params.step === '1h')
-        .reply(200, {data: {}})
+      fakeDashboardBackend.favorite.list.resolves([{resource_name: 'myapp'}])
+      fakePlatform.app.info.resolves({
+        name: 'myapp', owner: {email: 'foo@bar.com'}, released_at: now.toString(),
+      })
+      fakePlatform.formation.list.resolves(formation)
+      fakePlatform.pipelineCoupling.infoByApp.rejects(new Error('not found'))
+      fakeMetrics.routerMetric.status.resolves(router.status)
+      fakeMetrics.routerMetric.latency.resolves(router.latency)
+      fakeMetrics.routerMetric.errors.resolves(router.errors)
+      fakeMetrics.formationMetric.errors.resolves({data: {}})
 
       const {stderr, stdout} = await runCommand(Cmd, [])
 
@@ -189,45 +186,24 @@ describe('dashboard', function () {
         See other CLI commands with heroku help
       `))
       expect(stderr).to.contain('Loading... done\n')
+      expect(fakePlatform.app.info.calledOnceWithExactly('myapp')).to.equal(true)
+      expect(fakeMetrics.routerMetric.latency.calledOnce).to.equal(true)
+      expect(fakeMetrics.routerMetric.latency.firstCall.args[1].process_type).to.equal('web')
     })
   })
 
   describe('with a apps and metrics', function () {
     it('shows the dashboard', async function () {
-      nock('https://particleboard.heroku.com:443')
-        .get('/favorites?type=app')
-        .reply(200, [{resource_name: 'myapp'}])
-      nock('https://api.heroku.com:443')
-        .get('/teams')
-        .reply(200, [])
-        .get('/apps/myapp')
-        .reply(200, {
-          name: 'myapp', owner: {email: 'foo@bar.com'}, released_at: now.toString(),
-        })
-        .get('/apps/myapp/formation')
-        .reply(200, formation)
-        .get('/apps/myapp/pipeline-couplings')
-        .reply(200, pipeline)
-      nock('https://telex.heroku.com:443')
-        .get('/user/notifications')
-        .reply(200, [])
-      nock('https://api.metrics.herokai.com:443')
-        .get('/apps/myapp/router-metrics/status')
-        // `.query` calls used below to avoid getting mocked time to match exactly for `start_time` and `end_time`
-        .query((params: any) => params.step === '1h' && params.process_type === 'web')
-        .reply(200, router.status)
-        .get('/apps/myapp/router-metrics/latency')
-        .query((params: any) => params.step === '1h' && params.process_type === 'web')
-        .reply(200, router.latency)
-        .get('/apps/myapp/router-metrics/errors')
-        .query((params: any) => params.step === '1h' && params.process_type === 'web')
-        .reply(200, router.errors)
-        .get('/apps/myapp/formation/node/metrics/errors')
-        .query((params: any) => params.step === '1h')
-        .reply(200, {data: {}})
-        .get('/apps/myapp/formation/web/metrics/errors')
-        .query((params: any) => params.step === '1h')
-        .reply(200, {data: {}})
+      fakeDashboardBackend.favorite.list.resolves([{resource_name: 'myapp'}])
+      fakePlatform.app.info.resolves({
+        name: 'myapp', owner: {email: 'foo@bar.com'}, released_at: now.toString(),
+      })
+      fakePlatform.formation.list.resolves(formation)
+      fakePlatform.pipelineCoupling.infoByApp.resolves(pipeline)
+      fakeMetrics.routerMetric.status.resolves(router.status)
+      fakeMetrics.routerMetric.latency.resolves(router.latency)
+      fakeMetrics.routerMetric.errors.resolves(router.errors)
+      fakeMetrics.formationMetric.errors.resolves({data: {}})
 
       const {stdout} = await runCommand(Cmd, [])
       expect(stdout).to.include('Pipeline: foobar')


### PR DESCRIPTION
## Summary
Migrates the `dashboard` command off the `APIClient` (`this.heroku`) and the deprecated `@heroku-cli/schema` onto `@heroku/sdk`. Part of **W-23384760** — adopt `@heroku/sdk` in root-level standalone commands (v12).

Dashboard fans out across four backend services, all now routed through the SDK:
- **platform** — `team.list`, `app.info`, `formation.list`, `pipelineCoupling.infoByApp`
- **dashboardBackend** — `favorite.list({type: 'app'})`
- **metrics** — `formationMetric.errors`, `routerMetric.latency/errors/status`
- **notifications** — `notification.list` (requires `@heroku/sdk` **0.6.2**, bumped in this PR)

Also: entity types now come from `@heroku/types/3.sdk`; `run()` returns the assembled `AppsWithMoreInfo[]`; the unauthenticated early-exit uses `execFileSync` instead of `execSync`.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [x] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [x] **test**: Add/update/remove tests

## Testing
**Notes**:
Verified end-to-end with `bin/run` against the live backend (authenticated, with favorited apps and unread notifications). All four services returned data: platform (pipelines/formation), dashboardBackend (favorites), metrics (rpm + sparkline + errors), notifications (unread count).

**Steps**:
1. `./bin/run dashboard` with favorited apps → shows each app's owner, pipeline, dynos, last release, metrics (rpm sparkline), and errors.
2. Confirm the unread-notifications line renders (`You have N unread notifications. Read them with heroku notifications`).
3. Confirm a pipeline-coupled app shows `Pipeline: <name>`.
4. `./bin/run dashboard` with no favorites → shows the "favorite them with heroku apps:favorites:add" hint.
5. Unauthenticated (no auth token) → falls through to `heroku help`.

## Screenshots (if applicable)

## Related Issues
GitHub issue: #N/A
GUS work item: W-23384760
