### PR TITLE
refactor(status): use @heroku/heroku-fetch instead of @heroku/http-call

### DIFF
--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,5 +1,5 @@
 import {color, hux} from '@heroku/heroku-cli-util'
-import {HTTP} from '@heroku/http-call'
+import {HerokuApiClient} from '@heroku/heroku-fetch'
 import {Command, Flags, ux} from '@oclif/core'
 
 import {lazyModuleLoader} from '../lib/lazy-module-loader.js'
@@ -16,6 +16,20 @@ import {
 
 const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)
 const errorMessage = 'Heroku platform status is unavailable at this time. Refer to https://status.salesforce.com/products/Heroku or try again later.'
+
+// The status APIs are third-party hosts (SF Trust, the Heroku status page),
+// so build an unauthenticated `custom` client — passing token: '' skips the
+// Authorization header (and the default token lookup that would otherwise
+// throw when the user isn't logged in).
+const statusClient = (baseUrl: string) => new HerokuApiClient({baseUrl, service: 'custom', token: ''})
+
+// Read a response body the way @heroku/http-call did: parse JSON when a body
+// is present, otherwise return the empty body untouched (some endpoints reply
+// 200 with no content). Response.json() throws on an empty body.
+const readBody = async <T>(response: Response): Promise<T> => {
+  const text = await response.text()
+  return (text ? JSON.parse(text) : text) as T
+}
 
 const printStatus = (status: string) => {
   const colorize = (color as any)[status]
@@ -37,16 +51,17 @@ const getTrustStatus = async () => {
   let localizations: Localization[] = []
 
   try {
+    const client = statusClient(trustHost)
     const [instanceResponse, activeIncidentsResponse, maintenancesResponse, localizationsResponse] = await Promise.all([
-      HTTP.get<TrustInstance[]>(`${trustHost}/instances?products=Heroku`),
-      HTTP.get<TrustIncident[]>(`${trustHost}/incidents/active`),
-      HTTP.get<TrustMaintenance[]>(`${trustHost}/maintenances?startTime=${currentDateTime}&limit=10&offset=0&product=Heroku&locale=en`),
-      HTTP.get<Localization[]>(`${trustHost}/localizations?locale=en`),
+      client.get('/instances?products=Heroku'),
+      client.get('/incidents/active'),
+      client.get(`/maintenances?startTime=${currentDateTime}&limit=10&offset=0&product=Heroku&locale=en`),
+      client.get('/localizations?locale=en'),
     ])
-    instances = instanceResponse.body
-    activeIncidents = activeIncidentsResponse.body
-    maintenances = maintenancesResponse.body
-    localizations = localizationsResponse.body
+    instances = await readBody<TrustInstance[]>(instanceResponse)
+    activeIncidents = await readBody<TrustIncident[]>(activeIncidentsResponse)
+    maintenances = await readBody<TrustMaintenance[]>(maintenancesResponse)
+    localizations = await readBody<Localization[]>(localizationsResponse)
   } catch {
     ux.error(errorMessage, {exit: 1})
   }
@@ -145,8 +160,8 @@ export default class Status extends Command {
       try {
         // Try calling the Heroku status API first
         const herokuHost = process.env.HEROKU_STATUS_HOST || 'https://status.heroku.com'
-        const herokuStatusResponse = await HTTP.get<HerokuStatus>(herokuHost + herokuApiPath)
-        herokuStatus = herokuStatusResponse.body
+        const herokuStatusResponse = await statusClient(herokuHost).get(herokuApiPath)
+        herokuStatus = await readBody<HerokuStatus>(herokuStatusResponse)
       } catch {
         // If the Heroku status API call fails, call the SF Trust API
         formattedTrustStatus = await getTrustStatus()

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -17,18 +17,13 @@ import {
 const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)
 const errorMessage = 'Heroku platform status is unavailable at this time. Refer to https://status.salesforce.com/products/Heroku or try again later.'
 
-// The status APIs are third-party hosts (SF Trust, the Heroku status page),
-// so build an unauthenticated `custom` client — passing token: '' skips the
-// Authorization header (and the default token lookup that would otherwise
-// throw when the user isn't logged in).
+// Status data comes from public third-party hosts, so token: '' keeps the request unauthenticated.
 const statusClient = (baseUrl: string) => new HerokuApiClient({baseUrl, service: 'custom', token: ''})
 
-// Read a response body the way @heroku/http-call did: parse JSON when a body
-// is present, otherwise return the empty body untouched (some endpoints reply
-// 200 with no content). Response.json() throws on an empty body.
-const readBody = async <T>(response: Response): Promise<T> => {
+// Some status endpoints reply 200 with no body; treat that as absent.
+const getJson = async <T>(response: Response): Promise<T | undefined> => {
   const text = await response.text()
-  return (text ? JSON.parse(text) : text) as T
+  return text ? JSON.parse(text) as T : undefined
 }
 
 const printStatus = (status: string) => {
@@ -58,10 +53,10 @@ const getTrustStatus = async () => {
       client.get(`/maintenances?startTime=${currentDateTime}&limit=10&offset=0&product=Heroku&locale=en`),
       client.get('/localizations?locale=en'),
     ])
-    instances = await readBody<TrustInstance[]>(instanceResponse)
-    activeIncidents = await readBody<TrustIncident[]>(activeIncidentsResponse)
-    maintenances = await readBody<TrustMaintenance[]>(maintenancesResponse)
-    localizations = await readBody<Localization[]>(localizationsResponse)
+    instances = await getJson<TrustInstance[]>(instanceResponse) ?? []
+    activeIncidents = await getJson<TrustIncident[]>(activeIncidentsResponse) ?? []
+    maintenances = await getJson<TrustMaintenance[]>(maintenancesResponse) ?? []
+    localizations = await getJson<Localization[]>(localizationsResponse) ?? []
   } catch {
     ux.error(errorMessage, {exit: 1})
   }
@@ -161,7 +156,7 @@ export default class Status extends Command {
         // Try calling the Heroku status API first
         const herokuHost = process.env.HEROKU_STATUS_HOST || 'https://status.heroku.com'
         const herokuStatusResponse = await statusClient(herokuHost).get(herokuApiPath)
-        herokuStatus = await readBody<HerokuStatus>(herokuStatusResponse)
+        herokuStatus = await getJson<HerokuStatus>(herokuStatusResponse)
       } catch {
         // If the Heroku status API call fails, call the SF Trust API
         formattedTrustStatus = await getTrustStatus()


### PR DESCRIPTION
## Summary
The `status` command previously made raw `HTTP.get` calls through `@heroku/http-call` to the Heroku status page and the Salesforce Trust status API. This switches those calls to an unauthenticated `@heroku/heroku-fetch` `custom` client, so the command uses the same HTTP layer the v12 SDK migration standardizes on.

These endpoints are third-party hosts (not `this.heroku.*` Platform API calls), so this is an HTTP-layer swap rather than adoption of an SDK service. Behavior is unchanged.

Notable details:
- The `custom` client is constructed with `token: ''`, which skips the `Authorization` header (and the default netrc/env token lookup that would otherwise throw for logged-out users) — correct for these tokenless third-party hosts.
- A small `readBody()` helper mirrors `http-call`'s empty-body handling: it parses JSON only when a body is present, since some endpoints reply `200` with no content and the native `Response.json()` throws on an empty body.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**:
No user-visible behavior change. The existing `test/unit/commands/status.unit.test.ts` suite (nock-based) passes unchanged. Steps below verify the two live code paths — the Heroku status API (default) and the Salesforce Trust API fallback.

**Steps**:
1. `npm run build`
2. `./bin/run status` — shows Apps/Data/Tools status from the Heroku status page.
3. `./bin/run status --json` — emits the same status as JSON.
4. `TRUST_ONLY=1 ./bin/run status` — forces the Salesforce Trust API path; still renders Apps/Data/Tools (confirms the unauthenticated `custom` client reaches `api.status.salesforce.com`).
5. `npx mocha --forbid-only test/unit/commands/status.unit.test.ts` — 8 passing.

## Screenshots (if applicable)

## Related Issues
GitHub issue: #N/A
GUS work item: [W-23384760](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002eMEdlYAG/view)
